### PR TITLE
fix(ai/test): assert interleaved-thinking beta is omitted on Sonnet 4.6

### DIFF
--- a/packages/ai/test/github-copilot-anthropic.test.ts
+++ b/packages/ai/test/github-copilot-anthropic.test.ts
@@ -91,7 +91,10 @@ describe("Copilot Claude via Anthropic Messages", () => {
 		expect(Array.isArray(params.messages)).toBe(true);
 	});
 
-	it("includes interleaved-thinking beta when reasoning is enabled", async () => {
+	it("omits interleaved-thinking beta for adaptive-thinking models", async () => {
+		// claude-sonnet-4.6 is an adaptive-thinking model: the provider intentionally
+		// drops the interleaved-thinking beta because it's redundant on Sonnet 4.6
+		// and deprecated on Opus 4.6 (anthropic.ts: supportsAdaptiveThinking).
 		const model = getModel("github-copilot", "claude-sonnet-4.6");
 		const { streamAnthropic } = await import("../src/providers/anthropic.js");
 		const s = streamAnthropic(model, context, {
@@ -103,6 +106,7 @@ describe("Copilot Claude via Anthropic Messages", () => {
 		}
 
 		const headers = mockState.constructorOpts!.defaultHeaders as Record<string, string>;
-		expect(headers["anthropic-beta"]).toContain("interleaved-thinking-2025-05-14");
+		const beta = headers["anthropic-beta"] ?? "";
+		expect(beta).not.toContain("interleaved-thinking-2025-05-14");
 	});
 });


### PR DESCRIPTION
## Summary

CI on `main` (run #7, job `build-check-test`) failed with:

> AssertionError: the given combination of arguments (undefined and string) is invalid for this assertion
> packages/ai/test/github-copilot-anthropic.test.ts:106
> "Copilot Claude via Anthropic Messages > includes interleaved-thinking beta when reasoning is enabled"

Bumping the test model from `claude-sonnet-4` to `claude-sonnet-4.6` in #2 flipped the expected provider behavior. `anthropic.ts:772` (`createClient`) computes `needsInterleavedBeta = interleavedThinking && !supportsAdaptiveThinking(model.id)`, and `claude-sonnet-4.6` is an adaptive-thinking model, so the `interleaved-thinking-2025-05-14` beta is intentionally dropped (redundant on Sonnet 4.6, deprecated on Opus 4.6+). With no other beta active in this code path, the `anthropic-beta` header is never set — hence the `undefined` assertion failure.

This PR inverts the assertion to verify the beta is **omitted** for adaptive-thinking models, matching the upstream `earendil-works/pi` test. Guards against undefined with the `?? ""` fallback used elsewhere in the same file (line 83).

## Test plan

- [ ] `build-check-test` job goes green on this branch and on the merge into `main`

https://claude.ai/code/session_01JwDMQdTUrDAgShR3bDeDa7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwDMQdTUrDAgShR3bDeDa7)_