### PR TITLE
fix(review): harden cleanup follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Skill discovery is a guardrail, not a workflow router: it helps Pi load the righ
 
 Packaged skills include `cognitive-doc-design`, `comment-writer`, `gentle-ai-judgment-day`, `gentle-ai-skill-creator`, `gentle-ai-skill-improver`, and the other delivery/review skills under `skills/`. SDD init is installed as the packaged `sdd-init` runtime agent under `assets/agents/` and refreshed with the SDD assets.
 
+Compatibility: the package keeps the existing skill folders (`skills/branch-pr`, `skills/judgment-day`, `skills/skill-creator`) but their exported frontmatter names are prefixed to avoid collisions with user/global skills. Treat former package names such as `branch-pr`, `judgment-day`, and `skill-creator` as legacy aliases in prose; runtime skill selection should use `gentle-ai-branch-pr`, `gentle-ai-judgment-day`, and `gentle-ai-skill-creator`.
+
 Delegation contract:
 
 - parent/orchestrator resolves project/user skills from the registry and passes matching paths under `## Skills to load before work`;

--- a/assets/orchestrator-delegation.md
+++ b/assets/orchestrator-delegation.md
@@ -163,7 +163,7 @@ The extension (`extensions/gentle-ai.ts`) gates `bash` tool calls that look like
   - Changed paths match hot globs: `**/auth/**`, `**/update/**`, `**/security/**`, `**/payments/**`
   - Diff exceeds 400 changed lines (added + deleted)
   - When blocked, the reason names all four agents to run first.
-- **post-sdd-phase** (design, apply): **strong gate** for `judgment-day`. Handled separately by SDD phase orchestration, not this diff-based hook.
+- **post-sdd-phase** (design, apply): **strong gate** for the packaged `gentle-ai-judgment-day` skill. Handled separately by SDD phase orchestration, not this diff-based hook.
 
 When the extension blocks a `gh pr create` command, the orchestrator must launch the `4r-review` chain (or run the four agents individually) and wait for their reports before the user retries the PR command.
 

--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -107,9 +107,9 @@ For skill-shaped requests, do not treat injected `<available_skills>` as complet
 
 ## 4R Review Triggers
 
-`extensions/gentle-ai.ts` gates `bash` calls that look like git/gh workflow events. **pre-commit**/**pre-push**: advisory only — notify to consider `review-readability`, do not block. **pre-pr** (`gh pr create`): strong gate — blocks when changed paths match hot globs (`**/auth/**`, `**/update/**`, `**/security/**`, `**/payments/**`) or the diff exceeds 400 changed lines; the reason names all four agents to run first. **post-sdd-phase** (design, apply): strong gate for `judgment-day`, handled by SDD phase orchestration.
+`extensions/gentle-ai.ts` gates git/gh `bash`: pre-commit/pre-push only suggest `review-readability`; pre-pr blocks on hot auth/update/security/payments paths or over 400 changed lines and requires `review-risk`, `review-resilience`, `review-readability`, `review-reliability`; post-SDD design/apply uses `gentle-ai-judgment-day`.
 
-When blocked, launch the `4r-review` chain or run `review-risk`, `review-reliability`, `review-resilience`, `review-readability` individually and wait for their reports before retrying.
+When blocked, run `4r-review` or all four review agents before retrying.
 
 ### Review Execution Contract
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -49,7 +49,7 @@ import {
 import { sanitizeTerminalText, stripAnsi } from "../lib/terminal-theme.ts";
 
 const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const ASSETS_DIR = process.env.GENTLE_PI_TEST_ASSETS_DIR ?? join(PACKAGE_ROOT, "assets");
+const ASSETS_DIR = join(PACKAGE_ROOT, "assets");
 
 function gentlePiAgentHome(): string {
 	return process.env.GENTLE_PI_AGENT_HOME ?? join(homedir(), ".pi", "agent");
@@ -116,35 +116,32 @@ function sddLocalAgentOverrideCount(cwd: string): number {
 }
 
 let orchestratorPromptCache: string | null = null;
-function getSddWorkflowPath(): string {
-	return join(ASSETS_DIR, "sdd-orchestrator-workflow.md");
-}
-
-function getDelegationPath(): string {
-	return join(ASSETS_DIR, "orchestrator-delegation.md");
-}
-
-function getMemoryPath(): string {
-	return join(ASSETS_DIR, "orchestrator-memory.md");
-}
-
-function getSkillsPath(): string {
-	return join(ASSETS_DIR, "orchestrator-skills.md");
-}
-
 function getOrchestratorPrompt(): string {
 	if (orchestratorPromptCache === null) {
-		orchestratorPromptCache = readFileSync(
-			join(ASSETS_DIR, "orchestrator.md"),
-			"utf8",
-		)
-			.replaceAll("{{GENTLE_PI_SDD_WORKFLOW_PATH}}", getSddWorkflowPath())
-			.replaceAll("{{GENTLE_PI_DELEGATION_PATH}}", getDelegationPath())
-			.replaceAll("{{GENTLE_PI_MEMORY_PATH}}", getMemoryPath())
-			.replaceAll("{{GENTLE_PI_SKILLS_PATH}}", getSkillsPath())
-			.trim();
+		orchestratorPromptCache = renderOrchestratorPrompt(ASSETS_DIR);
 	}
 	return orchestratorPromptCache;
+}
+
+function renderOrchestratorPrompt(assetsDir: string): string {
+	return readFileSync(join(assetsDir, "orchestrator.md"), "utf8")
+		.replaceAll(
+			"{{GENTLE_PI_SDD_WORKFLOW_PATH}}",
+			join(assetsDir, "sdd-orchestrator-workflow.md"),
+		)
+		.replaceAll(
+			"{{GENTLE_PI_DELEGATION_PATH}}",
+			join(assetsDir, "orchestrator-delegation.md"),
+		)
+		.replaceAll(
+			"{{GENTLE_PI_MEMORY_PATH}}",
+			join(assetsDir, "orchestrator-memory.md"),
+		)
+		.replaceAll(
+			"{{GENTLE_PI_SKILLS_PATH}}",
+			join(assetsDir, "orchestrator-skills.md"),
+		)
+		.trim();
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -2150,6 +2147,7 @@ export const __testing = {
 	parseNumstat,
 	renderSddModelPanel: renderSddModelPanelForTesting,
 	getOrchestratorPrompt,
+	renderOrchestratorPrompt,
 };
 
 export default function gentleAi(pi: ExtensionAPI): void {

--- a/tests/fixtures/measure-orchestrator-prompt.mjs
+++ b/tests/fixtures/measure-orchestrator-prompt.mjs
@@ -1,20 +1,22 @@
 // Standalone entry point spawned as a fresh Node process by
 // tests/orchestrator-budget.test.ts's realistic-path-length budget test.
 //
-// extensions/gentle-ai.ts resolves ASSETS_DIR (from
-// GENTLE_PI_TEST_ASSETS_DIR) at module-import time and memoizes
-// getOrchestratorPrompt()'s return value in a module-level cache
-// (first-read-wins for the process lifetime). Measuring the substituted
-// return at a second, longer ASSETS_DIR therefore requires a genuinely
-// separate process rather than a second dynamic import of the same module
-// specifier in an already-imported test process.
+// extensions/gentle-ai.ts memoizes getOrchestratorPrompt()'s production return
+// value in a module-level cache (first-read-wins for the process lifetime).
+// Measuring a fixture render at a second, longer assets path therefore uses the
+// test-only render helper in a genuinely separate process rather than relying
+// on ambient environment variables or a second dynamic import of the same
+// module specifier in an already-imported test process.
 //
-// Reads GENTLE_PI_TEST_ASSETS_DIR from the environment (set by the caller),
-// imports extensions/gentle-ai.ts fresh, and prints the rendered prompt's
-// UTF-8 byte length to stdout.
+// Reads the fixture assets path from argv[2], imports extensions/gentle-ai.ts
+// fresh, and prints the rendered prompt's UTF-8 byte length to stdout.
 
 import { join } from "node:path";
 
 const { __testing } = await import(join(import.meta.dirname, "..", "..", "extensions", "gentle-ai.ts"));
-const rendered = __testing.getOrchestratorPrompt();
+const assetsDir = process.argv[2];
+if (!assetsDir) {
+	throw new Error("usage: measure-orchestrator-prompt.mjs <assets-dir>");
+}
+const rendered = __testing.renderOrchestratorPrompt(assetsDir);
 process.stdout.write(String(Buffer.byteLength(rendered, "utf8")));

--- a/tests/fixtures/orchestrator.pre-diet.md
+++ b/tests/fixtures/orchestrator.pre-diet.md
@@ -292,7 +292,7 @@ The extension (`extensions/gentle-ai.ts`) gates `bash` tool calls that look like
   - Changed paths match hot globs: `**/auth/**`, `**/update/**`, `**/security/**`, `**/payments/**`
   - Diff exceeds 400 changed lines (added + deleted)
   - When blocked, the reason names all four agents to run first.
-- **post-sdd-phase** (design, apply): **strong gate** for `judgment-day`. Handled separately by SDD phase orchestration, not this diff-based hook.
+- **post-sdd-phase** (design, apply): **strong gate** for the packaged `gentle-ai-judgment-day` skill. Handled separately by SDD phase orchestration, not this diff-based hook.
 
 When the extension blocks a `gh pr create` command, the orchestrator must launch the `4r-review` chain (or run the four agents individually) and wait for their reports before the user retries the PR command.
 

--- a/tests/orchestrator-budget.test.ts
+++ b/tests/orchestrator-budget.test.ts
@@ -12,22 +12,18 @@ import test, { after } from "node:test";
 // plus three path-substituted lazy reference files (see design.md "Core
 // budget rebuilt from measured drafts" and "Appendix: drafted core texts").
 //
-// `getOrchestratorPrompt`'s `ASSETS_DIR` (extensions/gentle-ai.ts:52) is a
-// module-level `const` resolved at IMPORT time from
-// `process.env.GENTLE_PI_TEST_ASSETS_DIR`, and its rendered return value is
-// memoized in a module-level cache (first-read-wins for the process
-// lifetime — see design.md "Test seam (JD-005)"). Both constraints mean the
-// env override must be set BEFORE this module is first imported (a dynamic
-// `import()`, not a static top-of-file import), and every test below that
-// needs `__testing` must share the SAME module instance. To keep every test
-// in this file consistent, the stub fixture directory below is populated by
-// COPYING the real repo assets (dynamically, at test-run time) into a
-// short-path tmpdir — this isolates the byte-budget measurement from the
+// `getOrchestratorPrompt`'s rendered return value is memoized in a
+// module-level cache (first-read-wins for the process lifetime — see design.md
+// "Test seam (JD-005)"). Tests that need alternate asset roots use the
+// test-only `__testing.renderOrchestratorPrompt(assetsDir)` helper instead of
+// ambient environment variables, so production runtime asset resolution stays
+// deterministic. The representative production assets directory below is
+// populated by COPYING the real repo assets (dynamically, at test-run time)
+// into a short-path tmpdir — this isolates byte-budget measurement from the
 // real repo's absolute path length while keeping content representative of
 // production. Tests that need to inspect the real repo files directly (the
 // disposition-mapped union sweep, the core-alone token assertions) read
-// `assets/*.md` directly via `readFileSync`, sidestepping the cache/env
-// entirely.
+// `assets/*.md` directly via `readFileSync`, sidestepping the cache entirely.
 // ---------------------------------------------------------------------------
 
 const REPO_ROOT = join(import.meta.dirname, "..");
@@ -43,32 +39,29 @@ const LAZY_ASSET_NAMES = [
 	"orchestrator-skills.md",
 ] as const;
 
-const stubDir = mkdtempSync(join(tmpdir(), "gp-b-"));
+const representativeProductionAssetsDir = mkdtempSync(join(tmpdir(), "gp-b-"));
 for (const name of LAZY_ASSET_NAMES) {
 	const src = join(REAL_ASSETS_DIR, name);
 	writeFileSync(
-		join(stubDir, name),
+		join(representativeProductionAssetsDir, name),
 		existsSync(src) ? readFileSync(src) : `stub placeholder for ${name} (not authored yet)\n`,
 	);
 }
-process.env.GENTLE_PI_TEST_ASSETS_DIR = stubDir;
 const { __testing } = await import("../extensions/gentle-ai.ts");
 
-// Realistic-length ASSETS_DIR: mirrors an actual installed path such as
-// `~/.pi/agent/npm/node_modules/gentle-pi/assets` (measured well over 59
-// chars on real installs), so the budget assertion is not laundered through
-// an artificially short mkdtemp path. `ASSETS_DIR` and the memoized
-// `orchestratorPromptCache` are both resolved at module-import time
-// (first-read-wins for the process lifetime — see the file-level comment
-// above), so this longer directory cannot be measured via a second dynamic
-// import in THIS already-imported process; it is measured in a genuinely
-// fresh child process instead (`tests/fixtures/measure-orchestrator-prompt.mjs`).
+const MIN_REALISTIC_INSTALL_ASSETS_PATH_CHARS = 59;
+
+// Realistic-length assets path: mirrors an actual installed path such as
+// `~/.pi/agent/npm/node_modules/gentle-pi/assets`, so the budget assertion is
+// not laundered through an artificially short mkdtemp path. The helper is also
+// exercised in a fresh child process (`tests/fixtures/measure-orchestrator-prompt.mjs`)
+// to keep production cache behavior separate from fixture measurements.
 const realisticBaseDir = mkdtempSync(join(tmpdir(), "gp-realistic-"));
 const realisticDir = join(realisticBaseDir, ".pi", "agent", "npm", "node_modules", "gentle-pi", "assets");
 mkdirSync(realisticDir, { recursive: true });
 assert.ok(
-	realisticDir.length >= 59,
-	`realistic scratch ASSETS_DIR path is only ${realisticDir.length} chars, need >= 59 to mirror a real install path`,
+	realisticDir.length >= MIN_REALISTIC_INSTALL_ASSETS_PATH_CHARS,
+	`realistic scratch assets path is only ${realisticDir.length} chars, need >= ${MIN_REALISTIC_INSTALL_ASSETS_PATH_CHARS} to mirror a real install path`,
 );
 for (const name of LAZY_ASSET_NAMES) {
 	const src = join(REAL_ASSETS_DIR, name);
@@ -79,7 +72,7 @@ for (const name of LAZY_ASSET_NAMES) {
 }
 
 after(() => {
-	rmSync(stubDir, { recursive: true, force: true });
+	rmSync(representativeProductionAssetsDir, { recursive: true, force: true });
 	rmSync(realisticBaseDir, { recursive: true, force: true });
 });
 
@@ -89,8 +82,8 @@ function readRealAsset(name: string): string {
 
 function measureOrchestratorPromptBytes(assetsDir: string): number {
 	const scriptPath = join(import.meta.dirname, "fixtures", "measure-orchestrator-prompt.mjs");
-	const result = spawnSync(process.execPath, ["--experimental-strip-types", scriptPath], {
-		env: { ...process.env, GENTLE_PI_TEST_ASSETS_DIR: assetsDir },
+	const result = spawnSync(process.execPath, ["--experimental-strip-types", scriptPath, assetsDir], {
+		env: process.env,
 		encoding: "utf8",
 	});
 	assert.equal(
@@ -106,7 +99,7 @@ function measureOrchestratorPromptBytes(assetsDir: string): number {
 // ---------------------------------------------------------------------------
 
 test("getOrchestratorPrompt return value stays within the 10,240 B budget (short-path stub sanity check)", () => {
-	const rendered = __testing.getOrchestratorPrompt();
+	const rendered = __testing.renderOrchestratorPrompt(representativeProductionAssetsDir);
 	const bytes = Buffer.byteLength(rendered, "utf8");
 	assert.ok(
 		bytes <= BUDGET_BYTES,
@@ -114,7 +107,7 @@ test("getOrchestratorPrompt return value stays within the 10,240 B budget (short
 	);
 });
 
-test("getOrchestratorPrompt return value stays within the 10,240 B budget at a realistic (>= 59 char) install path length", () => {
+test(`getOrchestratorPrompt return value stays within the 10,240 B budget at a realistic (>= ${MIN_REALISTIC_INSTALL_ASSETS_PATH_CHARS} char) install path length`, () => {
 	const bytes = measureOrchestratorPromptBytes(realisticDir);
 	assert.ok(
 		bytes <= BUDGET_BYTES,
@@ -274,15 +267,15 @@ test("relocated lazy bodies are not double-delivered in the always-on core", () 
 test("relocated lazy files are reachable via in-core pointer paths", () => {
 	const rendered = __testing.getOrchestratorPrompt();
 	assert.ok(
-		rendered.includes(join(stubDir, "orchestrator-delegation.md")),
+		rendered.includes(join(REAL_ASSETS_DIR, "orchestrator-delegation.md")),
 		"core is missing a reachable pointer to orchestrator-delegation.md",
 	);
 	assert.ok(
-		rendered.includes(join(stubDir, "orchestrator-memory.md")),
+		rendered.includes(join(REAL_ASSETS_DIR, "orchestrator-memory.md")),
 		"core is missing a reachable pointer to orchestrator-memory.md",
 	);
 	assert.ok(
-		rendered.includes(join(stubDir, "orchestrator-skills.md")),
+		rendered.includes(join(REAL_ASSETS_DIR, "orchestrator-skills.md")),
 		"core is missing a reachable pointer to orchestrator-skills.md",
 	);
 });

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -164,8 +164,10 @@ async function loadExtensions(pi) {
 async function run() {
 	const globalConfigHome = await tempWorkspace();
 	const globalAgentHome = await tempWorkspace();
+	const ambientTestAssetsDir = await tempWorkspace();
 	process.env.GENTLE_PI_CONFIG_HOME = globalConfigHome;
 	process.env.GENTLE_PI_AGENT_HOME = globalAgentHome;
+	process.env.GENTLE_PI_TEST_ASSETS_DIR = ambientTestAssetsDir;
 	const globalModelsPath = join(globalConfigHome, "models.json");
 	const globalSubagentsPath = join(globalAgentHome, "subagents.json");
 	const { pi, hooks, commands, flags } = createPi();
@@ -227,7 +229,14 @@ async function run() {
 			promptResult.systemPrompt,
 			new RegExp(`${ROOT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}.*assets.*sdd-orchestrator-workflow\\.md`),
 		);
+		assert.doesNotMatch(
+			promptResult.systemPrompt,
+			new RegExp(ambientTestAssetsDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+			"normal runtime must ignore ambient GENTLE_PI_TEST_ASSETS_DIR",
+		);
 		assert.doesNotMatch(promptResult.systemPrompt, /\{\{GENTLE_PI_SDD_WORKFLOW_PATH\}\}/);
+		delete process.env.GENTLE_PI_TEST_ASSETS_DIR;
+		await rm(ambientTestAssetsDir, { recursive: true, force: true });
 		await writeFile(
 			join(globalConfigHome, "persona.json"),
 			'{"mode":"neutral"}\n',

--- a/tests/skill-collision-prefixes.test.ts
+++ b/tests/skill-collision-prefixes.test.ts
@@ -35,6 +35,18 @@ for (const [dir, expectedName] of Object.entries(PREFIXED_NAMES)) {
 	});
 }
 
+test("README documents legacy skill-name compatibility aliases", () => {
+	const readme = readFileSync(join(repoRoot, "README.md"), "utf8");
+	for (const [legacyName, prefixedName] of [
+		["branch-pr", "gentle-ai-branch-pr"],
+		["judgment-day", "gentle-ai-judgment-day"],
+		["skill-creator", "gentle-ai-skill-creator"],
+	] as const) {
+		assert.match(readme, new RegExp(`former package names such as[\\s\\S]*${legacyName}`));
+		assert.match(readme, new RegExp(`runtime skill selection should use[\\s\\S]*${prefixedName}`));
+	}
+});
+
 for (const dir of UNPREFIXED_DIRS) {
 	test(`skills/${dir}/SKILL.md frontmatter name carries no gentle-ai- prefix`, () => {
 		const name = readSkillName(dir);


### PR DESCRIPTION
Closes #79

## Summary
- Remove the ambient `GENTLE_PI_TEST_ASSETS_DIR` production asset-loading seam and replace it with an explicit test-only render helper.
- Update post-SDD review guidance to use packaged `gentle-ai-judgment-day` and document legacy skill-name aliases.
- Tighten budget/runtime tests so production prompt paths stay deterministic and former skill names have behavior-level documentation coverage.

## Changes
| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Always resolve production assets from the package root; expose explicit test-only prompt renderer. |
| `tests/orchestrator-budget.test.ts` | Use explicit fixture asset dirs, clearer naming, and named install-path threshold. |
| `tests/runtime-harness.mjs` | Assert ambient `GENTLE_PI_TEST_ASSETS_DIR` is ignored by normal runtime. |
| `tests/skill-collision-prefixes.test.ts` / `README.md` | Document and test legacy skill-name compatibility guidance. |
| `assets/orchestrator*.md` | Point post-SDD recovery guidance at `gentle-ai-judgment-day`. |

## Review / Test Plan
- [x] 4R fresh review on PRs #70/#76/#78 before implementation
- [x] Fresh 4R pre-PR review on this diff
- [x] Scoped readability re-review after cleanup fix
- [x] `pnpm test` — 308/308 passing
- [x] `pnpm run test:harness`
- [x] `node scripts/verify-package-files.mjs`
- [x] `git diff --check`

## Notes
- Untracked `.codegraph/` remains local and is not part of this PR.
