### PR TITLE
feat(harness): re-anchor after session compaction

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1907,6 +1907,39 @@ async function applyReviewGate(
 	};
 }
 
+const GENTLE_HARNESS_REMINDER_CONTENT = `<gentle-harness-reminder>
+Active discipline (el Gentleman harness):
+- Keep the parent session as orchestrator; delegate exploration, implementation, and review to subagents when available.
+- For non-trivial work, anchor decisions in SDD/OpenSpec artifacts, not floating chat context.
+- Single-writer discipline: never run parallel writes without explicit user-approved isolation.
+- With tests present, follow strict TDD evidence: RED, GREEN, TRIANGULATE, REFACTOR.
+- Protect the reviewer: keep changes small; surface review-workload risk before expanding scope.
+- Never fabricate persistent memory or capabilities; report failures honestly.
+</gentle-harness-reminder>`;
+
+function buildContextReminder() {
+	return {
+		role: "custom" as const,
+		customType: "gentle-harness-reminder",
+		content: GENTLE_HARNESS_REMINDER_CONTENT,
+		display: false,
+		timestamp: Date.now(),
+	};
+}
+
+function applyHarnessReminder(
+	messages: Array<{ customType?: string; role?: string } | unknown>,
+): unknown[] {
+	// Strip all existing reminders and append fresh one
+	// This ensures exactly one reminder per context event
+	const filtered = messages.filter((msg) => {
+		if (!isRecord(msg)) return true;
+		return (msg as Record<string, unknown>).customType !== "gentle-harness-reminder";
+	});
+	filtered.push(buildContextReminder());
+	return filtered;
+}
+
 /** @internal */
 export const __testing = {
 	listAgentsFromDir,
@@ -1918,6 +1951,8 @@ export const __testing = {
 	parseNumstat,
 	getOrchestratorPrompt: (pathOverride?: string) =>
 		getOrchestratorPromptImpl(pathOverride),
+	buildContextReminder,
+	applyHarnessReminder,
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {
@@ -1956,6 +1991,10 @@ export default function gentleAi(pi: ExtensionAPI): void {
 				);
 			}
 		}
+	});
+
+	pi.on("context", (event) => {
+		return { messages: applyHarnessReminder(event.messages) };
 	});
 
 	pi.on("input", async (event, ctx) => {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -120,15 +120,22 @@ function sddLocalOverrideDriftCount(cwd: string): number {
 	return stale;
 }
 
-let orchestratorPromptCache: string | null = null;
-function getOrchestratorPrompt(): string {
-	if (orchestratorPromptCache === null) {
-		orchestratorPromptCache = readFileSync(
-			join(ASSETS_DIR, "orchestrator.md"),
-			"utf8",
-		).trim();
+function getOrchestratorPromptImpl(pathOverride?: string): string {
+	const path = pathOverride ?? join(ASSETS_DIR, "orchestrator.md");
+	try {
+		return readFileSync(path, "utf8").trim();
+	} catch (error) {
+		// Fallback if file is missing or unreadable
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+			return "";
+		}
+		// For permission denied or other errors, also return empty to avoid crash
+		return "";
 	}
-	return orchestratorPromptCache;
+}
+
+function getOrchestratorPrompt(): string {
+	return getOrchestratorPromptImpl();
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -1909,6 +1916,8 @@ export const __testing = {
 	buildGentlePrompt,
 	classifyReviewEvent,
 	parseNumstat,
+	getOrchestratorPrompt: (pathOverride?: string) =>
+		getOrchestratorPromptImpl(pathOverride),
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1917,11 +1917,29 @@ Active discipline (el Gentleman harness):
 - Never fabricate persistent memory or capabilities; report failures honestly.
 </gentle-harness-reminder>`;
 
+const POST_COMPACTION_REMINDER_CONTENT = `Context was just compacted: earlier conversation details now exist only as a summary.
+Re-check current SDD/OpenSpec state on disk before continuing multi-step work, and restate scope and acceptance criteria for the active task before further changes.`;
+
+// Module-scoped, but safe across sessions: Pi loads extensions with jiti
+// moduleCache:false, so each session/runner re-evaluates this module and gets
+// its own `compactionPending`. There is one ExtensionRunner per agent session,
+// and the flag is reset on session_start. No shared mutable state across
+// concurrent sessions, so no cross-session race.
+let compactionPending = false;
+
 function buildContextReminder() {
+	const baseContent = GENTLE_HARNESS_REMINDER_CONTENT;
+	let fullContent = baseContent;
+
+	if (compactionPending) {
+		fullContent = `${baseContent}\n\n${POST_COMPACTION_REMINDER_CONTENT}`;
+		compactionPending = false;
+	}
+
 	return {
 		role: "custom" as const,
 		customType: "gentle-harness-reminder",
-		content: GENTLE_HARNESS_REMINDER_CONTENT,
+		content: fullContent,
 		display: false,
 		timestamp: Date.now(),
 	};
@@ -1931,7 +1949,7 @@ function applyHarnessReminder(
 	messages: Array<{ customType?: string; role?: string } | unknown>,
 ): unknown[] {
 	// Strip all existing reminders and append fresh one
-	// This ensures exactly one reminder per context event
+	// This ensures exactly one reminder per context event and resets compactionPending flag
 	const filtered = messages.filter((msg) => {
 		if (!isRecord(msg)) return true;
 		return (msg as Record<string, unknown>).customType !== "gentle-harness-reminder";
@@ -1953,6 +1971,10 @@ export const __testing = {
 		getOrchestratorPromptImpl(pathOverride),
 	buildContextReminder,
 	applyHarnessReminder,
+	setCompactionPending: (value: boolean) => {
+		compactionPending = value;
+	},
+	getCompactionPending: () => compactionPending,
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {
@@ -1966,6 +1988,8 @@ export default function gentleAi(pi: ExtensionAPI): void {
 
 	pi.on("session_start", async (_event, ctx) => {
 		try {
+			// Reset compaction state at session start to prevent reminder leakage across sessions
+			compactionPending = false;
 			const installResult = installSddAssets(ctx.cwd, true);
 			const modelResult = await applySavedModelConfig(ctx);
 			if (ctx.hasUI && modelResult.invalidPath) {
@@ -1991,6 +2015,10 @@ export default function gentleAi(pi: ExtensionAPI): void {
 				);
 			}
 		}
+	});
+
+	pi.on("session_compact", (_event, _ctx) => {
+		compactionPending = true;
 	});
 
 	pi.on("context", (event) => {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -65,3 +65,78 @@ test("orchestrator prompt returns empty string when file is missing", (t) => {
 	// Should not throw, should return empty string instead
 	assert.equal(result, "");
 });
+
+test("context event handler builds reminder message", () => {
+	const original: typeof __testing.buildContextReminder = (...args) => {
+		throw new Error("Not implemented");
+	};
+	const reminder = __testing.buildContextReminder();
+	assert.equal(reminder.role, "custom");
+	assert.equal(reminder.customType, "gentle-harness-reminder");
+	assert.equal(typeof reminder.content, "string");
+	assert.equal(reminder.display, false);
+	assert.equal(typeof reminder.timestamp, "number");
+	assert(reminder.content.includes("Active discipline"));
+	assert(reminder.content.includes("el Gentleman harness"));
+	assert(reminder.content.includes("Keep the parent session as orchestrator"));
+});
+
+test("applyHarnessReminder appends reminder to messages without mutation", () => {
+	const messages: typeof __testing.buildContextReminder[] = [];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.notEqual(result, messages, "should return new array");
+	assert.equal(messages.length, 0, "original should not be mutated");
+	assert.equal(result.length, 1, "result should have one message");
+	assert.equal(result[0].customType, "gentle-harness-reminder");
+});
+
+test("applyHarnessReminder deduplicates reminder messages", () => {
+	const reminder = __testing.buildContextReminder();
+	const messages = [
+		{ role: "user", content: "hello" },
+		reminder,
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result.length, 2, "should not double-append duplicate reminder");
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder");
+	// Verify only one reminder exists (dedup strips old and appends fresh)
+	const reminderCount = result.filter((m: any) => m.customType === "gentle-harness-reminder").length;
+	assert.equal(reminderCount, 1, "should have exactly one reminder");
+});
+
+test("applyHarnessReminder removes reminder from middle of message array", () => {
+	const reminder = __testing.buildContextReminder();
+	// Simulate scenario where reminder is not in last position
+	const messages = [
+		{ role: "user", content: "message 1" },
+		reminder,
+		{ role: "assistant", content: "response" },
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	// Original: 3 messages (user, old reminder, assistant)
+	// After dedup: 3 messages (user, assistant, new reminder)
+	assert.equal(result.length, 3, "should maintain message count");
+	// Verify only one reminder and it is at the end
+	const reminderCount = result.filter((m: any) => m.customType === "gentle-harness-reminder").length;
+	assert.equal(reminderCount, 1, "should have exactly one reminder after dedup");
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder", "reminder should be last");
+	assert.equal(result[0].role, "user", "first message should be user");
+	assert.equal(result[1].role, "assistant", "second message should be assistant");
+});
+
+test("applyHarnessReminder handles empty messages", () => {
+	const messages: typeof __testing.buildContextReminder[] = [];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result.length, 1);
+	assert.equal(result[0].customType, "gentle-harness-reminder");
+});
+
+test("applyHarnessReminder appends reminder as last message", () => {
+	const messages = [
+		{ role: "user", content: "message 1" },
+		{ role: "user", content: "message 2" },
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder");
+	assert.equal(result.length, 3);
+});

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -140,3 +140,77 @@ test("applyHarnessReminder appends reminder as last message", () => {
 	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder");
 	assert.equal(result.length, 3);
 });
+
+test("buildContextReminder with compaction pending includes post-compaction block", () => {
+	__testing.setCompactionPending(true);
+	const reminder = __testing.buildContextReminder();
+	assert.equal(reminder.role, "custom");
+	assert.equal(reminder.customType, "gentle-harness-reminder");
+	assert(
+		reminder.content.includes("Context was just compacted"),
+		"should include post-compaction block when pending"
+	);
+	assert(
+		reminder.content.includes("Re-check current SDD/OpenSpec state on disk"),
+		"should include re-check instruction"
+	);
+	assert(
+		reminder.content.includes("restate scope and acceptance criteria"),
+		"should include restate instruction"
+	);
+	// Verify flag is cleared after building
+	assert.equal(
+		__testing.getCompactionPending(),
+		false,
+		"flag should be cleared after one-shot use"
+	);
+});
+
+test("buildContextReminder without compaction pending returns standard reminder", () => {
+	__testing.setCompactionPending(false);
+	const reminder = __testing.buildContextReminder();
+	const content = reminder.content;
+	assert(!content.includes("Context was just compacted"), "should not include post-compaction block when not pending");
+	assert(content.includes("Active discipline"), "should include standard discipline content");
+});
+
+test("setCompactionPending and getCompactionPending control flag", () => {
+	__testing.setCompactionPending(true);
+	assert.equal(__testing.getCompactionPending(), true);
+	__testing.setCompactionPending(false);
+	assert.equal(__testing.getCompactionPending(), false);
+});
+
+test("applyHarnessReminder multi-turn scenario: reminder persists and refreshes correctly", () => {
+	// Simulate first context event
+	__testing.setCompactionPending(false);
+	let messages: any[] = [{ role: "user", content: "first message" }];
+	let result = __testing.applyHarnessReminder(messages);
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder", "first turn should have reminder");
+	const firstReminder = result[result.length - 1];
+
+	// Simulate second context event with new message appended (tool result)
+	messages = result;
+	messages.push({ role: "tool", content: "tool result" });
+	result = __testing.applyHarnessReminder(messages);
+
+	// Should have exactly one reminder and it should be fresh (not the old one)
+	const reminderCount = result.filter((m: any) => m.customType === "gentle-harness-reminder").length;
+	assert.equal(reminderCount, 1, "should still have exactly one reminder after multi-turn");
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder", "reminder should be last");
+	// Verify it's a fresh reminder (timestamp should be different)
+	const secondReminder = result[result.length - 1];
+	assert(secondReminder.timestamp >= firstReminder.timestamp, "fresh reminder should have equal or newer timestamp");
+});
+
+test("compaction flag resets when applyHarnessReminder builds fresh reminder", () => {
+	__testing.setCompactionPending(true);
+	assert.equal(__testing.getCompactionPending(), true, "flag should be set");
+
+	const messages: any[] = [];
+	const result = __testing.applyHarnessReminder(messages);
+
+	// Flag should now be reset by buildContextReminder call
+	assert.equal(__testing.getCompactionPending(), false, "flag should be reset after applyHarnessReminder");
+	assert(result[0].content.includes("Context was just compacted"), "reminder should include compaction content");
+});

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -34,3 +34,34 @@ test("agent discovery skips skills directories", async (t) => {
 		["reviewer", "worker"],
 	);
 });
+
+test("orchestrator prompt refreshes from disk on each access", (t) => {
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-orchestrator-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const promptFile = join(tmpDir, "orchestrator.md");
+
+	// Write initial content
+	writeFileSync(promptFile, "First version");
+	const first = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(first, "First version");
+
+	// Update the file
+	writeFileSync(promptFile, "Updated version");
+	const second = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(second, "Updated version");
+
+	// Change it again to prove freshness on each call
+	writeFileSync(promptFile, "Third version");
+	const third = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(third, "Third version");
+});
+
+test("orchestrator prompt returns empty string when file is missing", (t) => {
+	// Build a deterministic, cross-platform missing path: the dir exists, the child does not.
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-missing-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const missingPath = join(tmpDir, "orchestrator.md");
+	const result = __testing.getOrchestratorPrompt(missingPath);
+	// Should not throw, should return empty string instead
+	assert.equal(result, "");
+});


### PR DESCRIPTION
> **Re-land of #42** (approved, then closed; head branch deleted, so this is a fresh PR with the same commit). Rebased onto current `main` (`1c218795`). Opened as **draft** for now.
>
> **What changed vs the original #42:** rebased cleanly — no textual conflict. Composes with `#46`'s autonomous runtime guard (both touch session-level behavior; no double-injection or ordering conflict). The harness logic is byte-identical to the approved commit.
>
> Stacked on #41; cumulative diff until predecessors merge.

Part of #39. Stacked on #41 (review the last commit only).

## Summary
- Registers `session_compact`: sets a one-shot flag so the next context-event reminder carries a post-compaction block (re-check SDD/OpenSpec state on disk, restate scope and acceptance criteria before continuing).
- The flag resets when consumed and at `session_start`, preventing leakage across sessions.

## Changes
| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | `compactionPending` flag, `session_compact` handler, post-compaction block in `buildContextReminder()`, reset at `session_start` |
| `tests/gentle-ai.test.ts` | One-shot semantics, flag reset through `applyHarnessReminder`, multi-turn integration scenario |

## Test plan
- [x] `pnpm test` green at this commit on current `main`: **166 pass, 0 fail**. Original count on the older base was 65.

## Notes
Deliberately minimal v1: no `session_before_compact` interception and no custom `CompactionResult`. Those stay open as a possible follow-up if this direction lands well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “gentle-harness” reminder that’s injected into outgoing context messages to improve continuity across multi-turn conversations.

* **Improvements**
  * Updated orchestrator prompt handling to load on demand (no caching) with safe fallback when the prompt file can’t be read.
  * Enhanced reminder logic with compaction-aware, one-time “just compacted” messaging and automatic deduplication so only one reminder is present per turn.

* **Tests**
  * Expanded unit tests for prompt reload behavior, reminder structure/content, deduplication, and compaction state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->