### PR TITLE
feat(persona): configuración global de persona con override por proyecto

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -342,15 +342,28 @@ function personaConfigPath(cwd: string): string {
 }
 
 function readPersonaMode(cwd: string): PersonaMode {
-	const path = personaConfigPath(cwd);
-	if (!existsSync(path)) return "gentleman";
-	try {
-		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-		if (!isRecord(parsed)) return "gentleman";
-		return parsed.mode === "neutral" ? "neutral" : "gentleman";
-	} catch {
-		return "gentleman";
+	// 1. Project-local override
+	const localPath = personaConfigPath(cwd);
+	if (existsSync(localPath)) {
+		try {
+			const parsed: unknown = JSON.parse(readFileSync(localPath, "utf8"));
+			if (isRecord(parsed)) {
+				return parsed.mode === "neutral" ? "neutral" : "gentleman";
+			}
+		} catch { /* fall through */ }
 	}
+	// 2. Global fallback
+	const globalPath = join(gentleAiConfigHome(), "persona.json");
+	if (existsSync(globalPath)) {
+		try {
+			const parsed: unknown = JSON.parse(readFileSync(globalPath, "utf8"));
+			if (isRecord(parsed)) {
+				return parsed.mode === "neutral" ? "neutral" : "gentleman";
+			}
+		} catch { /* fall through */ }
+	}
+	// 3. Package default
+	return "gentleman";
 }
 
 function writePersonaMode(cwd: string, mode: PersonaMode): void {


### PR DESCRIPTION
## Qué hace este PR

Hace que `readPersonaMode` respete una jerarquía de configuración:

1. **Proyecto-local** `.pi/gentle-ai/persona.json` (override)
2. **Global** `~/.pi/gentle-ai/persona.json` (default del usuario)
3. **Fallback** `"gentleman"` (default del paquete)

## Por qué

Actualmente `models.json` vive global en `~/.pi/gentle-ai/`, pero `persona.json` solo existe a nivel de proyecto. Esto obliga a los usuarios que prefieren `neutral` a configurarlo en cada repo nuevo.

## Cambio

`extensions/gentle-ai.ts` — función `readPersonaMode()`:

- Antes: leía solo `<cwd>/.pi/gentle-ai/persona.json`
- Ahora: si no existe local, prueba `~/.pi/gentle-ai/persona.json`

## Issue relacionada

Closes #30
