### PR TITLE
fix(review): allow approved first branch push

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -53,7 +53,10 @@ import { domainHashV1 } from "../lib/review-canonical.ts";
 import { inspectLegacyReviewAuthorityV1, type LegacyInspectionV1 } from "../lib/review-legacy-detector.ts";
 import { destructiveResetReviewAuthorityV1 } from "../lib/review-reset.ts";
 import { ReviewMutationLockV1 } from "../lib/review-lock.ts";
-import { resolveRepositoryAuthorityV1 } from "../lib/review-repository.ts";
+import {
+	inheritedUnsafeGitEnvironmentKeys,
+	resolveRepositoryAuthorityV1,
+} from "../lib/review-repository.ts";
 import {
 	EXTERNAL_RELEASE_EVIDENCE,
 	GATE_RESULT,
@@ -67,6 +70,8 @@ import {
 	createReviewState,
 	evaluateReleaseFastPathV1,
 	recheckReleaseFastPathRemoteHeadV1,
+	resolvePushDestinationRefV1,
+	resolvePushRemoteRefV1,
 	validateAuthoritativeReviewGate,
 	type GateTargetV1,
 	type ReleaseFastPathEvidenceV1,
@@ -2803,25 +2808,6 @@ function resolveLocalFullRef(cwd: string, value: string, label: string): string 
 	return resolved[0]!;
 }
 
-function destinationFullRef(value: string, sourceRef: string): string {
-	if (value.startsWith("refs/")) return value;
-	if (sourceRef.startsWith("refs/tags/")) return `refs/tags/${value}`;
-	return `refs/heads/${value}`;
-}
-
-function remoteRefObject(cwd: string, remote: string, destinationRef: string): string | null {
-	const output = runReviewGit(cwd, ["ls-remote", "--refs", remote, destinationRef]);
-	if (!output) return null;
-	const rows = output
-		.split(/\r?\n/)
-		.map((line) => line.split(/\s+/))
-		.filter((parts) => parts[1] === destinationRef);
-	if (rows.length !== 1 || !/^[0-9a-f]{40,64}$/.test(rows[0]?.[0] ?? "")) {
-		throw new Error("Push remote destination did not resolve to one exact object");
-	}
-	return rows[0]![0]!;
-}
-
 function pushRemoteAndRefspec(arguments_: readonly string[]): { remote: string; refspec: string } {
 	const unsupported = arguments_.find((argument) =>
 		/^(?:--all|--delete|--follow-tags|--mirror|--prune|--tags|-d)$/.test(argument),
@@ -2831,7 +2817,6 @@ function pushRemoteAndRefspec(arguments_: readonly string[]): { remote: string; 
 		"--exec",
 		"--push-option",
 		"--receive-pack",
-		"--repo",
 		"-o",
 	]);
 	const booleanOptions = new Set([
@@ -2886,17 +2871,27 @@ function pushRemoteAndRefspec(arguments_: readonly string[]): { remote: string; 
 function derivePushTarget(command: ReviewLifecycleCommand): GateTargetV1 {
 	const { remote, refspec } = pushRemoteAndRefspec(command.arguments);
 	if (refspec.startsWith(":")) throw new Error("Push deletion is unsupported");
-	const normalized = refspec.startsWith("+") ? refspec.slice(1) : refspec;
+	if (refspec.startsWith("+")) throw new Error("Force push refspecs are unsupported");
+	const normalized = refspec;
 	const separator = normalized.indexOf(":");
 	const sourceValue = separator < 0 ? normalized : normalized.slice(0, separator);
 	const destinationValue = separator < 0 ? normalized : normalized.slice(separator + 1);
 	if (!sourceValue || !destinationValue) throw new Error("Push refspec is incomplete");
 	const sourceRef = resolveLocalFullRef(command.cwd, sourceValue, "Push source");
-	const destinationRef = destinationFullRef(destinationValue, sourceRef);
 	const newObject = runReviewGit(command.cwd, ["rev-parse", "--verify", sourceRef]);
 	const newPeeledCommit = runReviewGit(command.cwd, ["rev-parse", "--verify", `${sourceRef}^{commit}`]);
 	const newTree = runReviewGit(command.cwd, ["rev-parse", "--verify", `${newPeeledCommit}^{tree}`]);
-	const oldObject = remoteRefObject(command.cwd, remote, destinationRef);
+	const remoteResolution = separator < 0
+		? { ...resolvePushRemoteRefV1(command.cwd, remote, sourceRef, "push remote destination ref"), ref: sourceRef }
+		: resolvePushDestinationRefV1(
+				command.cwd,
+				remote,
+				destinationValue,
+				sourceRef,
+				"push remote destination ref",
+			);
+	const destinationRef = remoteResolution.ref;
+	const oldObject = remoteResolution.object_id;
 	const update = oldObject === null
 		? {
 				kind: PUSH_UPDATE_KIND.CREATE,
@@ -2923,6 +2918,7 @@ function derivePushTarget(command: ReviewLifecycleCommand): GateTargetV1 {
 	return {
 		kind: GATE_TARGET_KIND.PUSH,
 		remote,
+		destination_id: remoteResolution.destination.destination_id,
 		updates: [update],
 	};
 }
@@ -3007,6 +3003,14 @@ function deriveReviewGateTarget(
 		throw new Error(
 			inspection.failClosedReason ?? "Command is not one supported direct review lifecycle operation",
 		);
+	}
+	if (inspection.command.event === "pre-push") {
+		const unsafeKeys = inheritedUnsafeGitEnvironmentKeys();
+		if (unsafeKeys.length > 0) {
+			throw new Error(
+				`Push execution inherits unsafe Git routing or configuration override variables: ${unsafeKeys.join(", ")}`,
+			);
+		}
 	}
 	if (inspection.command.event === "pre-commit") {
 		const tree = deriveCommitTree(inspection.command);

--- a/lib/review-repository.ts
+++ b/lib/review-repository.ts
@@ -31,6 +31,22 @@ const UNSAFE_GIT_ENVIRONMENT = new Set([
 	"GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE", "GIT_QUARANTINE_PATH", "GIT_PREFIX", "GIT_SUPER_PREFIX", "GIT_CEILING_DIRECTORIES", "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_CONFIG", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM", "GIT_CONFIG_COUNT", "GIT_REPLACE_REF_BASE", "GIT_NO_REPLACE_OBJECTS", "GIT_SHALLOW_FILE", "GIT_GRAFT_FILE",
 ]);
 
+const UNSAFE_PUBLICATION_GIT_ENVIRONMENT = new Set([
+	...UNSAFE_GIT_ENVIRONMENT,
+	"GIT_EXEC_PATH", "GIT_TEMPLATE_DIR", "GIT_CONFIG_PARAMETERS", "GIT_SSH", "GIT_SSH_COMMAND", "GIT_SSH_VARIANT", "GIT_PROXY_COMMAND",
+]);
+
+export function inheritedUnsafeGitEnvironmentKeys(
+	environment: NodeJS.ProcessEnv = process.env,
+): string[] {
+	return Object.keys(environment)
+		.filter((key) => {
+			const normalizedKey = key.toUpperCase();
+			return UNSAFE_PUBLICATION_GIT_ENVIRONMENT.has(normalizedKey) || /^GIT_CONFIG_(?:KEY|VALUE)_/.test(normalizedKey);
+		})
+		.toSorted();
+}
+
 export function reviewGitEnvironment(): NodeJS.ProcessEnv {
 	for (const key of Object.keys(process.env)) {
 		if (UNSAFE_GIT_ENVIRONMENT.has(key) || /^GIT_CONFIG_(?:KEY|VALUE)_/.test(key)) throw new ReviewRepositoryError("REVIEW_GIT_ENV_UNSAFE: inherited Git routing/configuration override is present");
@@ -40,6 +56,15 @@ export function reviewGitEnvironment(): NodeJS.ProcessEnv {
 	environment.GIT_CONFIG_NOSYSTEM = "1";
 	environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
 	environment.GIT_CONFIG_SYSTEM = process.platform === "win32" ? "NUL" : "/dev/null";
+	environment.GIT_OPTIONAL_LOCKS = "0";
+	environment.LC_ALL = "C";
+	environment.LANG = "C";
+	return environment;
+}
+
+export function publicationProbeGitEnvironment(): NodeJS.ProcessEnv {
+	const environment: NodeJS.ProcessEnv = { ...process.env };
+	for (const key of inheritedUnsafeGitEnvironmentKeys(environment)) delete environment[key];
 	environment.GIT_OPTIONAL_LOCKS = "0";
 	environment.LC_ALL = "C";
 	environment.LANG = "C";

--- a/lib/review-transaction.ts
+++ b/lib/review-transaction.ts
@@ -19,6 +19,7 @@ import { ReviewGraphObjectStoreV1 } from "./review-object-store.ts";
 import { assertNoLegacyReviewAuthorityV1 } from "./review-legacy-detector.ts";
 import { createReviewEventV1 } from "./review-graph-schema.ts";
 import {
+	publicationProbeGitEnvironment,
 	resolveRepositoryAuthorityV1,
 	reviewGitEnvironment,
 	type RepositoryAuthorityV1,
@@ -282,6 +283,7 @@ export type PushRefUpdateV1 = PushCreateUpdateV1 | PushExistingUpdateV1;
 export interface PushGateTargetV1 {
 	kind: typeof GATE_TARGET_KIND.PUSH;
 	remote: string;
+	destination_id: string;
 	updates: readonly PushRefUpdateV1[];
 }
 
@@ -1787,7 +1789,7 @@ interface GateTargetInspection {
 	reason: string;
 }
 
-const FULL_REF = /^refs\/(?:heads|tags)\/[A-Za-z0-9][A-Za-z0-9._\/-]*$/;
+const FULL_REF = /^refs\/[A-Za-z0-9][A-Za-z0-9._\/-]*$/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -1798,7 +1800,15 @@ function isObjectId(value: unknown): value is string {
 }
 
 function isFullRef(value: unknown): value is string {
-	return typeof value === "string" && FULL_REF.test(value) && !value.includes("..");
+	return (
+		typeof value === "string" &&
+		FULL_REF.test(value) &&
+		!value.includes("..") &&
+		!value.includes("//") &&
+		!value.includes("/.") &&
+		!value.endsWith("/") &&
+		!value.endsWith(".")
+	);
 }
 
 function runGateGit(cwd: string, args: readonly string[]): string {
@@ -1835,11 +1845,174 @@ function listConfiguredRemotes(cwd: string): string[] {
 	return result.stdout.split(/\r?\n/).filter(Boolean);
 }
 
-// Resolves `remote` to the repository's actually configured remote URL. The
-// caller may only ever supply a bare configured remote NAME (default and
-// expected: "origin") — never a URL or filesystem path — so a caller can
-// never redirect the release fast path's remote-head proof to an
-// attacker-controlled endpoint.
+// Resolves one configured remote NAME to the single endpoint Git would use
+// for push, including pushurl and user URL rewrites. Callers can never replace
+// that configured binding with an arbitrary URL or filesystem path.
+export interface ConfiguredPushDestinationV1 {
+	remote: string;
+	url: string;
+	destination_id: string;
+}
+
+function configuredRemoteValues(cwd: string, key: string): string[] {
+	const result = spawnSync("git", ["-C", cwd, "config", "--get-all", key], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+		env: publicationProbeGitEnvironment(),
+	});
+	if (result.error || (result.status !== 0 && result.status !== 1)) {
+		throw new ReviewIntegrityError(`Configured Git remote value "${key}" could not be resolved`);
+	}
+	if (result.status === 1) return [];
+	return result.stdout.split(/\r?\n/).filter(Boolean);
+}
+
+export function resolveConfiguredPushDestinationV1(cwd: string, remote: string): ConfiguredPushDestinationV1 {
+	if (typeof remote !== "string" || !CONFIGURED_REMOTE_NAME.test(remote)) {
+		throw new ReviewIntegrityError(
+			"Publication remote must be a bare configured Git remote name, not a URL or path",
+		);
+	}
+	if (!listConfiguredRemotes(cwd).includes(remote)) {
+		throw new ReviewIntegrityError(`Publication remote "${remote}" is not a configured Git remote`);
+	}
+	const result = spawnSync("git", ["-C", cwd, "remote", "get-url", "--push", "--all", remote], {
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+		env: publicationProbeGitEnvironment(),
+	});
+	if (result.error || result.status !== 0) {
+		throw new ReviewIntegrityError(`Configured remote "${remote}" push destination could not be resolved`);
+	}
+	const urls = result.stdout.split(/\r?\n/).filter(Boolean);
+	if (urls.length !== 1) throw new ReviewIntegrityError(`Configured remote "${remote}" must have one effective push destination`);
+	const configuredPushUrls = configuredRemoteValues(cwd, `remote.${remote}.pushurl`);
+	if (configuredPushUrls.length > 1) throw new ReviewIntegrityError(`Configured remote "${remote}" has multiple pushurl destinations`);
+	return {
+		remote,
+		url: urls[0]!,
+		destination_id: createHash("sha256").update(urls[0]!).digest("hex"),
+	};
+}
+
+export function resolvePushRemoteRefV1(
+	cwd: string,
+	remote: string,
+	ref: string,
+	label: string,
+	expectedDestinationId?: string,
+): { destination: ConfiguredPushDestinationV1; object_id: string | null } {
+	const destination = resolveConfiguredPushDestinationV1(cwd, remote);
+	if (expectedDestinationId !== undefined && destination.destination_id !== expectedDestinationId) {
+		throw new ReviewIntegrityError(`${label} publication destination changed or does not match`);
+	}
+	if (!isFullRef(ref)) throw new ReviewIntegrityError(`${label} is not a full ref`);
+	const result = spawnSync("git", ["ls-remote", "--refs", destination.url, ref], {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+		env: publicationProbeGitEnvironment(),
+	});
+	if (result.error) {
+		throw new ReviewIntegrityError(`${label} could not be resolved: ${result.error.message}`);
+	}
+	if (result.status !== 0) {
+		throw new ReviewIntegrityError(`${label} could not be resolved`);
+	}
+	if (result.stdout.length === 0) return { destination, object_id: null };
+	const rows = result.stdout.split(/\r?\n/).filter(Boolean);
+	const matches = rows.flatMap((line) => {
+		const parts = line.split("\t");
+		return parts.length === 2 && parts[1] === ref && isObjectId(parts[0]) ? [parts[0]] : [];
+	});
+	if (matches.length !== rows.length) throw new ReviewIntegrityError(`${label} returned malformed output`);
+	if (matches.length !== 1) {
+		throw new ReviewIntegrityError(`${label} resolved ambiguously`);
+	}
+	return { destination, object_id: matches[0]! };
+}
+
+export function resolvePushDestinationRefV1(
+	cwd: string,
+	remote: string,
+	destinationValue: string,
+	sourceRef: string,
+	label: string,
+): { destination: ConfiguredPushDestinationV1; ref: string; object_id: string | null } {
+	if (destinationValue.startsWith("refs/")) {
+		const resolved = resolvePushRemoteRefV1(cwd, remote, destinationValue, label);
+		return { ...resolved, ref: destinationValue };
+	}
+	const formatCheck = spawnSync("git", ["check-ref-format", `refs/${destinationValue}`], {
+		cwd,
+		stdio: "ignore",
+		env: reviewGitEnvironment(),
+	});
+	if (formatCheck.error || formatCheck.status !== 0) {
+		throw new ReviewIntegrityError(`${label} is malformed`);
+	}
+	const destination = resolveConfiguredPushDestinationV1(cwd, remote);
+	const result = spawnSync("git", ["ls-remote", "--refs", destination.url], {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+		env: publicationProbeGitEnvironment(),
+	});
+	if (result.error || result.status !== 0) {
+		throw new ReviewIntegrityError(`${label} could not be resolved`);
+	}
+	const rows = result.stdout.split(/\r?\n/).filter(Boolean);
+	const advertised = rows.flatMap((line) => {
+		const parts = line.split("\t");
+		return parts.length === 2 && isObjectId(parts[0]) && isFullRef(parts[1])
+			? [{ object_id: parts[0], ref: parts[1] }]
+			: [];
+	});
+	if (advertised.length !== rows.length || new Set(advertised.map(({ ref }) => ref)).size !== advertised.length) {
+		throw new ReviewIntegrityError(`${label} returned malformed output`);
+	}
+	const matches = advertised.filter(({ ref }) => ref.endsWith(`/${destinationValue}`));
+	if (matches.length > 1) throw new ReviewIntegrityError(`${label} resolved ambiguously`);
+	if (matches.length === 1) return { destination, ...matches[0]! };
+	const namespace = sourceRef.startsWith("refs/heads/")
+		? "refs/heads/"
+		: sourceRef.startsWith("refs/tags/")
+			? "refs/tags/"
+			: undefined;
+	if (!namespace) throw new ReviewIntegrityError(`${label} namespace cannot be inferred from the source ref`);
+	return { destination, ref: `${namespace}${destinationValue}`, object_id: null };
+}
+
+function pushRemoteAdvertisesObjectV1(
+	cwd: string,
+	remote: string,
+	expectedDestinationId: string,
+	objectId: string,
+): boolean {
+	const destination = resolveConfiguredPushDestinationV1(cwd, remote);
+	if (destination.destination_id !== expectedDestinationId) {
+		throw new ReviewIntegrityError("Push parent publication destination changed or does not match");
+	}
+	const result = spawnSync("git", ["ls-remote", "--refs", destination.url], {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+		env: publicationProbeGitEnvironment(),
+	});
+	if (result.error || result.status !== 0) {
+		throw new ReviewIntegrityError("Push parent advertisement could not be resolved");
+	}
+	const rows = result.stdout.split(/\r?\n/).filter(Boolean);
+	const advertised = rows.flatMap((line) => {
+		const parts = line.split("\t");
+		return parts.length === 2 && isObjectId(parts[0]) && isFullRef(parts[1]) ? [parts[0]] : [];
+	});
+	if (advertised.length !== rows.length) {
+		throw new ReviewIntegrityError("Push parent advertisement returned malformed output");
+	}
+	return advertised.includes(objectId);
+}
+
 function resolveConfiguredRemoteUrl(cwd: string, remote: string): string {
 	if (typeof remote !== "string" || !CONFIGURED_REMOTE_NAME.test(remote)) {
 		throw new ReviewIntegrityError(
@@ -1876,12 +2049,8 @@ function resolveRemoteGateRef(
 		stdio: ["ignore", "pipe", "pipe"],
 		env: reviewGitEnvironment(),
 	});
-	if (result.error) {
-		throw new ReviewIntegrityError(`${label} could not be resolved: ${result.error.message}`);
-	}
-	if (result.status !== 0) {
-		throw new ReviewIntegrityError(`${label} could not be resolved`);
-	}
+	if (result.error) throw new ReviewIntegrityError(`${label} could not be resolved: ${result.error.message}`);
+	if (result.status !== 0) throw new ReviewIntegrityError(`${label} could not be resolved`);
 	const matches = result.stdout
 		.split(/\r?\n/)
 		.filter(Boolean)
@@ -1890,9 +2059,7 @@ function resolveRemoteGateRef(
 			return remoteRef === ref && isObjectId(objectId) ? [objectId] : [];
 		});
 	if (matches.length === 0) return null;
-	if (matches.length !== 1) {
-		throw new ReviewIntegrityError(`${label} resolved ambiguously`);
-	}
+	if (matches.length !== 1) throw new ReviewIntegrityError(`${label} resolved ambiguously`);
 	return matches[0]!;
 }
 
@@ -1939,6 +2106,9 @@ function inspectPushTarget(
 	if (typeof target.remote !== "string") {
 		return { valid: false, matchesReceipt: false, reason: "Push target requires an exact remote identity." };
 	}
+	if (typeof target.destination_id !== "string" || !DIGEST.test(target.destination_id)) {
+		return { valid: false, matchesReceipt: false, reason: "Push target requires one bound publication destination." };
+	}
 	if (!Array.isArray(target.updates) || target.updates.length === 0) {
 		return { valid: false, matchesReceipt: false, reason: "Push target requires a complete non-empty update set." };
 	}
@@ -1981,14 +2151,27 @@ function inspectPushTarget(
 				return { valid: false, matchesReceipt: false, reason: "Push create must bind an explicitly absent old identity." };
 			}
 			if (
-				resolveRemoteGateRef(
+				resolvePushRemoteRefV1(
 					repositoryCwd,
 					target.remote,
 					value.destination_ref,
 					"push remote destination ref",
-				) !== null
+					target.destination_id,
+				).object_id !== null
 			) {
 				return { valid: false, matchesReceipt: false, reason: "Push create destination ref already exists." };
+			}
+			const parentLine = runGateGit(repositoryCwd, ["rev-list", "--parents", "-n", "1", value.new_peeled_commit]);
+			const parents = parentLine.split(" ");
+			if (parents.length !== 2 || parents[0] !== value.new_peeled_commit || !isObjectId(parents[1])) {
+				return { valid: false, matchesReceipt: false, reason: "Push create requires exactly one resolved parent commit." };
+			}
+			const parent = parents[1]!;
+			if (runGateGit(repositoryCwd, ["rev-parse", "--verify", `${parent}^{tree}`]) !== receipt.body.base_tree) {
+				return { valid: false, matchesReceipt: false, reason: "Push create parent tree does not match the approved receipt base tree." };
+			}
+			if (!pushRemoteAdvertisesObjectV1(repositoryCwd, target.remote, target.destination_id, parent)) {
+				return { valid: false, matchesReceipt: false, reason: "Push create parent is not advertised by the bound publication destination." };
 			}
 		} else if (value.kind === PUSH_UPDATE_KIND.UPDATE) {
 			if (
@@ -1998,12 +2181,13 @@ function inspectPushTarget(
 			) {
 				return { valid: false, matchesReceipt: false, reason: "Push old identity is unresolved." };
 			}
-			const destinationObject = resolveRemoteGateRef(
+			const destinationObject = resolvePushRemoteRefV1(
 				repositoryCwd,
 				target.remote,
 				value.destination_ref,
 				"push remote destination ref",
-			);
+				target.destination_id,
+			).object_id;
 			if (destinationObject === null) {
 				return { valid: false, matchesReceipt: false, reason: "Push update destination ref does not exist." };
 			}

--- a/tests/review-controller.test.ts
+++ b/tests/review-controller.test.ts
@@ -841,9 +841,32 @@ test("controller binds push, PR, and release authorization to exact command argu
 				undefined,
 				ctx,
 			),
-			/exactly derive|unsupported.*push|complete ref update/i,
+			/exactly derive|unsupported.*push|complete ref update|force push refspec/i,
 		);
 	}
+	await t.test("rejects force refspecs and unsupported push --repo parsing", async () => {
+		for (const [command, pattern] of [
+			["git push origin +main:main", /force push refspec/i],
+			["git push --repo attacker origin main:main", /unsupported push option.*--repo/i],
+		] as const) {
+			await assert.rejects(
+				controller.execute(
+					"unsafe-push-form",
+					{
+						operation: "validate",
+						lineageId: "controller-targets",
+						idempotencyKey: `unsafe-push-form-${command.length}`,
+						command,
+						input: JSON.stringify({ scopeBudget: budget() }),
+					},
+					undefined,
+					undefined,
+					ctx,
+				),
+				pattern,
+			);
+		}
+	});
 	for (const [command, key] of [
 		["env SAFE=1 git push --follow-tags origin main:main", "env"],
 		["command git push origin --follow-tags main:main", "command"],
@@ -928,6 +951,202 @@ test("controller binds push, PR, and release authorization to exact command argu
 	);
 	assert.equal(mismatchedRelease?.block, true);
 	assert.match(mismatchedRelease?.reason ?? "", /registered review controller authorization/i);
+});
+
+test("controller authorizes the exact first push after an approved intended-commit receipt", async (t) => {
+	const fixture = createRepository(t, true);
+	assert.ok(fixture.finalCommit && fixture.finalTree);
+	const fetchRemotePath = join(fixture.parent, "fetch.git");
+	const pushRemotePath = join(fixture.parent, "push.git");
+	execFileSync("git", ["clone", "--bare", fixture.repository, fetchRemotePath], {
+		cwd: fixture.parent,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	execFileSync("git", ["--git-dir", fetchRemotePath, "update-ref", "refs/heads/feature/first-push", fixture.finalCommit]);
+	execFileSync("git", ["clone", "--bare", fixture.repository, pushRemotePath], {
+		cwd: fixture.parent,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	execFileSync("git", ["--git-dir", pushRemotePath, "update-ref", "refs/heads/main", fixture.baseCommit]);
+	git(fixture.repository, "remote", "add", "origin", fetchRemotePath);
+	git(fixture.repository, "remote", "set-url", "--add", "--push", "origin", pushRemotePath);
+	git(fixture.repository, "branch", "feature/first-push", fixture.finalCommit);
+	createTerminalAuthority(fixture, "controller-first-push");
+	const { controller, toolCall } = registerRuntime();
+	const ctx = extensionContext(fixture.repository, true);
+	const command = "git push -u origin feature/first-push";
+	const validated = await controllerCall(controller, ctx, {
+		operation: "validate",
+		lineageId: "controller-first-push",
+		idempotencyKey: "controller-first-push-gate",
+		command,
+		input: JSON.stringify({ scopeBudget: budget() }),
+	});
+
+	assert.equal((validated.result as Record<string, unknown>).status, "allow", JSON.stringify(validated));
+	const derivedTarget = validated.derived_target as Record<string, unknown>;
+	assert.equal((derivedTarget.updates as Array<Record<string, unknown>>)[0]?.kind, "create");
+	assert.equal(await toolCall({ toolName: "bash", input: { command } }, ctx), undefined);
+});
+
+test("controller resolves explicit abbreviated push destinations against advertised refs", async (t) => {
+	const fixture = createRepository(t, true);
+	assert.ok(fixture.finalCommit && fixture.finalTree);
+	const remotePath = join(fixture.parent, "destination-resolution.git");
+	execFileSync("git", ["clone", "--bare", fixture.repository, remotePath], {
+		cwd: fixture.parent,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	execFileSync("git", ["--git-dir", remotePath, "update-ref", "refs/tags/publish-target", fixture.baseCommit]);
+	git(fixture.repository, "remote", "add", "origin", remotePath);
+	createTerminalAuthority(fixture, "controller-destination-resolution");
+	const { controller } = registerRuntime();
+	const ctx = extensionContext(fixture.repository, true);
+	const validated = await controllerCall(controller, ctx, {
+		operation: "validate",
+		lineageId: "controller-destination-resolution",
+		idempotencyKey: "controller-destination-tag",
+		command: "git push origin final:publish-target",
+		input: JSON.stringify({ scopeBudget: budget() }),
+	});
+	const update = (validated.derived_target as { updates: Array<Record<string, unknown>> }).updates[0];
+	assert.equal(update?.destination_ref, "refs/tags/publish-target");
+
+	execFileSync("git", ["--git-dir", remotePath, "update-ref", "refs/heads/ambiguous-target", fixture.baseCommit]);
+	execFileSync("git", ["--git-dir", remotePath, "update-ref", "refs/tags/ambiguous-target", fixture.baseCommit]);
+	await assert.rejects(
+		controller.execute(
+			"ambiguous-push-destination",
+			{
+				operation: "validate",
+				lineageId: "controller-destination-resolution",
+				idempotencyKey: "controller-destination-ambiguous",
+				command: "git push origin final:ambiguous-target",
+				input: JSON.stringify({ scopeBudget: budget() }),
+			},
+			undefined,
+			undefined,
+			ctx,
+		),
+		/ambiguous/i,
+	);
+});
+
+test("controller push probes preserve safe user URL rewriting and ordinary credentials", async (t) => {
+	const fixture = createRepository(t, true);
+	assert.ok(fixture.finalCommit && fixture.finalTree);
+	const fetchRemotePath = join(fixture.parent, "fetch.git");
+	const pushRemotePath = join(fixture.parent, "push.git");
+	const userHome = join(fixture.parent, "home");
+	mkdirSync(userHome);
+	execFileSync("git", ["init", "--bare", fetchRemotePath], { cwd: fixture.parent, stdio: ["ignore", "pipe", "pipe"] });
+	execFileSync("git", ["clone", "--bare", fixture.repository, pushRemotePath], { cwd: fixture.parent, stdio: ["ignore", "pipe", "pipe"] });
+	execFileSync("git", ["--git-dir", pushRemotePath, "update-ref", "refs/heads/main", fixture.baseCommit]);
+	const logicalPushUrl = "https://github.com/example/first-push.git";
+	execFileSync("git", ["config", "--global", `url.${pushRemotePath}.insteadOf`, logicalPushUrl], {
+		env: { ...process.env, HOME: userHome },
+	});
+	git(fixture.repository, "remote", "add", "origin", fetchRemotePath);
+	git(fixture.repository, "remote", "set-url", "--add", "--push", "origin", logicalPushUrl);
+	git(fixture.repository, "branch", "feature/safe-config", fixture.finalCommit);
+	createTerminalAuthority(fixture, "controller-safe-config");
+	const { controller } = registerRuntime();
+	const ctx = extensionContext(fixture.repository, true);
+	const originalEnvironment = new Map<string, string | undefined>();
+	for (const [key, value] of Object.entries({
+		HOME: userHome,
+		GIT_ASKPASS: join(fixture.parent, "askpass"),
+	})) {
+		originalEnvironment.set(key, process.env[key]);
+		process.env[key] = value;
+	}
+	t.after(() => {
+		for (const [key, value] of originalEnvironment) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	const validated = await controllerCall(controller, ctx, {
+		operation: "validate",
+		lineageId: "controller-safe-config",
+		idempotencyKey: "controller-safe-config-gate",
+		command: "git push -u origin feature/safe-config",
+		input: JSON.stringify({ scopeBudget: budget() }),
+	});
+	assert.equal((validated.result as Record<string, unknown>).status, "allow", JSON.stringify(validated));
+});
+
+test("controller blocks a previously authorized push when inherited Git config injection appears at execution", async (t) => {
+	const fixture = createRepository(t, true);
+	assert.ok(fixture.finalCommit && fixture.finalTree);
+	const pushRemotePath = join(fixture.parent, "execution-boundary-push.git");
+	execFileSync("git", ["clone", "--bare", fixture.repository, pushRemotePath], {
+		cwd: fixture.parent,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	execFileSync("git", ["--git-dir", pushRemotePath, "update-ref", "refs/heads/main", fixture.baseCommit]);
+	git(fixture.repository, "remote", "add", "origin", pushRemotePath);
+	git(fixture.repository, "branch", "feature/execution-boundary", fixture.finalCommit);
+	createTerminalAuthority(fixture, "controller-execution-boundary");
+	const { controller, toolCall } = registerRuntime();
+	const ctx = extensionContext(fixture.repository, true);
+	const command = "git push -u origin feature/execution-boundary";
+	const validated = await controllerCall(controller, ctx, {
+		operation: "validate",
+		lineageId: "controller-execution-boundary",
+		idempotencyKey: "controller-execution-boundary-gate",
+		command,
+		input: JSON.stringify({ scopeBudget: budget() }),
+	});
+	assert.equal((validated.result as Record<string, unknown>).status, "allow");
+
+	const originalCount = process.env.GIT_CONFIG_COUNT;
+	const originalKey = process.env.GIT_CONFIG_KEY_0;
+	const originalValue = process.env.GIT_CONFIG_VALUE_0;
+	process.env.GIT_CONFIG_COUNT = "1";
+	process.env.GIT_CONFIG_KEY_0 = "remote.origin.pushurl";
+	process.env.GIT_CONFIG_VALUE_0 = join(fixture.parent, "attacker.git");
+	try {
+		const blocked = await toolCall({ toolName: "bash", input: { command } }, ctx);
+		assert.equal(blocked?.block, true);
+		assert.match(blocked?.reason ?? "", /Git.*environment|routing|configuration override/i);
+	} finally {
+		if (originalCount === undefined) delete process.env.GIT_CONFIG_COUNT;
+		else process.env.GIT_CONFIG_COUNT = originalCount;
+		if (originalKey === undefined) delete process.env.GIT_CONFIG_KEY_0;
+		else process.env.GIT_CONFIG_KEY_0 = originalKey;
+		if (originalValue === undefined) delete process.env.GIT_CONFIG_VALUE_0;
+		else process.env.GIT_CONFIG_VALUE_0 = originalValue;
+	}
+});
+
+test("controller fails closed when a configured remote has multiple pushurl destinations", async (t) => {
+	const fixture = createRepository(t, true);
+	assert.ok(fixture.finalCommit);
+	const fetchRemotePath = join(fixture.parent, "fetch.git");
+	const firstPushPath = join(fixture.parent, "push-one.git");
+	const secondPushPath = join(fixture.parent, "push-two.git");
+	for (const path of [fetchRemotePath, firstPushPath, secondPushPath]) {
+		execFileSync("git", ["init", "--bare", path], { cwd: fixture.parent, stdio: ["ignore", "pipe", "pipe"] });
+	}
+	git(fixture.repository, "remote", "add", "origin", fetchRemotePath);
+	git(fixture.repository, "remote", "set-url", "--add", "--push", "origin", firstPushPath);
+	git(fixture.repository, "remote", "set-url", "--add", "--push", "origin", secondPushPath);
+	git(fixture.repository, "branch", "feature/multiple-pushurl", fixture.finalCommit);
+	createTerminalAuthority(fixture, "controller-multiple-pushurl");
+	const { controller } = registerRuntime();
+
+	await assert.rejects(
+		controller.execute("multiple-pushurl", {
+			operation: "validate",
+			lineageId: "controller-multiple-pushurl",
+			idempotencyKey: "controller-multiple-pushurl-gate",
+			command: "git push -u origin feature/multiple-pushurl",
+			input: JSON.stringify({ scopeBudget: budget() }),
+		}, undefined, undefined, extensionContext(fixture.repository, true)),
+		/multiple pushurl|one effective push destination/i,
+	);
 });
 
 test("controller release fast path bypasses receipt validation only for the proven immutable origin/main SHA", async (t) => {

--- a/tests/review-gate.test.ts
+++ b/tests/review-gate.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -22,6 +22,7 @@ import {
 	evaluateGateTarget,
 	evaluateReleaseFastPathV1,
 	recheckReleaseFastPathRemoteHeadV1,
+	resolveConfiguredPushDestinationV1,
 	validateReviewGate,
 	type GateTargetV1,
 	type GhCommandRunnerV1,
@@ -32,6 +33,7 @@ import {
 	type ReviewStateV1,
 } from "../lib/review-transaction.ts";
 import { REVIEW_LENS, REVIEW_ROUTE } from "../lib/review-triggers.ts";
+import { inheritedUnsafeGitEnvironmentKeys } from "../lib/review-repository.ts";
 import { qualifiedReviewLockPlatform, testSnapshot } from "./review-test-fixtures.ts";
 
 interface GateRepository {
@@ -45,6 +47,19 @@ interface GateRepository {
 	finalCommit: string;
 	tagObject: string;
 }
+
+test("unsafe publication Git environment matching preserves actual mixed-case keys", () => {
+	assert.deepEqual(
+		inheritedUnsafeGitEnvironmentKeys({
+			git_config_count: "1",
+			Git_Config_Key_0: "remote.origin.pushurl",
+			git_config_value_0: "attacker",
+			GIT_SSH_COMMAND: "unsafe",
+			GIT_ASKPASS: "safe",
+		}),
+		["GIT_SSH_COMMAND", "Git_Config_Key_0", "git_config_count", "git_config_value_0"],
+	);
+});
 
 function createGateRepository(t: test.TestContext): GateRepository {
 	const parent = mkdtempSync(join(tmpdir(), "gentle-pi-gate-repo-"));
@@ -289,9 +304,11 @@ test("changed exact target returns one deterministic child with a non-refreshing
 test("push gate allows normal same-name updates while preserving exact-old and create rules", (t) => {
 	const authority = temporaryAuthority(t);
 	const { repository, remote, baseTree, finalTree, baseCommit, finalCommit, receipt } = authority;
+	const destination = resolveConfiguredPushDestinationV1(repository, remote);
 	const target = {
 		kind: GATE_TARGET_KIND.PUSH,
 		remote,
+		destination_id: destination.destination_id,
 		updates: [
 			{
 				kind: PUSH_UPDATE_KIND.CREATE,
@@ -366,10 +383,105 @@ test("push gate allows normal same-name updates while preserving exact-old and c
 		evaluateGateTarget(receipt, { ...target, remote: "missing-remote" }, repository).status,
 		GATE_RESULT.DENY,
 	);
+	const changedDestination = join(authority.repository, "changed-destination.git");
+	execFileSync("git", ["init", "--bare", changedDestination], { stdio: ["ignore", "pipe", "pipe"] });
+	execFileSync("git", ["remote", "set-url", "--add", "--push", remote, changedDestination], { cwd: repository });
+	assert.equal(
+		evaluateGateTarget(receipt, target, repository).status,
+		GATE_RESULT.DENY,
+		"a target bound to the former publication destination must fail closed",
+	);
+});
+
+test("push gate treats only successful empty output as absent and fails closed on probe failures", async (t) => {
+	const authority = temporaryAuthority(t);
+	const { repository, remote, finalTree, finalCommit, receipt } = authority;
+	const destination = resolveConfiguredPushDestinationV1(repository, remote);
+	const target = {
+		kind: GATE_TARGET_KIND.PUSH,
+		remote,
+		destination_id: destination.destination_id,
+		updates: [{
+			kind: PUSH_UPDATE_KIND.CREATE,
+			source_ref: "refs/heads/final",
+			destination_ref: "refs/heads/feature",
+			old_object: null,
+			old_peeled_commit: null,
+			old_tree: null,
+			new_object: finalCommit,
+			new_peeled_commit: finalCommit,
+			new_tree: finalTree,
+		}],
+	} as const;
+	assert.equal(evaluateGateTarget(receipt, target, repository).status, GATE_RESULT.ALLOW);
+	const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+	const originalPath = process.env.PATH;
+	for (const [name, body] of [
+		["nonzero", "exit 1"],
+		["malformed", "printf 'not-a-valid-row\\n'; exit 0"],
+		["ambiguous", `printf '${finalCommit}\\trefs/heads/feature\\n${finalCommit}\\trefs/heads/feature\\n'; exit 0`],
+	] as const) {
+		await t.test(name, () => {
+			const bin = join(authority.repository, `fake-git-${name}`);
+			mkdirSync(bin);
+			const fakeGit = join(bin, "git");
+			writeFileSync(fakeGit, `#!/bin/sh\nif [ "$1" = "ls-remote" ]; then ${body}; fi\nexec "${realGit}" "$@"\n`);
+			chmodSync(fakeGit, 0o755);
+			process.env.PATH = `${bin}:${originalPath ?? ""}`;
+			try {
+				const result = evaluateGateTarget(receipt, target, repository);
+				assert.equal(result.status, GATE_RESULT.DENY, result.reason);
+			} finally {
+				process.env.PATH = originalPath;
+			}
+		});
+	}
+});
+
+test("push CREATE rejects unreviewed ancestor history", (t) => {
+	const authority = temporaryAuthority(t);
+	const { repository, remote, baseTree, finalTree, baseCommit, receipt } = authority;
+	const git = (...args: string[]): string =>
+		execFileSync("git", args, { cwd: repository, encoding: "utf8" }).trim();
+	git("checkout", "--force", "--detach", baseCommit);
+	writeFileSync(join(repository, "ancestor.ts"), "export const unreviewed = true;\n");
+	git("add", ".");
+	git("-c", "user.name=Gate Test", "-c", "user.email=gate@example.invalid", "commit", "-m", "unreviewed ancestor");
+	const unreviewedParent = git("rev-parse", "HEAD");
+	git("read-tree", finalTree);
+	git("-c", "user.name=Gate Test", "-c", "user.email=gate@example.invalid", "commit", "-m", "reviewed tree");
+	const newCommit = git("rev-parse", "HEAD");
+	git("branch", "unsafe-first-push", newCommit);
+	execFileSync("git", ["--git-dir", authority.remotePath, "fetch", repository, `${unreviewedParent}:refs/heads/unreviewed`], {
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const destination = resolveConfiguredPushDestinationV1(repository, remote);
+	const target = {
+		kind: GATE_TARGET_KIND.PUSH,
+		remote,
+		destination_id: destination.destination_id,
+		updates: [{
+			kind: PUSH_UPDATE_KIND.CREATE,
+			source_ref: "refs/heads/unsafe-first-push",
+			destination_ref: "refs/heads/unsafe-first-push",
+			old_object: null,
+			old_peeled_commit: null,
+			old_tree: null,
+			new_object: newCommit,
+			new_peeled_commit: newCommit,
+			new_tree: finalTree,
+		}],
+	} as const;
+
+	const result = evaluateGateTarget(receipt, target, repository);
+	assert.equal(result.status, GATE_RESULT.DENY, result.reason);
+	assert.match(result.reason, /parent tree|base tree/i);
+	assert.notEqual(git("rev-parse", `${unreviewedParent}^{tree}`), baseTree);
 });
 
 test("PR and release gates resolve exact refs, commits, tag objects, peels, and trees", (t) => {
-	const { repository, baseTree, finalTree, changedTree, baseCommit, finalCommit, tagObject, receipt } = temporaryAuthority(t);
+	const authority = temporaryAuthority(t);
+	const { repository, baseTree, finalTree, changedTree, baseCommit, finalCommit, receipt } = authority;
 	const pullRequest = {
 		kind: GATE_TARGET_KIND.PULL_REQUEST,
 		base_ref: "refs/heads/base",
@@ -385,13 +497,7 @@ test("PR and release gates resolve exact refs, commits, tag objects, peels, and 
 		evaluateGateTarget(receipt, { ...pullRequest, base_commit: finalCommit }, repository).status,
 		GATE_RESULT.DENY,
 	);
-	const release = {
-		kind: GATE_TARGET_KIND.RELEASE,
-		tag_ref: "refs/tags/v1.2.3",
-		tag_object: tagObject,
-		peeled_commit: finalCommit,
-		tree: finalTree,
-	} as const;
+	const release = releaseTarget(authority);
 	const releaseResult = evaluateGateTarget(receipt, release, repository);
 	assert.equal(releaseResult.status, GATE_RESULT.ALLOW, releaseResult.reason);
 	assert.equal(


### PR DESCRIPTION
Closes #91

## Type

- [x] Bug fix

## Summary

- Authorizes an exact first branch push when the reviewed commit tree matches and the destination is absent.
- Binds validation to the effective push destination, including `pushurl` and safe URL rewriting.
- Fails closed on destination drift, malformed probes, unsafe Git environment injection, forced refspecs, ambiguous destination refs, and unreviewed ancestry.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Derives exact push targets and rejects unsupported or unsafe push forms. |
| `lib/review-repository.ts` | Adds a publication-specific sanitized Git environment. |
| `lib/review-transaction.ts` | Binds push destinations, remote absence, destination refs, and CREATE ancestry. |
| `tests/review-controller.test.ts` | Covers first-push controller behavior and command parsing. |
| `tests/review-gate.test.ts` | Covers destination, transport, ancestry, and environment invariants. |

## Test Plan

- [x] Focused controller/gate/reset tests: 62 passed
- [x] Full test suite: 451 passed
- [x] Runtime harness passed
- [x] `git diff --check` passed
- [x] Native bounded review and pre-commit/pre-push/pre-PR receipt gates passed

## Checklist

- [x] Linked approved issue
- [x] Exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [x] Scope limited to first-push authorization; release, CI, and recovery changes excluded
- [x] Maintainer-approved single-PR size exception recorded on #91
