### PR TITLE
fix(harness): refresh orchestrator prompt from disk on each access

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -113,15 +113,22 @@ function sddLocalOverrideDriftCount(cwd: string): number {
 	return stale;
 }
 
-let orchestratorPromptCache: string | null = null;
-function getOrchestratorPrompt(): string {
-	if (orchestratorPromptCache === null) {
-		orchestratorPromptCache = readFileSync(
-			join(ASSETS_DIR, "orchestrator.md"),
-			"utf8",
-		).trim();
+function getOrchestratorPromptImpl(pathOverride?: string): string {
+	const path = pathOverride ?? join(ASSETS_DIR, "orchestrator.md");
+	try {
+		return readFileSync(path, "utf8").trim();
+	} catch (error) {
+		// Fallback if file is missing or unreadable
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+			return "";
+		}
+		// For permission denied or other errors, also return empty to avoid crash
+		return "";
 	}
-	return orchestratorPromptCache;
+}
+
+function getOrchestratorPrompt(): string {
+	return getOrchestratorPromptImpl();
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -1573,6 +1580,8 @@ async function handlePersonaCommand(ctx: ExtensionContext): Promise<void> {
 export const __testing = {
 	listAgentsFromDir,
 	listAgentsFromDirAsync,
+	getOrchestratorPrompt: (pathOverride?: string) =>
+		getOrchestratorPromptImpl(pathOverride),
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -34,3 +34,31 @@ test("agent discovery skips skills directories", async (t) => {
 		["reviewer", "worker"],
 	);
 });
+
+test("orchestrator prompt refreshes from disk on each access", async (t) => {
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-orchestrator-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const promptFile = join(tmpDir, "orchestrator.md");
+
+	// Write initial content
+	writeFileSync(promptFile, "First version");
+	const first = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(first, "First version");
+
+	// Update the file
+	writeFileSync(promptFile, "Updated version");
+	const second = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(second, "Updated version");
+
+	// Change it again to prove freshness on each call
+	writeFileSync(promptFile, "Third version");
+	const third = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(third, "Third version");
+});
+
+test("orchestrator prompt returns empty string when file is missing", async () => {
+	const missingPath = "/nonexistent/path/orchestrator.md";
+	const result = __testing.getOrchestratorPrompt(missingPath);
+	// Should not throw, should return empty string instead
+	assert.equal(result, "");
+});


### PR DESCRIPTION
Part of #39.

## Summary
- Removes the module-level cache so `getOrchestratorPrompt()` reads `assets/orchestrator.md` fresh on each access (one small file read per user turn).
- Adds a fallback: if the asset is missing or unreadable, the function returns an empty string instead of throwing inside the `before_agent_start` handler on every turn.

## Changes
| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Drop `orchestratorPromptCache`; add try/catch fallback in `getOrchestratorPromptImpl` |
| `tests/gentle-ai.test.ts` | Freshness test (three sequential file writes each reflected) plus missing-file fallback test |

## Test plan
- [x] `pnpm test` green at this commit: 54 pass, 0 fail (runtime harness exit 0)
- [x] New tests: orchestrator prompt refreshes from disk on each access; returns empty string when file is missing

## Notes
First of four stacked PRs implementing #39. Independent and safe to merge on its own.
