### PR TITLE
fix(review): harden Pi review recovery flow

### DIFF
--- a/assets/orchestrator-delegation.md
+++ b/assets/orchestrator-delegation.md
@@ -177,6 +177,20 @@ If multiple rows match, run the narrow set that covers the risk. Example: shell 
 
 ## Bounded Review Transaction Contract
 
+### Controller Start and Recovery Routing
+
+Call `gentle_review` INSPECT before START. On `clean`, ordinary review uses this outer tool shape, with `input` serialized as a JSON string rather than supplied as a nested object:
+
+```json
+{"operation":"start","lineageId":"<lineage>","idempotencyKey":"<key>","input":"{\"mode\":\"ordinary\",\"projection\":{\"kind\":\"complete\"},\"policyHash\":\"<hash>\",\"evidenceHash\":\"<hash>\",\"budget\":{...}}"}
+```
+
+START supports exactly `ordinary` and `judgment-day`. Use mode `ordinary` for normal review. Use `judgment-day` only when the user explicitly selected Judgment Day.
+
+When INSPECT or START reports `blocked-legacy` or `blocked-mixed`, do not retry START and do not present migration as an option. Explain that the old receipts, approvals, ledgers, and lineages will lose authority, then request explicit user authorization for the exact returned `reset_request.confirmation`. RESET and RECOVER independently require a fresh operation-bound confirmation through the interactive Pi UI and fail closed in headless execution. The UI boundary cannot cryptographically attest the human's identity, so its residual trust is the operator controlling that Pi session; challenge freshness and repository/inventory binding remain runtime-enforced. Only after authorization, call RESET with the exact serialized `reset_request`; RESET and RECOVER internally INSPECT authority, and only a returned `clean` inspection with `start-fresh-ordinary-review-after-verified-clean` permits an immediate fresh ordinary START. If INSPECT reports `reset-in-progress`, use its durable original `reset_request` for authorized RECOVER.
+
+A `lineage_created: false` result or a validation error explicitly marked as occurring before authority access proves that no lineage was created; never call STATUS or ADVANCE for that attempt. A thrown START after authority access or lost output/response is ambiguous because authority may already be committed. Before any fresh START, replay or resume with the same `lineageId`, `idempotencyKey`, and exact request; the durable journal must return the committed result or reject a mismatch. Never choose a different fresh lineage merely because START output was lost.
+
 Ordinary review runs the selected zero, one, or four lenses exactly once against `initial_review_tree`.
 
 Before corroboration, the controller freezes canonical ID-sorted identity, claim, and evidence rows under `frozen_ledger_hash`.

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -49,7 +49,8 @@ import {
 } from "../lib/sdd-status.ts";
 import type { TriggerEvent } from "../lib/review-triggers.ts";
 import { ReviewBundleExporter, ReviewBundleImporter } from "../lib/review-bundle.ts";
-import { inspectLegacyReviewAuthorityV1 } from "../lib/review-legacy-detector.ts";
+import { domainHashV1 } from "../lib/review-canonical.ts";
+import { inspectLegacyReviewAuthorityV1, type LegacyInspectionV1 } from "../lib/review-legacy-detector.ts";
 import { destructiveResetReviewAuthorityV1 } from "../lib/review-reset.ts";
 import { ReviewMutationLockV1 } from "../lib/review-lock.ts";
 import { resolveRepositoryAuthorityV1 } from "../lib/review-repository.ts";
@@ -57,7 +58,9 @@ import {
 	EXTERNAL_RELEASE_EVIDENCE,
 	GATE_RESULT,
 	GATE_TARGET_KIND,
+	JOURNAL_STATUS,
 	PUSH_UPDATE_KIND,
+	REVIEW_OPERATION,
 	REVIEW_TRANSITION,
 	ReviewTransactionStore,
 	canonicalHash,
@@ -69,6 +72,7 @@ import {
 	type ReleaseFastPathEvidenceV1,
 	type ReviewBudgetV1,
 	type ReviewReducerInput,
+	type StartOperationResultV1,
 	type ReviewTransition,
 } from "../lib/review-transaction.ts";
 import {
@@ -2073,11 +2077,11 @@ const REVIEW_CONTROLLER_PARAMETERS = {
 		operation: {
 			type: "string",
 			enum: Object.values(REVIEW_CONTROLLER_OPERATION),
-			description: "Controller operation: start, advance, status, or validate.",
+			description: "Controller operation. Inspect authority before start. Reset requires the exact challenge returned by inspect.",
 		},
 		lineageId: {
 			type: "string",
-			description: "Bounded review lineage identifier.",
+			description: "Bounded review lineage identifier. A failed start creates no lineage; do not use it with status or advance.",
 		},
 		idempotencyKey: {
 			type: "string",
@@ -2093,7 +2097,7 @@ const REVIEW_CONTROLLER_PARAMETERS = {
 		},
 		input: {
 			type: "string",
-			description: "JSON object containing operation-specific controller input.",
+			description: "A JSON-serialized object string, not a nested object. Exact ordinary START shape: {\"mode\":\"ordinary\",\"projection\":{\"kind\":\"complete\"},\"policyHash\":\"<hash>\",\"evidenceHash\":\"<hash>\",\"budget\":{...}}. START supports only mode ordinary or judgment-day; use judgment-day only when explicitly selected.",
 		},
 		outputPath: { type: "string", description: "Destination path for deterministic bundle export." },
 		inputPath: { type: "string", description: "Source path for staged bundle import." },
@@ -2128,6 +2132,26 @@ interface ReviewControllerStartInput {
 interface ReviewControllerValidateInput {
 	scopeBudget: ReviewBudgetV1;
 	release?: ReleaseFastPathEvidenceV1;
+}
+
+interface ReviewResetStateBody {
+	schema: string;
+	reset_id: string;
+	repository_id: string;
+	common_directory_hash: string;
+	authorized_inventory_hash: string;
+	authorization_hash: string;
+	sequence: number;
+	phase: string;
+	quarantine_relative_path: string;
+	moved_roots: string[];
+	deleted_roots: string[];
+	identity_recovery?: boolean;
+}
+
+interface ReviewResetStateEnvelope {
+	body: ReviewResetStateBody;
+	reset_state_hash: string;
 }
 
 interface DerivedReviewGateTarget {
@@ -2172,6 +2196,9 @@ function parseReviewControllerParameters(value: unknown): ReviewControllerParame
 	for (const key of ["idempotencyKey", "transition", "command", "input", "outputPath", "inputPath", "operationId", "lineageIds", "acknowledgeUntrustedBundleSource"] as const) {
 		const optional = value[key];
 		if (optional !== undefined && typeof optional !== "string") {
+			if (value.operation === REVIEW_CONTROLLER_OPERATION.START && key === "input") {
+				throw new Error("Review controller START input must be a JSON string encoding an object, not a nested object. No lineage was created; do not call STATUS or ADVANCE for this attempted lineage.");
+			}
 			throw new Error(`Review controller ${key} must be a string`);
 		}
 		if (typeof optional === "string") parameters[key] = optional;
@@ -2209,12 +2236,119 @@ function parseControllerJson(input: string, operation: ReviewControllerOperation
 	try {
 		value = JSON.parse(input);
 	} catch (error) {
+		if (operation === REVIEW_CONTROLLER_OPERATION.START) {
+			throw new Error(
+				`Review controller START input must be a JSON string encoding an object: ${error instanceof Error ? error.message : String(error)}. No lineage was created; do not call STATUS or ADVANCE for this attempted lineage.`,
+			);
+		}
 		throw new Error(
 			`Review controller ${operation} input is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	}
 	if (!isRecord(value)) throw new Error(`Review controller ${operation} input must be a JSON object`);
 	return value;
+}
+
+function durableResetRecoveryRequest(cwd: string): LegacyInspectionV1["reset_request"] {
+	const authority = resolveRepositoryAuthorityV1(cwd);
+	const value = JSON.parse(readFileSync(join(authority.store_root, "control", "reset-state.json"), "utf8")) as unknown;
+	if (!isRecord(value) || !isRecord(value.body)) throw new Error("Review reset recovery state is malformed");
+	const envelope = value as unknown as ReviewResetStateEnvelope;
+	const body = envelope.body;
+	if (
+		body.schema !== "gentle-ai.review-reset-state/v1" ||
+		typeof body.reset_id !== "string" ||
+		typeof body.repository_id !== "string" ||
+		typeof body.common_directory_hash !== "string" ||
+		typeof body.authorized_inventory_hash !== "string" ||
+		typeof body.authorization_hash !== "string" ||
+		!Number.isSafeInteger(body.sequence) ||
+		typeof body.phase !== "string" ||
+		typeof body.quarantine_relative_path !== "string" ||
+		!Array.isArray(body.moved_roots) ||
+		!Array.isArray(body.deleted_roots) ||
+		typeof envelope.reset_state_hash !== "string" ||
+		envelope.reset_state_hash !== domainHashV1("reset-state", body)
+	) {
+		throw new Error("Review reset recovery state failed integrity validation");
+	}
+	const currentCommonDirectoryHash = domainHashV1("common-directory", authority.common_directory);
+	if (
+		body.repository_id !== authority.repository_id ||
+		body.common_directory_hash !== currentCommonDirectoryHash
+	) {
+		throw new Error("Review reset recovery state does not match the current repository authority");
+	}
+	const allowedRoots = new Set([
+		"lineages",
+		"locks",
+		"legacy-evidence",
+		"migration",
+		"migration-operations",
+		"graph-v1",
+		...(body.identity_recovery === true ? ["IDENTITY"] : []),
+	]);
+	const expectedQuarantinePath = join("reset-quarantine", body.reset_id);
+	if (
+		!/^[0-9a-f]{64}$/.test(body.reset_id) ||
+		body.quarantine_relative_path !== expectedQuarantinePath ||
+		isAbsolute(body.quarantine_relative_path) ||
+		body.moved_roots.some((root) => typeof root !== "string" || !allowedRoots.has(root)) ||
+		body.deleted_roots.some((root) => typeof root !== "string" || !body.moved_roots.includes(root)) ||
+		new Set(body.moved_roots).size !== body.moved_roots.length ||
+		new Set(body.deleted_roots).size !== body.deleted_roots.length
+	) {
+		throw new Error("Review reset recovery state contains unsafe quarantine path semantics");
+	}
+	const confirmation = `DESTROY REVIEW AUTHORITY ${body.repository_id} AT ${body.common_directory_hash} INVENTORY ${body.authorized_inventory_hash}`;
+	if (body.authorization_hash !== domainHashV1("reset-authorization", confirmation)) {
+		throw new Error("Review reset recovery authorization failed integrity validation");
+	}
+	return {
+		repositoryId: body.repository_id,
+		commonDirHash: body.common_directory_hash,
+		inventoryHash: body.authorized_inventory_hash,
+		confirmation,
+	};
+}
+
+function inspectReviewAuthorityForController(cwd: string): LegacyInspectionV1 {
+	const inspection = inspectLegacyReviewAuthorityV1(cwd);
+	return inspection.outcome === "reset-in-progress"
+		? { ...inspection, reset_request: durableResetRecoveryRequest(cwd) }
+		: inspection;
+}
+
+async function authorizeDestructiveReviewOperation(
+	parametersValue: unknown,
+	ctx: ExtensionContext,
+): Promise<void> {
+	const parameters = parseReviewControllerParameters(parametersValue);
+	if (
+		parameters.operation !== REVIEW_CONTROLLER_OPERATION.RESET &&
+		parameters.operation !== REVIEW_CONTROLLER_OPERATION.RECOVER
+	) return;
+	const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);
+	for (const key of ["repositoryId", "commonDirHash", "inventoryHash", "confirmation"] as const) {
+		if (typeof input[key] !== "string" || input[key].length === 0) {
+			throw new Error(`Review controller ${parameters.operation} requires an exact string ${key}`);
+		}
+	}
+	if (!ctx.hasUI) {
+		throw new Error(`Review controller ${parameters.operation.toUpperCase()} requires fresh explicit authorization through the interactive Pi UI; headless execution fails closed`);
+	}
+	const approved = await ctx.ui.confirm(
+		`Authorize destructive review authority ${parameters.operation.toUpperCase()}?`,
+		[
+			`Operation: ${parameters.operation.toUpperCase()}`,
+			`Repository: ${input.repositoryId}`,
+			`Exact challenge: ${input.confirmation}`,
+			"This invalidates all prior review authority for this repository.",
+		].join("\n"),
+	);
+	if (!approved) {
+		throw new Error(`Review controller ${parameters.operation.toUpperCase()} was not explicitly authorized`);
+	}
 }
 
 function parseReviewBudget(value: unknown, label: string): ReviewBudgetV1 {
@@ -2224,7 +2358,9 @@ function parseReviewBudget(value: unknown, label: string): ReviewBudgetV1 {
 
 function parseStartInput(value: Record<string, unknown>): ReviewControllerStartInput {
 	if (value.mode !== REVIEW_MODE.ORDINARY && value.mode !== REVIEW_MODE.JUDGMENT_DAY) {
-		throw new Error("Review controller start mode is unsupported");
+		throw new Error(
+			'Review controller START supports only "ordinary" or "judgment-day" mode; use "ordinary" unless Judgment Day was explicitly selected. Pass input as a JSON string encoding the START object. START failed before authority access, so no lineage was created; do not call STATUS or ADVANCE for this attempted lineage.',
+		);
 	}
 	if (!isRecord(value.projection) || typeof value.projection.kind !== "string") {
 		throw new Error("Review controller start requires a projection");
@@ -2932,7 +3068,22 @@ function executeReviewControllerOperation(
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.INSPECT) {
 		const authority = resolveRepositoryAuthorityV1(defaultCwd);
 		const lock = new ReviewMutationLockV1(join(authority.store_root, "control"), authority.repository_id, authority.authority_id);
-		return { operation: parameters.operation, inspection: inspectLegacyReviewAuthorityV1(defaultCwd), lock: lock.inspect() };
+		const inspection = inspectReviewAuthorityForController(defaultCwd);
+		return {
+			operation: parameters.operation,
+			inspection,
+			lock: lock.inspect(),
+			...(inspection.outcome === "clean"
+				? { status: "ready", next_action: "start-ordinary-review" }
+				: inspection.outcome === "blocked-ambiguous"
+					? { status: "blocked", next_action: "stop-and-report-ambiguous-authority" }
+					: {
+						status: "blocked",
+						next_action: inspection.outcome === "reset-in-progress"
+							? "request-explicit-reset-recovery-authorization"
+							: "request-explicit-reset-authorization",
+					}),
+		};
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.RECOVER_LOCK) {
 		const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);
@@ -2944,11 +3095,16 @@ function executeReviewControllerOperation(
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.RECOVER) {
 		const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);
-		return { operation: parameters.operation, result: destructiveResetReviewAuthorityV1({ cwd: defaultCwd, repositoryId: String(input.repositoryId), commonDirHash: String(input.commonDirHash), inventoryHash: String(input.inventoryHash), confirmation: String(input.confirmation), resume: true }) };
+		durableResetRecoveryRequest(defaultCwd);
+		const result = destructiveResetReviewAuthorityV1({ cwd: defaultCwd, repositoryId: String(input.repositoryId), commonDirHash: String(input.commonDirHash), inventoryHash: String(input.inventoryHash), confirmation: String(input.confirmation), resume: true });
+		const inspection = inspectReviewAuthorityForController(defaultCwd);
+		return { operation: parameters.operation, result, inspection, next_action: inspection.outcome === "clean" ? "start-fresh-ordinary-review-after-verified-clean" : "inspect-reset-recovery" };
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.RESET) {
 		const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);
-		return { operation: parameters.operation, result: destructiveResetReviewAuthorityV1({ cwd: defaultCwd, repositoryId: String(input.repositoryId), commonDirHash: String(input.commonDirHash), inventoryHash: String(input.inventoryHash), confirmation: String(input.confirmation), resume: false }) };
+		const result = destructiveResetReviewAuthorityV1({ cwd: defaultCwd, repositoryId: String(input.repositoryId), commonDirHash: String(input.commonDirHash), inventoryHash: String(input.inventoryHash), confirmation: String(input.confirmation), resume: false });
+		const inspection = inspectReviewAuthorityForController(defaultCwd);
+		return { operation: parameters.operation, result, inspection, next_action: inspection.outcome === "clean" ? "start-fresh-ordinary-review-after-verified-clean" : "inspect-reset-recovery" };
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.REPAIR) {
 		const store = ReviewTransactionStore.forRepository(defaultCwd);
@@ -2963,6 +3119,20 @@ function executeReviewControllerOperation(
 				REVIEW_CONTROLLER_OPERATION.START,
 			),
 		);
+		const inspection = inspectReviewAuthorityForController(defaultCwd);
+		if (inspection.outcome !== "clean") {
+			return {
+				operation: parameters.operation,
+				status: "blocked",
+				lineage_created: false,
+				inspection,
+				next_action: inspection.outcome === "blocked-ambiguous"
+					? "stop-and-report-ambiguous-authority"
+					: inspection.outcome === "reset-in-progress"
+						? "request-explicit-reset-recovery-authorization"
+						: "request-explicit-reset-authorization",
+			};
+		}
 		const snapshot = captureReviewSnapshot({
 			cwd: defaultCwd,
 			mode: input.mode,
@@ -2981,10 +3151,23 @@ function executeReviewControllerOperation(
 				? stateInput
 				: { ...stateInput, parentLineageId: input.parentLineageId },
 		);
-		const result = ReviewTransactionStore.forRepository(defaultCwd).create(
-			state,
-			idempotencyKey,
-		);
+		const store = ReviewTransactionStore.forRepository(defaultCwd);
+		let result: StartOperationResultV1;
+		try {
+			result = store.create(state, idempotencyKey);
+		} catch (error) {
+			if (!(error instanceof Error) || error.message !== "Graph lineage already exists") throw error;
+			const current = store.read(parameters.lineageId!);
+			const existing = current.request_journal.find((entry) => entry.idempotency_key === idempotencyKey);
+			if (
+				existing?.operation !== REVIEW_OPERATION.START ||
+				existing.request_hash !== canonicalHash(state) ||
+				existing.status !== JOURNAL_STATUS.COMPLETED
+			) {
+				throw new Error("Idempotency key was reused with a different START request; replay requires the same lineageId, idempotencyKey, and exact request");
+			}
+			result = existing.canonical_result as StartOperationResultV1;
+		}
 		return { operation: parameters.operation, result, state };
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.ADVANCE) {
@@ -3235,15 +3418,20 @@ export default function gentleAi(pi: ExtensionAPI): void {
 		name: "gentle_review",
 		label: "Gentle Review Controller",
 		description:
-			"Create, advance, inspect, and validate a bounded Gentle AI review transaction. Validate accepts one exact direct lifecycle command, derives its typed target from the command itself, and produces a one-shot authorization consumed by that exact subsequent bash command.",
-		promptSnippet: "Create, advance, inspect, or validate a bounded review transaction",
+			"Inspect, recover, create, advance, and validate a bounded Gentle AI review transaction. Before START, call INSPECT. RESET and RECOVER require fresh explicit authorization through the interactive Pi UI and fail closed headlessly. Their response internally INSPECTS authority; only a verified clean result permits an immediate fresh ordinary START. Validate accepts one exact direct lifecycle command and produces a one-shot authorization for that exact subsequent bash command.",
+		promptSnippet: "Inspect review authority before START; recover blocked legacy authority only with explicit authorization; then start ordinary review",
 		promptGuidelines: [
-			"Use gentle_review for bounded review transaction start, advance, status, and exact lifecycle validation; never fabricate bash tool metadata or a separate gate target.",
+			'Call {"operation":"inspect"} before START. Ordinary START requires operation, lineageId, idempotencyKey, and input as a JSON string such as "{\\"mode\\":\\"ordinary\\",\\"projection\\":{\\"kind\\":\\"complete\\"},\\"policyHash\\":\\"<hash>\\",\\"evidenceHash\\":\\"<hash>\\",\\"budget\\":{...}}".',
+			'Only START modes "ordinary" and "judgment-day" are supported. Use "ordinary" by default; use "judgment-day" only when the user explicitly selected Judgment Day.',
+			"For blocked-legacy or blocked-mixed, do not call START repeatedly. Explain invalidation, request explicit user authorization for the exact reset_request challenge, then call RESET or RECOVER only after authorization. RESET and RECOVER internally INSPECT authority; require their verified clean result and next_action start-fresh-ordinary-review-after-verified-clean before continuing directly to a fresh ordinary START.",
+			"A reported lineage_created false or a validation error explicitly marked before authority access proves no lineage was created; do not call STATUS or ADVANCE for that attempt. If START output or response is lost after authority access, completion is ambiguous: before any fresh START, replay or resume with the same lineageId, idempotencyKey, and exact request so the durable journal returns the committed result or rejects a mismatch.",
+			"Use gentle_review for bounded review transaction operations and exact lifecycle validation; never fabricate bash tool metadata or a separate gate target.",
 		],
 		parameters: REVIEW_CONTROLLER_PARAMETERS,
 		executionMode: "sequential",
 		async execute(_toolCallId, parameters, signal, _onUpdate, ctx) {
 			if (signal?.aborted) throw new Error("Review controller operation was cancelled");
+			await authorizeDestructiveReviewOperation(parameters, ctx);
 			const details = executeReviewControllerOperation(
 				parameters,
 				ctx.cwd,

--- a/skills/gentle-ai/SKILL.md
+++ b/skills/gentle-ai/SKILL.md
@@ -73,6 +73,12 @@ If multiple rows match, run the narrow set that covers the risk. Example: shell 
 
 ## Bounded Review Transaction Contract
 
+Call `gentle_review` INSPECT before START. Normal review START uses exact mode `ordinary` and passes its operation-specific `input` as a JSON-serialized object string; mode `judgment-day` is valid only when the user explicitly selected Judgment Day.
+
+If INSPECT or START reports `blocked-legacy` or `blocked-mixed`, explain that legacy authority cannot be migrated and request explicit user authorization for the exact destructive-reset challenge. RESET and RECOVER each require fresh operation-bound confirmation through the interactive Pi UI and fail closed headlessly. The UI cannot cryptographically attest the human's identity; its residual trust is the operator controlling that Pi session, while exact challenge binding remains runtime-enforced. Only after authorization, call RESET with that exact challenge. RESET and RECOVER internally INSPECT authority; require a returned `clean` inspection with `start-fresh-ordinary-review-after-verified-clean`, then immediately issue a fresh ordinary START. For `reset-in-progress`, use INSPECT's durable original `reset_request` with authorized RECOVER.
+
+A `lineage_created: false` result or a validation error explicitly marked before authority access proves no lineage was created; do not call STATUS or ADVANCE for that attempt. A thrown START after authority access or lost output/response is ambiguous because authority may already be committed. Before any fresh START, replay or resume with the same `lineageId`, `idempotencyKey`, and exact request; the durable journal returns the committed result or rejects a mismatch. Never choose a different fresh lineage merely because START output was lost.
+
 Ordinary review runs the selected zero, one, or four lenses exactly once against `initial_review_tree`.
 
 Before corroboration, the controller freezes canonical ID-sorted identity, claim, and evidence rows under `frozen_ledger_hash`.

--- a/tests/review-controller.test.ts
+++ b/tests/review-controller.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -20,6 +20,8 @@ import {
 	type ReviewBudgetV1,
 } from "../lib/review-transaction.ts";
 import { ordinaryValidatorRequest } from "../lib/review-policy-ordinary.ts";
+import { domainHashV1 } from "../lib/review-canonical.ts";
+import { destructiveResetReviewAuthorityV1 } from "../lib/review-reset.ts";
 import { REVIEW_LENS, REVIEW_ROUTE } from "../lib/review-triggers.ts";
 import { qualifiedReviewLockPlatform, testSnapshot } from "./review-test-fixtures.ts";
 
@@ -36,6 +38,9 @@ interface ReviewToolResult {
 
 interface RegisteredReviewTool {
 	name: string;
+	description: string;
+	promptSnippet?: string;
+	promptGuidelines?: readonly string[];
 	parameters: unknown;
 	execute: (
 		toolCallId: string,
@@ -44,6 +49,27 @@ interface RegisteredReviewTool {
 		onUpdate: undefined,
 		ctx: ExtensionContext,
 	) => Promise<ReviewToolResult>;
+}
+
+function createLegacyReviewAuthority(repository: string): void {
+	mkdirSync(join(repository, ".git", "gentle-ai", "reviews", "lineages", "legacy", "revisions"), { recursive: true });
+	writeFileSync(join(repository, ".git", "gentle-ai", "reviews", "lineages", "legacy", "HEAD"), "legacy authority");
+}
+
+function rewriteResetState(
+	repository: string,
+	mutate: (body: Record<string, unknown>) => void,
+): string {
+	const path = join(repository, ".git", "gentle-ai", "reviews", "control", "reset-state.json");
+	const envelope = JSON.parse(readFileSync(path, "utf8")) as {
+		body: Record<string, unknown>;
+		reset_state_hash: string;
+	};
+	mutate(envelope.body);
+	envelope.reset_state_hash = domainHashV1("reset-state", envelope.body);
+	const serialized = JSON.stringify(envelope);
+	writeFileSync(path, serialized);
+	return serialized;
 }
 
 type ToolCallHandler = (
@@ -99,12 +125,16 @@ function registerRuntime(): RuntimeRegistration {
 	return { controller, toolCall };
 }
 
-function extensionContext(repository: string, confirmDangerous = false): ExtensionContext {
+function extensionContext(
+	repository: string,
+	hasUI = false,
+	confirm: (title: string, message: string) => Promise<boolean> = async () => true,
+): ExtensionContext {
 	return {
 		cwd: repository,
-		hasUI: confirmDangerous,
+		hasUI,
 		ui: {
-			confirm: async () => true,
+			confirm,
 		},
 	} as unknown as ExtensionContext;
 }
@@ -387,8 +417,319 @@ test("controller inspect reports lock state and recover never force-steals an ab
 	);
 	await assert.rejects(
 		controller.execute("recover-reset-requires-confirmation", { operation: "recover", input: JSON.stringify({ ownerHash: "a".repeat(64) }) }, undefined, undefined, ctx),
-		/confirmation|reset/i,
+		/exact string|confirmation|reset/i,
 	);
+});
+
+test("controller routes legacy authority through explicit reset, verifies clean, and starts ordinary review", async (t) => {
+	const fixture = createRepository(t, false);
+	createLegacyReviewAuthority(fixture.repository);
+	const { controller } = registerRuntime();
+	const ctx = extensionContext(fixture.repository);
+
+	const inspected = await controllerCall(controller, ctx, { operation: "inspect" });
+	const blockedInspection = inspected.inspection as Record<string, unknown>;
+	assert.equal(blockedInspection.outcome, "blocked-legacy");
+	assert.equal(inspected.status, "blocked");
+	assert.equal(inspected.next_action, "request-explicit-reset-authorization");
+
+	const blockedStart = await controllerCall(controller, ctx, {
+		operation: "start",
+		lineageId: "blocked-before-reset",
+		idempotencyKey: "blocked-before-reset-start",
+		input: JSON.stringify({ mode: "ordinary", projection: { kind: "complete" }, policyHash: "a".repeat(64), evidenceHash: "b".repeat(64), budget: budget() }),
+	});
+	assert.equal(blockedStart.status, "blocked");
+	assert.equal(blockedStart.lineage_created, false);
+	assert.equal(blockedStart.next_action, "request-explicit-reset-authorization");
+	assert.equal((blockedStart.inspection as Record<string, unknown>).outcome, "blocked-legacy");
+
+	const resetRequest = blockedInspection.reset_request as Record<string, unknown>;
+	await assert.rejects(
+		controller.execute("unauthorized-reset", { operation: "reset", input: JSON.stringify(resetRequest) }, undefined, undefined, ctx),
+		/interactive Pi UI.*fails closed/i,
+	);
+	const stillBlocked = await controllerCall(controller, ctx, { operation: "inspect" });
+	assert.equal((stillBlocked.inspection as Record<string, unknown>).outcome, "blocked-legacy");
+	assert.deepEqual((stillBlocked.inspection as Record<string, unknown>).reset_request, resetRequest);
+	await assert.rejects(
+		controller.execute("rejected-reset", { operation: "reset", input: JSON.stringify(resetRequest) }, undefined, undefined, extensionContext(fixture.repository, true, async () => false)),
+		/not explicitly authorized/i,
+	);
+	const stillBlockedAfterRejection = await controllerCall(controller, ctx, { operation: "inspect" });
+	assert.deepEqual(stillBlockedAfterRejection.inspection, stillBlocked.inspection);
+
+	const confirmations: Array<{ title: string; message: string }> = [];
+	const authorizedCtx = extensionContext(fixture.repository, true, async (title, message) => {
+		confirmations.push({ title, message });
+		return true;
+	});
+	const reset = await controllerCall(controller, authorizedCtx, {
+		operation: "reset",
+		input: JSON.stringify(resetRequest),
+	});
+	assert.equal(confirmations.length, 1);
+	assert.match(confirmations[0]?.title ?? "", /RESET/);
+	assert.match(confirmations[0]?.message ?? "", new RegExp(String(resetRequest.confirmation).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	assert.equal((reset.inspection as Record<string, unknown>).outcome, "clean");
+	assert.equal(reset.next_action, "start-fresh-ordinary-review-after-verified-clean");
+
+	const clean = await controllerCall(controller, ctx, { operation: "inspect" });
+	assert.equal((clean.inspection as Record<string, unknown>).outcome, "clean");
+	assert.equal(clean.status, "ready");
+
+	const started = await controllerCall(controller, ctx, {
+		operation: "start",
+		lineageId: "ordinary-after-reset",
+		idempotencyKey: "ordinary-after-reset-start",
+		input: JSON.stringify({ mode: "ordinary", projection: { kind: "complete" }, policyHash: "a".repeat(64), evidenceHash: "b".repeat(64), budget: budget() }),
+	});
+	assert.equal(started.operation, "start");
+	assert.equal((started.state as Record<string, unknown>).mode, "ordinary");
+});
+
+test("controller rejects altered destructive reset bindings without authority mutation", async (t) => {
+	const fixture = createRepository(t, false);
+	createLegacyReviewAuthority(fixture.repository);
+	const { controller } = registerRuntime();
+	const ctx = extensionContext(fixture.repository, true);
+	const inspected = await controllerCall(controller, ctx, { operation: "inspect" });
+	const original = (inspected.inspection as Record<string, unknown>).reset_request as Record<string, unknown>;
+
+	for (const altered of [
+		{ ...original, confirmation: `${String(original.confirmation)} altered` },
+		{ ...original, inventoryHash: "0".repeat(64) },
+	]) {
+		await assert.rejects(
+			controller.execute("altered-reset", { operation: "reset", input: JSON.stringify(altered) }, undefined, undefined, ctx),
+			/exactly match/i,
+		);
+		const unchanged = await controllerCall(controller, ctx, { operation: "inspect" });
+		assert.equal((unchanged.inspection as Record<string, unknown>).outcome, "blocked-legacy");
+		assert.deepEqual((unchanged.inspection as Record<string, unknown>).reset_request, original);
+		assert.equal(existsSync(join(fixture.repository, ".git", "gentle-ai", "reviews", "control", "reset-state.json")), false);
+	}
+});
+
+test("controller INSPECT preserves the durable recovery request after interrupted RESET changes inventory", async (t) => {
+	const fixture = createRepository(t, false);
+	createLegacyReviewAuthority(fixture.repository);
+	const { controller } = registerRuntime();
+	const ctx = extensionContext(fixture.repository);
+	const inspected = await controllerCall(controller, ctx, { operation: "inspect" });
+	const original = (inspected.inspection as Record<string, unknown>).reset_request as Record<string, unknown>;
+
+	assert.throws(
+		() => destructiveResetReviewAuthorityV1({
+			cwd: fixture.repository,
+			repositoryId: String(original.repositoryId),
+			commonDirHash: String(original.commonDirHash),
+			inventoryHash: String(original.inventoryHash),
+			confirmation: String(original.confirmation),
+			faultAfterPhase: "deleting",
+		}),
+		/injected/i,
+	);
+	const interrupted = await controllerCall(controller, ctx, { operation: "inspect" });
+	assert.equal((interrupted.inspection as Record<string, unknown>).outcome, "reset-in-progress");
+	assert.deepEqual((interrupted.inspection as Record<string, unknown>).reset_request, original);
+	await assert.rejects(
+		controller.execute("unauthorized-recover", { operation: "recover", input: JSON.stringify(original) }, undefined, undefined, ctx),
+		/interactive Pi UI.*fails closed/i,
+	);
+	const stillInterrupted = await controllerCall(controller, ctx, { operation: "inspect" });
+	assert.deepEqual(stillInterrupted.inspection, interrupted.inspection);
+
+	const recovered = await controllerCall(controller, extensionContext(fixture.repository, true), {
+		operation: "recover",
+		input: JSON.stringify(original),
+	});
+	assert.equal((recovered.inspection as Record<string, unknown>).outcome, "clean");
+	assert.equal(recovered.next_action, "start-fresh-ordinary-review-after-verified-clean");
+});
+
+test("controller RECOVER rejects transplanted reset identity and common-directory hash without mutation", async (t) => {
+	const source = createRepository(t, false);
+	const target = createRepository(t, false);
+	createLegacyReviewAuthority(source.repository);
+	const { controller } = registerRuntime();
+	const sourceCtx = extensionContext(source.repository);
+	const sourceInspection = await controllerCall(controller, sourceCtx, { operation: "inspect" });
+	const sourceRequest = (sourceInspection.inspection as Record<string, unknown>).reset_request as Record<string, unknown>;
+	assert.throws(() => destructiveResetReviewAuthorityV1({
+		cwd: source.repository,
+		repositoryId: String(sourceRequest.repositoryId),
+		commonDirHash: String(sourceRequest.commonDirHash),
+		inventoryHash: String(sourceRequest.inventoryHash),
+		confirmation: String(sourceRequest.confirmation),
+		faultAfterPhase: "deleting",
+	}), /injected/i);
+	const sourceState = readFileSync(join(source.repository, ".git", "gentle-ai", "reviews", "control", "reset-state.json"), "utf8");
+
+	const cleanTarget = await controllerCall(controller, extensionContext(target.repository), { operation: "inspect" });
+	const targetRepositoryId = String((cleanTarget.inspection as Record<string, unknown>).repository_id);
+	const targetControl = join(target.repository, ".git", "gentle-ai", "reviews", "control");
+	mkdirSync(targetControl, { recursive: true });
+	const targetStatePath = join(targetControl, "reset-state.json");
+	writeFileSync(targetStatePath, sourceState);
+	const sentinel = join(target.parent, "transplanted-sentinel.txt");
+	writeFileSync(sentinel, "keep");
+
+	await assert.rejects(
+		controller.execute("transplanted-recovery", { operation: "recover", input: JSON.stringify(sourceRequest) }, undefined, undefined, extensionContext(target.repository, true)),
+		/current repository authority|repository identity|common directory/i,
+	);
+	assert.equal(readFileSync(targetStatePath, "utf8"), sourceState);
+	assert.equal(readFileSync(sentinel, "utf8"), "keep");
+	assert.equal(existsSync(join(target.repository, ".git", "gentle-ai", "reviews", "graph-v1")), false);
+
+	const targetInspection = await controllerCall(controller, extensionContext(target.repository), { operation: "inspect" }).catch(() => undefined);
+	assert.equal(targetInspection, undefined);
+	const foreignCommonHashState = rewriteResetState(target.repository, (body) => {
+		body.repository_id = targetRepositoryId;
+		body.common_directory_hash = "f".repeat(64);
+		const confirmation = `DESTROY REVIEW AUTHORITY ${body.repository_id} AT ${body.common_directory_hash} INVENTORY ${body.authorized_inventory_hash}`;
+		body.authorization_hash = domainHashV1("reset-authorization", confirmation);
+	});
+	await assert.rejects(
+		controller.execute("transplanted-hash-recovery", { operation: "recover", input: JSON.stringify(sourceRequest) }, undefined, undefined, extensionContext(target.repository, true)),
+		/current repository authority|common directory/i,
+	);
+	assert.equal(readFileSync(targetStatePath, "utf8"), foreignCommonHashState);
+	assert.equal(readFileSync(sentinel, "utf8"), "keep");
+});
+
+test("controller RECOVER rejects malicious quarantine paths before external deletion or state mutation", async (t) => {
+	const fixture = createRepository(t, false);
+	createLegacyReviewAuthority(fixture.repository);
+	const { controller } = registerRuntime();
+	const inspected = await controllerCall(controller, extensionContext(fixture.repository), { operation: "inspect" });
+	const request = (inspected.inspection as Record<string, unknown>).reset_request as Record<string, unknown>;
+	assert.throws(() => destructiveResetReviewAuthorityV1({
+		cwd: fixture.repository,
+		repositoryId: String(request.repositoryId),
+		commonDirHash: String(request.commonDirHash),
+		inventoryHash: String(request.inventoryHash),
+		confirmation: String(request.confirmation),
+		faultAfterPhase: "deleting",
+	}), /injected/i);
+	const external = join(fixture.repository, ".git", "gentle-ai", "reviews", "external", "lineages");
+	mkdirSync(external, { recursive: true });
+	const sentinel = join(external, "sentinel");
+	writeFileSync(sentinel, "keep");
+
+	for (const quarantinePath of ["../external", "reset-quarantine/../external"]) {
+		const state = rewriteResetState(fixture.repository, (body) => {
+			body.quarantine_relative_path = quarantinePath;
+		});
+		await assert.rejects(
+			controller.execute("malicious-quarantine-recovery", { operation: "recover", input: JSON.stringify(request) }, undefined, undefined, extensionContext(fixture.repository, true)),
+			/quarantine|recovery path|reset state/i,
+		);
+		assert.equal(readFileSync(sentinel, "utf8"), "keep");
+		assert.equal(readFileSync(join(fixture.repository, ".git", "gentle-ai", "reviews", "control", "reset-state.json"), "utf8"), state);
+	}
+});
+
+test("controller successfully starts the explicitly supported judgment-day mode", async (t) => {
+	const fixture = createRepository(t, false);
+	const { controller } = registerRuntime();
+	const started = await controllerCall(controller, extensionContext(fixture.repository), {
+		operation: "start",
+		lineageId: "judgment-day-start",
+		idempotencyKey: "judgment-day-start-key",
+		input: JSON.stringify({ mode: "judgment-day", projection: { kind: "complete" }, policyHash: "a".repeat(64), evidenceHash: "b".repeat(64), budget: budget() }),
+	});
+	assert.equal(started.operation, "start");
+	assert.equal((started.state as Record<string, unknown>).mode, "judgment-day");
+});
+
+test("failed START gives exact mode and serialization guidance and creates no lineage", async (t) => {
+	const fixture = createRepository(t, false);
+	const { controller } = registerRuntime();
+	const ctx = extensionContext(fixture.repository);
+
+	await assert.rejects(
+		controller.execute("unsupported-start", {
+			operation: "start",
+			lineageId: "unsupported-start",
+			idempotencyKey: "unsupported-start-key",
+			input: JSON.stringify({ mode: "standard" }),
+		}, undefined, undefined, ctx),
+		/only "ordinary" or "judgment-day".*JSON string.*no lineage was created.*do not call STATUS or ADVANCE/is,
+	);
+	await assert.rejects(
+		controller.execute("nested-start-input", {
+			operation: "start",
+			lineageId: "nested-start-input",
+			idempotencyKey: "nested-start-input-key",
+			input: { mode: "ordinary" },
+		}, undefined, undefined, ctx),
+		/START input must be a JSON string.*no lineage was created.*do not call STATUS or ADVANCE/is,
+	);
+	await assert.rejects(
+		controller.execute("invalid-json-start-input", {
+			operation: "start",
+			lineageId: "invalid-json-start-input",
+			idempotencyKey: "invalid-json-start-input-key",
+			input: "{not-json}",
+		}, undefined, undefined, ctx),
+		/START input must be a JSON string encoding an object.*no lineage was created.*do not call STATUS or ADVANCE/is,
+	);
+	assert.equal(existsSync(join(fixture.repository, ".git", "gentle-ai", "reviews", "graph-v1")), false);
+});
+
+test("ambiguous START output loss is recovered only by exact idempotent replay", async (t) => {
+	const fixture = createRepository(t, false);
+	const { controller } = registerRuntime();
+	const ctx = extensionContext(fixture.repository);
+	const request = {
+		operation: "start",
+		lineageId: "ambiguous-start",
+		idempotencyKey: "ambiguous-start-key",
+		input: JSON.stringify({ mode: "ordinary", projection: { kind: "complete" }, policyHash: "a".repeat(64), evidenceHash: "b".repeat(64), budget: budget() }),
+	};
+
+	await controllerCall(controller, ctx, request); // Simulate committed authority whose response was lost.
+	const replay = await controllerCall(controller, ctx, request);
+	assert.deepEqual(replay.result, { lineage_id: "ambiguous-start", revision: 0, phase: "started" });
+	await assert.rejects(
+		controller.execute("changed-start-replay", { ...request, input: JSON.stringify({ mode: "ordinary", projection: { kind: "complete" }, policyHash: "c".repeat(64), evidenceHash: "b".repeat(64), budget: budget() }) }, undefined, undefined, ctx),
+		/idempotency key.*different.*request/i,
+	);
+});
+
+test("shipped controller and orchestrator contracts specify inspect-first START without cascade", () => {
+	const { controller } = registerRuntime();
+	const toolContract = [
+		controller.description,
+		controller.promptSnippet ?? "",
+		...(controller.promptGuidelines ?? []),
+		JSON.stringify(controller.parameters),
+	].join("\n");
+	assert.match(toolContract, /operation.*start.*lineageId.*idempotencyKey.*input/is);
+	assert.match(toolContract, /mode\\?":\\?"ordinary|mode.*ordinary/is);
+	assert.match(toolContract, /ordinary.*judgment-day/is);
+	assert.match(toolContract, /input.*JSON string/is);
+	assert.match(toolContract, /blocked-legacy.*explicit.*authorization/is);
+	assert.match(toolContract, /reset.*inspect.*clean.*start/is);
+	assert.match(toolContract, /output.*lost|response.*lost|ambiguous.*START/is);
+	assert.match(toolContract, /same lineageId.*idempotencyKey.*request/is);
+	assert.doesNotMatch(toolContract, /START throws.*lineage does not exist/is);
+
+	for (const path of ["assets/orchestrator-delegation.md", "skills/gentle-ai/SKILL.md"]) {
+		const contract = readFileSync(path, "utf8");
+		assert.match(contract, /INSPECT before START|inspect.*before.*start/is, path);
+		assert.match(contract, /mode `ordinary`|mode.*ordinary/is, path);
+		assert.match(contract, /Judgment Day.*explicit/is, path);
+		assert.match(contract, /before authority access.*no lineage|pre-authority.*no lineage/is, path);
+		assert.match(contract, /same `?lineageId`?.*`?idempotencyKey`?.*request/is, path);
+	}
+	for (const path of ["assets/orchestrator-delegation.md", "skills/gentle-ai/SKILL.md"]) {
+		const recoveryContract = readFileSync(path, "utf8");
+		assert.match(recoveryContract, /blocked-legacy.*explicit.*authoriz/is, path);
+		assert.match(recoveryContract, /RESET.*RECOVER.*internally.*INSPECT|RESET.*RECOVER.*verified.*clean/is, path);
+	}
 });
 
 test("registered controller creates, advances, reports, and authorizes an exact all-tracked commit once", async (t) => {


### PR DESCRIPTION
## Linked Issue

Closes #93

---

## PR Type

What kind of change does this PR introduce?

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Makes ordinary `START` inspect-first so existing review state is identified before any mutation.
- Requires explicit interactive authorization for destructive reset/recover operations and enforces durable authority/path confinement.
- Replays the exact idempotent command after ambiguous output instead of synthesizing a new recovery action.

---

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Hardened review controller START, reset/recover authorization, authority/path confinement, and idempotent replay behavior. |
| `tests/review-controller.test.ts` | Added focused regression coverage for recovery flow safety, confinement, and ambiguous-output replay. |
| `assets/orchestrator-delegation.md` | Documented the shipped orchestration contract for inspect-first START and authorized recovery. |
| `skills/gentle-ai/SKILL.md` | Updated the project harness contract to match the hardened review flow. |

---

## Test Plan

- [x] Focused review controller tests pass: 16/16.
- [x] Full test suite passes: 439/439.
- [x] Runtime harness passes.
- [x] Package resources pass: 49.
- [x] Native pre-commit, pre-push, and pre-PR gates returned `allow`.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`.
- [x] I have added exactly one appropriate `type:*` label to this PR.
- [x] Shellcheck is not applicable because no shell scripts changed.
- [x] Skills were tested in the target agent runtime harness.
- [x] I have updated documentation for the behavior change.
- [x] My commit follows [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] My commit does not include `Co-Authored-By` trailers.
