### PR TITLE
fix(harness): refresh orchestrator prompt from disk on each access

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -120,15 +120,22 @@ function sddLocalOverrideDriftCount(cwd: string): number {
 	return stale;
 }
 
-let orchestratorPromptCache: string | null = null;
-function getOrchestratorPrompt(): string {
-	if (orchestratorPromptCache === null) {
-		orchestratorPromptCache = readFileSync(
-			join(ASSETS_DIR, "orchestrator.md"),
-			"utf8",
-		).trim();
+function getOrchestratorPromptImpl(pathOverride?: string): string {
+	const path = pathOverride ?? join(ASSETS_DIR, "orchestrator.md");
+	try {
+		return readFileSync(path, "utf8").trim();
+	} catch (error) {
+		// Fallback if file is missing or unreadable
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+			return "";
+		}
+		// For permission denied or other errors, also return empty to avoid crash
+		return "";
 	}
-	return orchestratorPromptCache;
+}
+
+function getOrchestratorPrompt(): string {
+	return getOrchestratorPromptImpl();
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -1909,6 +1916,8 @@ export const __testing = {
 	buildGentlePrompt,
 	classifyReviewEvent,
 	parseNumstat,
+	getOrchestratorPrompt: (pathOverride?: string) =>
+		getOrchestratorPromptImpl(pathOverride),
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -34,3 +34,34 @@ test("agent discovery skips skills directories", async (t) => {
 		["reviewer", "worker"],
 	);
 });
+
+test("orchestrator prompt refreshes from disk on each access", (t) => {
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-orchestrator-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const promptFile = join(tmpDir, "orchestrator.md");
+
+	// Write initial content
+	writeFileSync(promptFile, "First version");
+	const first = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(first, "First version");
+
+	// Update the file
+	writeFileSync(promptFile, "Updated version");
+	const second = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(second, "Updated version");
+
+	// Change it again to prove freshness on each call
+	writeFileSync(promptFile, "Third version");
+	const third = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(third, "Third version");
+});
+
+test("orchestrator prompt returns empty string when file is missing", (t) => {
+	// Build a deterministic, cross-platform missing path: the dir exists, the child does not.
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-missing-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const missingPath = join(tmpDir, "orchestrator.md");
+	const result = __testing.getOrchestratorPrompt(missingPath);
+	// Should not throw, should return empty string instead
+	assert.equal(result, "");
+});


### PR DESCRIPTION
> **Re-land of #40** (approved, then closed; the head branch was deleted afterward, so reopening was not possible — this is a fresh PR with the same commit). Rebased onto current `main` (`1c218795`, v0.6.0). Opened as **draft** for now.
>
> **What changed vs the original #40:** one conflict in the `__testing` export object, resolved additively — the entries added upstream since approval (`#45`/`#46`/`#50`) are kept alongside the new `getOrchestratorPrompt`. The harness change itself is byte-identical to the approved commit.
>
> First of four re-landed stacked PRs (#40 → #41 → #42 → #43), all targeting `main`.

Part of #39.

## Summary
- Removes the module-level cache so `getOrchestratorPrompt()` reads `assets/orchestrator.md` fresh on each access (one small file read per user turn).
- Adds a fallback: if the asset is missing or unreadable, the function returns an empty string instead of throwing inside the `before_agent_start` handler on every turn.

## Changes
| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Drop `orchestratorPromptCache`; add try/catch fallback in `getOrchestratorPromptImpl` |
| `tests/gentle-ai.test.ts` | Freshness test (three sequential file writes each reflected) plus missing-file fallback test |

## Test plan
- [x] `pnpm test` green at this commit on current `main`: **155 pass, 0 fail** (runtime harness exit 0). Original count on the older base was 54.
- [x] New tests: orchestrator prompt refreshes from disk on each access; returns empty string when file is missing

## Notes
First of four stacked PRs implementing #39. Independent and safe to merge on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability when loading the orchestrator prompt by safely handling missing or unreadable files and returning an empty result instead of failing.
  * Ensures prompt contents are read fresh from the expected source rather than relying on cached behavior that could cause startup issues.

* **Tests**
  * Added coverage to confirm prompt contents reflect updates on subsequent reads.
  * Added coverage to ensure missing-path scenarios return an empty string without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->