### PR TITLE
perf(prompt): improve cache-friendly prompt ordering

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -2220,7 +2220,7 @@ export default function gentleAi(pi: ExtensionAPI): void {
 			? ""
 			: `\n\n${buildGentlePrompt(readPersonaMode(ctx.cwd))}`;
 		return {
-			systemPrompt: `${event.systemPrompt}${gentlePrompt}${sddPrompt}${nativeStatusPrompt}`,
+			systemPrompt: `${gentlePrompt}${event.systemPrompt}${sddPrompt}${nativeStatusPrompt}`,
 		};
 	});
 

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -216,6 +216,11 @@ async function run() {
 		const promptResult = await promptHook({ systemPrompt: "base" }, createCtx(promptCwd));
 		assert.match(promptResult.systemPrompt, /base/);
 		assert.match(promptResult.systemPrompt, /el Gentleman/);
+		assert.ok(
+			promptResult.systemPrompt.indexOf("el Gentleman Identity and Harness") <
+				promptResult.systemPrompt.indexOf("base"),
+			"stable el Gentleman prompt should be prepended before volatile runtime system context for better prompt-cache reuse",
+		);
 		assert.match(promptResult.systemPrompt + delegationDetail, /do not pass the `model` parameter by default/);
 		assert.match(
 			promptResult.systemPrompt + delegationDetail,


### PR DESCRIPTION
## Summary
- Improve prompt-cache friendliness by placing the stable el Gentleman harness prompt before the runtime system prompt for parent sessions.
- Preserve named/SDD executor isolation because their `gentlePrompt` remains empty.
- Add runtime harness coverage for the prompt ordering contract.

## Changes
| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Prepends `gentlePrompt` before `event.systemPrompt` in the parent prompt hook. |
| `tests/runtime-harness.mjs` | Asserts `el Gentleman Identity and Harness` appears before the base runtime prompt. |

## Testing
- [x] `pnpm test`
- [x] Fresh reliability review: No findings.

Closes #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the agent startup prompt ordering so the Gentleman identity content is placed before the runtime-provided base prompt.
  * This makes the generated agent context more consistent and predictable.

* **Tests**
  * Updated the runtime harness to assert the relative ordering of the stable identity segment versus the volatile base prompt during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->