### PR TITLE
feat(runtime): add autonomous guard profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,17 +369,53 @@ Config shape (per agent):
 
 Legacy string entries are still accepted and treated as `model`-only config.
 
+## Runtime guardrails
+
+Gentle AI protects shell execution before `bash` tool calls run. Destructive deny rules always run first, so force pushes (`--force`, `--force-with-lease`, or `-f`), hard resets, forced cleans, critical `rm -rf`, recursive `chmod 777`, and recursive `chown` remain blocked even when a profile allows a guarded command.
+
+Autonomous runtime defaults can be enabled with:
+
+```bash
+GENTLE_PI_AUTONOMOUS_MODE=1 pi
+```
+
+When autonomous mode is active, normal `git push` is allowed without an interactive prompt; `git rebase`, forced branch delete (`git branch --delete --force` / `git branch -D`), and `pi remove` still require confirmation; `npm publish` is blocked.
+
+You can persist a profile globally or per project:
+
+```text
+${GENTLE_PI_CONFIG_HOME:-~/.pi/gentle-ai}/runtime-guardrails.json
+<project>/.pi/gentle-ai/runtime-guardrails.json
+```
+
+Project config overrides global config. Minimal shape:
+
+```json
+{
+  "autonomousMode": true,
+  "guardedCommands": {
+    "gitPush": "allow",
+    "gitRebase": "confirm",
+    "gitBranchDeleteForce": "confirm",
+    "npmPublish": "block",
+    "piRemove": "confirm"
+  }
+}
+```
+
+Each guarded command action is one of `allow`, `confirm`, or `block`.
+
 ## Commands
 
-| Command                          | What it does                                                        |
-| -------------------------------- | ------------------------------------------------------------------- |
-| `/gentle-ai:status`              | Shows package, SDD asset, OpenSpec, and global model config status. |
-| `/gentle:models`                 | Opens global model + effort assignment UI.                          |
-| `/gentle:persona`                | Switches persona mode.                                              |
-| `/sdd-init`                      | Initializes or refreshes `openspec/config.yaml`.                    |
+| Command                          | What it does                                                         |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `/gentle-ai:status`              | Shows package, SDD asset, OpenSpec, and global model config status.  |
+| `/gentle:models`                 | Opens global model + effort assignment UI.                           |
+| `/gentle:persona`                | Switches persona mode.                                               |
+| `/sdd-init`                      | Initializes or refreshes `openspec/config.yaml`.                     |
 | `/gentle-ai:install-sdd`         | Repairs missing global SDD runtime assets without overwriting files. |
 | `/gentle-ai:install-sdd --force` | Force-refreshes installed global SDD assets.                         |
-| `/skill-registry:refresh`        | Regenerates `.atl/skill-registry.md`.                               |
+| `/skill-registry:refresh`        | Regenerates `.atl/skill-registry.md`.                                |
 
 Startup flag:
 
@@ -430,18 +466,18 @@ Memory contract for SDD delegation:
 
 ## Package contents
 
-| Path                           | Purpose                                                                                                    |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Path                           | Purpose                                                                                                              |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | `extensions/gentle-ai.ts`      | Injects identity, ensures global SDD assets, registers commands, applies model config, and protects shell execution. |
-| `extensions/startup-banner.ts` | Shows the rose startup intro, compact runtime panel, and collaboration credit.                             |
-| `extensions/sdd-init.ts`       | Registers `/sdd-init` for OpenSpec initialization.                                                         |
-| `extensions/skill-registry.ts` | Maintains `.atl/skill-registry.md` from project/user skills.                                               |
-| `assets/orchestrator.md`       | Parent-session orchestration contract.                                                                     |
-| `assets/agents/`               | SDD agents installed as global Pi runtime assets.                                                          |
-| `assets/chains/`               | SDD chains installed as global Pi runtime assets.                                                          |
-| `assets/support/`              | Strict TDD support docs for apply/verify phases.                                                           |
-| `skills/`                      | Gentle AI delivery and collaboration skills.                                                               |
-| `prompts/`                     | Gentle-prefixed prompt templates.                                                                          |
+| `extensions/startup-banner.ts` | Shows the rose startup intro, compact runtime panel, and collaboration credit.                                       |
+| `extensions/sdd-init.ts`       | Registers `/sdd-init` for OpenSpec initialization.                                                                   |
+| `extensions/skill-registry.ts` | Maintains `.atl/skill-registry.md` from project/user skills.                                                         |
+| `assets/orchestrator.md`       | Parent-session orchestration contract.                                                                               |
+| `assets/agents/`               | SDD agents installed as global Pi runtime assets.                                                                    |
+| `assets/chains/`               | SDD chains installed as global Pi runtime assets.                                                                    |
+| `assets/support/`              | Strict TDD support docs for apply/verify phases.                                                                     |
+| `skills/`                      | Gentle AI delivery and collaboration skills.                                                                         |
+| `prompts/`                     | Gentle-prefixed prompt templates.                                                                                    |
 
 ## Development
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5,13 +5,7 @@ import {
 	readFileSync,
 	writeFileSync,
 } from "node:fs";
-import {
-	access,
-	mkdir,
-	readFile,
-	readdir,
-	writeFile,
-} from "node:fs/promises";
+import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,6 +15,17 @@ import type {
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
 import { matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+	AUTONOMOUS_GUARD_DEFAULTS,
+	commandRequiresConfirmation,
+	evaluateDeniedCommand,
+	evaluateRuntimeGuardCommand as evaluateRuntimeGuardProfileCommand,
+	guardedCommandFor,
+	type RuntimeGuardAction,
+	type RuntimeGuardedCommand,
+	type RuntimeGuardedCommands,
+	type RuntimeGuardProfile,
+} from "../lib/runtime-guardrails.ts";
 import {
 	ensureSddPreflight,
 	getSddPreflightPreferences,
@@ -47,7 +52,11 @@ function sddGlobalAssetDriftCount(): number {
 		if (!existsSync(assetDir)) continue;
 		for (const entry of readdirSync(assetDir, { withFileTypes: true })) {
 			if (!entry.isFile()) continue;
-			const installedPath = join(gentlePiAgentHome(), installedSubdir, entry.name);
+			const installedPath = join(
+				gentlePiAgentHome(),
+				installedSubdir,
+				entry.name,
+			);
 			try {
 				if (!existsSync(installedPath)) {
 					stale += 1;
@@ -164,22 +173,10 @@ Harness principles:
 ${getOrchestratorPrompt()}`;
 }
 
-const DENIED_BASH_PATTERNS: RegExp[] = [
-	/\brm\s+-rf\s+(?:\/|~|\$HOME|\.\.?)(?:\s|$)/,
-	/\bgit\s+reset\s+--hard\b/,
-	/\bgit\s+clean\b(?=[^\n]*(?:-[^\n]*f|--force))(?=[^\n]*(?:-[^\n]*d|--directories))/,
-	/\bgit\s+push\b(?=[^\n]*\s--force(?:-with-lease)?\b)/,
-	/\bchmod\s+-R\s+777\b/,
-	/\bchown\s+-R\b/,
-];
-
-const CONFIRM_BASH_PATTERNS: RegExp[] = [
-	/\bgit\s+push\b/,
-	/\bgit\s+rebase\b/,
-	/\bgit\s+branch\s+-D\b/,
-	/\bnpm\s+publish\b/,
-	/\bpi\s+remove\b/,
-];
+type RuntimeGuardConfigFileResult =
+	| { status: "missing" }
+	| { status: "invalid"; path: string }
+	| { status: "valid"; profile: Partial<RuntimeGuardProfile> };
 
 const SDD_AGENT_NAMES = [
 	"sdd-init",
@@ -271,23 +268,90 @@ function isNamedAgentStartEvent(event: unknown): boolean {
 	return readAgentStartNames(event).length > 0;
 }
 
-function evaluateDeniedCommand(
-	command: string,
-): ToolCallEventResult | undefined {
-	for (const pattern of DENIED_BASH_PATTERNS) {
-		if (pattern.test(command)) {
-			return {
-				block: true,
-				reason:
-					"Gentle AI safety policy blocked a destructive shell command. Ask the user for an explicit safer plan.",
-			};
-		}
-	}
-	return undefined;
+function isRuntimeGuardAction(value: unknown): value is RuntimeGuardAction {
+	return value === "allow" || value === "confirm" || value === "block";
 }
 
-function commandRequiresConfirmation(command: string): boolean {
-	return CONFIRM_BASH_PATTERNS.some((pattern) => pattern.test(command));
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function gentleAiConfigHome(): string {
+	return (
+		process.env.GENTLE_PI_CONFIG_HOME || join(homedir(), ".pi", "gentle-ai")
+	);
+}
+
+function runtimeGuardConfigPath(_cwd: string): string {
+	return join(gentleAiConfigHome(), "runtime-guardrails.json");
+}
+
+function projectRuntimeGuardConfigPath(cwd: string): string {
+	return join(cwd, ".pi", "gentle-ai", "runtime-guardrails.json");
+}
+
+function normalizeRuntimeGuardProfile(
+	value: unknown,
+): Partial<RuntimeGuardProfile> | undefined {
+	if (!isRecord(value)) return undefined;
+	const profile: Partial<RuntimeGuardProfile> = {};
+	if (typeof value.autonomousMode === "boolean") {
+		profile.autonomousMode = value.autonomousMode;
+	}
+	if (isRecord(value.guardedCommands)) {
+		const guardedCommands: RuntimeGuardedCommands = {};
+		for (const key of Object.keys(
+			AUTONOMOUS_GUARD_DEFAULTS,
+		) as RuntimeGuardedCommand[]) {
+			const action = value.guardedCommands[key];
+			if (isRuntimeGuardAction(action)) guardedCommands[key] = action;
+		}
+		profile.guardedCommands = guardedCommands;
+	}
+	return profile;
+}
+
+function readRuntimeGuardConfigFile(
+	path: string,
+): RuntimeGuardConfigFileResult {
+	if (!existsSync(path)) return { status: "missing" };
+	try {
+		const profile = normalizeRuntimeGuardProfile(
+			JSON.parse(readFileSync(path, "utf8")),
+		);
+		return profile ? { status: "valid", profile } : { status: "invalid", path };
+	} catch {
+		return { status: "invalid", path };
+	}
+}
+
+function readRuntimeGuardProfile(cwd: string): RuntimeGuardProfile {
+	const projectResult = readRuntimeGuardConfigFile(
+		projectRuntimeGuardConfigPath(cwd),
+	);
+	const globalResult = readRuntimeGuardConfigFile(runtimeGuardConfigPath(cwd));
+	const selected =
+		projectResult.status !== "missing" ? projectResult : globalResult;
+	const configured = selected.status === "valid" ? selected.profile : {};
+	const autonomousMode =
+		process.env.GENTLE_PI_AUTONOMOUS_MODE === "1" ||
+		configured.autonomousMode === true;
+	return {
+		autonomousMode,
+		guardedCommands: autonomousMode
+			? { ...AUTONOMOUS_GUARD_DEFAULTS, ...configured.guardedCommands }
+			: (configured.guardedCommands ?? {}),
+	};
+}
+
+function evaluateRuntimeGuardCommand(
+	command: string,
+	cwd: string,
+): ToolCallEventResult | undefined {
+	return evaluateRuntimeGuardProfileCommand(
+		command,
+		readRuntimeGuardProfile(cwd),
+	);
 }
 
 async function confirmCommand(
@@ -296,6 +360,20 @@ async function confirmCommand(
 ): Promise<ToolCallEventResult | undefined> {
 	const denied = evaluateDeniedCommand(command);
 	if (denied) return denied;
+	const runtimeGuardProfile = readRuntimeGuardProfile(ctx.cwd);
+	const runtimeGuard = evaluateRuntimeGuardProfileCommand(
+		command,
+		runtimeGuardProfile,
+	);
+	if (runtimeGuard) return runtimeGuard;
+	const guardedCommand = guardedCommandFor(command);
+	if (
+		runtimeGuardProfile.autonomousMode &&
+		guardedCommand &&
+		runtimeGuardProfile.guardedCommands[guardedCommand] === "allow"
+	) {
+		return undefined;
+	}
 	if (!commandRequiresConfirmation(command)) return undefined;
 	if (!ctx.hasUI) {
 		return {
@@ -316,14 +394,6 @@ async function confirmCommand(
 		reason:
 			"Gentle AI safety policy blocked the command because it was not confirmed.",
 	};
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function gentleAiConfigHome(): string {
-	return process.env.GENTLE_PI_CONFIG_HOME ?? join(homedir(), ".pi", "gentle-ai");
 }
 
 function modelConfigPath(_cwd: string): string {
@@ -1265,8 +1335,20 @@ async function handlePersonaCommand(ctx: ExtensionContext): Promise<void> {
 	);
 }
 
+export const __testing = {
+	commandRequiresConfirmation,
+	evaluateDeniedCommand,
+	evaluateRuntimeGuardCommand,
+	guardedCommandFor,
+	readRuntimeGuardProfile,
+	runtimeGuardConfigPath,
+	projectRuntimeGuardConfigPath,
+};
+
 export default function gentleAi(pi: ExtensionAPI): void {
-	function runSddPreflight(ctx: ExtensionContext): Promise<SddPreflightPreferences> {
+	function runSddPreflight(
+		ctx: ExtensionContext,
+	): Promise<SddPreflightPreferences> {
 		return ensureSddPreflight(ctx, {
 			pi,
 			installAssets: (cwd) => installSddAssets(cwd, false),
@@ -1293,8 +1375,7 @@ export default function gentleAi(pi: ExtensionAPI): void {
 			}
 		} catch (error) {
 			if (ctx.hasUI) {
-				const message =
-					error instanceof Error ? error.message : String(error);
+				const message = error instanceof Error ? error.message : String(error);
 				ctx.ui.notify(
 					`el Gentleman model config sweep failed: ${message}`,
 					"warning",
@@ -1322,9 +1403,10 @@ export default function gentleAi(pi: ExtensionAPI): void {
 			prefs && (!isNamedAgent || isSddAgent)
 				? `\n\n${renderSddPreflightPrompt(prefs)}`
 				: "";
-		const gentlePrompt = isNamedAgent || isSddAgent
-			? ""
-			: `\n\n${buildGentlePrompt(readPersonaMode(ctx.cwd))}`;
+		const gentlePrompt =
+			isNamedAgent || isSddAgent
+				? ""
+				: `\n\n${buildGentlePrompt(readPersonaMode(ctx.cwd))}`;
 		return {
 			systemPrompt: `${event.systemPrompt}${gentlePrompt}${sddPrompt}`,
 		};
@@ -1351,8 +1433,7 @@ export default function gentleAi(pi: ExtensionAPI): void {
 	});
 
 	pi.registerCommand("gentle-ai:sdd-preflight", {
-		description:
-			"Run or reuse the lazy SDD preflight for this Pi session.",
+		description: "Run or reuse the lazy SDD preflight for this Pi session.",
 		handler: async (_args, ctx) => {
 			await runSddPreflight(ctx);
 		},

--- a/lib/runtime-guardrails.ts
+++ b/lib/runtime-guardrails.ts
@@ -1,0 +1,118 @@
+export interface RuntimeToolCallResult {
+	block: boolean;
+	reason: string;
+}
+
+const FORCE_BRANCH_DELETE_PATTERN =
+	/\bgit\s+branch\b(?=[^\n]*(?:\s-D(?:\s|$)|\s--delete\b|\s-[A-Za-z]*d[A-Za-z]*(?:\s|$)))(?=[^\n]*(?:\s-D(?:\s|$)|\s--force\b|\s-[A-Za-z]*f[A-Za-z]*(?:\s|$)))/;
+
+const DENIED_BASH_PATTERNS = [
+	/\brm\s+-rf\s+(?:\/|~|\$HOME|\.\.?)(?:\s|$)/,
+	/\bgit\s+reset\s+--hard\b/,
+	/\bgit\s+clean\b(?=[^\n]*(?:-[^\n]*f|--force))(?=[^\n]*(?:-[^\n]*d|--directories))/,
+	/\bgit\s+push\b(?=[^\n]*(?:\s--force(?:-with-lease)?\b|\s-[A-Za-z]*f[A-Za-z]*(?:\s|$)))/,
+	/\bchmod\s+-R\s+777\b/,
+	/\bchown\s+-R\b/,
+];
+
+const CONFIRM_BASH_PATTERNS = [
+	/\bgit\s+push\b/,
+	/\bgit\s+rebase\b/,
+	FORCE_BRANCH_DELETE_PATTERN,
+	/\bnpm\s+publish\b/,
+	/\bpi\s+remove\b/,
+];
+
+export type RuntimeGuardAction = "allow" | "confirm" | "block";
+export type RuntimeGuardedCommand =
+	| "gitPush"
+	| "gitRebase"
+	| "gitBranchDeleteForce"
+	| "npmPublish"
+	| "piRemove";
+export interface RuntimeGuardedCommands {
+	gitPush?: RuntimeGuardAction;
+	gitRebase?: RuntimeGuardAction;
+	gitBranchDeleteForce?: RuntimeGuardAction;
+	npmPublish?: RuntimeGuardAction;
+	piRemove?: RuntimeGuardAction;
+}
+export interface RuntimeGuardProfile {
+	autonomousMode: boolean;
+	guardedCommands: RuntimeGuardedCommands;
+}
+
+export const AUTONOMOUS_GUARD_DEFAULTS: {
+	gitPush: RuntimeGuardAction;
+	gitRebase: RuntimeGuardAction;
+	gitBranchDeleteForce: RuntimeGuardAction;
+	npmPublish: RuntimeGuardAction;
+	piRemove: RuntimeGuardAction;
+} = {
+	gitPush: "allow",
+	gitRebase: "confirm",
+	gitBranchDeleteForce: "confirm",
+	npmPublish: "block",
+	piRemove: "confirm",
+};
+
+const GUARDED_COMMAND_PATTERNS = [
+	{ name: "gitPush", pattern: /\bgit\s+push\b/ },
+	{ name: "gitRebase", pattern: /\bgit\s+rebase\b/ },
+	{
+		name: "gitBranchDeleteForce",
+		pattern: FORCE_BRANCH_DELETE_PATTERN,
+	},
+	{ name: "npmPublish", pattern: /\bnpm\s+publish\b/ },
+	{ name: "piRemove", pattern: /\bpi\s+remove\b/ },
+];
+
+export function evaluateDeniedCommand(
+	command: string,
+): RuntimeToolCallResult | undefined {
+	for (const pattern of DENIED_BASH_PATTERNS) {
+		if (pattern.test(command)) {
+			return {
+				block: true,
+				reason:
+					"Gentle AI safety policy blocked a destructive shell command. Ask the user for an explicit safer plan.",
+			};
+		}
+	}
+	return undefined;
+}
+
+export function commandRequiresConfirmation(command: string): boolean {
+	for (const pattern of CONFIRM_BASH_PATTERNS) {
+		if (pattern.test(command)) return true;
+	}
+	return false;
+}
+
+export function guardedCommandFor(
+	command: string,
+): RuntimeGuardedCommand | undefined {
+	for (const entry of GUARDED_COMMAND_PATTERNS) {
+		if (entry.pattern.test(command)) return entry.name;
+	}
+	return undefined;
+}
+
+export function evaluateRuntimeGuardCommand(
+	command: string,
+	profile: RuntimeGuardProfile,
+): RuntimeToolCallResult | undefined {
+	if (!profile.autonomousMode) return undefined;
+	const guardedCommand = guardedCommandFor(command);
+	if (!guardedCommand) return undefined;
+	const action = profile.guardedCommands[guardedCommand];
+	if (action === "allow") return undefined;
+	if (action === "block") {
+		return {
+			block: true,
+			reason:
+				"Gentle AI autonomous runtime permission profile blocked this guarded command.",
+		};
+	}
+	return undefined;
+}

--- a/tests/runtime-guardrails.test.ts
+++ b/tests/runtime-guardrails.test.ts
@@ -1,0 +1,114 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const {
+	AUTONOMOUS_GUARD_DEFAULTS,
+	commandRequiresConfirmation,
+	evaluateDeniedCommand,
+	evaluateRuntimeGuardCommand,
+	guardedCommandFor,
+} = await import("../lib/runtime-guardrails.ts");
+
+function autonomousProfile(overrides = {}) {
+	return {
+		autonomousMode: true,
+		guardedCommands: { ...AUTONOMOUS_GUARD_DEFAULTS, ...overrides },
+	};
+}
+
+test("autonomous runtime profile allows normal git push but denied force push wins first", () => {
+	const profile = autonomousProfile();
+
+	assert.equal(
+		evaluateRuntimeGuardCommand("git push origin feature/test", profile),
+		undefined,
+	);
+	const forcePush = evaluateDeniedCommand(
+		"git push --force origin feature/test",
+	);
+	assert.equal(forcePush && forcePush.block, true);
+	const forceWithLeasePush = evaluateDeniedCommand(
+		"git push --force-with-lease origin feature/test",
+	);
+	assert.equal(forceWithLeasePush && forceWithLeasePush.block, true);
+	const shortForcePush = evaluateDeniedCommand(
+		"git push -f origin feature/test",
+	);
+	assert.equal(shortForcePush && shortForcePush.block, true);
+});
+
+test("autonomous runtime defaults block publish and keep rebase/delete/remove on confirmation path", () => {
+	const profile = autonomousProfile();
+	const publish = evaluateRuntimeGuardCommand("npm publish", profile);
+	assert.equal(publish && publish.block, true);
+	assert.match(
+		publish ? publish.reason : "",
+		/autonomous runtime permission profile/,
+	);
+
+	assert.equal(
+		evaluateRuntimeGuardCommand("git rebase main", profile),
+		undefined,
+	);
+	assert.equal(commandRequiresConfirmation("git rebase main"), true);
+	assert.equal(
+		evaluateRuntimeGuardCommand(
+			"git branch --delete --force old-branch",
+			profile,
+		),
+		undefined,
+	);
+	assert.equal(
+		commandRequiresConfirmation("git branch --delete --force old-branch"),
+		true,
+	);
+	assert.equal(commandRequiresConfirmation("git branch -df old-branch"), true);
+	assert.equal(commandRequiresConfirmation("git branch -fd old-branch"), true);
+	assert.equal(
+		evaluateRuntimeGuardCommand("pi remove package", profile),
+		undefined,
+	);
+	assert.equal(commandRequiresConfirmation("pi remove package"), true);
+});
+
+test("allow action is distinguishable from unguarded commands", () => {
+	const profile = autonomousProfile();
+	assert.equal(guardedCommandFor("git push origin feature/test"), "gitPush");
+	assert.equal(
+		evaluateRuntimeGuardCommand("git push origin feature/test", profile),
+		undefined,
+	);
+	assert.equal(guardedCommandFor("echo ok"), undefined);
+	assert.equal(evaluateRuntimeGuardCommand("echo ok", profile), undefined);
+});
+
+test("runtime guard profile overrides can block or allow guarded commands", () => {
+	const globalProfile = autonomousProfile({
+		gitPush: "block",
+		npmPublish: "allow",
+	});
+	const blockedPush = evaluateRuntimeGuardCommand(
+		"git push origin feature/test",
+		globalProfile,
+	);
+	assert.equal(blockedPush && blockedPush.block, true);
+	assert.equal(
+		evaluateRuntimeGuardCommand("npm publish", globalProfile),
+		undefined,
+	);
+
+	const projectProfile = autonomousProfile({
+		gitPush: "allow",
+		npmPublish: "block",
+	});
+	assert.equal(
+		evaluateRuntimeGuardCommand("git push origin feature/test", projectProfile),
+		undefined,
+	);
+	const blockedPublish = evaluateRuntimeGuardCommand(
+		"npm publish",
+		projectProfile,
+	);
+	assert.equal(blockedPublish && blockedPublish.block, true);
+});


### PR DESCRIPTION
## Summary

- Add configurable runtime guardrails for autonomous Gentle AI sessions.
- Allow normal `git push` in autonomous mode while preserving hard blocks for destructive commands.
- Add focused runtime guardrail tests and README documentation for the config profile.

## Changes

| File | Change |
|------|--------|
| `lib/runtime-guardrails.ts` | Extracted shell command guard classification, deny/confirm patterns, autonomous defaults, and profile evaluation. |
| `extensions/gentle-ai.ts` | Reads global/project `runtime-guardrails.json`, supports `GENTLE_PI_AUTONOMOUS_MODE=1`, and applies profile decisions before interactive confirmation. |
| `tests/runtime-guardrails.test.ts` | Covers normal push allow, force-push denial including `-f`, guarded branch force delete variants, publish block, and profile overrides. |
| `README.md` | Documents runtime guardrails, env var activation, config locations, and config shape. |

## Safety

- Denied/destructive patterns run before profile allow decisions.
- Force push variants remain blocked: `--force`, `--force-with-lease`, and short/combined `-f` flags.
- Forced branch delete variants remain guarded: `-D`, `-df`, `-fd`, and `--delete --force`.
- `npm publish` is blocked by the autonomous default profile.
- `git rebase`, forced branch deletion, and `pi remove` still require confirmation by default.

## Test plan

- [x] `node --experimental-strip-types --check extensions/gentle-ai.ts`
- [x] `node --experimental-strip-types --test tests/*.test.ts` — 29 passed
- [x] `npm pack --dry-run` — prepack ran `pnpm test` and runtime harness successfully
- [x] `git diff --check`

## Issue linkage

No linked issue: this repository currently grants this contributor read access only, so I could not create or label an approved issue upstream before opening this PR. The change is submitted for maintainer review.
