### PR TITLE
feat(harness): apply slim rules layer to named and SDD agents

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1975,7 +1975,16 @@ export const __testing = {
 		compactionPending = value;
 	},
 	getCompactionPending: () => compactionPending,
+	getAgentSlimRules: () => AGENT_SLIM_RULES,
 };
+
+const AGENT_SLIM_RULES = `## Gentle Agent Rules
+You operate inside the el Gentleman harness as a delegated agent.
+- Stay strictly within your assigned scope; do not expand the task.
+- Never run destructive commands (rm -rf on broad paths, git reset --hard, force push) without explicit instruction.
+- With tests present, provide TDD evidence: failing test first, then the implementation that makes it pass.
+- Do not spawn further orchestration; execute your role and return.
+- Report results honestly, including failures and skipped steps.`;
 
 export default function gentleAi(pi: ExtensionAPI): void {
 	function runSddPreflight(ctx: ExtensionContext): Promise<SddPreflightPreferences> {
@@ -2052,7 +2061,7 @@ export default function gentleAi(pi: ExtensionAPI): void {
 			}), phase)}`
 			: "";
 		const gentlePrompt = isNamedAgent || isSddAgent
-			? ""
+			? `\n\n${AGENT_SLIM_RULES}`
 			: `\n\n${buildGentlePrompt(readPersonaMode(ctx.cwd))}`;
 		return {
 			systemPrompt: `${event.systemPrompt}${gentlePrompt}${sddPrompt}${nativeStatusPrompt}`,

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1907,6 +1907,39 @@ async function applyReviewGate(
 	};
 }
 
+const GENTLE_HARNESS_REMINDER_CONTENT = `<gentle-harness-reminder>
+Active discipline (el Gentleman harness):
+- Keep the parent session as orchestrator; delegate exploration, implementation, and review to subagents when available.
+- For non-trivial work, anchor decisions in SDD/OpenSpec artifacts, not floating chat context.
+- Single-writer discipline: never run parallel writes without explicit user-approved isolation.
+- With tests present, follow strict TDD evidence: RED, GREEN, TRIANGULATE, REFACTOR.
+- Protect the reviewer: keep changes small; surface review-workload risk before expanding scope.
+- Never fabricate persistent memory or capabilities; report failures honestly.
+</gentle-harness-reminder>`;
+
+function buildContextReminder() {
+	return {
+		role: "custom" as const,
+		customType: "gentle-harness-reminder",
+		content: GENTLE_HARNESS_REMINDER_CONTENT,
+		display: false,
+		timestamp: Date.now(),
+	};
+}
+
+function applyHarnessReminder(
+	messages: Array<{ customType?: string; role?: string } | unknown>,
+): unknown[] {
+	// Strip all existing reminders and append fresh one
+	// This ensures exactly one reminder per context event
+	const filtered = messages.filter((msg) => {
+		if (!isRecord(msg)) return true;
+		return (msg as Record<string, unknown>).customType !== "gentle-harness-reminder";
+	});
+	filtered.push(buildContextReminder());
+	return filtered;
+}
+
 /** @internal */
 export const __testing = {
 	listAgentsFromDir,
@@ -1918,6 +1951,8 @@ export const __testing = {
 	parseNumstat,
 	getOrchestratorPrompt: (pathOverride?: string) =>
 		getOrchestratorPromptImpl(pathOverride),
+	buildContextReminder,
+	applyHarnessReminder,
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {
@@ -1956,6 +1991,10 @@ export default function gentleAi(pi: ExtensionAPI): void {
 				);
 			}
 		}
+	});
+
+	pi.on("context", (event) => {
+		return { messages: applyHarnessReminder(event.messages) };
 	});
 
 	pi.on("input", async (event, ctx) => {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -120,15 +120,22 @@ function sddLocalOverrideDriftCount(cwd: string): number {
 	return stale;
 }
 
-let orchestratorPromptCache: string | null = null;
-function getOrchestratorPrompt(): string {
-	if (orchestratorPromptCache === null) {
-		orchestratorPromptCache = readFileSync(
-			join(ASSETS_DIR, "orchestrator.md"),
-			"utf8",
-		).trim();
+function getOrchestratorPromptImpl(pathOverride?: string): string {
+	const path = pathOverride ?? join(ASSETS_DIR, "orchestrator.md");
+	try {
+		return readFileSync(path, "utf8").trim();
+	} catch (error) {
+		// Fallback if file is missing or unreadable
+		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+			return "";
+		}
+		// For permission denied or other errors, also return empty to avoid crash
+		return "";
 	}
-	return orchestratorPromptCache;
+}
+
+function getOrchestratorPrompt(): string {
+	return getOrchestratorPromptImpl();
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -1909,6 +1916,8 @@ export const __testing = {
 	buildGentlePrompt,
 	classifyReviewEvent,
 	parseNumstat,
+	getOrchestratorPrompt: (pathOverride?: string) =>
+		getOrchestratorPromptImpl(pathOverride),
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1917,11 +1917,29 @@ Active discipline (el Gentleman harness):
 - Never fabricate persistent memory or capabilities; report failures honestly.
 </gentle-harness-reminder>`;
 
+const POST_COMPACTION_REMINDER_CONTENT = `Context was just compacted: earlier conversation details now exist only as a summary.
+Re-check current SDD/OpenSpec state on disk before continuing multi-step work, and restate scope and acceptance criteria for the active task before further changes.`;
+
+// Module-scoped, but safe across sessions: Pi loads extensions with jiti
+// moduleCache:false, so each session/runner re-evaluates this module and gets
+// its own `compactionPending`. There is one ExtensionRunner per agent session,
+// and the flag is reset on session_start. No shared mutable state across
+// concurrent sessions, so no cross-session race.
+let compactionPending = false;
+
 function buildContextReminder() {
+	const baseContent = GENTLE_HARNESS_REMINDER_CONTENT;
+	let fullContent = baseContent;
+
+	if (compactionPending) {
+		fullContent = `${baseContent}\n\n${POST_COMPACTION_REMINDER_CONTENT}`;
+		compactionPending = false;
+	}
+
 	return {
 		role: "custom" as const,
 		customType: "gentle-harness-reminder",
-		content: GENTLE_HARNESS_REMINDER_CONTENT,
+		content: fullContent,
 		display: false,
 		timestamp: Date.now(),
 	};
@@ -1931,7 +1949,7 @@ function applyHarnessReminder(
 	messages: Array<{ customType?: string; role?: string } | unknown>,
 ): unknown[] {
 	// Strip all existing reminders and append fresh one
-	// This ensures exactly one reminder per context event
+	// This ensures exactly one reminder per context event and resets compactionPending flag
 	const filtered = messages.filter((msg) => {
 		if (!isRecord(msg)) return true;
 		return (msg as Record<string, unknown>).customType !== "gentle-harness-reminder";
@@ -1953,6 +1971,10 @@ export const __testing = {
 		getOrchestratorPromptImpl(pathOverride),
 	buildContextReminder,
 	applyHarnessReminder,
+	setCompactionPending: (value: boolean) => {
+		compactionPending = value;
+	},
+	getCompactionPending: () => compactionPending,
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {
@@ -1966,6 +1988,8 @@ export default function gentleAi(pi: ExtensionAPI): void {
 
 	pi.on("session_start", async (_event, ctx) => {
 		try {
+			// Reset compaction state at session start to prevent reminder leakage across sessions
+			compactionPending = false;
 			const installResult = installSddAssets(ctx.cwd, true);
 			const modelResult = await applySavedModelConfig(ctx);
 			if (ctx.hasUI && modelResult.invalidPath) {
@@ -1991,6 +2015,10 @@ export default function gentleAi(pi: ExtensionAPI): void {
 				);
 			}
 		}
+	});
+
+	pi.on("session_compact", (_event, _ctx) => {
+		compactionPending = true;
 	});
 
 	pi.on("context", (event) => {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -65,3 +65,78 @@ test("orchestrator prompt returns empty string when file is missing", (t) => {
 	// Should not throw, should return empty string instead
 	assert.equal(result, "");
 });
+
+test("context event handler builds reminder message", () => {
+	const original: typeof __testing.buildContextReminder = (...args) => {
+		throw new Error("Not implemented");
+	};
+	const reminder = __testing.buildContextReminder();
+	assert.equal(reminder.role, "custom");
+	assert.equal(reminder.customType, "gentle-harness-reminder");
+	assert.equal(typeof reminder.content, "string");
+	assert.equal(reminder.display, false);
+	assert.equal(typeof reminder.timestamp, "number");
+	assert(reminder.content.includes("Active discipline"));
+	assert(reminder.content.includes("el Gentleman harness"));
+	assert(reminder.content.includes("Keep the parent session as orchestrator"));
+});
+
+test("applyHarnessReminder appends reminder to messages without mutation", () => {
+	const messages: typeof __testing.buildContextReminder[] = [];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.notEqual(result, messages, "should return new array");
+	assert.equal(messages.length, 0, "original should not be mutated");
+	assert.equal(result.length, 1, "result should have one message");
+	assert.equal(result[0].customType, "gentle-harness-reminder");
+});
+
+test("applyHarnessReminder deduplicates reminder messages", () => {
+	const reminder = __testing.buildContextReminder();
+	const messages = [
+		{ role: "user", content: "hello" },
+		reminder,
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result.length, 2, "should not double-append duplicate reminder");
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder");
+	// Verify only one reminder exists (dedup strips old and appends fresh)
+	const reminderCount = result.filter((m: any) => m.customType === "gentle-harness-reminder").length;
+	assert.equal(reminderCount, 1, "should have exactly one reminder");
+});
+
+test("applyHarnessReminder removes reminder from middle of message array", () => {
+	const reminder = __testing.buildContextReminder();
+	// Simulate scenario where reminder is not in last position
+	const messages = [
+		{ role: "user", content: "message 1" },
+		reminder,
+		{ role: "assistant", content: "response" },
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	// Original: 3 messages (user, old reminder, assistant)
+	// After dedup: 3 messages (user, assistant, new reminder)
+	assert.equal(result.length, 3, "should maintain message count");
+	// Verify only one reminder and it is at the end
+	const reminderCount = result.filter((m: any) => m.customType === "gentle-harness-reminder").length;
+	assert.equal(reminderCount, 1, "should have exactly one reminder after dedup");
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder", "reminder should be last");
+	assert.equal(result[0].role, "user", "first message should be user");
+	assert.equal(result[1].role, "assistant", "second message should be assistant");
+});
+
+test("applyHarnessReminder handles empty messages", () => {
+	const messages: typeof __testing.buildContextReminder[] = [];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result.length, 1);
+	assert.equal(result[0].customType, "gentle-harness-reminder");
+});
+
+test("applyHarnessReminder appends reminder as last message", () => {
+	const messages = [
+		{ role: "user", content: "message 1" },
+		{ role: "user", content: "message 2" },
+	];
+	const result = __testing.applyHarnessReminder(messages);
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder");
+	assert.equal(result.length, 3);
+});

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -214,3 +214,21 @@ test("compaction flag resets when applyHarnessReminder builds fresh reminder", (
 	assert.equal(__testing.getCompactionPending(), false, "flag should be reset after applyHarnessReminder");
 	assert(result[0].content.includes("Context was just compacted"), "reminder should include compaction content");
 });
+
+test("agent slim rules contain expected content", () => {
+	const slimRules = __testing.getAgentSlimRules();
+	assert(slimRules.includes("Gentle Agent Rules"), "should include header");
+	assert(slimRules.includes("Stay strictly within your assigned scope"), "should include scope rule");
+	assert(slimRules.includes("Never run destructive commands"), "should include safety rule");
+	assert(slimRules.includes("TDD evidence"), "should include TDD rule");
+	assert(slimRules.includes("Do not spawn further orchestration"), "should include no-orchestration rule");
+	assert(slimRules.includes("Report results honestly"), "should include honesty rule");
+});
+
+test("agent slim rules do not contain persona or orchestrator markers", () => {
+	const slimRules = __testing.getAgentSlimRules();
+	assert(!slimRules.includes("el Gentleman Identity"), "slim rules must not contain identity contract");
+	assert(!slimRules.includes("Persona:"), "slim rules must not contain persona marker");
+	assert(!slimRules.includes("orchestrator.md"), "slim rules must not reference orchestrator");
+	assert(!slimRules.includes("Harness principles"), "slim rules must not contain harness principles");
+});

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -140,3 +140,77 @@ test("applyHarnessReminder appends reminder as last message", () => {
 	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder");
 	assert.equal(result.length, 3);
 });
+
+test("buildContextReminder with compaction pending includes post-compaction block", () => {
+	__testing.setCompactionPending(true);
+	const reminder = __testing.buildContextReminder();
+	assert.equal(reminder.role, "custom");
+	assert.equal(reminder.customType, "gentle-harness-reminder");
+	assert(
+		reminder.content.includes("Context was just compacted"),
+		"should include post-compaction block when pending"
+	);
+	assert(
+		reminder.content.includes("Re-check current SDD/OpenSpec state on disk"),
+		"should include re-check instruction"
+	);
+	assert(
+		reminder.content.includes("restate scope and acceptance criteria"),
+		"should include restate instruction"
+	);
+	// Verify flag is cleared after building
+	assert.equal(
+		__testing.getCompactionPending(),
+		false,
+		"flag should be cleared after one-shot use"
+	);
+});
+
+test("buildContextReminder without compaction pending returns standard reminder", () => {
+	__testing.setCompactionPending(false);
+	const reminder = __testing.buildContextReminder();
+	const content = reminder.content;
+	assert(!content.includes("Context was just compacted"), "should not include post-compaction block when not pending");
+	assert(content.includes("Active discipline"), "should include standard discipline content");
+});
+
+test("setCompactionPending and getCompactionPending control flag", () => {
+	__testing.setCompactionPending(true);
+	assert.equal(__testing.getCompactionPending(), true);
+	__testing.setCompactionPending(false);
+	assert.equal(__testing.getCompactionPending(), false);
+});
+
+test("applyHarnessReminder multi-turn scenario: reminder persists and refreshes correctly", () => {
+	// Simulate first context event
+	__testing.setCompactionPending(false);
+	let messages: any[] = [{ role: "user", content: "first message" }];
+	let result = __testing.applyHarnessReminder(messages);
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder", "first turn should have reminder");
+	const firstReminder = result[result.length - 1];
+
+	// Simulate second context event with new message appended (tool result)
+	messages = result;
+	messages.push({ role: "tool", content: "tool result" });
+	result = __testing.applyHarnessReminder(messages);
+
+	// Should have exactly one reminder and it should be fresh (not the old one)
+	const reminderCount = result.filter((m: any) => m.customType === "gentle-harness-reminder").length;
+	assert.equal(reminderCount, 1, "should still have exactly one reminder after multi-turn");
+	assert.equal(result[result.length - 1].customType, "gentle-harness-reminder", "reminder should be last");
+	// Verify it's a fresh reminder (timestamp should be different)
+	const secondReminder = result[result.length - 1];
+	assert(secondReminder.timestamp >= firstReminder.timestamp, "fresh reminder should have equal or newer timestamp");
+});
+
+test("compaction flag resets when applyHarnessReminder builds fresh reminder", () => {
+	__testing.setCompactionPending(true);
+	assert.equal(__testing.getCompactionPending(), true, "flag should be set");
+
+	const messages: any[] = [];
+	const result = __testing.applyHarnessReminder(messages);
+
+	// Flag should now be reset by buildContextReminder call
+	assert.equal(__testing.getCompactionPending(), false, "flag should be reset after applyHarnessReminder");
+	assert(result[0].content.includes("Context was just compacted"), "reminder should include compaction content");
+});

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -34,3 +34,34 @@ test("agent discovery skips skills directories", async (t) => {
 		["reviewer", "worker"],
 	);
 });
+
+test("orchestrator prompt refreshes from disk on each access", (t) => {
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-orchestrator-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const promptFile = join(tmpDir, "orchestrator.md");
+
+	// Write initial content
+	writeFileSync(promptFile, "First version");
+	const first = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(first, "First version");
+
+	// Update the file
+	writeFileSync(promptFile, "Updated version");
+	const second = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(second, "Updated version");
+
+	// Change it again to prove freshness on each call
+	writeFileSync(promptFile, "Third version");
+	const third = __testing.getOrchestratorPrompt(promptFile);
+	assert.equal(third, "Third version");
+});
+
+test("orchestrator prompt returns empty string when file is missing", (t) => {
+	// Build a deterministic, cross-platform missing path: the dir exists, the child does not.
+	const tmpDir = mkdtempSync(join(tmpdir(), "gentle-pi-missing-"));
+	t.after(() => rmSync(tmpDir, { recursive: true, force: true }));
+	const missingPath = join(tmpDir, "orchestrator.md");
+	const result = __testing.getOrchestratorPrompt(missingPath);
+	// Should not throw, should return empty string instead
+	assert.equal(result, "");
+});

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -213,7 +213,15 @@ async function run() {
 			{ agentName: "worker", systemPrompt: "worker base" },
 			createCtx(promptCwd),
 		);
-		assert.equal(subagentPromptResult.systemPrompt, "worker base");
+		assert.match(subagentPromptResult.systemPrompt, /worker base/);
+		assert.match(subagentPromptResult.systemPrompt, /Gentle Agent Rules/);
+		assert.match(subagentPromptResult.systemPrompt, /Stay strictly within your assigned scope/);
+		assert.doesNotMatch(subagentPromptResult.systemPrompt, /el Gentleman Identity/);
+		assert.doesNotMatch(
+			subagentPromptResult.systemPrompt,
+			/## SDD Session Preflight/,
+			"non-SDD subagents must not receive SDD preflight prompts",
+		);
 		assert.equal(
 			existsSync(join(promptCwd, ".pi", "agents", "sdd-apply.md")),
 			false,
@@ -504,10 +512,17 @@ async function run() {
 			{ agentName: "worker", systemPrompt: "worker base" },
 			ctx,
 		);
-		assert.equal(
+		assert.match(
 			workerPromptResult.systemPrompt,
-			"worker base",
-			"non-SDD subagents must not receive parent harness or SDD preflight prompts",
+			/worker base/,
+			"non-SDD subagents must receive slim rules but not parent harness or SDD preflight prompts",
+		);
+		assert.match(workerPromptResult.systemPrompt, /Gentle Agent Rules/);
+		assert.doesNotMatch(workerPromptResult.systemPrompt, /el Gentleman Identity/);
+		assert.doesNotMatch(
+			workerPromptResult.systemPrompt,
+			/## SDD Session Preflight/,
+			"non-SDD subagents must not receive SDD preflight prompts",
 		);
 	} finally {
 		await rm(lazySddCwd, { recursive: true, force: true });


### PR DESCRIPTION
> **Re-land of #43** (approved, then closed; head branch deleted, so this is a fresh PR with the same commit). Rebased onto current `main` (`1c218795`). Opened as **draft** for now.
>
> **What changed vs the original #43:** rebased cleanly. Re-verified after the rebase that `AGENT_SLIM_RULES` still contains **only** the thin discipline floor — no persona, identity, or orchestrator content, and no voseo leak from `#45`'s neutral-mode fix. The separation tests assert exactly this and pass. The harness logic is byte-identical to the approved commit.
>
> Last in the stack, stacked on #42. This is the one PR that revisits the design call discussed in #39.

Part of #39 (please read the design note in the issue before reviewing this one). Stacked on #42 (review the last commit only).

## Summary
- Named and SDD agents currently receive an empty `gentlePrompt`. This PR keeps persona, identity, and orchestrator content out of them (that part of the design is unchanged) and appends a 9-line discipline floor instead: scope confinement, destructive-command safety, TDD evidence, no nested orchestration, honest reporting.
- Parent sessions are untouched; they keep the full harness exactly as today.

## Changes
| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | `AGENT_SLIM_RULES` const; `before_agent_start` appends it for named/SDD agents instead of the empty string |
| `tests/gentle-ai.test.ts` | Slim rules content assertions; explicit absence checks for persona and orchestrator markers |
| `tests/runtime-harness.mjs` | Assertions updated from exact-empty to pattern matching (slim rules present, persona markers absent) |

## Test plan
- [x] `pnpm test` green at this commit on current `main`: **168 pass, 0 fail** (full stack). Original count on the older base was 67.

## Notes
This is the one PR in the stack that revisits a deliberate design choice. If you prefer subagents fully clean, closing this PR drops the change without affecting #40, #41, or #42.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved orchestrator prompt handling by loading it on demand and safely returning an empty result when the file can’t be read.

* **New Features**
  * Enhanced context management with smarter harness reminders, including refresh behavior after compaction and deduplication.
  * Improved agent prompt composition by reliably injecting the “slim rules” content.

* **Tests**
  * Expanded unit tests for prompt loading and reminder/compaction logic, plus updated runtime harness assertions to match the new prompt composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->