### PR TITLE
feat(harness): re-anchor discipline via context event on every LLM call

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1907,6 +1907,39 @@ async function applyReviewGate(
 	};
 }
 
+const GENTLE_HARNESS_REMINDER_CONTENT = `<gentle-harness-reminder>
+Active discipline (el Gentleman harness):
+- Keep the parent session as orchestrator; delegate exploration, implementation, and review to subagents when available.
+- For non-trivial work, anchor decisions in SDD/OpenSpec artifacts, not floating chat context.
+- Single-writer discipline: never run parallel writes without explicit user-approved isolation.
+- With tests present, follow strict TDD evidence: RED, GREEN, TRIANGULATE, REFACTOR.
+- Protect the reviewer: keep changes small; surface review-workload risk before expanding scope.
+- Never fabricate persistent memory or capabilities; report failures honestly.
+</gentle-harness-reminder>`;
+
+function buildContextReminder() {
+	return {
+		role: "custom" as const,
+		customType: "gentle-harness-reminder",
+		content: GENTLE_HARNESS_REMINDER_CONTENT,
+		display: false,
+		timestamp: Date.now(),
+	};
+}
+
+function applyHarnessReminder(
+	messages: Array<{ customType?: string; role?: string } | unknown>,
+): unknown[] {
+	// Strip all existing reminders and append fresh one
+	// This ensures exactly one reminder per context event
+	const filtered = messages.filter((msg) => {
+		if (!isRecord(msg)) return true;
+		return (msg as Record<string, unknown>).customType !== "gentle-harness-reminder";
+	});
+	filtered.push(buildContextReminder());
+	return filtered;
+}
+
 /** @internal */
 export const __testing = {
 	listAgentsFromDir,
@@ -1918,6 +1951,8 @@ export const __testing = {
 	parseNumstat,
 	getOrchestratorPrompt: (pathOverride?: string) =>
 		getOrchestratorPromptImpl(pathOverride),
+	buildContextReminder,
+	applyHarnessReminder,
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {
@@ -1956,6 +1991,10 @@ export default function gentleAi(pi: ExtensionAPI): void {
 				);
 			}
 		}
+	});
+
+	pi.on("context", (event) => {
+		return { messages: applyHarnessReminder(event.messages) };
 	});
 
 	pi.on("input", async (event, ctx) => {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -120,15 +120,22 @@ function sddLocalOverrideDriftCount(cwd: string): number {
 	return stale;
 }
 
-let orchestratorPromptCache: string | null = null;
-function getOrchestratorPrompt(): string {
-	if (orchestratorPromptCache === null) {
-		orchestratorPromptCache = readFileSync(
-			join(ASSETS_DIR, "orchestrator.md"),
-			"utf8",
-		).trim();
+function getOrchestratorPromptImpl(pathOverride?: string): string {
+	const path = pathOverride ?? join(ASSETS_DIR, "orchestrator.md");
+	try {
+		return readFileSync(path, "utf8").trim();
+	} catch (error) {
+		// Fallback if file is missing or unreadable
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+			return "";
+		}
+		// For permission denied or other errors, also return empty to avoid crash
+		return "";
 	}
-	return orchestratorPromptCache;
+}
+
+function getOrchestratorPrompt(): string {
+	return getOrchestratorPromptImpl();
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -1909,6 +1916,8 @@ export const __testing = {
 	buildGentlePrompt,
 	classifyReviewEvent,
 	parseNumstat,
+	getOrchestratorPrompt: (pathOverride?: string) =>
+		getOrchestratorPromptImpl(pathOverride),
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -65,3 +65,78 @@ test("orchestrator prompt returns empty string when file is missing", (t) => {
 	// Should not throw, should return empty string instead
 	assert.equal(result, "");
 });
+
+test("context event handler builds reminder message", () => {
+	const original: typeof __testing.buildContextReminder = (...args) => {
+		throw new Error("Not implemented");
+	};
+	const reminder = __testing.buildContextReminder();
+	assert.equal(reminder.role, "custom");
+	assert.equal(reminder.customType, "gentle-harness-reminder");
+	assert.equal(typeof reminder.content, "string");
+	assert.equal(reminder.display, false);
+	assert.equal(typeof reminder.timestamp, "number");
+	assert(reminder.content.includes("Active discipline"));
+	assert(reminder.content.includes("el Gentleman harness"));
+	assert(reminder.content.includes("Keep the parent session as orchestrator"));
+});
+
+test("applyHarnessReminder appends reminder to messages without mutation", () => {
+	const messages: typeof __testing.buildContextReminder[] = [];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.notEqual(result, messages, "should return new array");
+	assert.equal(messages.length, 0, "original should not be mutated");
+	assert.equal(result.length, 1, "result should have one message");
+	assert.equal(result[0].customType, "gentle-harness-reminder");
+});
+
+test("applyHarnessReminder deduplicates reminder messages", () => {
+	const reminder = __testing.buildContextReminder();
+	const messages = [
+		{ role: "user", content: "hello" },
+		reminder,
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result.length, 2, "should not double-append duplicate reminder");
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder");
+	// Verify only one reminder exists (dedup strips old and appends fresh)
+	const reminderCount = result.filter((m: any) => m.customType === "gentle-harness-reminder").length;
+	assert.equal(reminderCount, 1, "should have exactly one reminder");
+});
+
+test("applyHarnessReminder removes reminder from middle of message array", () => {
+	const reminder = __testing.buildContextReminder();
+	// Simulate scenario where reminder is not in last position
+	const messages = [
+		{ role: "user", content: "message 1" },
+		reminder,
+		{ role: "assistant", content: "response" },
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	// Original: 3 messages (user, old reminder, assistant)
+	// After dedup: 3 messages (user, assistant, new reminder)
+	assert.equal(result.length, 3, "should maintain message count");
+	// Verify only one reminder and it is at the end
+	const reminderCount = result.filter((m: any) => m.customType === "gentle-harness-reminder").length;
+	assert.equal(reminderCount, 1, "should have exactly one reminder after dedup");
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder", "reminder should be last");
+	assert.equal(result[0].role, "user", "first message should be user");
+	assert.equal(result[1].role, "assistant", "second message should be assistant");
+});
+
+test("applyHarnessReminder handles empty messages", () => {
+	const messages: typeof __testing.buildContextReminder[] = [];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result.length, 1);
+	assert.equal(result[0].customType, "gentle-harness-reminder");
+});
+
+test("applyHarnessReminder appends reminder as last message", () => {
+	const messages = [
+		{ role: "user", content: "message 1" },
+		{ role: "user", content: "message 2" },
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder");
+	assert.equal(result.length, 3);
+});

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -34,3 +34,34 @@ test("agent discovery skips skills directories", async (t) => {
 		["reviewer", "worker"],
 	);
 });
+
+test("orchestrator prompt refreshes from disk on each access", (t) => {
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-orchestrator-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const promptFile = join(tmpDir, "orchestrator.md");
+
+	// Write initial content
+	writeFileSync(promptFile, "First version");
+	const first = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(first, "First version");
+
+	// Update the file
+	writeFileSync(promptFile, "Updated version");
+	const second = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(second, "Updated version");
+
+	// Change it again to prove freshness on each call
+	writeFileSync(promptFile, "Third version");
+	const third = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(third, "Third version");
+});
+
+test("orchestrator prompt returns empty string when file is missing", (t) => {
+	// Build a deterministic, cross-platform missing path: the dir exists, the child does not.
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-missing-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const missingPath = join(tmpDir, "orchestrator.md");
+	const result = __testing.getOrchestratorPrompt(missingPath);
+	// Should not throw, should return empty string instead
+	assert.equal(result, "");
+});


### PR DESCRIPTION
> **Re-land of #41** (approved, then closed; head branch deleted, so this is a fresh PR with the same commit). Rebased onto current `main` (`1c218795`). Opened as **draft** for now.
>
> **What changed vs the original #41:** one conflict resolved by keeping **both** the `#50` 4R review-gate helpers and the new harness-reminder functions — they happened to land in the same region of `extensions/gentle-ai.ts`. The harness logic is byte-identical to the approved commit.
>
> Stacked on #40 (re-land of the orchestrator-prompt-refresh PR); shows a cumulative diff until that one merges, then collapses to its single commit.

Part of #39. Stacked on #40 (review the last commit only).

## Summary
- Registers Pi's `context` event and appends a compact harness reminder before every LLM call, including iterations after `steer()`/`followUp()` where `before_agent_start` does not fire.
- The reminder is a `role: "custom"` message (Pi converts it to a user message for the provider). Per-call ephemeral by design: the transform result is used for that single call and never persisted to session history.
- Strip-then-append strategy guarantees exactly one reminder per call, even if a previous reminder sits mid-array or another extension appended messages after it.

## Changes
| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | `buildContextReminder()`, `applyHarnessReminder()`, `pi.on("context")` registration |
| `tests/gentle-ai.test.ts` | Immutability, dedupe (including reminder mid-array), ordering, and empty-array tests |

## Test plan
- [x] `pnpm test` green at this commit on current `main`: **161 pass, 0 fail**. Original count on the older base was 60.
- [x] Live smoke on pi 0.78.0: in a real session the model confirms the reminder block is visible and quotes its first rule verbatim
- [x] Event surface verified identical between pi-coding-agent 0.74.0 (lockfile dev dep) and 0.78.0

## Notes
The reminder costs roughly 90 tokens per call. Its content lives in a single module const so it stays the only source of truth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved context handling by automatically injecting a single, up-to-date “gentle-harness-reminder” into each context message payload.
  * Enhanced orchestrator prompt loading with safer file reading and graceful handling when the prompt file is missing.

* **Tests**
  * Added unit tests covering prompt reloading behavior, missing-file behavior, and reminder injection rules (non-mutation, deduplication, and correct placement).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->