### PR TITLE
feat(memory): port Engram memory lifecycle rule to orchestrator contract

### DIFF
--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -271,6 +271,15 @@ When Engram or another callable memory package is available, the parent owns mem
 - SDD artifact keys: in memory/hybrid mode, phase artifacts should use stable topic keys such as `sdd/<change>/proposal`, `sdd/<change>/spec`, `sdd/<change>/design`, `sdd/<change>/tasks`, `sdd/<change>/apply-progress`, and `sdd/<change>/verify-report`.
 - If memory tools are unavailable, do not pretend persistence exists; return artifacts inline and/or write OpenSpec files.
 
+Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
+
+- At session start or before architecture-sensitive work, call `mem_review` with action `list` for the current project when the tool is available.
+- If `mem_review` is unavailable, do not fail the task. Continue with normal `mem_context`/`mem_search`, and still apply lifecycle metadata from any returned observations when present.
+- `active` memories may be used normally.
+- `needs_review` memories are stale context, not trusted facts.
+- When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
+- Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
+
 ## Execution Mode
 
 Use the session's SDD preflight choice:

--- a/tests/artifact-language.test.ts
+++ b/tests/artifact-language.test.ts
@@ -84,6 +84,33 @@ test("rendered SDD preflight prompt is English artifact copy", () => {
 	}
 });
 
+test("orchestrator Memory Contract carries the Engram memory lifecycle rule", async () => {
+	const orchestrator = await readFile(join(ROOT, "assets/orchestrator.md"), "utf8");
+
+	// Mirrors gentle-ai's engram-protocol/engram-convention lifecycle rule (PRs #842 + #844),
+	// in its final availability-gated form: agents must treat needs_review memories as stale,
+	// prefer mem_review when present, fall back safely when it is not, and never auto-mark reviewed.
+	for (const required of [
+		"when Engram exposes lifecycle metadata/tooling",
+		"At session start or before architecture-sensitive work",
+		"call `mem_review` with action `list`",
+		"for the current project when the tool is available",
+		"If `mem_review` is unavailable, do not fail the task",
+		"Continue with normal `mem_context`/`mem_search`",
+		"still apply lifecycle metadata from any returned observations when present",
+		"`active` memories may be used normally",
+		"`needs_review` memories are stale context, not trusted facts",
+		"verify it against current evidence before relying on it",
+		"Do NOT call `mem_review` with action `mark_reviewed` automatically",
+		"Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command",
+	]) {
+		assert.ok(
+			orchestrator.includes(required),
+			`orchestrator.md missing memory lifecycle rule: ${required}`,
+		);
+	}
+});
+
 test("SDD proposal questions focus on business and PRD gaps", async () => {
 	const proposalAgent = await readFile(join(ROOT, "assets/agents/sdd-proposal.md"), "utf8");
 


### PR DESCRIPTION
## Linked Issue

Closes #47

## Summary

Ports the Engram memory lifecycle guardrails from gentle-ai (`Gentleman-Programming/gentle-ai#842` + `#844`) into gentle-pi.

gentle-pi does not ship a standalone Engram protocol asset — that text is owned by the Engram plugin (being ported to gentle-engram separately). The package-owned analogue of gentle-ai's `engram-protocol.md` / `engram-convention.md` is the **`## Memory Contract`** section of `assets/orchestrator.md`, which already governs how the parent treats retrieved memory. The lifecycle rule lands there in its final, availability-gated form.

## What changed

- `assets/orchestrator.md` — adds the "Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling)" block to the Memory Contract:
  - prefer `mem_review` (action `list`) at session start / before architecture-sensitive work **when available**;
  - fall back safely to `mem_context`/`mem_search` when `mem_review` is absent, still applying lifecycle metadata from returned observations;
  - treat `needs_review` memories as stale context — surface and verify against current evidence;
  - never auto-mark reviewed — only after explicit user confirmation or a dedicated maintenance command.
- `tests/artifact-language.test.ts` — new test asserting the lifecycle wording is present (mirrors gentle-ai `assets_test.go`).

## Safety / compatibility

Forward-compatible and availability-gated, exactly like the source PRs. Does not require an Engram release exposing `mem_review`, and bumps no dependency.

## Test plan

- [x] `pnpm test` — 53 unit tests + runtime harness green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added memory lifecycle rules specifying how the system manages memory status, handles memory review at session initialization, and requires user confirmation before marking memory as reviewed.

* **Tests**
  * Added validation tests for memory lifecycle rule implementation and safe fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->