### PR TITLE
fix(models): exclude skill dirs from agent discovery

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -484,13 +484,29 @@ async function parseAgentNameAsync(
 	return packageName ? `${packageName}.${name}` : name;
 }
 
-function listAgentFilesRecursive(dir: string): string[] {
+type AgentDiscoveryOptions = {
+	skipDirectoryNames?: readonly string[];
+};
+
+function shouldSkipDiscoveryDirectory(
+	name: string,
+	options: AgentDiscoveryOptions,
+): boolean {
+	return options.skipDirectoryNames?.includes(name) ?? false;
+}
+
+function listAgentFilesRecursive(
+	dir: string,
+	options: AgentDiscoveryOptions = {},
+): string[] {
 	if (!existsSync(dir)) return [];
 	const files: string[] = [];
 	for (const entry of readdirSync(dir, { withFileTypes: true })) {
 		const path = join(dir, entry.name);
-		if (entry.isDirectory()) files.push(...listAgentFilesRecursive(path));
-		else if (
+		if (entry.isDirectory()) {
+			if (shouldSkipDiscoveryDirectory(entry.name, options)) continue;
+			files.push(...listAgentFilesRecursive(path, options));
+		} else if (
 			entry.isFile() &&
 			entry.name.endsWith(".md") &&
 			!entry.name.endsWith(".chain.md")
@@ -500,7 +516,10 @@ function listAgentFilesRecursive(dir: string): string[] {
 	return files;
 }
 
-async function listAgentFilesRecursiveAsync(dir: string): Promise<string[]> {
+async function listAgentFilesRecursiveAsync(
+	dir: string,
+	options: AgentDiscoveryOptions = {},
+): Promise<string[]> {
 	if (!(await pathExists(dir))) return [];
 	const files: string[] = [];
 	let entries;
@@ -512,7 +531,8 @@ async function listAgentFilesRecursiveAsync(dir: string): Promise<string[]> {
 	for (const entry of entries) {
 		const path = join(dir, entry.name);
 		if (entry.isDirectory()) {
-			files.push(...(await listAgentFilesRecursiveAsync(path)));
+			if (shouldSkipDiscoveryDirectory(entry.name, options)) continue;
+			files.push(...(await listAgentFilesRecursiveAsync(path, options)));
 		} else if (
 			entry.isFile() &&
 			entry.name.endsWith(".md") &&
@@ -524,8 +544,12 @@ async function listAgentFilesRecursiveAsync(dir: string): Promise<string[]> {
 	return files;
 }
 
-function listAgentsFromDir(dir: string, source: AgentSource): AgentEntry[] {
-	return listAgentFilesRecursive(dir)
+function listAgentsFromDir(
+	dir: string,
+	source: AgentSource,
+	options: AgentDiscoveryOptions = {},
+): AgentEntry[] {
+	return listAgentFilesRecursive(dir, options)
 		.map((filePath): AgentEntry | undefined => {
 			const name = parseAgentName(filePath);
 			return name ? { name, source, filePath } : undefined;
@@ -536,8 +560,9 @@ function listAgentsFromDir(dir: string, source: AgentSource): AgentEntry[] {
 async function listAgentsFromDirAsync(
 	dir: string,
 	source: AgentSource,
+	options: AgentDiscoveryOptions = {},
 ): Promise<AgentEntry[]> {
-	const filePaths = await listAgentFilesRecursiveAsync(dir);
+	const filePaths = await listAgentFilesRecursiveAsync(dir, options);
 	const entries: AgentEntry[] = [];
 	for (const filePath of filePaths) {
 		const name = await parseAgentNameAsync(filePath);
@@ -552,11 +577,12 @@ function listDiscoverableAgents(cwd: string): AgentEntry[] {
 		join(cwd, ".pi", "npm", "node_modules", "pi-subagents", "agents"),
 		join(homedir(), ".local", "lib", "node_modules", "pi-subagents", "agents"),
 	];
+	const dotAgentsOptions = { skipDirectoryNames: ["skills"] };
 	const agents = [
 		...builtinDirs.flatMap((dir) => listAgentsFromDir(dir, "builtin")),
 		...listAgentsFromDir(join(homedir(), ".pi", "agent", "agents"), "user"),
-		...listAgentsFromDir(join(homedir(), ".agents"), "user"),
-		...listAgentsFromDir(join(cwd, ".agents"), "project"),
+		...listAgentsFromDir(join(homedir(), ".agents"), "user", dotAgentsOptions),
+		...listAgentsFromDir(join(cwd, ".agents"), "project", dotAgentsOptions),
 		...listAgentsFromDir(join(cwd, ".pi", "agents"), "project"),
 	];
 	const byName = new Map<string, AgentEntry>();
@@ -581,14 +607,19 @@ async function listDiscoverableAgentsAsync(cwd: string): Promise<AgentEntry[]> {
 	for (const dir of builtinDirs) {
 		agents.push(...(await listAgentsFromDirAsync(dir, "builtin")));
 	}
-	const otherDirs: Array<[string, AgentSource]> = [
-		[join(homedir(), ".pi", "agent", "agents"), "user"],
-		[join(homedir(), ".agents"), "user"],
-		[join(cwd, ".agents"), "project"],
-		[join(cwd, ".pi", "agents"), "project"],
+	const dotAgentsOptions = { skipDirectoryNames: ["skills"] };
+	const otherDirs: Array<[
+		string,
+		AgentSource,
+		AgentDiscoveryOptions | undefined,
+	]> = [
+		[join(homedir(), ".pi", "agent", "agents"), "user", undefined],
+		[join(homedir(), ".agents"), "user", dotAgentsOptions],
+		[join(cwd, ".agents"), "project", dotAgentsOptions],
+		[join(cwd, ".pi", "agents"), "project", undefined],
 	];
-	for (const [dir, source] of otherDirs) {
-		agents.push(...(await listAgentsFromDirAsync(dir, source)));
+	for (const [dir, source, options] of otherDirs) {
+		agents.push(...(await listAgentsFromDirAsync(dir, source, options)));
 	}
 	const byName = new Map<string, AgentEntry>();
 	for (const agent of agents) byName.set(agent.name, agent);
@@ -1223,6 +1254,11 @@ async function handlePersonaCommand(ctx: ExtensionContext): Promise<void> {
 		"info",
 	);
 }
+
+export const __testing = {
+	listAgentsFromDir,
+	listAgentFilesRecursive,
+};
 
 export default function gentleAi(pi: ExtensionAPI): void {
 	function runSddPreflight(ctx: ExtensionContext): Promise<SddPreflightPreferences> {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -484,28 +484,14 @@ async function parseAgentNameAsync(
 	return packageName ? `${packageName}.${name}` : name;
 }
 
-type AgentDiscoveryOptions = {
-	skipDirectoryNames?: readonly string[];
-};
-
-function shouldSkipDiscoveryDirectory(
-	name: string,
-	options: AgentDiscoveryOptions,
-): boolean {
-	return options.skipDirectoryNames?.includes(name) ?? false;
-}
-
-function listAgentFilesRecursive(
-	dir: string,
-	options: AgentDiscoveryOptions = {},
-): string[] {
+function listAgentFilesRecursive(dir: string): string[] {
 	if (!existsSync(dir)) return [];
 	const files: string[] = [];
 	for (const entry of readdirSync(dir, { withFileTypes: true })) {
 		const path = join(dir, entry.name);
 		if (entry.isDirectory()) {
-			if (shouldSkipDiscoveryDirectory(entry.name, options)) continue;
-			files.push(...listAgentFilesRecursive(path, options));
+			if (entry.name === "skills") continue;
+			files.push(...listAgentFilesRecursive(path));
 		} else if (
 			entry.isFile() &&
 			entry.name.endsWith(".md") &&
@@ -516,10 +502,7 @@ function listAgentFilesRecursive(
 	return files;
 }
 
-async function listAgentFilesRecursiveAsync(
-	dir: string,
-	options: AgentDiscoveryOptions = {},
-): Promise<string[]> {
+async function listAgentFilesRecursiveAsync(dir: string): Promise<string[]> {
 	if (!(await pathExists(dir))) return [];
 	const files: string[] = [];
 	let entries;
@@ -531,8 +514,8 @@ async function listAgentFilesRecursiveAsync(
 	for (const entry of entries) {
 		const path = join(dir, entry.name);
 		if (entry.isDirectory()) {
-			if (shouldSkipDiscoveryDirectory(entry.name, options)) continue;
-			files.push(...(await listAgentFilesRecursiveAsync(path, options)));
+			if (entry.name === "skills") continue;
+			files.push(...(await listAgentFilesRecursiveAsync(path)));
 		} else if (
 			entry.isFile() &&
 			entry.name.endsWith(".md") &&
@@ -544,12 +527,8 @@ async function listAgentFilesRecursiveAsync(
 	return files;
 }
 
-function listAgentsFromDir(
-	dir: string,
-	source: AgentSource,
-	options: AgentDiscoveryOptions = {},
-): AgentEntry[] {
-	return listAgentFilesRecursive(dir, options)
+function listAgentsFromDir(dir: string, source: AgentSource): AgentEntry[] {
+	return listAgentFilesRecursive(dir)
 		.map((filePath): AgentEntry | undefined => {
 			const name = parseAgentName(filePath);
 			return name ? { name, source, filePath } : undefined;
@@ -560,9 +539,8 @@ function listAgentsFromDir(
 async function listAgentsFromDirAsync(
 	dir: string,
 	source: AgentSource,
-	options: AgentDiscoveryOptions = {},
 ): Promise<AgentEntry[]> {
-	const filePaths = await listAgentFilesRecursiveAsync(dir, options);
+	const filePaths = await listAgentFilesRecursiveAsync(dir);
 	const entries: AgentEntry[] = [];
 	for (const filePath of filePaths) {
 		const name = await parseAgentNameAsync(filePath);
@@ -577,12 +555,11 @@ function listDiscoverableAgents(cwd: string): AgentEntry[] {
 		join(cwd, ".pi", "npm", "node_modules", "pi-subagents", "agents"),
 		join(homedir(), ".local", "lib", "node_modules", "pi-subagents", "agents"),
 	];
-	const dotAgentsOptions = { skipDirectoryNames: ["skills"] };
 	const agents = [
 		...builtinDirs.flatMap((dir) => listAgentsFromDir(dir, "builtin")),
 		...listAgentsFromDir(join(homedir(), ".pi", "agent", "agents"), "user"),
-		...listAgentsFromDir(join(homedir(), ".agents"), "user", dotAgentsOptions),
-		...listAgentsFromDir(join(cwd, ".agents"), "project", dotAgentsOptions),
+		...listAgentsFromDir(join(homedir(), ".agents"), "user"),
+		...listAgentsFromDir(join(cwd, ".agents"), "project"),
 		...listAgentsFromDir(join(cwd, ".pi", "agents"), "project"),
 	];
 	const byName = new Map<string, AgentEntry>();
@@ -607,19 +584,14 @@ async function listDiscoverableAgentsAsync(cwd: string): Promise<AgentEntry[]> {
 	for (const dir of builtinDirs) {
 		agents.push(...(await listAgentsFromDirAsync(dir, "builtin")));
 	}
-	const dotAgentsOptions = { skipDirectoryNames: ["skills"] };
-	const otherDirs: Array<[
-		string,
-		AgentSource,
-		AgentDiscoveryOptions | undefined,
-	]> = [
-		[join(homedir(), ".pi", "agent", "agents"), "user", undefined],
-		[join(homedir(), ".agents"), "user", dotAgentsOptions],
-		[join(cwd, ".agents"), "project", dotAgentsOptions],
-		[join(cwd, ".pi", "agents"), "project", undefined],
+	const otherDirs: Array<[string, AgentSource]> = [
+		[join(homedir(), ".pi", "agent", "agents"), "user"],
+		[join(homedir(), ".agents"), "user"],
+		[join(cwd, ".agents"), "project"],
+		[join(cwd, ".pi", "agents"), "project"],
 	];
-	for (const [dir, source, options] of otherDirs) {
-		agents.push(...(await listAgentsFromDirAsync(dir, source, options)));
+	for (const [dir, source] of otherDirs) {
+		agents.push(...(await listAgentsFromDirAsync(dir, source)));
 	}
 	const byName = new Map<string, AgentEntry>();
 	for (const agent of agents) byName.set(agent.name, agent);
@@ -1255,9 +1227,10 @@ async function handlePersonaCommand(ctx: ExtensionContext): Promise<void> {
 	);
 }
 
+/** @internal */
 export const __testing = {
 	listAgentsFromDir,
-	listAgentFilesRecursive,
+	listAgentsFromDirAsync,
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -10,67 +10,27 @@ function writeMarkdown(path: string, content: string): void {
 	writeFileSync(path, content);
 }
 
-test("agent discovery can skip .agents skills directories", () => {
-	const root = join(tmpdir(), `gentle-pi-agents-${Date.now()}`);
+test("agent discovery skips skills directories", async (t) => {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-agents-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
 	const dotAgents = join(root, ".agents");
-	writeMarkdown(
-		join(dotAgents, "reviewer.md"),
-		`---
-name: reviewer
----
-
-# Reviewer
-`,
-	);
-	writeMarkdown(
-		join(dotAgents, "skills", "ai-sdk", "SKILL.md"),
-		`---
-name: ai-sdk
-description: AI SDK skill.
----
-
-# AI SDK
-`,
-	);
+	writeMarkdown(join(dotAgents, "reviewer.md"), "name: reviewer\n");
+	writeMarkdown(join(dotAgents, "team", "worker.md"), "name: worker\n");
+	writeMarkdown(join(dotAgents, "skills", "ai-sdk", "SKILL.md"), "name: ai-sdk\n");
 	writeMarkdown(
 		join(dotAgents, "skills", "ai-sdk", "references", "evaluation.md"),
-		`---
-name: Prompt Evaluation
----
-
-# Prompt Evaluation
-`,
+		"name: Prompt Evaluation\n",
 	);
 
-	const agents = __testing.listAgentsFromDir(dotAgents, "user", {
-		skipDirectoryNames: ["skills"],
-	});
+	const syncAgents = __testing.listAgentsFromDir(dotAgents, "user");
+	const asyncAgents = await __testing.listAgentsFromDirAsync(dotAgents, "user");
 
 	assert.deepEqual(
-		agents.map((agent) => agent.name),
-		["reviewer"],
+		syncAgents.map((agent) => agent.name),
+		["reviewer", "worker"],
 	);
-});
-
-test("agent discovery still scans non-skill subdirectories", () => {
-	const root = join(tmpdir(), `gentle-pi-nested-agents-${Date.now()}`);
-	const dotAgents = join(root, ".agents");
-	writeMarkdown(
-		join(dotAgents, "team", "worker.md"),
-		`---
-name: worker
----
-
-# Worker
-`,
-	);
-
-	const agents = __testing.listAgentsFromDir(dotAgents, "project", {
-		skipDirectoryNames: ["skills"],
-	});
-
 	assert.deepEqual(
-		agents.map((agent) => agent.name),
-		["worker"],
+		asyncAgents.map((agent) => agent.name),
+		["reviewer", "worker"],
 	);
 });

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { __testing } from "../extensions/gentle-ai.ts";
+
+function writeMarkdown(path: string, content: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, content);
+}
+
+test("agent discovery can skip .agents skills directories", () => {
+	const root = join(tmpdir(), `gentle-pi-agents-${Date.now()}`);
+	const dotAgents = join(root, ".agents");
+	writeMarkdown(
+		join(dotAgents, "reviewer.md"),
+		`---
+name: reviewer
+---
+
+# Reviewer
+`,
+	);
+	writeMarkdown(
+		join(dotAgents, "skills", "ai-sdk", "SKILL.md"),
+		`---
+name: ai-sdk
+description: AI SDK skill.
+---
+
+# AI SDK
+`,
+	);
+	writeMarkdown(
+		join(dotAgents, "skills", "ai-sdk", "references", "evaluation.md"),
+		`---
+name: Prompt Evaluation
+---
+
+# Prompt Evaluation
+`,
+	);
+
+	const agents = __testing.listAgentsFromDir(dotAgents, "user", {
+		skipDirectoryNames: ["skills"],
+	});
+
+	assert.deepEqual(
+		agents.map((agent) => agent.name),
+		["reviewer"],
+	);
+});
+
+test("agent discovery still scans non-skill subdirectories", () => {
+	const root = join(tmpdir(), `gentle-pi-nested-agents-${Date.now()}`);
+	const dotAgents = join(root, ".agents");
+	writeMarkdown(
+		join(dotAgents, "team", "worker.md"),
+		`---
+name: worker
+---
+
+# Worker
+`,
+	);
+
+	const agents = __testing.listAgentsFromDir(dotAgents, "project", {
+		skipDirectoryNames: ["skills"],
+	});
+
+	assert.deepEqual(
+		agents.map((agent) => agent.name),
+		["worker"],
+	);
+});


### PR DESCRIPTION
Fixes #15

## Summary
- Excludes `skills` subdirectories while discovering model-routable agents from `.agents` roots.
- Keeps recursive discovery for non-skill nested agent directories.
- Adds regression tests covering `SKILL.md` and reference markdown files under `.agents/skills`.

## Test plan
- [x] `node --experimental-strip-types --test tests/gentle-ai.test.ts`
- [x] `node --experimental-strip-types --test tests/*.test.ts`
- [x] `npm run test:harness`

Note: I used direct Node/npm commands locally because `pnpm` is not installed in my shell. CI still uses the repository's `pnpm` workflow.
