### PR TITLE
fix: skip _-prefixed skill folders and make engram available globally

### DIFF
--- a/packages/agent/src/harness/skills.ts
+++ b/packages/agent/src/harness/skills.ts
@@ -117,7 +117,9 @@ async function loadSkillsFromDirInternal(
 	}
 
 	for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-		if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+		// Skip hidden ("."), convention-private ("_", e.g. "_shared/" per
+		// anthropics/skills) and node_modules entries during tree discovery.
+		if (entry.name.startsWith(".") || entry.name.startsWith("_") || entry.name === "node_modules") continue;
 		const fullPath = entry.path;
 		const kind = await resolveKind(env, entry);
 		if (!kind) continue;

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -226,7 +226,10 @@ function loadSkillsFromDirInternal(
 		}
 
 		for (const entry of entries) {
-			if (entry.name.startsWith(".")) {
+			// Skip hidden entries (".") and convention-private entries ("_") so
+			// shared utility folders like "_shared/" (anthropics/skills convention)
+			// are not picked up as skills and rejected by the name validator.
+			if (entry.name.startsWith(".") || entry.name.startsWith("_")) {
 				continue;
 			}
 

--- a/packages/coding-agent/test/fixtures/skills/_shared/SKILL.md
+++ b/packages/coding-agent/test/fixtures/skills/_shared/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: _shared
+description: Shared utilities folder using the anthropics/skills "_" convention. Should be skipped by the loader, not loaded as a skill.
+---
+
+# _shared
+
+Convention-private folder used to hold helpers reused across skills. The
+underscore prefix signals "do not treat this as a skill" — the loader
+must skip it instead of validating its name.

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -161,7 +161,7 @@ describe("skills", () => {
 		});
 
 		it("should load all skills from fixture directory", () => {
-			const { skills } = loadSkillsFromDir({
+			const { skills, diagnostics } = loadSkillsFromDir({
 				dir: fixturesDir,
 				source: "test",
 			});
@@ -169,7 +169,14 @@ describe("skills", () => {
 			// Should load all skills that have descriptions (even with warnings)
 			// valid-skill, name-mismatch, invalid-name-chars, long-name, unknown-field, nested/child-skill, consecutive-hyphens
 			// NOT: missing-description, no-frontmatter (both missing descriptions)
+			// NOT: _shared (underscore-prefixed folders are skipped per anthropics/skills convention)
 			expect(skills.length).toBeGreaterThanOrEqual(6);
+			expect(skills.find((s) => s.name === "_shared")).toBeUndefined();
+			expect(
+				diagnostics.some(
+					(d: ResourceDiagnostic) => d.message.includes("_shared") && d.message.includes("invalid characters"),
+				),
+			).toBe(false);
 		});
 
 		it("should return empty for non-existent directory", () => {

--- a/scripts/setup-gentle-pi.sh
+++ b/scripts/setup-gentle-pi.sh
@@ -160,6 +160,38 @@ echo "Installing global MCP config to ${GLOBAL_MCP_CONFIG}..."
 mkdir -p "${AGENT_DIR}"
 install -m 0644 "${MCP_CONFIG}" "${GLOBAL_MCP_CONFIG}"
 
+GLOBAL_SETTINGS="${AGENT_DIR}/settings.json"
+echo "Ensuring pi-mcp-adapter is registered in global settings (${GLOBAL_SETTINGS})..."
+GLOBAL_SETTINGS="${GLOBAL_SETTINGS}" node <<'NODE'
+const fs = require("fs");
+const path = process.env.GLOBAL_SETTINGS;
+const pkg = "npm:pi-mcp-adapter";
+let data = {};
+if (fs.existsSync(path)) {
+	try {
+		data = JSON.parse(fs.readFileSync(path, "utf-8"));
+	} catch (err) {
+		console.error(`Refusing to seed ${path}: existing file is not valid JSON (${err.message}).`);
+		console.error("Fix the file by hand or delete it and re-run the setup.");
+		process.exit(1);
+	}
+	if (typeof data !== "object" || data === null || Array.isArray(data)) {
+		console.error(`Refusing to seed ${path}: top-level value must be a JSON object.`);
+		process.exit(1);
+	}
+}
+if (!Array.isArray(data.packages)) {
+	data.packages = [];
+}
+if (data.packages.includes(pkg)) {
+	console.log(`${pkg} already declared in ${path}`);
+	process.exit(0);
+}
+data.packages.push(pkg);
+fs.writeFileSync(path, `${JSON.stringify(data, null, "\t")}\n`, "utf-8");
+console.log(`Added ${pkg} to ${path}`);
+NODE
+
 SHELL_NAME="$(detect_shell_name)"
 echo "Detected shell: ${SHELL_NAME}"
 install_shell_alias "${SHELL_NAME}" || true


### PR DESCRIPTION
## Summary

Two unrelated UX fixes surfaced while running gentle-pi outside the repo, building on top of the `--mcp-config` removal in #2.

### 1. `fix(skills)`: skip `_`-prefixed entries during skill tree discovery (commit `9ee6886`)

Both skill loaders walked every non-hidden child of the skills root and called `validateName` on whatever was inside, so a folder following the `anthropics/skills` `_shared/` convention (utility content reused across skills, not itself a skill) reached the validator and was rejected with:

> `name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)`

This surfaced at startup as a `[Skill conflicts]` diagnostic for every user with a `_shared/` folder under `~/.agents/skills/`. The loader already skipped `.`-prefixed entries (hidden) and `node_modules`; this PR treats `_`-prefixed entries the same way so the convention-private folders get filtered out before they reach `validateName`.

Both copies of the discovery loop are patched so the fix is consistent between the in-process coding-agent loader (`packages/coding-agent/src/core/skills.ts:228`) and the harness loader (`packages/agent/src/harness/skills.ts:119`). Adds a `_shared` fixture and extends the existing "load all skills from fixture directory" test to assert that `_shared` is not in the loaded skills and that no "invalid characters" diagnostic is emitted for it. Loading `_shared` via an explicit `dir` path is still allowed — the skip only applies when iterating a parent.

### 2. `fix(setup)`: seed `pi-mcp-adapter` in global settings so engram works in any cwd (commit `82c5883`)

Copying `.pi/mcp.json` to `${AGENT_DIR}/mcp.json` in #2 was necessary but not sufficient to make engram available outside the gentle-pi repo. The runtime engram tools come from the `pi-mcp-adapter` package, which is loaded from `settings.packages` by the package manager's merge of project + global settings (`package-manager.ts:859-864`). Since `~/.pi/agent/settings.json` never declared `pi-mcp-adapter`, running gentle-pi outside the repo had no project settings to merge in and the adapter (and therefore engram) was simply not loaded.

This PR adds a node-driven seeding step to `setup-gentle-pi.sh` that ensures `"npm:pi-mcp-adapter"` is listed under `packages` in `${AGENT_DIR}/settings.json`. Behavior:

- **Missing file**: creates `{ "packages": ["npm:pi-mcp-adapter"] }` with tab indentation matching the project `settings.json` convention.
- **Existing settings.json**: parses, appends `pi-mcp-adapter` only if not already present, preserves all other keys (theme, gentlePi block, etc.) and the rest of the packages array. Idempotent on re-run.
- **Malformed JSON**: refuses to overwrite, exits 1 with a clear message pointing the user to fix the file by hand.

`pi-coding-agent`'s package manager auto-installs `npm:*` sources on first use, so no extra `npm install` step is needed — the next time gentle-pi launches in any directory it will pull `pi-mcp-adapter` and the engram MCP tools become available.

## Test plan

- [ ] CI `build-check-test` stays green
- [ ] After re-running `./scripts/setup-gentle-pi.sh`, `~/.pi/agent/settings.json` contains `"npm:pi-mcp-adapter"` under `packages` (and any pre-existing keys are preserved)
- [ ] Re-running setup is a no-op for that key
- [ ] `gentle-pi` launched from a directory **without** its own `.pi/settings.json` exposes engram tools (`mem_save`, `mem_search`, …)
- [ ] On a machine with `~/.agents/skills/_shared/SKILL.md`, `gentle-pi` no longer prints the `name contains invalid characters` skill-conflict diagnostic

https://claude.ai/code/session_01JwDMQdTUrDAgShR3bDeDa7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwDMQdTUrDAgShR3bDeDa7)_