### PR TITLE
feat: add quiet tool rendering

### DIFF
--- a/extensions/pi-pretty.ts
+++ b/extensions/pi-pretty.ts
@@ -1,6 +1,11 @@
 import { realpathSync } from "node:fs";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import {
+	mergeDisabledTools,
+	PI_PRETTY_SUPPRESSED_TOOL_NAMES,
+	quietToolsEnabled,
+} from "../lib/quiet-tools-config.ts";
 
 const packageJsonPath = realpathSync(
 	fileURLToPath(new URL("../package.json", import.meta.url)),
@@ -13,4 +18,12 @@ const piPrettyExtension =
 		? piPrettyModule
 		: piPrettyModule.default;
 
-export default piPrettyExtension;
+export default async function gentlePiPrettyExtension(pi: unknown, deps?: unknown): Promise<unknown> {
+	if (quietToolsEnabled()) {
+		process.env.PRETTY_DISABLE_TOOLS = mergeDisabledTools(
+			process.env.PRETTY_DISABLE_TOOLS,
+			PI_PRETTY_SUPPRESSED_TOOL_NAMES,
+		);
+	}
+	return piPrettyExtension(pi, deps);
+}

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -1,0 +1,218 @@
+import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	createBashTool,
+	createEditTool,
+	createFindTool,
+	createGrepTool,
+	createLsTool,
+	createReadTool,
+	createWriteTool,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { homedir } from "node:os";
+import { quietToolsEnabled } from "../lib/quiet-tools-config.ts";
+import { sanitizeTerminalText } from "../lib/terminal-theme.ts";
+
+type QuietToolName = "read" | "bash" | "grep" | "find" | "ls" | "edit" | "write";
+type ThemeLike = {
+	bold(value: string): string;
+	fg(color: string, value: string): string;
+};
+
+const TOOL_CREATORS = {
+	read: createReadTool,
+	bash: createBashTool,
+	grep: createGrepTool,
+	find: createFindTool,
+	ls: createLsTool,
+	edit: createEditTool,
+	write: createWriteTool,
+} satisfies Record<QuietToolName, (cwd: string) => any>;
+
+const COLLAPSED_COUNT_LABELS: Partial<Record<QuietToolName, string>> = {
+	grep: "matches",
+	find: "files",
+	ls: "entries",
+};
+
+const NO_COLLAPSED_RESULT_TOOLS = new Set<QuietToolName>(["read", "bash"]);
+const COLLAPSED_TAIL_TOOLS = new Set<QuietToolName>(["edit", "write"]);
+const COLLAPSED_TAIL_LINE_LIMIT = 10;
+
+const EMPTY_RESULT_MESSAGES: Partial<Record<QuietToolName, string[]>> = {
+	grep: ["No matches found"],
+	find: ["No files found matching pattern"],
+	ls: ["Directory is empty"],
+};
+
+const toolCache = new Map<string, Record<QuietToolName, any>>();
+
+function createBuiltInTools(cwd: string): Record<QuietToolName, any> {
+	return Object.fromEntries(
+		(Object.entries(TOOL_CREATORS) as [QuietToolName, (cwd: string) => any][]).map(
+			([name, createTool]) => [name, createTool(cwd)],
+		),
+	) as Record<QuietToolName, any>;
+}
+
+function getBuiltInTools(cwd: string): Record<QuietToolName, any> {
+	let tools = toolCache.get(cwd);
+	if (!tools) {
+		tools = createBuiltInTools(cwd);
+		toolCache.set(cwd, tools);
+	}
+	return tools;
+}
+
+function shortenPath(path: unknown): string {
+	if (typeof path !== "string" || path.length === 0) return "";
+	const home = homedir();
+	return path.startsWith(home) ? `~${path.slice(home.length)}` : path;
+}
+
+function asString(value: unknown, fallback = ""): string {
+	return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+export function countNonEmptyLines(text: string): number {
+	return text.split("\n").filter((line) => line.trim().length > 0).length;
+}
+
+export function tailLines(text: string, limit: number): string {
+	const lines = text.split("\n");
+	return lines.slice(Math.max(0, lines.length - limit)).join("\n");
+}
+
+export function extractTextContent(result: AgentToolResult<unknown>): string {
+	return result.content
+		.flatMap((content) => (content.type === "text" ? [content.text] : []))
+		.join("\n");
+}
+
+function safeText(value: string): string {
+	return sanitizeTerminalText(value);
+}
+
+function isEmptyResultMessage(toolName: QuietToolName, text: string): boolean {
+	const normalized = text.trim();
+	return EMPTY_RESULT_MESSAGES[toolName]?.some((message) => normalized.startsWith(message)) ?? false;
+}
+
+function isGitCommand(args: Record<string, unknown> | undefined): boolean {
+	const command = typeof args?.command === "string" ? args.command.trim() : "";
+	return /^(?:env\s+\S+=\S+\s+|command\s+|\w+=\S+\s+)*git(?:\s|$)/.test(command);
+}
+
+interface ToolResultFormatOptions {
+	expanded: boolean;
+	isError?: boolean;
+	args?: Record<string, unknown>;
+}
+
+export function formatToolResultOutput(
+	toolName: QuietToolName,
+	result: AgentToolResult<unknown>,
+	{ expanded, isError = false, args }: ToolResultFormatOptions,
+): string {
+	const text = safeText(extractTextContent(result));
+	if (expanded || isError) return text ? `\n${text}` : "";
+
+	if (toolName === "bash" && isGitCommand(args)) {
+		const tail = tailLines(text, COLLAPSED_TAIL_LINE_LIMIT);
+		return tail ? `\n${tail}` : "";
+	}
+	if (NO_COLLAPSED_RESULT_TOOLS.has(toolName)) return "";
+	if (COLLAPSED_TAIL_TOOLS.has(toolName)) {
+		const tail = tailLines(text, COLLAPSED_TAIL_LINE_LIMIT);
+		return tail ? `\n${tail}` : "";
+	}
+	if (isEmptyResultMessage(toolName, text)) return "";
+
+	const summaryLabel = COLLAPSED_COUNT_LABELS[toolName];
+	if (!summaryLabel) return "";
+
+	const count = countNonEmptyLines(text);
+	return count > 0 ? ` → ${count} ${summaryLabel}` : "";
+}
+
+function lineRangeSuffix(args: Record<string, unknown>, theme: ThemeLike): string {
+	if (args.offset === undefined && args.limit === undefined) return "";
+	const startLine = typeof args.offset === "number" ? args.offset : 1;
+	const endLine = typeof args.limit === "number" ? startLine + args.limit - 1 : undefined;
+	return theme.fg("warning", `:${startLine}${endLine === undefined ? "" : `-${endLine}`}`);
+}
+
+function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, theme: ThemeLike): string {
+	switch (toolName) {
+		case "read": {
+			const path = safeText(shortenPath(args.path) || "...");
+			return `${theme.fg("toolTitle", theme.bold("read"))} ${theme.fg("accent", path)}${lineRangeSuffix(args, theme)}`;
+		}
+		case "bash": {
+			const command = safeText(asString(args.command, "..."));
+			const timeout = typeof args.timeout === "number" ? theme.fg("muted", ` (timeout ${args.timeout}s)`) : "";
+			return `${theme.fg("toolTitle", theme.bold(`$ ${command}`))}${timeout}`;
+		}
+		case "grep": {
+			let text = `${theme.fg("toolTitle", theme.bold("grep"))} ${theme.fg("accent", `/${safeText(asString(args.pattern))}/`)} in ${safeText(shortenPath(args.path) || ".")}`;
+			if (typeof args.glob === "string") text += theme.fg("toolOutput", ` (${safeText(args.glob)})`);
+			if (typeof args.limit === "number") text += theme.fg("toolOutput", ` limit ${args.limit}`);
+			return text;
+		}
+		case "find": {
+			let text = `${theme.fg("toolTitle", theme.bold("find"))} ${theme.fg("accent", safeText(asString(args.pattern, "*")))} in ${safeText(shortenPath(args.path) || ".")}`;
+			if (typeof args.limit === "number") text += theme.fg("toolOutput", ` limit ${args.limit}`);
+			return text;
+		}
+		case "ls": {
+			let text = `${theme.fg("toolTitle", theme.bold("ls"))} ${theme.fg("accent", safeText(shortenPath(args.path) || "."))}`;
+			if (typeof args.limit === "number") text += theme.fg("toolOutput", ` limit ${args.limit}`);
+			return text;
+		}
+		case "edit":
+			return `${theme.fg("toolTitle", theme.bold("edit"))} ${theme.fg("accent", safeText(shortenPath(args.path) || "..."))}`;
+		case "write": {
+			const content = typeof args.content === "string" ? args.content : "";
+			const lineInfo = content.length > 0 ? theme.fg("muted", ` (${content.split("\n").length} lines)`) : "";
+			return `${theme.fg("toolTitle", theme.bold("write"))} ${theme.fg("accent", safeText(shortenPath(args.path) || "..."))}${lineInfo}`;
+		}
+	}
+}
+
+function partialLabel(toolName: QuietToolName): string {
+	return toolName === "bash" ? "Running..." : `${toolName}...`;
+}
+
+function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
+	const registrationTool = getBuiltInTools(process.cwd())[toolName];
+
+	pi.registerTool({
+		...registrationTool,
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const runtimeTool = getBuiltInTools(ctx.cwd)[toolName];
+			return runtimeTool.execute(toolCallId, params, signal, onUpdate, ctx);
+		},
+		renderCall(args, theme) {
+			return new Text(formatToolCall(toolName, args as Record<string, unknown>, theme), 0, 0);
+		},
+		renderResult(result, options, theme, context) {
+			if (options.isPartial) {
+				return new Text(theme.fg("warning", partialLabel(toolName)), 0, 0);
+			}
+			const output = formatToolResultOutput(toolName, result, {
+				expanded: options.expanded,
+				isError: options.isError,
+				args: context.args as Record<string, unknown> | undefined,
+			});
+			const color = options.expanded ? "toolOutput" : options.isError ? "error" : "muted";
+			return new Text(output ? theme.fg(color, output) : "", 0, 0);
+		},
+	});
+}
+
+export default function quietTools(pi: ExtensionAPI): void {
+	if (!quietToolsEnabled()) return;
+	for (const toolName of Object.keys(TOOL_CREATORS) as QuietToolName[]) {
+		registerQuietTool(pi, toolName);
+	}
+}

--- a/lib/quiet-tools-config.ts
+++ b/lib/quiet-tools-config.ts
@@ -1,0 +1,17 @@
+export const QUIET_TOOLS_ENV = "GENTLE_PI_QUIET_TOOLS";
+export const PI_PRETTY_SUPPRESSED_TOOL_NAMES = ["read", "bash", "ls", "find", "grep"] as const;
+
+export function quietToolsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	return env[QUIET_TOOLS_ENV] !== "0";
+}
+
+export function mergeDisabledTools(existing: string | undefined, tools: readonly string[]): string {
+	const disabled = new Set(
+		(existing ?? "")
+			.split(",")
+			.map((tool) => tool.trim().toLowerCase())
+			.filter(Boolean),
+	);
+	for (const tool of tools) disabled.add(tool);
+	return [...disabled].join(",");
+}

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -50,6 +50,10 @@ test("package manifest installs pi-pretty through a wrapper without bundling nat
 		"gentle-pi must expose pi-pretty through a packaged wrapper extension",
 	);
 	assert.ok(
+		existsSync(join(PACKAGE_ROOT, "extensions", "quiet-tools.ts")),
+		"gentle-pi must expose quiet built-in tool rendering through a packaged extension",
+	);
+	assert.ok(
 		!packageJson.bundledDependencies?.includes("@heyhuynhgiabuu/pi-pretty"),
 		"pi-pretty must not be bundled because its native optional dependencies are platform-specific",
 	);
@@ -105,4 +109,6 @@ test("pi-pretty wrapper uses real package path resolution for pnpm symlink insta
 	assert.match(wrapper, /realpathSync/);
 	assert.match(wrapper, /createRequire/);
 	assert.match(wrapper, /@heyhuynhgiabuu\/pi-pretty/);
+	assert.match(wrapper, /PI_PRETTY_SUPPRESSED_TOOL_NAMES/);
+	assert.match(wrapper, /quietToolsEnabled/);
 });

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import piPretty from "../extensions/pi-pretty.ts";
+import quietTools, {
+	countNonEmptyLines,
+	extractTextContent,
+	formatToolResultOutput,
+	tailLines,
+} from "../extensions/quiet-tools.ts";
+
+const passthroughTheme = {
+	bold(value: string) {
+		return value;
+	},
+	fg(_color: string, value: string) {
+		return value;
+	},
+};
+
+function renderToString(component: { render(width: number): string[] }): string {
+	return component.render(120).join("\n");
+}
+
+function textResult(text: string) {
+	return {
+		content: [{ type: "text", text }],
+	};
+}
+
+function createPi(options: { throwOnToolConflict?: boolean } = {}) {
+	const tools = new Map<string, any>();
+	const commands = new Map<string, any>();
+	const hooks = new Map<string, any[]>();
+	return {
+		tools,
+		pi: {
+			registerTool(tool: any) {
+				if (options.throwOnToolConflict && tools.has(tool.name)) {
+					throw new Error(`Tool ${tool.name} already registered`);
+				}
+				tools.set(tool.name, tool);
+			},
+			registerCommand(name: string, command: any) {
+				commands.set(name, command);
+			},
+			on(name: string, handler: any) {
+				hooks.set(name, [...(hooks.get(name) ?? []), handler]);
+			},
+		},
+	};
+}
+
+function createSdkTool(name: string) {
+	return {
+		name,
+		label: name,
+		description: `${name} tool`,
+		parameters: { type: "object", properties: {} },
+		execute: async () => textResult(`${name} result`),
+	};
+}
+
+const fakePiPrettyDeps = {
+	sdk: {
+		createReadTool: () => createSdkTool("read"),
+		createBashTool: () => createSdkTool("bash"),
+		createLsTool: () => createSdkTool("ls"),
+		createFindTool: () => createSdkTool("find"),
+		createGrepTool: () => createSdkTool("grep"),
+	},
+};
+
+function withEnv<T>(updates: Record<string, string | undefined>, run: () => T): T {
+	const previous = Object.fromEntries(Object.keys(updates).map((key) => [key, process.env[key]]));
+	try {
+		for (const [key, value] of Object.entries(updates)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		return run();
+	} finally {
+		for (const [key, value] of Object.entries(previous)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	}
+}
+
+async function withEnvAsync<T>(updates: Record<string, string | undefined>, run: () => Promise<T>): Promise<T> {
+	const previous = Object.fromEntries(Object.keys(updates).map((key) => [key, process.env[key]]));
+	try {
+		for (const [key, value] of Object.entries(updates)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		return await run();
+	} finally {
+		for (const [key, value] of Object.entries(previous)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	}
+}
+
+test("quiet tool rendering registers noisy built-in tools", () => {
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => {
+		const { pi, tools } = createPi();
+
+		quietTools(pi as any);
+
+		for (const toolName of ["read", "bash", "grep", "find", "ls", "edit", "write"]) {
+			const tool = tools.get(toolName);
+			assert.ok(tool, `missing quiet renderer for ${toolName}`);
+			assert.equal(typeof tool.execute, "function", `${toolName} must delegate execution`);
+			assert.ok(tool.parameters, `${toolName} must preserve built-in parameters`);
+		}
+	});
+});
+
+test("quiet tool rendering can be disabled by env", () => {
+	withEnv({ GENTLE_PI_QUIET_TOOLS: "0" }, () => {
+		const { pi, tools } = createPi();
+
+		quietTools(pi as any);
+
+		assert.equal(tools.size, 0);
+	});
+});
+
+test("pi-pretty suppresses overlapping tools before quiet tools register", async () => {
+	await withEnvAsync(
+		{ GENTLE_PI_QUIET_TOOLS: undefined, PRETTY_DISABLE_TOOLS: "multi_grep" },
+		async () => {
+			const { pi, tools } = createPi({ throwOnToolConflict: true });
+
+			await piPretty(pi as any, fakePiPrettyDeps as any);
+			quietTools(pi as any);
+
+			for (const toolName of ["read", "bash", "grep", "find", "ls", "edit", "write"]) {
+				assert.ok(tools.has(toolName), `missing quiet tool ${toolName}`);
+			}
+			assert.equal(process.env.PRETTY_DISABLE_TOOLS, "multi_grep,read,bash,ls,find,grep");
+		},
+	);
+});
+
+test("pi-pretty suppression is skipped when quiet tools are disabled", async () => {
+	await withEnvAsync(
+		{ GENTLE_PI_QUIET_TOOLS: "0", PRETTY_DISABLE_TOOLS: undefined },
+		async () => {
+			const { pi, tools } = createPi();
+
+			await piPretty(pi as any, fakePiPrettyDeps as any);
+			quietTools(pi as any);
+
+			for (const toolName of ["read", "bash", "grep", "find", "ls"]) {
+				assert.ok(tools.has(toolName), `pi-pretty should keep ${toolName} when quiet tools are disabled`);
+			}
+			assert.equal(process.env.PRETTY_DISABLE_TOOLS, undefined);
+		},
+	);
+});
+
+test("quiet tool rendering hides noisy result bodies while collapsed and restores them when expanded", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+
+	const cases = [
+		{ tool: "read", text: "first line\nsecond line", hidden: "first line", expanded: "second line" },
+		{ tool: "bash", text: "stdout line\nstderr line", hidden: "stdout line", expanded: "stderr line" },
+		{ tool: "grep", text: "src/a.ts:1:match\nsrc/b.ts:2:match", hidden: "src/a.ts", expanded: "src/b.ts" },
+		{ tool: "find", text: "src/a.ts\nsrc/b.ts", hidden: "src/a.ts", expanded: "src/b.ts" },
+		{ tool: "ls", text: "file-a.ts\nfile-b.ts", hidden: "file-a.ts", expanded: "file-b.ts" },
+	];
+
+	for (const entry of cases) {
+		const tool = tools.get(entry.tool);
+		const collapsed = renderToString(
+			tool.renderResult(textResult(entry.text), { expanded: false, isPartial: false }, passthroughTheme, {}),
+		);
+		const expanded = renderToString(
+			tool.renderResult(textResult(entry.text), { expanded: true, isPartial: false }, passthroughTheme, {}),
+		);
+
+		assert.doesNotMatch(collapsed, new RegExp(entry.hidden.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${entry.tool} collapsed output must not include result body`);
+		assert.match(expanded, new RegExp(entry.expanded.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${entry.tool} expanded output must include full result body`);
+	}
+});
+
+test("quiet tool rendering keeps compact collapsed summaries for search and listing tools", () => {
+	assert.equal(countNonEmptyLines("a\n\n b \n"), 2);
+	assert.equal(extractTextContent(textResult("alpha\nbeta") as any), "alpha\nbeta");
+	assert.equal(formatToolResultOutput("grep", textResult("a\nb\n") as any, { expanded: false }), " → 2 matches");
+	assert.equal(formatToolResultOutput("find", textResult("a\nb\n") as any, { expanded: false }), " → 2 files");
+	assert.equal(formatToolResultOutput("ls", textResult("a\nb\n") as any, { expanded: false }), " → 2 entries");
+	assert.equal(formatToolResultOutput("grep", textResult("No matches found") as any, { expanded: false }), "");
+	assert.equal(formatToolResultOutput("find", textResult("No files found matching pattern") as any, { expanded: false }), "");
+	assert.equal(formatToolResultOutput("ls", textResult("Directory is empty") as any, { expanded: false }), "");
+	assert.equal(formatToolResultOutput("read", textResult("a\nb\n") as any, { expanded: false }), "");
+	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false }), "");
+	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false, args: { command: "git diff" } }), "\na\nb\n");
+	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false, args: { command: "git -C repo status" } }), "\na\nb\n");
+	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false, args: { command: "echo git diff" } }), "");
+	assert.equal(formatToolResultOutput("edit", textResult("updated") as any, { expanded: false }), "\nupdated");
+	assert.equal(formatToolResultOutput("write", textResult("wrote") as any, { expanded: false }), "\nwrote");
+	assert.equal(formatToolResultOutput("grep", textResult("a\nb\n") as any, { expanded: true }), "\na\nb\n");
+	assert.equal(formatToolResultOutput("read", textResult("ENOENT: missing file") as any, { expanded: false, isError: true }), "\nENOENT: missing file");
+});
+
+test("quiet tool rendering keeps collapsed git bash result tails", () => {
+	const text = Array.from({ length: 12 }, (_, index) => `git line ${index + 1}`).join("\n");
+
+	assert.equal(formatToolResultOutput("bash", textResult(text) as any, { expanded: false, args: { command: "git diff" } }), `\n${tailLines(text, 10)}`);
+	assert.equal(formatToolResultOutput("bash", textResult(text) as any, { expanded: false, args: { command: "git status --short" } }), `\n${tailLines(text, 10)}`);
+});
+
+test("quiet tool rendering keeps collapsed edit and write result tails", () => {
+	const text = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n");
+
+	assert.equal(tailLines(text, 10), Array.from({ length: 10 }, (_, index) => `line ${index + 3}`).join("\n"));
+	assert.equal(formatToolResultOutput("edit", textResult(text) as any, { expanded: false }), `\n${tailLines(text, 10)}`);
+	assert.equal(formatToolResultOutput("write", textResult(text) as any, { expanded: false }), `\n${tailLines(text, 10)}`);
+});
+
+test("quiet tool rendering sanitizes collapsed output and call rows", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+
+	const collapsed = renderToString(
+		tools.get("write").renderResult(textResult("safe\x1b[31mred\x1b[0m"), { expanded: false, isPartial: false }, passthroughTheme, {}),
+	);
+	const call = renderToString(tools.get("bash").renderCall({ command: "echo \x1b[31mred\x1b[0m" }, passthroughTheme, {}));
+
+	assert.equal(collapsed.replace(/[ \t]+$/gm, ""), "\nsafered");
+	assert.equal(call.trimEnd(), "$ echo red");
+});
+
+test("quiet tool rendering call rows show tool calls without result output", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+
+	const readCall = renderToString(tools.get("read").renderCall({ path: "/tmp/example.ts", offset: 2, limit: 3 }, passthroughTheme, {}));
+	const bashCall = renderToString(tools.get("bash").renderCall({ command: "printf noisy", timeout: 5 }, passthroughTheme, {}));
+	const grepCall = renderToString(tools.get("grep").renderCall({ pattern: "needle", path: "src", glob: "*.ts" }, passthroughTheme, {}));
+
+	assert.match(readCall, /read .*example\.ts:2-4/);
+	assert.match(bashCall, /\$ printf noisy \(timeout 5s\)/);
+	assert.match(grepCall, /grep \/needle\/ in src \(\*\.ts\)/);
+});

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -12,6 +12,7 @@ import { stripAnsi } from "../lib/terminal-theme.ts";
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const EXTENSIONS = [
 	"extensions/gentle-ai.ts",
+	"extensions/quiet-tools.ts",
 	"extensions/skill-registry.ts",
 	"extensions/sdd-init.ts",
 	"extensions/startup-banner.ts",
@@ -59,6 +60,7 @@ function createPi() {
 	const hooks = new Map();
 	const commands = new Map();
 	const flags = new Map();
+	const tools = new Map();
 	const flagValues = new Map([["no-skill-registry", true]]);
 	let activeTools = ["read", "bash", "edit", "write"];
 
@@ -73,6 +75,9 @@ function createPi() {
 		},
 		registerFlag(name, definition) {
 			flags.set(name, definition);
+		},
+		registerTool(definition) {
+			tools.set(definition.name, definition);
 		},
 		getFlag(name) {
 			return flagValues.get(name) ?? false;
@@ -100,7 +105,7 @@ function createPi() {
 		},
 	};
 
-	return { pi, hooks, commands, flags };
+	return { pi, hooks, commands, flags, tools };
 }
 
 function createUi() {
@@ -170,7 +175,7 @@ async function run() {
 	process.env.GENTLE_PI_TEST_ASSETS_DIR = ambientTestAssetsDir;
 	const globalModelsPath = join(globalConfigHome, "models.json");
 	const globalSubagentsPath = join(globalAgentHome, "subagents.json");
-	const { pi, hooks, commands, flags } = createPi();
+	const { pi, hooks, commands, flags, tools } = createPi();
 	await loadExtensions(pi);
 
 	for (const name of EXPECTED_COMMANDS) {
@@ -185,6 +190,9 @@ async function run() {
 	assert.ok(hooks.has("input"), "missing input hook");
 	assert.ok(hooks.has("before_agent_start"), "missing before_agent_start hook");
 	assert.ok(hooks.has("tool_call"), "missing tool_call hook");
+	for (const toolName of ["read", "bash", "grep", "find", "ls", "edit", "write"]) {
+		assert.ok(tools.has(toolName), `missing quiet built-in tool renderer ${toolName}`);
+	}
 
 	for (const entry of await readdir(join(ROOT, "assets", "agents"))) {
 		if (!entry.endsWith(".md")) continue;


### PR DESCRIPTION
Closes #81

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a quiet built-in tool renderer extension for calmer collapsed Pi TUI output.
- Preserves full expanded output and keeps errors visible.
- Coordinates with pi-pretty to avoid duplicate tool registration conflicts.

## Changes
| File | Change |
|------|--------|
| `extensions/quiet-tools.ts` | Adds quiet renderers for read/bash/grep/find/ls/edit/write with sanitized output. |
| `extensions/pi-pretty.ts` | Suppresses overlapping pi-pretty tools while quiet tools are enabled. |
| `lib/quiet-tools-config.ts` | Centralizes quiet-tool env/config helpers. |
| `tests/quiet-tool-rendering.test.ts` | Covers collapsed/expanded behavior, env disablement, pi-pretty interop, git/edit/write tails, and sanitization. |
| `tests/package-manifest.test.ts` | Verifies quiet extension packaging expectations. |
| `tests/runtime-harness.mjs` | Ensures quiet renderers load in runtime harness. |

## Test Plan
- [x] `pnpm test`
- [x] `node scripts/verify-package-files.mjs`
- [x] `git diff --check`
- [x] `GENTLE_PI_QUIET_TOOLS=0 node --experimental-strip-types --test tests/quiet-tool-rendering.test.ts tests/package-manifest.test.ts`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck not applicable; no shell scripts changed
- [x] Tested in Pi locally with local extension stack
- [x] Docs updated if behavior changed: not required, package behavior is extension-driven
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quieter tool-rendering mode with cleaner, more compact output for built-in commands.
  * Introduced support for automatically suppressing selected tool output when quiet mode is enabled.
  * Added handling to preserve useful details like paths, ranges, and recent output where helpful.

* **Bug Fixes**
  * Improved consistency of tool-call displays and collapsed results.
  * Sanitized terminal formatting so hidden output is easier to read.

* **Tests**
  * Expanded coverage for package contents, quiet-mode behavior, and tool-rendering output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->