### PR TITLE
fix(persona): prevent voseo leak in neutral mode composed prompt

### DIFF
--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -27,7 +27,7 @@ Keep synthesis short by default: decision, outcome, next action. Expand only whe
 
 ## Language Boundary
 
-User-facing conversation should stay in the user's language and follow the currently selected persona mode. In `gentleman` mode, Spanish uses natural Rioplatense voseo. In `neutral` mode, Spanish stays neutral/professional without regional expression.
+User-facing conversation should stay in the user's language and follow the currently active persona mode. The active mode is stated in the `Current persona mode:` line at the top of this system prompt — always honor it for language style.
 
 Subagent-facing prompts should be written in English by default, even when the user speaks Spanish. Translate the user's request into concise English before delegation. This keeps token usage lower and gives built-in/project subagents a consistent operating language without changing the user-facing persona.
 

--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -27,7 +27,7 @@ Keep synthesis short by default: decision, outcome, next action. Expand only whe
 
 ## Language Boundary
 
-User-facing conversation should stay in the user's language and follow the currently active persona mode. The active mode is stated in the `Current persona mode:` line at the top of this system prompt — always honor it for language style.
+User-facing conversation should stay in the user's language and follow the currently active persona mode. The active mode is stated in the `Current persona mode:` line in the identity/harness section of this system prompt — always honor it for language style.
 
 Subagent-facing prompts should be written in English by default, even when the user speaks Spanish. Translate the user's request into concise English before delegation. This keeps token usage lower and gives built-in/project subagents a consistent operating language without changing the user-facing persona.
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -149,6 +149,7 @@ const NEUTRAL_PERSONA_PROMPT = `Persona:
 - Be direct, technical, concise, warm, and professional.
 - Always respond in the same language the user writes in.
 - Do not use slang or regional expressions.
+- When the user writes Spanish, use neutral/professional Spanish. Do NOT use voseo (vos tenés, vos querés, hacé, andá, etc.) or any regional conjugations.
 - Act as a senior architect and teacher: concepts before code, no shortcuts.
 - Treat AI as a tool directed by the human; never present yourself as a default chatbot.
 - Push back when the user asks for code without enough context or understanding.
@@ -157,7 +158,13 @@ const NEUTRAL_PERSONA_PROMPT = `Persona:
 function buildGentlePrompt(persona: PersonaMode): string {
 	const personaPrompt =
 		persona === "neutral" ? NEUTRAL_PERSONA_PROMPT : GENTLEMAN_PERSONA_PROMPT;
+	const languageBoundary =
+		persona === "neutral"
+			? "Language: neutral/professional Spanish when the user writes Spanish. Do NOT use voseo or Rioplatense regional expressions."
+			: "Language: natural Rioplatense Spanish with voseo when the user writes Spanish.";
 	return `## el Gentleman Identity and Harness
+Current persona mode: ${persona}
+
 You are el Gentleman: a Pi-specific coding-agent harness for controlled development work.
 
 Identity contract:
@@ -168,6 +175,8 @@ Identity contract:
 - Do not claim portability outside the Pi runtime.
 
 ${personaPrompt}
+
+${languageBoundary}
 
 Harness principles:
 - el Gentleman is not prompt engineering. It is runtime discipline around powerful agents.
@@ -1573,6 +1582,7 @@ async function handlePersonaCommand(ctx: ExtensionContext): Promise<void> {
 export const __testing = {
 	listAgentsFromDir,
 	listAgentsFromDirAsync,
+	buildGentlePrompt,
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -163,6 +163,7 @@ function buildGentlePrompt(persona: PersonaMode): string {
 			? "Language: neutral/professional Spanish when the user writes Spanish. Do NOT use voseo or Rioplatense regional expressions."
 			: "Language: natural Rioplatense Spanish with voseo when the user writes Spanish.";
 	return `## el Gentleman Identity and Harness
+
 Current persona mode: ${persona}
 
 You are el Gentleman: a Pi-specific coding-agent harness for controlled development work.

--- a/tests/persona-neutral-voseo.test.ts
+++ b/tests/persona-neutral-voseo.test.ts
@@ -21,13 +21,28 @@ test("neutral mode composed prompt does not instruct to use voseo", () => {
 	);
 });
 
-test("neutral mode composed prompt does not contain unqualified Rioplatense instruction", () => {
+test("neutral mode composed prompt has no positive voseo/Rioplatense instruction and includes explicit prohibition", () => {
 	const prompt = __testing.buildGentlePrompt("neutral");
-	// Must not say "In gentleman mode, Spanish uses natural Rioplatense voseo"
+	// Any sentence that affirmatively tells the model to use voseo or natural Rioplatense
+	// must be absent. The prohibition line ("Do NOT use voseo") is the only allowed voseo
+	// mention. We match patterns that indicate a positive directive by requiring the word
+	// "use" (or its inflections) in proximity to "voseo" or "Rioplatense" WITHOUT a
+	// preceding negation — concretely, lines that start/contain "use", "uses", or "with voseo".
 	assert.doesNotMatch(
 		prompt,
-		/In `gentleman` mode, Spanish uses natural Rioplatense voseo/i,
-		"neutral prompt must not carry static mode-description mentioning Rioplatense voseo",
+		/\bwith voseo\b/i,
+		"neutral prompt must not contain 'with voseo' (positive directive)",
+	);
+	assert.doesNotMatch(
+		prompt,
+		/\buse(?:s)? (?:natural )?Rioplatense\b/i,
+		"neutral prompt must not instruct to use Rioplatense",
+	);
+	// The prohibition line must remain present so the model knows NOT to use voseo
+	assert.match(
+		prompt,
+		/Do NOT use voseo/i,
+		"neutral prompt must explicitly prohibit voseo",
 	);
 });
 

--- a/tests/persona-neutral-voseo.test.ts
+++ b/tests/persona-neutral-voseo.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { __testing } from "../extensions/gentle-ai.ts";
+
+// These tests assert that the composed main-agent prompt (built by buildGentlePrompt)
+// does not encourage Rioplatense voseo in neutral mode, and does include the expected
+// voseo/Rioplatense markers in gentleman mode.
+
+test("neutral mode composed prompt does not instruct to use voseo", () => {
+	const prompt = __testing.buildGentlePrompt("neutral");
+	// The neutral prompt must never tell the model to USE voseo
+	assert.doesNotMatch(
+		prompt,
+		/answer in natural Rioplatense Spanish with voseo/i,
+		"neutral prompt must not instruct to use Rioplatense voseo",
+	);
+	assert.doesNotMatch(
+		prompt,
+		/uses natural Rioplatense voseo/i,
+		"neutral prompt must not describe voseo as the language mode to use",
+	);
+});
+
+test("neutral mode composed prompt does not contain unqualified Rioplatense instruction", () => {
+	const prompt = __testing.buildGentlePrompt("neutral");
+	// Must not say "In gentleman mode, Spanish uses natural Rioplatense voseo"
+	assert.doesNotMatch(
+		prompt,
+		/In `gentleman` mode, Spanish uses natural Rioplatense voseo/i,
+		"neutral prompt must not carry static mode-description mentioning Rioplatense voseo",
+	);
+});
+
+test("gentleman mode composed prompt contains voseo reference", () => {
+	const prompt = __testing.buildGentlePrompt("gentleman");
+	assert.match(
+		prompt,
+		/voseo/i,
+		"gentleman prompt must reference voseo",
+	);
+});
+
+test("gentleman mode composed prompt contains Rioplatense reference", () => {
+	const prompt = __testing.buildGentlePrompt("gentleman");
+	assert.match(
+		prompt,
+		/Rioplatense/i,
+		"gentleman prompt must reference Rioplatense",
+	);
+});
+
+test("neutral mode composed prompt explicitly states active mode is neutral", () => {
+	const prompt = __testing.buildGentlePrompt("neutral");
+	assert.match(
+		prompt,
+		/Current persona mode: neutral/i,
+		"neutral prompt must state active mode is neutral",
+	);
+});
+
+test("gentleman mode composed prompt explicitly states active mode is gentleman", () => {
+	const prompt = __testing.buildGentlePrompt("gentleman");
+	assert.match(
+		prompt,
+		/Current persona mode: gentleman/i,
+		"gentleman prompt must state active mode is gentleman",
+	);
+});
+
+test("neutral mode composed prompt explicitly forbids voseo conjugations", () => {
+	const prompt = __testing.buildGentlePrompt("neutral");
+	// The neutral persona prompt must explicitly forbid voseo conjugation forms
+	assert.match(
+		prompt,
+		/Do NOT use voseo/i,
+		"neutral prompt must explicitly forbid voseo",
+	);
+});
+
+test("neutral and gentleman modes produce different language-boundary text", () => {
+	const neutralPrompt = __testing.buildGentlePrompt("neutral");
+	const gentlemanPrompt = __testing.buildGentlePrompt("gentleman");
+
+	// The language-boundary section must differ between modes
+	assert.notEqual(
+		neutralPrompt,
+		gentlemanPrompt,
+		"neutral and gentleman prompts must differ",
+	);
+
+	// Neutral must not include a positive instruction to use Rioplatense
+	assert.doesNotMatch(
+		neutralPrompt,
+		/Language: natural Rioplatense/i,
+		"neutral prompt must not contain positive 'natural Rioplatense' language instruction",
+	);
+
+	// Gentleman must contain the Rioplatense instruction
+	assert.match(
+		gentlemanPrompt,
+		/Language: natural Rioplatense/i,
+		"gentleman prompt must contain 'Language: natural Rioplatense' instruction",
+	);
+});


### PR DESCRIPTION
## Summary

- In neutral persona mode, the main-agent system prompt was leaking Rioplatense voseo cues through two paths: the static `orchestrator.md` language-boundary sentence and a weak `NEUTRAL_PERSONA_PROMPT` that only said "no slang" without explicitly naming voseo.
- The model had no explicit indicator of which mode was active, forcing it to infer, which produced voseo responses even in neutral mode.

## Root causes

1. **`assets/orchestrator.md` (primary)** — The language-boundary section contained: *"In `gentleman` mode, Spanish uses natural Rioplatense voseo."* This file is injected unconditionally, so the model always saw voseo described as a valid mode even when `neutral` was active.
2. **`NEUTRAL_PERSONA_PROMPT`** — Only said "do not use slang or regional expressions"; the model did not map this to voseo verb conjugation.
3. **`buildGentlePrompt`** — No explicit active-mode indicator, so the model had to infer which mode applied.

## What changed

| File | Change |
|---|---|
| `assets/orchestrator.md` | Replaced hardcoded mode+voseo sentence with a mode-agnostic pointer to the `Current persona mode:` header |
| `extensions/gentle-ai.ts` | Added `Current persona mode: <mode>` header to `buildGentlePrompt`; added mode-conditional language-boundary line; added explicit "Do NOT use voseo" to `NEUTRAL_PERSONA_PROMPT`; exported `buildGentlePrompt` via `__testing` |
| `tests/persona-neutral-voseo.test.ts` | 8 new tests asserting the composed prompt by mode |

## Test plan

- [x] `pnpm test` — all 60 tests pass (was 52 before this PR)
- [x] Neutral mode composed prompt does not instruct to use voseo or describe Rioplatense as the language style
- [x] Gentleman mode composed prompt still contains voseo and Rioplatense references
- [x] Both modes include an explicit `Current persona mode:` line
- [x] Neutral mode explicitly includes "Do NOT use voseo" with conjugation examples
- [x] Language-boundary text differs between modes (neutral prohibits, gentleman enables)

Closes #44
Also resolves #38 (duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified language-boundary guidance to a single rule: conversations should use the user's language and match the active persona mode.

* **Improvements**
  * Neutral persona tuned to use consistent, professional Spanish and explicitly avoid regional voseo/Rioplatense forms.

* **Tests**
  * Added tests verifying persona prompt composition and differences between neutral and gentleman modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->