### PR TITLE
feat: add /gentle:shy command to toggle startup role and title animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Most coding-agent sessions fail for operational reasons, not model reasons:
 | Capability                     | What it does                                                                                                                                  |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | **el Gentleman persona**       | Makes Pi behave like a senior architect and teacher, not a generic chatbot. Spanish responses use Rioplatense voseo by default.               |
-| **Rose startup intro**         | Adds a pink rose fade-in, compact project/runtime panel, and visible startup collaboration credit for @aporcelli's `pi-gentle-startup` ideas. |
+| **Rose startup intro**         | Adds a pink rose fade-in, compact project/runtime panel, and visible startup collaboration credit for @aporcelli's `pi-gentle-startup` ideas. Toggle via `/gentle:shy`. |
 | **Work routing discipline**    | Small tasks stay inline. Context-heavy exploration can be delegated. Large or risky changes go through SDD/OpenSpec.                          |
 | **SDD/OpenSpec assets**        | Installs phase agents and chains for `init`, `explore`, `proposal`, `spec`, `design`, `tasks`, `apply`, `verify`, and `archive`.              |
 | **Lazy SDD preflight**         | Asks once per session for SDD mode, artifact store, PR chaining strategy, and review budget before the first SDD flow.                        |
@@ -92,6 +92,7 @@ pi
 /sdd-init                  Create or refresh openspec/config.yaml.
 /gentle:models             Assign global model/effort routing to SDD/custom agents.
 /gentle:persona            Switch between gentleman and neutral persona modes.
+/gentle:shy                Toggle startup role and title animation on/off.
 ```
 
 Typical flow:
@@ -324,6 +325,30 @@ Saved at:
 
 Run `/reload` or start a new Pi session after switching persona.
 
+## Shy mode
+
+```text
+/gentle:shy
+```
+
+When shy mode is **ON**, the startup role and title animation (rose fade-in, pen-writing logo, runtime stats panel) are skipped entirely. Pi starts directly on a clean prompt, respecting users who prefer a minimal startup.
+
+Off by default — run the command once to persist the choice.
+
+Saved at:
+
+```text
+.pi/gentle-ai/shy.json
+```
+
+```json
+{
+  "shy": true
+}
+```
+
+Restart Pi after toggling. Status visible via `/gentle-ai:status`.
+
 ## Model and effort assignment
 
 ```text
@@ -377,6 +402,7 @@ Legacy string entries are still accepted and treated as `model`-only config.
 | `/gentle-ai:status`              | Shows package, SDD asset, OpenSpec, and global model config status. |
 | `/gentle:models`                 | Opens global model + effort assignment UI.                          |
 | `/gentle:persona`                | Switches persona mode.                                              |
+| `/gentle:shy`                    | Toggles startup role and title animation on/off.                    |
 | `/sdd-init`                      | Initializes or refreshes `openspec/config.yaml`.                    |
 | `/gentle-ai:install-sdd`         | Reinstalls SDD assets without overwriting local files.              |
 | `/gentle-ai:install-sdd --force` | Force-refreshes installed SDD assets.                               |
@@ -397,6 +423,8 @@ Compatibility aliases:
 /gentleman:models
 /gentle-ai:persona
 /gentleman:persona
+/gentle-ai:shy
+/gentleman:shy
 ```
 
 ## Included skills

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -29,6 +29,7 @@ import {
 	renderSddPreflightPrompt,
 	type SddPreflightPreferences,
 } from "../lib/sdd-preflight.ts";
+import { isShyMode, toggleShyMode } from "../lib/shy-config.ts";
 
 const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const ASSETS_DIR = join(PACKAGE_ROOT, "assets");
@@ -1375,6 +1376,7 @@ export default function gentleAi(pi: ExtensionAPI): void {
 				[
 					"el Gentleman package is active.",
 					`Persona: ${readPersonaMode(ctx.cwd)}`,
+					`Shy mode: ${isShyMode(ctx.cwd) ? "ON (startup hidden)" : "OFF"}`,
 					`SDD agents: ${agentsInstalled ? "installed" : "not installed"}`,
 					`SDD chains: ${chainsInstalled ? "installed" : "not installed"}`,
 					`SDD assets stale: ${staleSddAssets} file(s)${
@@ -1387,6 +1389,39 @@ export default function gentleAi(pi: ExtensionAPI): void {
 					...describeModelConfig(ctx.cwd, modelConfig),
 				].join("\n"),
 				staleSddAssets > 0 ? "warning" : "info",
+			);
+		},
+	});
+
+	pi.registerCommand("gentle:shy", {
+		description: "Toggle shy mode: disable/enable startup role and title animation.",
+		handler: async (_args, ctx) => {
+			const next = toggleShyMode(ctx.cwd);
+			ctx.ui.notify(
+				`Shy mode is now ${next ? "ON" : "OFF"}. ${next ? "Startup animation hidden." : "Startup animation visible."}\nRestart Pi for the change to take effect.`,
+				"info",
+			);
+		},
+	});
+
+	pi.registerCommand("gentle-ai:shy", {
+		description: "Compatibility alias for /gentle:shy.",
+		handler: async (_args, ctx) => {
+			const next = toggleShyMode(ctx.cwd);
+			ctx.ui.notify(
+				`Shy mode is now ${next ? "ON" : "OFF"}. ${next ? "Startup animation hidden." : "Startup animation visible."}\nRestart Pi for the change to take effect.`,
+				"info",
+			);
+		},
+	});
+
+	pi.registerCommand("gentleman:shy", {
+		description: "Compatibility alias for /gentle:shy.",
+		handler: async (_args, ctx) => {
+			const next = toggleShyMode(ctx.cwd);
+			ctx.ui.notify(
+				`Shy mode is now ${next ? "ON" : "OFF"}. ${next ? "Startup animation hidden." : "Startup animation visible."}\nRestart Pi for the change to take effect.`,
+				"info",
 			);
 		},
 	});

--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -6,6 +6,7 @@ import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { isShyMode } from "../lib/shy-config.ts";
 
 const execAsync = promisify(exec);
 
@@ -436,6 +437,9 @@ function currentIntroMode(): IntroMode {
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     if (!ctx.hasUI) return;
+
+    // Shy mode: skip startup animation entirely
+    if (isShyMode(ctx.cwd)) return;
 
     // Si se está ejecutando un comando de CLI como "pi update" o "pi install", no mostramos la intro animada.
     const isCLICommand =

--- a/lib/shy-config.ts
+++ b/lib/shy-config.ts
@@ -1,0 +1,33 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+function shyConfigPath(cwd: string): string {
+	return join(cwd, ".pi", "gentle-ai", "shy.json");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isShyMode(cwd: string): boolean {
+	const path = shyConfigPath(cwd);
+	if (!existsSync(path)) return false;
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+		return isRecord(parsed) && parsed.shy === true;
+	} catch {
+		return false;
+	}
+}
+
+export function setShyMode(cwd: string, enabled: boolean): void {
+	const path = shyConfigPath(cwd);
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify({ shy: enabled }, null, 2)}\n`);
+}
+
+export function toggleShyMode(cwd: string): boolean {
+	const next = !isShyMode(cwd);
+	setShyMode(cwd, next);
+	return next;
+}


### PR DESCRIPTION
## Summary

Adds **shy mode** — a per-project toggle to disable the rose startup intro, pen-writing logo animation, and runtime stats panel. Inspired by the "shy gentle pi" concept: let users who prefer a clean, quiet startup opt out without modifying the extension.

## Changes

### New file: `lib/shy-config.ts`
Shared config module providing `isShyMode()`, `setShyMode()`, and `toggleShyMode()`. Persists state in `.pi/gentle-ai/shy.json`.

### Modified: `extensions/startup-banner.ts`
Added a `isShyMode(ctx.cwd)` early return at the top of the `session_start` handler. When shy mode is ON, the entire startup animation block is skipped — no screen clear, no ASCII art, no pen writing, no stats panel.

### Modified: `extensions/gentle-ai.ts`
- Registers `/gentle:shy`, `/gentle-ai:shy`, and `/gentleman:shy` commands that toggle shy mode and notify the user.
- `/gentle-ai:status` now reports shy mode status (`ON` / `OFF`).

### Modified: `README.md`
- Adds shy mode to the capabilities table.
- Adds a dedicated **Shy mode** section with config path example.
- Adds shy commands to the quick-start, commands table, and compatibility aliases.

## Design decisions

- **Off by default** — existing users see no behavior change. Only those who run `/gentle:shy` get the silent startup.
- **Project-scoped config** — follows the existing `.pi/gentle-ai/` pattern used by persona config.
- **Three command aliases** — consistent with how `/gentle:persona`, `/gentle-ai:persona`, and `/gentleman:persona` work.
- **Status visible** — `/gentle-ai:status` shows whether shy mode is active.
- **Restart required** — the change takes effect on next Pi session (consistent with persona mode).
- **Minimal diff** — adds 4 lines to startup-banner.ts, 35 lines to gentle-ai.ts, 33 lines of new module, README docs. No test changes needed; all 20 existing tests pass.
