### PR TITLE
fix(review): recover SDD changes from legacy authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,15 @@ parent git/status + clarify → bind ordinary snapshot/route → one worker writ
 
 Review lenses are controller-selected transaction actors, not lifecycle hooks. `scout`/`context-builder` save parent context by compressing broad exploration. `worker` preserves a single writer thread. Commit, push, PR, and release validate receipts with zero actors.
 
-### Review-store migration safety
+### Review authority recovery and reset safety
 
-Legacy pre-graph authority is never migrated. `gentle_review inspect` reports an exact repository-bound destructive reset challenge; only that authorized reset can quarantine graph-v1 and compact-v2 authority, initialize an empty graph-v1 incarnation, and require fresh review. Interrupted resets remain blocked until explicit forward recovery. Existing graph-v1 ordinary lineages remain readable, gate-validatable, and exportable but are read-only; Judgment Day remains mutable on graph-v1.
+Legacy pre-graph authority is never migrated. `gentle_review inspect` reports an exact repository-bound destructive reset challenge; only that authorized RESET or RECOVER can quarantine graph-v1 and compact-v2 authority, initialize an empty graph-v1 incarnation, and require fresh review. Interrupted destructive recovery remains blocked until explicit forward recovery. Existing graph-v1 ordinary lineages remain readable, gate-validatable, and exportable but are read-only; Judgment Day remains mutable on graph-v1.
+
+A **non-destructive supersession** is available only for an eligible, immutable graph-v1 source and an independently approved compact-v2 successor with identical repository, change, target, scope, untracked, policy, ledger, and receipt bindings. First call `prepare-supersession`, review its exact English challenge, then call `supersede` only after fresh interactive approval. Headless approval, a changed challenge, a stale binding, unsupported data, or ambiguous authority fails closed and leaves the change `resolve-review` blocked.
+
+Supersession records are append-only under `authority-supersession-v1`; they do not rewrite graph-v1 history. An exact retry is idempotent. A divergent retry or conflict fails closed and requires a new operation. RESET/RECOVER stay destructive and never run as a fallback from supersession. Rollback can stop recognizing a record but does not delete it, re-enable graph-v1 mutation, or select another successor.
+
+Pre-commit, pre-push, pre-PR, and release gates revalidate the recovered source, successor, receipt, policy, scope, intended-untracked proof, and live target. Recovery does not grant a new budget or bypass dangerous-command authorization, publication checks, historical graph-v1 receipt validation, or graph export.
 
 `reviewer` is not an installed subagent name. It is a routing intent. Select the concrete lens by risk profile:
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -49,7 +49,7 @@ import {
 } from "../lib/sdd-status.ts";
 import type { TriggerEvent } from "../lib/review-triggers.ts";
 import { ReviewBundleExporter, ReviewBundleImporter } from "../lib/review-bundle.ts";
-import { domainHashV1 } from "../lib/review-canonical.ts";
+import { canonicalJsonV1, domainHashV1 } from "../lib/review-canonical.ts";
 import { inspectLegacyReviewAuthorityV1, type LegacyInspectionV1 } from "../lib/review-legacy-detector.ts";
 import { compactResetRequestV1, destructiveResetReviewAuthorityV1 } from "../lib/review-reset.ts";
 import { ReviewMutationLockV1 } from "../lib/review-lock.ts";
@@ -62,6 +62,18 @@ import {
 	startCompactReview,
 } from "../lib/review-facade.ts";
 import { validateCompactReviewGate } from "../lib/review-compact-gate.ts";
+import {
+	assertLiveRecoveredSourceBindingV1,
+	assertLiveRecoveredSuccessorBindingV1,
+	createSupersessionEnvelopeV1,
+	hasEligibleGraphV1RecoveryAuthorityV1,
+	inspectApprovedCompactSuccessorV1,
+	inspectRecoverableGraphSourceV1,
+	prepareSupersessionV1,
+	resolveReviewAuthorityForChange,
+	SupersessionStoreV1,
+	type PrepareSupersessionInputV1,
+} from "../lib/review-authority-supersession.ts";
 import {
 	COMPACT_AUTHORITY_OUTCOME,
 	compactV2LineageExists,
@@ -2086,6 +2098,8 @@ const REVIEW_CONTROLLER_OPERATION = {
 	RESET: "reset",
 	RECOVER: "recover",
 	RECOVER_LOCK: "recover-lock",
+	PREPARE_SUPERSESSION: "prepare-supersession",
+	SUPERSEDE: "supersede",
 	REPAIR: "repair",
 } as const;
 
@@ -2105,6 +2119,10 @@ const REVIEW_CONTROLLER_PARAMETERS = {
 		lineageId: {
 			type: "string",
 			description: "Bounded review lineage identifier. A failed start creates no lineage; do not use it with status or advance.",
+		},
+		changeName: {
+			type: "string",
+			description: "Canonical OpenSpec change name required to resolve a recovered authority during lifecycle validate.",
 		},
 		idempotencyKey: {
 			type: "string",
@@ -2132,6 +2150,7 @@ const REVIEW_CONTROLLER_PARAMETERS = {
 interface ReviewControllerParameters {
 	operation: ReviewControllerOperation;
 	lineageId?: string;
+	changeName?: string;
 	idempotencyKey?: string;
 	transition?: string;
 	command?: string;
@@ -2141,6 +2160,16 @@ interface ReviewControllerParameters {
 	operationId?: string;
 	lineageIds?: string;
 	acknowledgeUntrustedBundleSource?: string;
+}
+
+interface SupersessionControllerInput {
+	changeName: string;
+	sourceLineageId: string;
+	successorLineageId: string;
+	operationId: string;
+	prepared: PrepareSupersessionInputV1;
+	challenge?: string;
+	request_hash?: string;
 }
 
 interface ReviewControllerStartInput {
@@ -2208,7 +2237,7 @@ function parseReviewControllerParameters(value: unknown): ReviewControllerParame
 	// VALIDATE defers its lineage requirement to execution time: the proven
 	// release-from-protected-main fast path needs no receipt lineage, while
 	// every other validation still requires one before receipt validation.
-	const needsLineage = ![REVIEW_CONTROLLER_OPERATION.START, REVIEW_CONTROLLER_OPERATION.FINALIZE, REVIEW_CONTROLLER_OPERATION.EXPORT, REVIEW_CONTROLLER_OPERATION.IMPORT, REVIEW_CONTROLLER_OPERATION.INSPECT, REVIEW_CONTROLLER_OPERATION.RESET, REVIEW_CONTROLLER_OPERATION.RECOVER, REVIEW_CONTROLLER_OPERATION.RECOVER_LOCK, REVIEW_CONTROLLER_OPERATION.REPAIR, REVIEW_CONTROLLER_OPERATION.VALIDATE].includes(value.operation as ReviewControllerOperation);
+	const needsLineage = ![REVIEW_CONTROLLER_OPERATION.START, REVIEW_CONTROLLER_OPERATION.FINALIZE, REVIEW_CONTROLLER_OPERATION.EXPORT, REVIEW_CONTROLLER_OPERATION.IMPORT, REVIEW_CONTROLLER_OPERATION.INSPECT, REVIEW_CONTROLLER_OPERATION.RESET, REVIEW_CONTROLLER_OPERATION.RECOVER, REVIEW_CONTROLLER_OPERATION.RECOVER_LOCK, REVIEW_CONTROLLER_OPERATION.PREPARE_SUPERSESSION, REVIEW_CONTROLLER_OPERATION.SUPERSEDE, REVIEW_CONTROLLER_OPERATION.REPAIR, REVIEW_CONTROLLER_OPERATION.VALIDATE].includes(value.operation as ReviewControllerOperation);
 	if (needsLineage && (typeof value.lineageId !== "string" || value.lineageId.trim().length === 0)) {
 		throw new Error("Review controller requires a lineageId");
 	}
@@ -2216,7 +2245,7 @@ function parseReviewControllerParameters(value: unknown): ReviewControllerParame
 		operation: value.operation,
 		...(typeof value.lineageId === "string" ? { lineageId: value.lineageId } : {}),
 	};
-	for (const key of ["idempotencyKey", "transition", "command", "input", "outputPath", "inputPath", "operationId", "lineageIds", "acknowledgeUntrustedBundleSource"] as const) {
+	for (const key of ["changeName", "idempotencyKey", "transition", "command", "input", "outputPath", "inputPath", "operationId", "lineageIds", "acknowledgeUntrustedBundleSource"] as const) {
 		const optional = value[key];
 		if (optional !== undefined && typeof optional !== "string") {
 			if (value.operation === REVIEW_CONTROLLER_OPERATION.START && key === "input") {
@@ -2270,6 +2299,41 @@ function parseControllerJson(input: string, operation: ReviewControllerOperation
 	}
 	if (!isRecord(value)) throw new Error(`Review controller ${operation} input must be a JSON object`);
 	return value;
+}
+
+function parseSupersessionControllerInput(value: Record<string, unknown>): SupersessionControllerInput {
+	for (const key of ["changeName", "sourceLineageId", "successorLineageId", "operationId"] as const) {
+		if (typeof value[key] !== "string" || value[key].trim().length === 0) throw new Error(`Review controller supersession requires ${key}`);
+	}
+	if (!isRecord(value.prepared)) throw new Error("Review controller supersession requires the exact prepared request input");
+	return {
+		changeName: value.changeName as string,
+		sourceLineageId: value.sourceLineageId as string,
+		successorLineageId: value.successorLineageId as string,
+		operationId: value.operationId as string,
+		prepared: value.prepared as unknown as PrepareSupersessionInputV1,
+		...(typeof value.challenge === "string" ? { challenge: value.challenge } : {}),
+		...(typeof value.request_hash === "string" ? { request_hash: value.request_hash } : {}),
+	};
+}
+
+function assertSupersessionControllerIdentity(
+	input: SupersessionControllerInput,
+	prepared: ReturnType<typeof prepareSupersessionV1>,
+): void {
+	if (
+		input.operationId !== prepared.body.operation_id ||
+		input.changeName !== prepared.body.change.change_name ||
+		input.sourceLineageId !== prepared.body.source.lineage_id ||
+		input.successorLineageId !== prepared.body.successor.lineage_id ||
+		canonicalJsonV1(input.prepared) !== canonicalJsonV1({
+			operation_id: prepared.body.operation_id,
+			eligibility: input.prepared.eligibility,
+			equivalence: input.prepared.equivalence,
+			...(input.prepared.predecessor_recovery_id === undefined ? {} : { predecessor_recovery_id: input.prepared.predecessor_recovery_id }),
+			...(input.prepared.sequence === undefined ? {} : { sequence: input.prepared.sequence }),
+		})
+	) throw new Error("Review controller supersession identity does not exactly match the prepared request");
 }
 
 function durableResetRecoveryRequest(cwd: string): LegacyInspectionV1["reset_request"] {
@@ -2375,31 +2439,29 @@ async function authorizeDestructiveReviewOperation(
 	ctx: ExtensionContext,
 ): Promise<void> {
 	const parameters = parseReviewControllerParameters(parametersValue);
-	if (
-		parameters.operation !== REVIEW_CONTROLLER_OPERATION.RESET &&
-		parameters.operation !== REVIEW_CONTROLLER_OPERATION.RECOVER
-	) return;
+	const isReset = parameters.operation === REVIEW_CONTROLLER_OPERATION.RESET || parameters.operation === REVIEW_CONTROLLER_OPERATION.RECOVER;
+	const isSupersession = parameters.operation === REVIEW_CONTROLLER_OPERATION.SUPERSEDE;
+	if (!isReset && !isSupersession) return;
 	const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);
-	for (const key of ["repositoryId", "commonDirHash", "inventoryHash", "confirmation"] as const) {
-		if (typeof input[key] !== "string" || input[key].length === 0) {
-			throw new Error(`Review controller ${parameters.operation} requires an exact string ${key}`);
+	const challengeKey = isSupersession ? "challenge" : "confirmation";
+	if (isReset) {
+		for (const key of ["repositoryId", "commonDirHash", "inventoryHash"] as const) {
+			if (typeof input[key] !== "string" || input[key].length === 0) throw new Error(`Review controller ${parameters.operation} requires an exact string ${key}`);
 		}
+	}
+	if (typeof input[challengeKey] !== "string" || input[challengeKey].length === 0) {
+		throw new Error(`Review controller ${parameters.operation} requires an exact string ${challengeKey}`);
 	}
 	if (!ctx.hasUI) {
 		throw new Error(`Review controller ${parameters.operation.toUpperCase()} requires fresh explicit authorization through the interactive Pi UI; headless execution fails closed`);
 	}
 	const approved = await ctx.ui.confirm(
-		`Authorize destructive review authority ${parameters.operation.toUpperCase()}?`,
-		[
-			`Operation: ${parameters.operation.toUpperCase()}`,
-			`Repository: ${input.repositoryId}`,
-			`Exact challenge: ${input.confirmation}`,
-			"This invalidates all prior review authority for this repository.",
-		].join("\n"),
+		isSupersession ? "Authorize review authority SUPERSESSION?" : `Authorize destructive review authority ${parameters.operation.toUpperCase()}?`,
+		isSupersession
+			? ["Operation: SUPERSEDE", `Exact challenge: ${input.challenge}`, "This preserves graph-v1 history and activates only the exact compact-v2 successor."].join("\n")
+			: [`Operation: ${parameters.operation.toUpperCase()}`, `Repository: ${input.repositoryId}`, `Exact challenge: ${input.confirmation}`, "This invalidates all prior review authority for this repository."].join("\n"),
 	);
-	if (!approved) {
-		throw new Error(`Review controller ${parameters.operation.toUpperCase()} was not explicitly authorized`);
-	}
+	if (!approved) throw new Error(`Review controller ${parameters.operation.toUpperCase()} was not explicitly authorized`);
 }
 
 function parseReviewBudget(value: unknown, label: string): ReviewBudgetV1 {
@@ -3113,6 +3175,45 @@ function executeReviewControllerOperation(
 		// operator-attested trust decision (see lib/review-bundle.ts import gate).
 		return { operation: parameters.operation, result: new ReviewBundleImporter(defaultCwd).import({ inputPath: requiredControllerString(parameters, "inputPath"), operationId: requiredControllerString(parameters, "operationId"), acknowledgeUntrustedBundleSource: parameters.acknowledgeUntrustedBundleSource === "true" }) };
 	}
+	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.PREPARE_SUPERSESSION) {
+		const input = parseSupersessionControllerInput(parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation));
+		const prepared = prepareSupersessionV1(input.prepared);
+		assertSupersessionControllerIdentity(input, prepared);
+		return { operation: parameters.operation, change_name: input.changeName, request_hash: prepared.request_hash, challenge: prepared.challenge, body: prepared.body };
+	}
+	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.SUPERSEDE) {
+		const input = parseSupersessionControllerInput(parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation));
+		if (typeof input.challenge !== "string" || typeof input.request_hash !== "string") throw new Error("Review controller SUPERSEDE requires the exact prepared request_hash and challenge");
+		const prepared = prepareSupersessionV1(input.prepared);
+		assertSupersessionControllerIdentity(input, prepared);
+		if (input.request_hash !== prepared.request_hash || input.challenge !== prepared.challenge) throw new Error("Review controller SUPERSEDE prepared request and challenge must exactly match the fresh authorization");
+		const body = { ...prepared.body, authorization_hash: domainHashV1("review-authority-supersession-authorization", { challenge: prepared.challenge, request_hash: prepared.request_hash }) };
+		const envelope = createSupersessionEnvelopeV1(body);
+		const installed = SupersessionStoreV1.forRepository(defaultCwd).install(input.changeName, envelope, {
+			casChecks: [
+				{
+					label: "graph source",
+					expected: canonicalJsonV1(prepared.body.source),
+					observe: () => {
+						assertLiveRecoveredSourceBindingV1(defaultCwd, envelope);
+						return canonicalJsonV1(inspectRecoverableGraphSourceV1(defaultCwd, input.changeName, input.sourceLineageId).source);
+					},
+				},
+				{
+					label: "compact successor",
+					expected: canonicalJsonV1(prepared.body.successor),
+					observe: () => {
+						const successor = inspectApprovedCompactSuccessorV1(defaultCwd, input.successorLineageId);
+						assertLiveRecoveredSuccessorBindingV1(defaultCwd, envelope, discoverCompactReview(defaultCwd, input.successorLineageId, true).record.state);
+						return canonicalJsonV1(successor);
+					},
+				},
+			],
+		});
+		const active = resolveReviewAuthorityForChange(defaultCwd, input.changeName);
+		if (!active || active.recovery.recovery_id !== installed.recovery_id) throw new Error("Review controller SUPERSEDE did not produce one validated active authority");
+		return { operation: parameters.operation, change_name: input.changeName, recovery_id: installed.recovery_id, active_authority_id: active.record.state.lineage_id, next_action: "validate-recovered-authority" };
+	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.INSPECT) {
 		const authority = resolveRepositoryAuthorityV1(defaultCwd);
 		const lock = new ReviewMutationLockV1(join(authority.store_root, "control"), authority.repository_id, authority.authority_id);
@@ -3450,13 +3551,30 @@ function executeReviewControllerOperation(
 			};
 		}
 	}
-	let compact = false;
-	if (typeof parameters.lineageId === "string" && parameters.lineageId.trim().length > 0) {
+	if (
+		parameters.changeName === undefined &&
+		(parameters.lineageId === undefined || !graphV1LineageExists(derived.command.cwd, parameters.lineageId)) &&
+		hasEligibleGraphV1RecoveryAuthorityV1(derived.command.cwd)
+	) {
+		throw new Error("Review controller validate requires changeName and a valid supersession for eligible graph-v1 recovery authority");
+	}
+	const recoveredAuthority = parameters.changeName === undefined
+		? undefined
+		: resolveReviewAuthorityForChange(derived.command.cwd, parameters.changeName);
+	if (
+		recoveredAuthority !== undefined &&
+		parameters.lineageId !== undefined &&
+		parameters.lineageId !== recoveredAuthority.record.state.lineage_id
+	) {
+		throw new Error("Review controller validate lineageId does not match the change-scoped recovered authority");
+	}
+	let compact = recoveredAuthority !== undefined;
+	if (!compact && typeof parameters.lineageId === "string" && parameters.lineageId.trim().length > 0) {
 		const compactExists = compactV2LineageExists(derived.command.cwd, parameters.lineageId);
 		const graphExists = graphV1LineageExists(derived.command.cwd, parameters.lineageId);
 		if (compactExists && graphExists) throw new Error("Review authority is ambiguous across graph-v1 and compact-v2");
 		compact = compactExists;
-	} else {
+	} else if (!compact) {
 		try {
 			discoverCompactReview(derived.command.cwd, undefined, true);
 			compact = true;
@@ -3468,6 +3586,7 @@ function executeReviewControllerOperation(
 		const result = validateCompactReviewGate({
 			cwd: derived.command.cwd,
 			...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
+			...(parameters.changeName === undefined ? {} : { changeName: parameters.changeName }),
 			deriveTarget: () => {
 				const rederived = deriveReviewGateTarget(commandValue, defaultCwd);
 				if (rederived.command.cwd !== derived.command.cwd) throw new Error("Lifecycle command repository changed during compact validation");
@@ -3614,7 +3733,43 @@ export const __testing = {
 	renderSddModelPanel: renderSddModelPanelForTesting,
 	getOrchestratorPrompt,
 	renderOrchestratorPrompt,
+	resolveControllerSddStatus,
 };
+
+function resolveControllerSddStatus(
+	cwd: string,
+	changeName: string | undefined,
+	includeInstructions: boolean,
+	artifactStore: SddPreflightPreferences["artifactStore"] | undefined,
+) {
+	const base = resolveSddStatus({ cwd, changeName, includeInstructions, artifactStore });
+	if (!base.changeName || !hasRecoveryObligationForChange(cwd, base.changeName)) return base;
+	return resolveSddStatus({
+		cwd,
+		changeName: base.changeName,
+		includeInstructions,
+		artifactStore,
+		reviewAuthority: {
+			expected: true,
+			resolve: () => {
+				const active = resolveReviewAuthorityForChange(cwd, base.changeName!);
+				if (!active) throw new Error("validated recovered review authority is missing");
+				return { activeAuthorityId: active.record.state.lineage_id };
+			},
+		},
+	});
+}
+
+function hasRecoveryObligationForChange(cwd: string, changeName: string): boolean {
+	try {
+		return SupersessionStoreV1.forRepository(cwd).hasRecoveryRequiredMarker(changeName) || hasEligibleGraphV1RecoveryAuthorityV1(cwd);
+	} catch (error) {
+		// A non-repository cannot have repository-anchored recovery authority.
+		if (error instanceof Error && error.message === "Unable to resolve Git repository authority") return false;
+		// An unreadable marker, store, or Git authority is recovery-required, never absent.
+		return true;
+	}
+}
 
 export default function gentleAi(pi: ExtensionAPI): void {
 	const pendingReviewAuthorizations = new Map<string, PendingReviewAuthorization>();
@@ -3623,10 +3778,11 @@ export default function gentleAi(pi: ExtensionAPI): void {
 		name: "gentle_review",
 		label: "Gentle Review Controller",
 		description:
-			"Inspect and recover review authority, run new ordinary review through compact start/finalize/validate, preserve graph-v1 Judgment Day and compatibility reads, and authorize one exact lifecycle command. RESET and RECOVER require fresh interactive authorization and fail closed headlessly.",
+			"Inspect and recover review authority, run new ordinary review through compact start/finalize/validate, preserve graph-v1 Judgment Day and compatibility reads, and authorize one exact lifecycle command. RESET/RECOVER remain destructive; prepare-supersession/supersede require fresh interactive authorization and fail closed headlessly.",
 		promptSnippet: "Inspect authority, then use compact start/finalize/validate for ordinary review; use graph-v1 only for explicit Judgment Day",
 		promptGuidelines: [
 			'Call {"operation":"inspect"} before START. Ordinary START uses a JSON string such as "{\\"mode\\":\\"ordinary\\",\\"policyHash\\":\\"<hash>\\"}"; the controller derives lineage, Git/untracked scope, tier, lenses, authored lines, and budget.',
+			"For non-destructive legacy recovery, call prepare-supersession with one exact change, source, successor, operation, and prepared evidence input. Call supersede only with the returned request hash and exact English challenge after fresh UI approval; it never falls back to RESET or RECOVER. Headless, stale, conflicting, malformed, or unsupported recovery remains resolve-review blocked; exact retries are idempotent, but semantic retries require a new operation.",
 			"Run selected lenses once, then call FINALIZE with causal result JSON. FINALIZE alone records correction forecast, Git-derived correction evidence, targeted validation, and final evidence. Use ADVANCE only for explicit graph-v1 Judgment Day.",
 			"For blocked-legacy or blocked-mixed, do not call START repeatedly. Explain invalidation, request explicit user authorization for the exact reset_request challenge, then call RESET or RECOVER only after authorization. RESET and RECOVER internally INSPECT authority; require their verified clean result and next_action start-fresh-ordinary-review-after-verified-clean before continuing directly to a fresh ordinary START.",
 			"A reported lineage_created false or pre-authority validation error proves no lineage was created. After ambiguous START or FINALIZE output, replay the exact operation so compact CAS returns the committed revision or rejects a stale/semantic retry.",
@@ -3708,11 +3864,12 @@ export default function gentleAi(pi: ExtensionAPI): void {
 				: "";
 		const phase = isSddAgent ? sddPhaseFromAgentStartEvent(event) : undefined;
 		const nativeStatusPrompt = phase
-			? `\n\n${renderNativeSddPhasePrompt(resolveSddStatus({
-				cwd: ctx.cwd,
-				includeInstructions: true,
-				artifactStore: prefs?.artifactStore,
-			}), phase)}`
+			? `\n\n${renderNativeSddPhasePrompt(resolveControllerSddStatus(
+				ctx.cwd,
+				undefined,
+				true,
+				prefs?.artifactStore,
+			), phase)}`
 			: "";
 		const gentlePrompt = isNamedAgent || isSddAgent
 			? ""
@@ -3761,12 +3918,12 @@ export default function gentleAi(pi: ExtensionAPI): void {
 
 	const handleSddStatusCommand = (args: string, ctx: ExtensionContext) => {
 		const parsed = parseSddStatusCommandArgs(args);
-		const status = resolveSddStatus({
-			cwd: ctx.cwd,
-			changeName: parsed.changeName,
-			includeInstructions: true,
-			artifactStore: getSddPreflightPreferences(ctx)?.artifactStore,
-		});
+		const status = resolveControllerSddStatus(
+			ctx.cwd,
+			parsed.changeName,
+			true,
+			getSddPreflightPreferences(ctx)?.artifactStore,
+		);
 		ctx.ui.notify(
 			parsed.json ? JSON.stringify(status, null, 2) : renderSddStatusMarkdown(status),
 			sddStatusSeverity(status),
@@ -3782,12 +3939,12 @@ export default function gentleAi(pi: ExtensionAPI): void {
 
 	const handleSddContinueCommand = (args: string, ctx: ExtensionContext) => {
 		const parsed = parseSddStatusCommandArgs(args);
-		const status = resolveSddStatus({
-			cwd: ctx.cwd,
-			changeName: parsed.changeName,
-			includeInstructions: true,
-			artifactStore: getSddPreflightPreferences(ctx)?.artifactStore,
-		});
+		const status = resolveControllerSddStatus(
+			ctx.cwd,
+			parsed.changeName,
+			true,
+			getSddPreflightPreferences(ctx)?.artifactStore,
+		);
 		ctx.ui.notify(
 			parsed.json ? JSON.stringify(status, null, 2) : renderSddDispatcherMarkdown(status),
 			sddStatusSeverity(status),

--- a/lib/review-authority-supersession.ts
+++ b/lib/review-authority-supersession.ts
@@ -1,0 +1,1055 @@
+import { execFileSync } from "node:child_process";
+import {
+	closeSync,
+	fsyncSync,
+	linkSync,
+	mkdirSync,
+	openSync,
+	lstatSync,
+	readFileSync,
+	existsSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join, relative } from "node:path";
+import { canonicalJsonV1, domainHashV1, parseCanonicalJsonV1 } from "./review-canonical.ts";
+import { COMPACT_REVIEW_STATE, type CompactReviewStateV2 } from "./review-compact.ts";
+import { CompactReviewStoreV2, discoverCompactReviewStores, hasGraphV1Authority } from "./review-compact-store.ts";
+import { ReviewGraphObjectStoreV1 } from "./review-object-store.ts";
+import { assertManagedStorePathV1, resolveRepositoryAuthorityV1, reviewGitEnvironment, type RepositoryAuthorityV1 } from "./review-repository.ts";
+import { ReviewMutationLockV1, type ReviewLockPlatformAdapterV1 } from "./review-lock.ts";
+import { discoverReviewUntrackedPaths } from "./review-snapshot.ts";
+import { assertFrozenLedgerIntegrity, canonicalHash, createReceiptForState, validateReviewGraphReplayV1, type ReviewStateV1 } from "./review-transaction.ts";
+
+const DIGEST = /^[0-9a-f]{64}$/;
+const OPERATION_ID = /^[0-9a-f]{64}$/;
+const CHANGE_NAME = /^[a-z0-9][a-z0-9-]*$/;
+
+export const REVIEW_AUTHORITY_SUPERSESSION_ERROR = {
+	INVALID: "REVIEW_SUPERSESSION_INVALID",
+	INELIGIBLE_SOURCE: "REVIEW_SUPERSESSION_INELIGIBLE_SOURCE",
+	EQUIVALENCE_MISMATCH: "REVIEW_SUPERSESSION_EQUIVALENCE_MISMATCH",
+	OPERATION_CONFLICT: "REVIEW_SUPERSESSION_OPERATION_CONFLICT",
+	CHAIN_AMBIGUOUS: "REVIEW_SUPERSESSION_CHAIN_AMBIGUOUS",
+	UNTRACKED_DRIFT: "REVIEW_SUPERSESSION_UNTRACKED_DRIFT",
+	STALE_AUTHORIZATION: "REVIEW_SUPERSESSION_STALE_AUTHORIZATION",
+	REPOSITORY_MISMATCH: "REVIEW_SUPERSESSION_REPOSITORY_MISMATCH",
+	RACE_UNSAFE: "REVIEW_SUPERSESSION_RACE_UNSAFE",
+} as const;
+
+export type ReviewAuthoritySupersessionErrorCode =
+	(typeof REVIEW_AUTHORITY_SUPERSESSION_ERROR)[keyof typeof REVIEW_AUTHORITY_SUPERSESSION_ERROR];
+
+export class ReviewAuthoritySupersessionError extends Error {
+	readonly code: ReviewAuthoritySupersessionErrorCode;
+
+	constructor(code: ReviewAuthoritySupersessionErrorCode, message: string) {
+		super(`${code}: ${message}`);
+		this.name = "ReviewAuthoritySupersessionError";
+		this.code = code;
+	}
+}
+
+export interface RepositoryBindingV1 {
+	repository_id: string;
+	authority_id: string;
+	common_directory_hash: string;
+	repository_identity_hash: string;
+}
+
+export interface OpenSpecChangeBindingV1 {
+	change_name: string;
+	change_name_hash: string;
+	change_root_relative_path: string;
+}
+
+export interface GraphAuthorityBindingV1 {
+	format: "graph-v1";
+	lineage_id: string;
+	head_event_id: string;
+	head_sequence: number;
+	reduced_state_hash: string;
+	source_closure_hash: string;
+	receipt_hash: string;
+	frozen_ledger_hash: string;
+}
+
+export interface CompactAuthorityBindingV1 {
+	format: "compact-v2";
+	lineage_id: string;
+	authority_revision: string;
+	state_hash: string;
+	receipt_hash: string;
+	ledger_hash: string;
+	runtime_identity_hash: string;
+}
+
+export const INTENDED_UNTRACKED_PROOF_STATE = {
+	ALL_UNTRACKED: "all-untracked",
+	COMPLETE_INDEX: "complete-index",
+} as const;
+
+export type IntendedUntrackedProofStateV1 =
+	(typeof INTENDED_UNTRACKED_PROOF_STATE)[keyof typeof INTENDED_UNTRACKED_PROOF_STATE];
+
+export interface IntendedUntrackedProofV1 {
+	state: IntendedUntrackedProofStateV1;
+	candidate_tree: string;
+	index_tree: string | null;
+	paths: string[];
+	proof_hash: string;
+}
+
+export interface RecoveryEquivalenceBindingV1 {
+	base_tree: string;
+	complete_snapshot_tree: string;
+	initial_review_tree: string;
+	final_candidate_tree: string;
+	review_projection_hash: string;
+	genesis_paths_hash: string;
+	scope_digest: string;
+	intended_untracked_hash: string;
+	intended_untracked_proof_hash: string;
+	policy_hash: string;
+	policy_evidence_hash: string;
+	source_receipt_hash: string;
+	successor_receipt_hash: string;
+	source_ledger_hash: string;
+	successor_ledger_hash: string;
+}
+
+export interface SupersessionBodyV1 {
+	schema: "gentle-ai.review-authority-supersession/v1";
+	operation_id: string;
+	request_hash: string;
+	sequence: number;
+	predecessor_recovery_id: string | null;
+	repository: RepositoryBindingV1;
+	change: OpenSpecChangeBindingV1;
+	source: GraphAuthorityBindingV1;
+	successor: CompactAuthorityBindingV1;
+	equivalence: RecoveryEquivalenceBindingV1;
+	authorization_hash: string;
+}
+
+export interface SupersessionEnvelopeV1 {
+	body: SupersessionBodyV1;
+	recovery_id: string;
+}
+
+/** Read-only inspection result required before a graph-v1 source can be superseded. */
+export interface RecoverableSourceEligibilityV1 {
+	repository: RepositoryBindingV1;
+	change: OpenSpecChangeBindingV1;
+	source: GraphAuthorityBindingV1;
+	immutable: boolean;
+	readable: boolean;
+	graph_replay_valid: boolean;
+	receipt_valid: boolean;
+	frozen_ledger_valid: boolean;
+	identity_broken: boolean;
+	reset_in_progress: boolean;
+	mixed_authority: boolean;
+	duplicate_authority: boolean;
+}
+
+/** Independently derived evidence from one authority; it is never supplied by a controller hash. */
+export interface RecoveryAuthorityEvidenceV1 {
+	base_tree: string;
+	complete_snapshot_tree: string;
+	initial_review_tree: string;
+	final_candidate_tree: string;
+	review_projection_hash: string;
+	genesis_paths_hash: string;
+	scope_digest: string;
+	intended_untracked_hash: string;
+	intended_untracked_proof_hash: string;
+	policy_hash: string;
+	policy_evidence_hash: string;
+	receipt_hash: string;
+	ledger_hash: string;
+}
+
+export interface RecoverySuccessorEquivalenceV1 {
+	repository: RepositoryBindingV1;
+	change: OpenSpecChangeBindingV1;
+	source: GraphAuthorityBindingV1;
+	successor: CompactAuthorityBindingV1;
+	source_evidence: RecoveryAuthorityEvidenceV1;
+	successor_evidence: RecoveryAuthorityEvidenceV1;
+}
+
+export interface PrepareSupersessionInputV1 {
+	operation_id: string;
+	eligibility: RecoverableSourceEligibilityV1;
+	equivalence: RecoverySuccessorEquivalenceV1;
+	predecessor_recovery_id?: string | null;
+	sequence?: number;
+}
+
+export interface PreparedSupersessionV1 {
+	body: SupersessionBodyV1;
+	request_hash: string;
+	challenge: string;
+}
+
+function assertDigest(value: unknown, field: string): asserts value is string {
+	if (typeof value !== "string" || !DIGEST.test(value)) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, `${field} must be a SHA-256 digest`);
+	}
+}
+
+function assertObject(value: unknown, field: string): asserts value is Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, `${field} must be an object`);
+	}
+}
+
+function assertExactKeys(value: Record<string, unknown>, keys: readonly string[], field: string): void {
+	if (Object.keys(value).length !== keys.length || keys.some((key) => !(key in value))) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, `${field} has an invalid schema`);
+	}
+}
+
+function assertBinding(value: unknown, keys: readonly string[], field: string): Record<string, unknown> {
+	assertObject(value, field);
+	assertExactKeys(value, keys, field);
+	for (const key of keys) {
+		if (key !== "format" && key !== "lineage_id" && key !== "head_sequence") assertDigest(value[key], `${field}.${key}`);
+	}
+	return value;
+}
+
+function assertBody(value: unknown): asserts value is SupersessionBodyV1 {
+	assertObject(value, "body");
+	assertExactKeys(value, ["schema", "operation_id", "request_hash", "sequence", "predecessor_recovery_id", "repository", "change", "source", "successor", "equivalence", "authorization_hash"], "body");
+	if (value.schema !== "gentle-ai.review-authority-supersession/v1") throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "unsupported supersession schema");
+	if (typeof value.operation_id !== "string" || !OPERATION_ID.test(value.operation_id)) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "operation_id must be a digest");
+	assertDigest(value.request_hash, "request_hash");
+	assertDigest(value.authorization_hash, "authorization_hash");
+	if (!Number.isSafeInteger(value.sequence) || value.sequence < 0) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "sequence must be a non-negative integer");
+	if (value.predecessor_recovery_id !== null) assertDigest(value.predecessor_recovery_id, "predecessor_recovery_id");
+	assertRepositoryBinding(value.repository);
+	assertChangeBinding(value.change);
+	assertSourceBinding(value.source);
+	assertSuccessorBinding(value.successor);
+	assertBinding(value.equivalence, ["base_tree", "complete_snapshot_tree", "initial_review_tree", "final_candidate_tree", "review_projection_hash", "genesis_paths_hash", "scope_digest", "intended_untracked_hash", "intended_untracked_proof_hash", "policy_hash", "policy_evidence_hash", "source_receipt_hash", "successor_receipt_hash", "source_ledger_hash", "successor_ledger_hash"], "equivalence");
+}
+
+function assertRecoveryEvidence(value: unknown, field: string): asserts value is RecoveryAuthorityEvidenceV1 {
+	assertObject(value, field);
+	const keys = ["base_tree", "complete_snapshot_tree", "initial_review_tree", "final_candidate_tree", "review_projection_hash", "genesis_paths_hash", "scope_digest", "intended_untracked_hash", "intended_untracked_proof_hash", "policy_hash", "policy_evidence_hash", "receipt_hash", "ledger_hash"] as const;
+	assertExactKeys(value, keys, field);
+	for (const key of keys) assertDigest(value[key], `${field}.${key}`);
+}
+
+function assertSourceBinding(value: unknown): asserts value is GraphAuthorityBindingV1 {
+	const source = assertBinding(value, ["format", "lineage_id", "head_event_id", "head_sequence", "reduced_state_hash", "source_closure_hash", "receipt_hash", "frozen_ledger_hash"], "source");
+	if (source.format !== "graph-v1" || typeof source.lineage_id !== "string" || !source.lineage_id || !Number.isSafeInteger(source.head_sequence) || (source.head_sequence as number) < 0) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "source binding is invalid");
+	}
+}
+
+function assertSuccessorBinding(value: unknown): asserts value is CompactAuthorityBindingV1 {
+	const successor = assertBinding(value, ["format", "lineage_id", "authority_revision", "state_hash", "receipt_hash", "ledger_hash", "runtime_identity_hash"], "successor");
+	if (successor.format !== "compact-v2" || typeof successor.lineage_id !== "string" || !successor.lineage_id) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "successor binding is invalid");
+	}
+}
+
+function assertRepositoryBinding(value: unknown): asserts value is RepositoryBindingV1 {
+	assertBinding(value, ["repository_id", "authority_id", "common_directory_hash", "repository_identity_hash"], "repository");
+}
+
+function assertChangeBinding(value: unknown): asserts value is OpenSpecChangeBindingV1 {
+	assertObject(value, "change");
+	assertExactKeys(value, ["change_name", "change_name_hash", "change_root_relative_path"], "change");
+	if (typeof value.change_name !== "string" || !CHANGE_NAME.test(value.change_name) || value.change_root_relative_path !== `openspec/changes/${value.change_name}`) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "change binding is not canonical");
+	assertDigest(value.change_name_hash, "change.change_name_hash");
+	if (value.change_name_hash !== domainHashV1("openspec-change-name", value.change_name)) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "change binding hash does not match the canonical change name");
+	}
+}
+
+export function assertRecoverableSourceEligibilityV1(input: unknown): RecoverableSourceEligibilityV1 {
+	assertObject(input, "source eligibility");
+	const keys = ["repository", "change", "source", "immutable", "readable", "graph_replay_valid", "receipt_valid", "frozen_ledger_valid", "identity_broken", "reset_in_progress", "mixed_authority", "duplicate_authority"] as const;
+	assertExactKeys(input, keys, "source eligibility");
+	assertRepositoryBinding(input.repository);
+	assertChangeBinding(input.change);
+	assertSourceBinding(input.source);
+	for (const key of keys.slice(3)) if (typeof input[key] !== "boolean") throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, `source eligibility.${key} must be boolean`);
+	if (!input.immutable || !input.readable || !input.graph_replay_valid || !input.receipt_valid || !input.frozen_ledger_valid || input.identity_broken || input.reset_in_progress || input.mixed_authority || input.duplicate_authority) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INELIGIBLE_SOURCE, "source is not one readable immutable unambiguous approved graph-v1 authority");
+	}
+	return input as RecoverableSourceEligibilityV1;
+}
+
+function assertCanonicalRepositoryPathV1(path: string): void {
+	if (!path || path.startsWith("/") || path.split("/").some((part) => part === "" || part === "." || part === "..")) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, "intended-untracked path is not canonical");
+	}
+}
+
+function runProofGitV1(cwd: string, args: readonly string[]): string {
+	return execFileSync("git", args, {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+		env: reviewGitEnvironment(),
+	}).trim();
+}
+
+function candidateTreeEntryV1(cwd: string, candidateTree: string, path: string): { mode: string; object: string } {
+	const entry = execFileSync("git", ["ls-tree", "-z", candidateTree, "--", path], {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+		env: reviewGitEnvironment(),
+	});
+	const record = entry.split("\0").filter(Boolean);
+	if (record.length !== 1) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, `candidate tree is missing intended-untracked path ${path}`);
+	}
+	const match = /^(100644|100755|120000) blob ([0-9a-f]{40,64})\t/.exec(record[0]!);
+	if (!match) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, `candidate tree has an invalid intended-untracked entry for ${path}`);
+	}
+	return { mode: match[1]!, object: match[2]! };
+}
+
+function workingTreeEntryV1(cwd: string, path: string): { mode: string; object: string } {
+	const entry = lstatSync(join(cwd, path));
+	const mode = entry.isSymbolicLink() ? "120000" : entry.isFile() ? (entry.mode & 0o111 ? "100755" : "100644") : null;
+	if (mode === null) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, `intended-untracked path is not a file or symlink: ${path}`);
+	}
+	return { mode, object: runProofGitV1(cwd, ["hash-object", "--path", path, path]) };
+}
+
+/**
+ * Re-derives the only two permitted live states for frozen intended-untracked paths.
+ * It never trusts a prior proof: every path, blob, mode, untracked set, and index tree
+ * is read from the repository at invocation time.
+ */
+export function deriveIntendedUntrackedProofV1(cwd: string, candidateTree: string, intendedPaths: readonly string[]): IntendedUntrackedProofV1 {
+	const paths = [...intendedPaths];
+	if (paths.length === 0 || new Set(paths).size !== paths.length) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, "intended-untracked paths must be a non-empty unique set");
+	}
+	for (const path of paths) assertCanonicalRepositoryPathV1(path);
+	paths.sort();
+	const root = runProofGitV1(cwd, ["rev-parse", "--show-toplevel"]);
+	const resolvedCandidate = runProofGitV1(root, ["rev-parse", `${candidateTree}^{tree}`]);
+	const untracked = discoverReviewUntrackedPaths(root);
+	const allUntracked = untracked.length === paths.length && untracked.every((path, index) => path === paths[index]);
+	if (allUntracked) {
+		for (const path of paths) {
+			const candidate = candidateTreeEntryV1(root, resolvedCandidate, path);
+			const working = workingTreeEntryV1(root, path);
+			if (candidate.mode !== working.mode || candidate.object !== working.object) {
+				throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, `working-tree content or mode drifted for ${path}`);
+			}
+		}
+		const state = INTENDED_UNTRACKED_PROOF_STATE.ALL_UNTRACKED;
+		return { state, candidate_tree: resolvedCandidate, index_tree: null, paths, proof_hash: domainHashV1("review-intended-untracked-proof", { state, candidate_tree: resolvedCandidate, paths }) };
+	}
+	if (untracked.length !== 0) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, "intended-untracked paths are in a mixed, missing, or extra untracked state");
+	}
+	for (const path of paths) {
+		if (!runProofGitV1(root, ["ls-files", "--error-unmatch", "--", path])) {
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, `index is missing intended-untracked path ${path}`);
+		}
+	}
+	const indexTree = runProofGitV1(root, ["write-tree"]);
+	if (indexTree !== resolvedCandidate) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT, "complete index tree does not exactly match the approved candidate");
+	}
+	const state = INTENDED_UNTRACKED_PROOF_STATE.COMPLETE_INDEX;
+	return { state, candidate_tree: resolvedCandidate, index_tree: indexTree, paths, proof_hash: domainHashV1("review-intended-untracked-proof", { state, candidate_tree: resolvedCandidate, index_tree: indexTree, paths }) };
+}
+
+export function assertRecoverySuccessorEquivalenceV1(input: unknown): RecoverySuccessorEquivalenceV1 {
+	assertObject(input, "successor equivalence");
+	assertExactKeys(input, ["repository", "change", "source", "successor", "source_evidence", "successor_evidence"], "successor equivalence");
+	assertRepositoryBinding(input.repository);
+	assertChangeBinding(input.change);
+	assertSourceBinding(input.source);
+	assertSuccessorBinding(input.successor);
+	assertRecoveryEvidence(input.source_evidence, "source evidence");
+	assertRecoveryEvidence(input.successor_evidence, "successor evidence");
+	const source = input.source_evidence;
+	const successor = input.successor_evidence;
+	const shared = ["base_tree", "complete_snapshot_tree", "initial_review_tree", "final_candidate_tree", "review_projection_hash", "genesis_paths_hash", "scope_digest", "intended_untracked_hash", "intended_untracked_proof_hash", "policy_hash", "policy_evidence_hash"] as const;
+	if (shared.some((key) => source[key] !== successor[key]) || source.receipt_hash !== input.source.receipt_hash || source.ledger_hash !== input.source.frozen_ledger_hash || successor.receipt_hash !== input.successor.receipt_hash || successor.ledger_hash !== input.successor.ledger_hash) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.EQUIVALENCE_MISMATCH, "source and successor do not prove complete target and evidence equivalence");
+	}
+	return input as RecoverySuccessorEquivalenceV1;
+}
+
+function repositoryBindingV1(cwd: string): RepositoryBindingV1 {
+	const authority = resolveRepositoryAuthorityV1(cwd);
+	return {
+		repository_id: authority.repository_id,
+		authority_id: authority.authority_id,
+		common_directory_hash: domainHashV1("common-directory", authority.common_directory),
+		repository_identity_hash: domainHashV1("repository-identity", authority.repository_identity),
+	};
+}
+
+function assertNoSupersessionResetInProgressV1(storeRoot: string): void {
+	const resetPath = join(storeRoot, "control", "reset-state.json");
+	if (!existsSync(resetPath)) return;
+	try {
+		const reset = JSON.parse(readFileSync(resetPath, "utf8")) as { body?: { phase?: unknown } };
+		if (reset.body?.phase === "complete") return;
+	} catch {
+		// An unreadable reset marker is authority ambiguity, never permission to recover.
+	}
+	throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INELIGIBLE_SOURCE, "destructive reset is in progress or unreadable");
+}
+
+function changeBindingV1(changeName: string): OpenSpecChangeBindingV1 {
+	if (!CHANGE_NAME.test(changeName)) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "change name is not canonical");
+	return { change_name: changeName, change_name_hash: domainHashV1("openspec-change-name", changeName), change_root_relative_path: `openspec/changes/${changeName}` };
+}
+
+/** Read a graph-v1 source directly from its immutable repository store without mutation. */
+export function hasEligibleGraphV1RecoveryAuthorityV1(cwd: string): boolean {
+	if (!hasGraphV1Authority(cwd)) return false;
+	try {
+		const authority = resolveRepositoryAuthorityV1(cwd);
+		assertNoSupersessionResetInProgressV1(authority.store_root);
+		const graph = new ReviewGraphObjectStoreV1(join(authority.store_root, "graph-v1"), authority.repository_id, authority.authority_id);
+		const entries = graph.readCurrent().body.lineages as Array<Record<string, unknown>>;
+		for (const entry of entries) {
+			if (entry.mode !== "graph") continue;
+			if (typeof entry.lineage_id !== "string" || typeof entry.head_event_id !== "string" || typeof entry.sequence !== "number" || typeof entry.reduced_state_hash !== "string") {
+				throw new Error("graph authority head is malformed");
+			}
+			const reversed: ReturnType<ReviewGraphObjectStoreV1["readEvent"]>[] = [];
+			let eventId: string | null = entry.head_event_id;
+			let sequence = entry.sequence;
+			while (eventId !== null) {
+				const event = graph.readEvent(eventId);
+				if (event.body.lineage_id !== entry.lineage_id || event.body.sequence !== sequence) throw new Error("graph authority closure is discontinuous");
+				reversed.push(event);
+				eventId = event.body.predecessor_event_id;
+				sequence -= 1;
+			}
+			const state = validateReviewGraphReplayV1(reversed.reverse());
+			if (state.mode !== "ordinary" || state.terminal_state !== "approved" || !state.frozen_ledger) continue;
+			assertFrozenLedgerIntegrity(state.frozen_ledger);
+			if (canonicalHash(state) !== entry.reduced_state_hash || createReceiptForState(state).body.terminal_state !== "approved") {
+				throw new Error("graph authority replay or receipt is invalid");
+			}
+			return true;
+		}
+		return false;
+	} catch (error) {
+		if (error instanceof ReviewAuthoritySupersessionError) throw error;
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INELIGIBLE_SOURCE, `graph recovery eligibility inspection failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+export function inspectRecoverableGraphSourceV1(cwd: string, changeName: string, lineageId: string): RecoverableSourceEligibilityV1 {
+	try {
+		const authority = resolveRepositoryAuthorityV1(cwd);
+		assertNoSupersessionResetInProgressV1(authority.store_root);
+		const graph = new ReviewGraphObjectStoreV1(join(authority.store_root, "graph-v1"), authority.repository_id, authority.authority_id);
+		const root = graph.readCurrent();
+		const graphEntries = root.body.lineages as Array<Record<string, unknown>>;
+		const entries = graphEntries.filter((entry) => entry.lineage_id === lineageId && entry.mode === "graph");
+		if (entries.length !== 1) throw new Error("source lineage is absent or duplicated");
+		const entry = entries[0]!;
+		if (typeof entry.head_event_id !== "string" || typeof entry.sequence !== "number" || typeof entry.reduced_state_hash !== "string") throw new Error("source graph head is malformed");
+		const reversed: ReturnType<ReviewGraphObjectStoreV1["readEvent"]>[] = [];
+		let eventId: string | null = entry.head_event_id;
+		let sequence = entry.sequence;
+		while (eventId !== null) {
+			const event = graph.readEvent(eventId);
+			if (event.body.lineage_id !== lineageId || event.body.sequence !== sequence) throw new Error("source graph closure is discontinuous");
+			reversed.push(event);
+			eventId = event.body.predecessor_event_id;
+			sequence -= 1;
+		}
+		const events = reversed.reverse();
+		const state = validateReviewGraphReplayV1(events);
+		if (state.mode !== "ordinary" || state.terminal_state !== "approved" || !state.frozen_ledger) throw new Error("source is not an approved ordinary graph lineage");
+		assertFrozenLedgerIntegrity(state.frozen_ledger);
+		const receipt = createReceiptForState(state);
+		if (receipt.body.terminal_state !== "approved") throw new Error("source receipt is not approved");
+		return assertRecoverableSourceEligibilityV1({
+			repository: repositoryBindingV1(cwd),
+			change: changeBindingV1(changeName),
+			source: {
+				format: "graph-v1", lineage_id: lineageId, head_event_id: entry.head_event_id, head_sequence: entry.sequence,
+				reduced_state_hash: entry.reduced_state_hash, source_closure_hash: domainHashV1("graph-source-closure", events),
+				receipt_hash: receipt.receipt_hash, frozen_ledger_hash: state.frozen_ledger.frozen_ledger_hash,
+			},
+			immutable: true, readable: true, graph_replay_valid: canonicalHash(state) === entry.reduced_state_hash,
+			receipt_valid: true, frozen_ledger_valid: true, identity_broken: false, reset_in_progress: false, mixed_authority: false, duplicate_authority: false,
+		});
+	} catch (error) {
+		if (error instanceof ReviewAuthoritySupersessionError) throw error;
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INELIGIBLE_SOURCE, `source inspection failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+/** Load and validate an independently approved compact-v2 successor from its repository store. */
+export function inspectApprovedCompactSuccessorV1(cwd: string, lineageId: string): CompactAuthorityBindingV1 {
+	try {
+		const claimants = discoverCompactReviewStores(cwd);
+		if (claimants.length !== 1) {
+			throw new Error("successor authority is absent or ambiguous");
+		}
+		const terminal = claimants[0]!.loadTerminalReceipt();
+		if (terminal.record.state.lineage_id !== lineageId) {
+			throw new Error("successor authority is claimed by another compact lineage");
+		}
+		if (terminal.record.state.state !== COMPACT_REVIEW_STATE.APPROVED) throw new Error("successor is not approved");
+		return {
+			format: "compact-v2", lineage_id: terminal.record.state.lineage_id, authority_revision: terminal.record.revision,
+			state_hash: canonicalHash(terminal.record.state), receipt_hash: terminal.receipt.receipt_hash,
+			ledger_hash: domainHashV1("compact-findings", terminal.record.state.findings), runtime_identity_hash: terminal.record.state.runtime_identity.identity_hash,
+		};
+	} catch (error) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INELIGIBLE_SOURCE, `successor inspection failed: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+export function prepareSupersessionV1(input: PrepareSupersessionInputV1): PreparedSupersessionV1 {
+	if (typeof input.operation_id !== "string" || !OPERATION_ID.test(input.operation_id)) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "operation_id must be a digest");
+	}
+	const eligibility = assertRecoverableSourceEligibilityV1(input.eligibility);
+	const equivalence = assertRecoverySuccessorEquivalenceV1(input.equivalence);
+	if (
+		canonicalJsonV1(eligibility.repository) !== canonicalJsonV1(equivalence.repository) ||
+		canonicalJsonV1(eligibility.change) !== canonicalJsonV1(equivalence.change) ||
+		canonicalJsonV1(eligibility.source) !== canonicalJsonV1(equivalence.source)
+	) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.EQUIVALENCE_MISMATCH, "inspection identities do not bind the same source");
+	}
+	const predecessor = input.predecessor_recovery_id ?? null;
+	if (predecessor !== null) assertDigest(predecessor, "predecessor_recovery_id");
+	const sequence = input.sequence ?? 0;
+	if (!Number.isSafeInteger(sequence) || sequence < 0) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "sequence must be a non-negative integer");
+	}
+	const equivalenceBinding: RecoveryEquivalenceBindingV1 = {
+		base_tree: equivalence.source_evidence.base_tree,
+		complete_snapshot_tree: equivalence.source_evidence.complete_snapshot_tree,
+		initial_review_tree: equivalence.source_evidence.initial_review_tree,
+		final_candidate_tree: equivalence.source_evidence.final_candidate_tree,
+		review_projection_hash: equivalence.source_evidence.review_projection_hash,
+		genesis_paths_hash: equivalence.source_evidence.genesis_paths_hash,
+		scope_digest: equivalence.source_evidence.scope_digest,
+		intended_untracked_hash: equivalence.source_evidence.intended_untracked_hash,
+		intended_untracked_proof_hash: equivalence.source_evidence.intended_untracked_proof_hash,
+		policy_hash: equivalence.source_evidence.policy_hash,
+		policy_evidence_hash: equivalence.source_evidence.policy_evidence_hash,
+		source_receipt_hash: eligibility.source.receipt_hash,
+		successor_receipt_hash: equivalence.successor.receipt_hash,
+		source_ledger_hash: eligibility.source.frozen_ledger_hash,
+		successor_ledger_hash: equivalence.successor.ledger_hash,
+	};
+	const request = { operation_id: input.operation_id, sequence, predecessor_recovery_id: predecessor, repository: eligibility.repository, change: eligibility.change, source: eligibility.source, successor: equivalence.successor, equivalence: equivalenceBinding };
+	const request_hash = domainHashV1("review-authority-supersession-request", request);
+	const challenge = `SUPERSEDE REVIEW AUTHORITY ${eligibility.repository.repository_id} CHANGE ${eligibility.change.change_name}\nSOURCE graph-v1:${eligibility.source.lineage_id}@${eligibility.source.head_event_id}\nWITH compact-v2:${equivalence.successor.lineage_id}@${equivalence.successor.authority_revision}\nREQUEST ${request_hash}`;
+	return {
+		request_hash,
+		challenge,
+		body: {
+			schema: "gentle-ai.review-authority-supersession/v1",
+			...request,
+			request_hash,
+			authorization_hash: domainHashV1("review-authority-supersession-pending-authorization", { challenge, request_hash }),
+		},
+	};
+}
+
+export function createSupersessionEnvelopeV1(body: SupersessionBodyV1): SupersessionEnvelopeV1 {
+	assertBody(body);
+	const canonicalBody = JSON.parse(canonicalJsonV1(body)) as SupersessionBodyV1;
+	return { body: canonicalBody, recovery_id: domainHashV1("review-authority-supersession", canonicalBody) };
+}
+
+export function parseSupersessionEnvelopeV1(input: string): SupersessionEnvelopeV1 {
+	const parsed = parseCanonicalJsonV1(input);
+	assertObject(parsed, "supersession envelope");
+	assertExactKeys(parsed, ["body", "recovery_id"], "supersession envelope");
+	assertBody(parsed.body);
+	assertDigest(parsed.recovery_id, "recovery_id");
+	const expected = createSupersessionEnvelopeV1(parsed.body);
+	if (expected.recovery_id !== parsed.recovery_id) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "recovery_id does not bind the body");
+	return expected;
+}
+
+/** Atomically append one operation record. Existing identical bytes are an idempotent retry. */
+export interface SupersessionWriteOptionsV1 {
+	faultInjector?: (point: "before-temp-fsync" | "before-link" | "after-link" | "before-directory-fsync") => void;
+}
+
+function fsyncDirectoryV1(directory: string): void {
+	const handle = openSync(directory, "r");
+	try { fsyncSync(handle); } finally { closeSync(handle); }
+}
+
+function fsyncSupersessionDirectoryV1(directory: string, options: SupersessionWriteOptionsV1): void {
+	options.faultInjector?.("before-directory-fsync");
+	fsyncDirectoryV1(directory);
+}
+
+export function writeSupersessionRecordV1(directory: string, envelope: SupersessionEnvelopeV1, options: SupersessionWriteOptionsV1 = {}): string {
+	const canonical = createSupersessionEnvelopeV1(envelope.body);
+	if (canonical.recovery_id !== envelope.recovery_id) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "envelope is not content-bound");
+	mkdirSync(directory, { recursive: true, mode: 0o700 });
+	const path = join(directory, `${canonical.body.operation_id}.json`);
+	const bytes = canonicalJsonV1(canonical);
+	try {
+		const existing = readFileSync(path, "utf8");
+		if (existing === bytes) {
+			fsyncSupersessionDirectoryV1(directory, options);
+			return path;
+		}
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.OPERATION_CONFLICT, "operation ID already has different semantics");
+	} catch (error) {
+		if (error instanceof ReviewAuthoritySupersessionError) throw error;
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+	const temporary = join(directory, `.${canonical.body.operation_id}.${process.pid}.tmp`);
+	try {
+		writeFileSync(temporary, bytes, { flag: "wx", mode: 0o600 });
+		options.faultInjector?.("before-temp-fsync");
+		const file = openSync(temporary, "r");
+		try { fsyncSync(file); } finally { closeSync(file); }
+		options.faultInjector?.("before-link");
+		try { linkSync(temporary, path); } catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+			const existing = readFileSync(path, "utf8");
+			if (existing !== bytes) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.OPERATION_CONFLICT, "operation ID already has different semantics");
+		}
+		options.faultInjector?.("after-link");
+		fsyncSupersessionDirectoryV1(directory, options);
+		return path;
+	} finally {
+		rmSync(temporary, { force: true });
+	}
+}
+
+function chainError(message: string): never {
+	throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, message);
+}
+
+/**
+ * Read immutable records for one change and derive their sole linear head.
+ * Filesystem ordering is deliberately ignored; every predecessor and sequence
+ * is bound by record content.
+ */
+export function loadSupersessionChainV1(directory: string): SupersessionEnvelopeV1[] {
+	let names: string[];
+	try {
+		names = readdirSync(directory);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+		throw error;
+	}
+	const records: SupersessionEnvelopeV1[] = [];
+	for (const name of names) {
+		if (/^\.[0-9a-f]{64}\.\d+\.tmp$/.test(name)) continue;
+		if (!/^[0-9a-f]{64}\.json$/.test(name)) chainError("supersession directory contains an unexpected entry");
+		const path = join(directory, name);
+		if (!lstatSync(path).isFile()) chainError("supersession record is not a regular file");
+		const record = parseSupersessionEnvelopeV1(readFileSync(path, "utf8"));
+		if (name !== `${record.body.operation_id}.json`) chainError("supersession record filename does not bind its operation");
+		records.push(record);
+	}
+	if (records.length === 0) return [];
+	const byRecoveryId = new Map(records.map((record) => [record.recovery_id, record]));
+	if (byRecoveryId.size !== records.length) chainError("duplicate recovery identity");
+	const children = new Map<string | null, SupersessionEnvelopeV1[]>();
+	for (const record of records) {
+		const predecessor = record.body.predecessor_recovery_id;
+		if (predecessor !== null && !byRecoveryId.has(predecessor)) chainError("supersession predecessor is missing");
+		const siblings = children.get(predecessor) ?? [];
+		siblings.push(record);
+		children.set(predecessor, siblings);
+	}
+	if ((children.get(null) ?? []).length !== 1) chainError("supersession chain must have one root");
+	const chain: SupersessionEnvelopeV1[] = [];
+	let current = children.get(null)![0]!;
+	while (true) {
+		if (current.body.sequence !== chain.length) chainError("supersession sequence is not contiguous");
+		chain.push(current);
+		const next = children.get(current.recovery_id) ?? [];
+		if (next.length === 0) break;
+		if (next.length !== 1) chainError("supersession chain forks");
+		current = next[0]!;
+	}
+	if (chain.length !== records.length) chainError("supersession chain contains a cycle or disconnected record");
+	return chain;
+}
+
+
+export interface SupersessionStoreOptionsV1 extends SupersessionWriteOptionsV1 {
+	mutationLockPlatform?: ReviewLockPlatformAdapterV1;
+}
+
+export interface InstalledSupersessionV1 {
+	recovery_id: string;
+	path: string;
+}
+
+/** A caller-owned live observation that is checked only after acquiring the mutation lock. */
+export interface SupersessionCasCheckV1 {
+	label: string;
+	expected: string;
+	observe: () => string;
+}
+
+export interface SupersessionInstallOptionsV1 {
+	casChecks?: readonly SupersessionCasCheckV1[];
+}
+
+/**
+ * Repository-anchored append-only supersession storage. This is deliberately
+ * storage-only: change-aware authority selection remains Task 4.
+ */
+export class SupersessionStoreV1 {
+	readonly root: string;
+	readonly #authority: RepositoryAuthorityV1;
+	readonly #lock: ReviewMutationLockV1;
+	readonly #options: SupersessionStoreOptionsV1;
+
+	static forRepository(cwd: string, options: SupersessionStoreOptionsV1 = {}): SupersessionStoreV1 {
+		return new SupersessionStoreV1(resolveRepositoryAuthorityV1(cwd), options);
+	}
+
+	private constructor(authority: RepositoryAuthorityV1, options: SupersessionStoreOptionsV1) {
+		this.#authority = authority;
+		this.#options = options;
+		this.root = assertManagedStorePathV1(authority.common_directory, join(authority.store_root, "control", "authority-supersession-v1"));
+		this.#lock = new ReviewMutationLockV1(join(authority.store_root, "control"), authority.repository_id, authority.authority_id, options.mutationLockPlatform);
+	}
+
+	load(changeName: string): SupersessionEnvelopeV1[] {
+		return loadSupersessionChainV1(this.directoryForChange(changeName, false));
+	}
+
+	hasRecoveryRequiredMarker(changeName?: string): boolean {
+		if (changeName !== undefined) return this.isRecoveryRequiredMarker(this.recoveryMarkerPath(changeName, false));
+		try {
+			return readdirSync(this.recoveryMarkerDirectory(false)).some((name) =>
+				/^[0-9a-f]{64}\.json$/.test(name) && this.isRecoveryRequiredMarker(join(this.recoveryMarkerDirectory(false), name)),
+			);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+			return true;
+		}
+	}
+
+	hasValidRecoveryRequiredMarker(changeName: string): boolean {
+		const path = this.recoveryMarkerPath(changeName, false);
+		try {
+			const entry = lstatSync(path);
+			if (!entry.isFile() || entry.isSymbolicLink()) throw new Error("marker is not a regular file");
+			const expected = { schema: "gentle-ai.recovery-required/v1", change_name: changeName };
+			const raw = readFileSync(path, "utf8");
+			if (canonicalJsonV1(JSON.parse(raw)) !== canonicalJsonV1(expected)) throw new Error("marker content is invalid");
+			return true;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, `recovery-required marker is unreadable or invalid: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	install(changeName: string, input: SupersessionEnvelopeV1, installOptions: SupersessionInstallOptionsV1 = {}): InstalledSupersessionV1 {
+		const envelope = createSupersessionEnvelopeV1(input.body);
+		if (envelope.recovery_id !== input.recovery_id) {
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "installation envelope is not content-bound");
+		}
+		const owner = this.#lock.acquire();
+		try {
+			const directory = this.directoryForChange(changeName, true);
+			this.assertCurrentRepository(envelope, changeName);
+			const chain = loadSupersessionChainV1(directory);
+			for (const check of installOptions.casChecks ?? []) {
+				if (!check.label || check.observe() !== check.expected) {
+					throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.STALE_AUTHORIZATION, `live ${check.label || "authority"} binding changed after preparation`);
+				}
+			}
+			const existing = chain.find((record) => record.body.operation_id === envelope.body.operation_id);
+			if (existing) {
+				if (canonicalJsonV1(existing) !== canonicalJsonV1(envelope)) {
+					throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.OPERATION_CONFLICT, "operation ID already has different semantics");
+				}
+				return { recovery_id: existing.recovery_id, path: writeSupersessionRecordV1(directory, envelope, this.#options) };
+			}
+			const predecessor = chain.at(-1);
+			if (envelope.body.predecessor_recovery_id !== (predecessor?.recovery_id ?? null) || envelope.body.sequence !== chain.length) {
+				throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.STALE_AUTHORIZATION, "prepared predecessor or sequence is stale");
+			}
+			for (const record of chain) this.assertSameChainBinding(record, envelope);
+			this.writeRecoveryRequiredMarker(changeName);
+			const path = writeSupersessionRecordV1(directory, envelope, this.#options);
+			const reread = loadSupersessionChainV1(directory);
+			if (reread.at(-1)?.recovery_id !== envelope.recovery_id || reread.length !== chain.length + 1) {
+				throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.RACE_UNSAFE, "supersession readback did not produce one expected chain head");
+			}
+			return { recovery_id: envelope.recovery_id, path };
+		} finally {
+			this.#lock.release(owner);
+		}
+	}
+
+	private directoryForChange(changeName: string, create: boolean): string {
+		if (!CHANGE_NAME.test(changeName)) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "change name is not canonical");
+		const directory = assertManagedStorePathV1(this.#authority.common_directory, join(this.root, domainHashV1("openspec-change-name", changeName)));
+		try {
+			if (create) this.ensureAnchoredDirectory(directory);
+			else if (existsSync(directory)) this.assertAnchoredDirectory(directory);
+			return directory;
+		} catch (error) {
+			if (error instanceof ReviewAuthoritySupersessionError) throw error;
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.REPOSITORY_MISMATCH, `supersession store path is unsafe: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	private recoveryMarkerDirectory(create: boolean): string {
+		const directory = assertManagedStorePathV1(this.#authority.common_directory, join(this.root, "recovery-required-v1"));
+		if (create) this.ensureAnchoredDirectory(directory);
+		else if (existsSync(directory)) this.assertAnchoredDirectory(directory);
+		return directory;
+	}
+
+	private recoveryMarkerPath(changeName: string, create: boolean): string {
+		if (!CHANGE_NAME.test(changeName)) throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.INVALID, "change name is not canonical");
+		return join(this.recoveryMarkerDirectory(create), `${domainHashV1("openspec-change-name", changeName)}.json`);
+	}
+
+	private isRecoveryRequiredMarker(path: string): boolean {
+		try {
+			const entry = lstatSync(path);
+			return entry.isFile() && !entry.isSymbolicLink();
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+			return true;
+		}
+	}
+
+	private writeRecoveryRequiredMarker(changeName: string): void {
+		const path = this.recoveryMarkerPath(changeName, true);
+		if (!this.isRecoveryRequiredMarker(path)) {
+			writeFileSync(path, canonicalJsonV1({ schema: "gentle-ai.recovery-required/v1", change_name: changeName }), { flag: "wx", mode: 0o600 });
+			const file = openSync(path, "r");
+			try { fsyncSync(file); } finally { closeSync(file); }
+		}
+		fsyncDirectoryV1(this.recoveryMarkerDirectory(false));
+	}
+
+	private ensureAnchoredDirectory(directory: string): void {
+		let current = this.#authority.common_directory;
+		for (const part of relative(current, directory).split(/[\\/]/).filter(Boolean)) {
+			const parent = current;
+			current = join(parent, part);
+			if (!existsSync(current)) {
+				mkdirSync(current, { mode: 0o700 });
+				fsyncDirectoryV1(parent);
+			}
+			this.assertAnchoredDirectory(current);
+		}
+	}
+
+	private assertAnchoredDirectory(directory: string): void {
+		const entry = lstatSync(directory);
+		if (!entry.isDirectory() || entry.isSymbolicLink()) throw new Error("supersession store directory is not a real directory");
+		assertManagedStorePathV1(this.#authority.common_directory, directory);
+	}
+
+	private assertCurrentRepository(envelope: SupersessionEnvelopeV1, changeName: string): void {
+		const expected = repositoryBindingV1(this.#authority.common_directory);
+		if (canonicalJsonV1(envelope.body.repository) !== canonicalJsonV1(expected) || envelope.body.change.change_name !== changeName) {
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.REPOSITORY_MISMATCH, "supersession does not bind this repository and change");
+		}
+	}
+
+	private assertSameChainBinding(previous: SupersessionEnvelopeV1, next: SupersessionEnvelopeV1): void {
+		if (canonicalJsonV1(previous.body.repository) !== canonicalJsonV1(next.body.repository) || canonicalJsonV1(previous.body.change) !== canonicalJsonV1(next.body.change) || canonicalJsonV1(previous.body.source) !== canonicalJsonV1(next.body.source)) {
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "supersession chain changes its repository, change, or source binding");
+		}
+	}
+}
+
+/**
+ * Re-derive successor-owned recovery bindings from live compact authority. This is
+ * intentionally read-only and is called on both sides of a lifecycle final recheck.
+ */
+export function assertLiveRecoveredSuccessorBindingV1(cwd: string, recovery: SupersessionEnvelopeV1, state: CompactReviewStateV2): void {
+	const proofHash = state.intended_untracked.length === 0
+		? domainHashV1("review-recovery-empty-untracked", { candidate_tree: state.current_candidate_tree, paths: [] })
+		: deriveIntendedUntrackedProofV1(cwd, state.current_candidate_tree, state.intended_untracked).proof_hash;
+	const live = {
+		base_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.base_tree),
+		complete_snapshot_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.complete_snapshot_tree),
+		initial_review_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.initial_review_tree),
+		final_candidate_tree: domainHashV1("review-recovery-tree", state.current_candidate_tree),
+		review_projection_hash: domainHashV1("review-recovery-projection", state.initial_snapshot.review_projection),
+		genesis_paths_hash: domainHashV1("compact-paths", state.genesis_paths),
+		scope_digest: domainHashV1("review-recovery-scope", {
+			base_tree: state.initial_snapshot.base_tree,
+			complete_snapshot_tree: state.initial_snapshot.complete_snapshot_tree,
+			initial_review_tree: state.initial_snapshot.initial_review_tree,
+			final_candidate_tree: state.current_candidate_tree,
+			genesis_paths: state.genesis_paths,
+			intended_untracked: state.intended_untracked,
+		}),
+		intended_untracked_hash: domainHashV1("compact-untracked", state.intended_untracked),
+		intended_untracked_proof_hash: proofHash,
+		policy_hash: state.policy_hash,
+		policy_evidence_hash: domainHashV1("review-recovery-policy-evidence", { policy_hash: state.policy_hash, runtime_identity_hash: state.runtime_identity.identity_hash }),
+		successor_ledger_hash: domainHashV1("compact-findings", state.findings),
+	};
+	const bound = recovery.body.equivalence;
+	for (const [field, value] of Object.entries(live)) {
+		if (bound[field as keyof RecoveryEquivalenceBindingV1] !== value) {
+		throw new ReviewAuthoritySupersessionError(
+			field.includes("untracked") ? REVIEW_AUTHORITY_SUPERSESSION_ERROR.UNTRACKED_DRIFT : REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS,
+			`recovery ${field} no longer matches live compact authority`,
+		);
+		}
+	}
+	if (bound.successor_receipt_hash !== recovery.body.successor.receipt_hash || bound.successor_ledger_hash !== recovery.body.successor.ledger_hash) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "recovery receipt or ledger binding is inconsistent");
+	}
+}
+
+/**
+ * Re-derive graph-v1 source-owned evidence from immutable authority before and
+ * after a recovered lifecycle target evaluation. Graph-v1 has no runtime
+ * identity field, so policy evidence is established by its immutable policy
+ * hash while the compact-side validator rederives the shared runtime evidence.
+ */
+export function assertLiveRecoveredSourceBindingV1(cwd: string, recovery: SupersessionEnvelopeV1): void {
+	const source = inspectRecoverableGraphSourceV1(cwd, recovery.body.change.change_name, recovery.body.source.lineage_id);
+	if (
+		canonicalJsonV1(source.repository) !== canonicalJsonV1(recovery.body.repository) ||
+		canonicalJsonV1(source.change) !== canonicalJsonV1(recovery.body.change) ||
+		canonicalJsonV1(source.source) !== canonicalJsonV1(recovery.body.source)
+	) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "recovery source identity no longer matches live graph authority");
+	}
+	const authority = resolveRepositoryAuthorityV1(cwd);
+	const graph = new ReviewGraphObjectStoreV1(join(authority.store_root, "graph-v1"), authority.repository_id, authority.authority_id);
+	const entry = (graph.readCurrent().body.lineages as Array<Record<string, unknown>>).find((candidate) => candidate.lineage_id === source.source.lineage_id && candidate.mode === "graph");
+	if (!entry || typeof entry.head_event_id !== "string" || typeof entry.sequence !== "number") {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "live graph source head is unavailable");
+	}
+	const reversed: ReturnType<ReviewGraphObjectStoreV1["readEvent"]>[] = [];
+	let eventId: string | null = entry.head_event_id;
+	let sequence = entry.sequence;
+	while (eventId !== null) {
+		const event = graph.readEvent(eventId);
+		if (event.body.lineage_id !== source.source.lineage_id || event.body.sequence !== sequence) {
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "live graph source closure is discontinuous");
+		}
+		reversed.push(event);
+		eventId = event.body.predecessor_event_id;
+		sequence -= 1;
+	}
+	const state = validateReviewGraphReplayV1(reversed.reverse());
+	if (!state.frozen_ledger || !state.final_candidate_tree) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "live graph source lacks terminal evidence");
+	}
+	// Graph-v1 did not persist an intended-untracked path set. Its immutable source
+	// target therefore proves the only representable graph-v1 state: an empty set.
+	const intendedUntracked: string[] = [];
+	const intendedUntrackedProofHash = domainHashV1("review-recovery-empty-untracked", {
+		candidate_tree: state.final_candidate_tree,
+		paths: intendedUntracked,
+	});
+	const genesisPaths = state.genesis_paths ?? [];
+	const live = {
+		base_tree: domainHashV1("review-recovery-tree", state.base_tree),
+		complete_snapshot_tree: domainHashV1("review-recovery-tree", state.complete_snapshot_tree),
+		initial_review_tree: domainHashV1("review-recovery-tree", state.initial_review_tree),
+		final_candidate_tree: domainHashV1("review-recovery-tree", state.final_candidate_tree),
+		review_projection_hash: domainHashV1("review-recovery-projection", state.review_projection),
+		genesis_paths_hash: domainHashV1("compact-paths", genesisPaths),
+		scope_digest: domainHashV1("review-recovery-scope", {
+			base_tree: state.base_tree,
+			complete_snapshot_tree: state.complete_snapshot_tree,
+			initial_review_tree: state.initial_review_tree,
+			final_candidate_tree: state.final_candidate_tree,
+			genesis_paths: genesisPaths,
+			intended_untracked: intendedUntracked,
+		}),
+		intended_untracked_hash: domainHashV1("compact-untracked", intendedUntracked),
+		intended_untracked_proof_hash: intendedUntrackedProofHash,
+		policy_hash: state.policy_hash,
+		source_receipt_hash: createReceiptForState(state).receipt_hash,
+		source_ledger_hash: state.frozen_ledger.frozen_ledger_hash,
+	};
+	for (const [field, value] of Object.entries(live)) {
+		if (recovery.body.equivalence[field as keyof RecoveryEquivalenceBindingV1] !== value) {
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, `recovery ${field} no longer matches live graph authority`);
+		}
+	}
+}
+
+/** A compact authority selected only through a complete, change-scoped recovery chain. */
+export interface ResolvedReviewAuthorityForChangeV1 {
+	recovery: SupersessionEnvelopeV1;
+	store: CompactReviewStoreV2;
+	record: ReturnType<CompactReviewStoreV2["load"]>;
+}
+
+/**
+ * Resolve recovery authority for one canonical OpenSpec change. Generic compact
+ * discovery intentionally does not call this: without the change name it cannot
+ * prove which supersession applies and must preserve graph/compact ambiguity.
+ */
+export function resolveReviewAuthorityForChange(cwd: string, changeName: string): ResolvedReviewAuthorityForChangeV1 | undefined {
+	const supersessions = SupersessionStoreV1.forRepository(cwd);
+	const eligibleGraphAuthority = hasEligibleGraphV1RecoveryAuthorityV1(cwd);
+	const markerIsValid = supersessions.hasValidRecoveryRequiredMarker(changeName);
+	const chain = supersessions.load(changeName);
+	if (chain.length === 0) {
+		if (eligibleGraphAuthority || markerIsValid) {
+			throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "recovery-required authority has no bound supersession record");
+		}
+		return undefined;
+	}
+	if (!markerIsValid) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "recovery-required supersession is missing its valid marker");
+	}
+	const recovery = chain.at(-1)!;
+	let source: RecoverableSourceEligibilityV1;
+	let successor: CompactAuthorityBindingV1;
+	try {
+		source = inspectRecoverableGraphSourceV1(cwd, changeName, recovery.body.source.lineage_id);
+		successor = inspectApprovedCompactSuccessorV1(cwd, recovery.body.successor.lineage_id);
+	} catch (error) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, `recovery authority is unreadable or ambiguous: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	if (
+		canonicalJsonV1(source.repository) !== canonicalJsonV1(recovery.body.repository) ||
+		canonicalJsonV1(source.change) !== canonicalJsonV1(recovery.body.change) ||
+		canonicalJsonV1(source.source) !== canonicalJsonV1(recovery.body.source)
+	) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "recovery source or repository binding no longer matches live authority");
+	}
+	if (canonicalJsonV1(successor) !== canonicalJsonV1(recovery.body.successor)) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "recovery successor binding no longer matches live authority");
+	}
+	const store = CompactReviewStoreV2.forRepository(cwd, successor.lineage_id);
+	const record = store.load();
+	if (record.state.state !== COMPACT_REVIEW_STATE.APPROVED || !existsSync(store.receiptPath)) {
+		throw new ReviewAuthoritySupersessionError(REVIEW_AUTHORITY_SUPERSESSION_ERROR.CHAIN_AMBIGUOUS, "recovery successor is not terminally approved");
+	}
+	assertLiveRecoveredSourceBindingV1(cwd, recovery);
+	assertLiveRecoveredSuccessorBindingV1(cwd, recovery, record.state);
+	return { recovery, store, record };
+}

--- a/lib/review-compact-gate.ts
+++ b/lib/review-compact-gate.ts
@@ -4,6 +4,7 @@ import {
 	type CompactReceiptEnvelopeV2,
 	type CompactReviewStateV2,
 } from "./review-compact.ts";
+import { hasEligibleGraphV1RecoveryAuthorityV1, resolveReviewAuthorityForChange, SupersessionStoreV1 } from "./review-authority-supersession.ts";
 import { discoverCompactReview } from "./review-facade.ts";
 import {
 	GATE_RESULT,
@@ -25,8 +26,63 @@ export interface DerivedCompactGateTarget {
 export interface ValidateCompactGateOptions {
 	cwd: string;
 	lineageId?: string;
+	/** Enables exact change-scoped recovery authority resolution; generic gates remain unchanged. */
+	changeName?: string;
 	deriveTarget: () => DerivedCompactGateTarget;
 	beforeFinalRecheck?: () => void;
+}
+
+const GATE_AUTHORITY_PROVENANCE = {
+	GENERIC: "generic",
+	RECOVERED: "recovered",
+} as const;
+
+interface GenericGateAuthoritySelection {
+	provenance: typeof GATE_AUTHORITY_PROVENANCE.GENERIC;
+	store: ReturnType<typeof discoverCompactReview>["store"];
+	record: ReturnType<typeof discoverCompactReview>["record"];
+}
+
+interface RecoveredGateAuthoritySelection {
+	provenance: typeof GATE_AUTHORITY_PROVENANCE.RECOVERED;
+	recoveryId: string;
+	store: ReturnType<typeof discoverCompactReview>["store"];
+	record: ReturnType<typeof discoverCompactReview>["record"];
+}
+
+type GateAuthoritySelection = GenericGateAuthoritySelection | RecoveredGateAuthoritySelection;
+
+function discoverGateAuthority(options: ValidateCompactGateOptions, lineageId?: string): GateAuthoritySelection {
+	if (options.changeName !== undefined) {
+		const recovered = resolveReviewAuthorityForChange(options.cwd, options.changeName);
+		if (recovered !== undefined) {
+			return {
+				provenance: GATE_AUTHORITY_PROVENANCE.RECOVERED,
+				recoveryId: recovered.recovery.recovery_id,
+				store: recovered.store,
+				record: recovered.record,
+			};
+		}
+	}
+	return { provenance: GATE_AUTHORITY_PROVENANCE.GENERIC, ...discoverCompactReview(options.cwd, lineageId, true) };
+}
+
+function rediscoverGateAuthority(options: ValidateCompactGateOptions, first: GateAuthoritySelection): GateAuthoritySelection {
+	if (first.provenance === GATE_AUTHORITY_PROVENANCE.GENERIC) {
+		if (hasEligibleGraphV1RecoveryAuthorityV1(options.cwd) || SupersessionStoreV1.forRepository(options.cwd).hasRecoveryRequiredMarker()) {
+			throw new Error("Recovery-required authority cannot be validated without a bound change.");
+		}
+		return { provenance: GATE_AUTHORITY_PROVENANCE.GENERIC, ...discoverCompactReview(options.cwd, first.record.state.lineage_id, true) };
+	}
+	if (options.changeName === undefined) throw new Error("Recovered gate authority lost its change binding.");
+	const recovered = resolveReviewAuthorityForChange(options.cwd, options.changeName);
+	if (recovered === undefined) throw new Error("Required recovered authority is missing.");
+	return {
+		provenance: GATE_AUTHORITY_PROVENANCE.RECOVERED,
+		recoveryId: recovered.recovery.recovery_id,
+		store: recovered.store,
+		record: recovered.record,
+	};
 }
 
 function equal(left: unknown, right: unknown): boolean {
@@ -96,8 +152,24 @@ function invalidResult(receiptHash: string, target: GateTargetV1, reason: string
 export function validateCompactReviewGate(
 	options: ValidateCompactGateOptions,
 ): GateResultV1 {
-	const firstDiscovery = discoverCompactReview(options.cwd, options.lineageId, true);
-	const first = firstDiscovery.store.loadTerminalReceipt();
+	try {
+		if (options.changeName === undefined && hasEligibleGraphV1RecoveryAuthorityV1(options.cwd)) {
+			return invalidResult("", options.deriveTarget().target, "Eligible graph-v1 recovery authority requires a bound change and valid supersession.");
+		}
+	} catch (error) {
+		return invalidResult("", options.deriveTarget().target, `Recovery authority is unresolved: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	let firstDiscovery: GateAuthoritySelection;
+	let first: ReturnType<ReturnType<typeof discoverCompactReview>["store"]["loadTerminalReceipt"]>;
+	try {
+		firstDiscovery = discoverGateAuthority(options, options.lineageId);
+		first = firstDiscovery.store.loadTerminalReceipt();
+		if (options.changeName === undefined && SupersessionStoreV1.forRepository(options.cwd).hasRecoveryRequiredMarker()) {
+			return invalidResult(first.receipt.receipt_hash, options.deriveTarget().target, "Recovery-required marker cannot be validated without a bound change.");
+		}
+	} catch (error) {
+		return invalidResult("", options.deriveTarget().target, `Recovery authority is unresolved: ${error instanceof Error ? error.message : String(error)}`);
+	}
 	if (first.record.state.state === COMPACT_REVIEW_STATE.ESCALATED) {
 		return invalidResult(first.receipt.receipt_hash, options.deriveTarget().target, "Escalated compact authority cannot cross a lifecycle gate.");
 	}
@@ -113,9 +185,21 @@ export function validateCompactReviewGate(
 	);
 	if (evaluated.status !== GATE_RESULT.ALLOW) return evaluated;
 	options.beforeFinalRecheck?.();
-	const finalDiscovery = discoverCompactReview(options.cwd, first.record.state.lineage_id, true);
-	const final = finalDiscovery.store.loadTerminalReceipt();
 	const finalTarget = options.deriveTarget();
+	let final: ReturnType<typeof firstDiscovery.store.loadTerminalReceipt>;
+	try {
+		const finalDiscovery = rediscoverGateAuthority(options, firstDiscovery);
+		if (
+			finalDiscovery.provenance !== firstDiscovery.provenance ||
+			(firstDiscovery.provenance === GATE_AUTHORITY_PROVENANCE.RECOVERED &&
+				(finalDiscovery.provenance !== GATE_AUTHORITY_PROVENANCE.RECOVERED || finalDiscovery.recoveryId !== firstDiscovery.recoveryId))
+		) {
+			return invalidResult(first.receipt.receipt_hash, finalTarget.target, "Recovered authority changed during final authorization.");
+		}
+		final = finalDiscovery.store.loadTerminalReceipt();
+	} catch (error) {
+		return invalidResult(first.receipt.receipt_hash, finalTarget.target, `Compact authority changed or became invalid during final authorization: ${error instanceof Error ? error.message : String(error)}`);
+	}
 	if (
 		final.record.revision !== first.record.revision ||
 		!equal(final.receipt, first.receipt) ||

--- a/lib/sdd-status.ts
+++ b/lib/sdd-status.ts
@@ -86,12 +86,26 @@ export interface SddStatus {
 	isNonAuthoritative: boolean;
 }
 
+export interface ValidatedReviewAuthorityResolution {
+	activeAuthorityId: string;
+}
+
+/**
+ * Optional controller-owned recovery overlay. Status never infers authority from
+ * OpenSpec artifacts: callers opt in only when a repository review binding exists.
+ */
+export interface SddReviewAuthorityOverlay {
+	expected: boolean;
+	resolve: () => ValidatedReviewAuthorityResolution | undefined;
+}
+
 export interface ResolveSddStatusOptions {
 	cwd: string;
 	changeName?: string;
 	includeInstructions?: boolean;
 	workspaceRoot?: string;
 	artifactStore?: SddArtifactStore;
+	reviewAuthority?: SddReviewAuthorityOverlay;
 }
 
 const EMPTY_PATHS: SddArtifactPaths = {
@@ -196,7 +210,31 @@ function reportIsClearlyPassing(path: string | undefined): boolean {
 	return hasPassSignal && !hasBlocker;
 }
 
-function emptyStatus(cwd: string, changeName: string | null, blockedReasons: string[], artifactStore: SddArtifactStore = "openspec", isNonAuthoritative = false): SddStatus {
+function withRecoveryBlock(status: SddStatus, reviewAuthority?: SddReviewAuthorityOverlay): SddStatus {
+	if (!reviewAuthority?.expected) return status;
+	try {
+		const resolved = reviewAuthority.resolve();
+		if (resolved?.activeAuthorityId) return status;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			...status,
+			applyState: "blocked",
+			dependencies: { apply: "blocked", verify: "blocked", sync: "blocked", archive: "blocked" },
+			nextRecommended: "resolve-review",
+			blockedReasons: [...status.blockedReasons, `resolve-review: ${message}`],
+		};
+	}
+	return {
+		...status,
+		applyState: "blocked",
+		dependencies: { apply: "blocked", verify: "blocked", sync: "blocked", archive: "blocked" },
+		nextRecommended: "resolve-review",
+		blockedReasons: [...status.blockedReasons, "resolve-review: validated active review authority is missing."],
+	};
+}
+
+function emptyStatus(cwd: string, changeName: string | null, blockedReasons: string[], artifactStore: SddArtifactStore = "openspec", isNonAuthoritative = false, reviewAuthority?: SddReviewAuthorityOverlay): SddStatus {
 	const root = resolve(cwd);
 	const changesDir = join(root, "openspec", "changes");
 	const actionContext: SddActionContext = {
@@ -205,7 +243,7 @@ function emptyStatus(cwd: string, changeName: string | null, blockedReasons: str
 		allowedEditRoots: [root],
 		warnings: [],
 	};
-	return {
+	return withRecoveryBlock({
 		schemaName: "gentle-pi.sdd-status",
 		schemaVersion: 1,
 		changeName,
@@ -238,7 +276,7 @@ function emptyStatus(cwd: string, changeName: string | null, blockedReasons: str
 		nextRecommended: blockedReasons[0] ?? "Start an SDD change.",
 		blockedReasons,
 		isNonAuthoritative,
-	};
+	}, reviewAuthority);
 }
 
 export function listActiveOpenSpecChanges(cwd: string): string[] {
@@ -383,13 +421,13 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 			if (store === "both") {
 				return nonAuthoritativeStatus(options.cwd, null, store, options.includeInstructions);
 			}
-			return emptyStatus(root, null, ["No active SDD changes found."], store);
+			return emptyStatus(root, null, ["No active SDD changes found."], store, false, options.reviewAuthority);
 		} else {
 			// Multiple active changes and no changeName: legit selection prompt (changes DO exist
 			// on disk). Keep the existing authoritative ambiguous-selection behavior for both stores.
 			return emptyStatus(root, null, [
 				`Change selection is ambiguous: ${activeChanges.join(", ")}.`,
-			], store);
+			], store, false, options.reviewAuthority);
 		}
 	}
 
@@ -400,7 +438,7 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 		if (store === "both") {
 			return nonAuthoritativeStatus(options.cwd, changeName, store, options.includeInstructions);
 		}
-		return emptyStatus(root, changeName, [`Active change not found: ${changeName}.`], store);
+		return emptyStatus(root, changeName, [`Active change not found: ${changeName}.`], store, false, options.reviewAuthority);
 	}
 
 	const changeRoot = join(changesDir, changeName);
@@ -465,8 +503,23 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 		blockedReasons.push(`Legacy flat spec is present without domain specs: ${legacyFlatSpec.path}.`);
 	}
 
+	// Planning-only status remains filesystem-read-only: do not invoke a resolver
+	// unless the controller has established that review authority is expected.
+	if (options.reviewAuthority?.expected) {
+		try {
+			const resolved = options.reviewAuthority.resolve();
+			if (!resolved || typeof resolved.activeAuthorityId !== "string" || resolved.activeAuthorityId.length === 0) {
+				blockedReasons.push("resolve-review: validated active review authority is missing.");
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			blockedReasons.push(`resolve-review: ${message}`);
+		}
+	}
+
 	const coreArtifactsReady = artifacts.proposal === "done" && artifacts.specs === "done" && artifacts.design === "done" && artifacts.tasks === "done" && taskProgress.total > 0 && !flatOnly;
-	const applyState: ApplyState = !coreArtifactsReady
+	const reviewBlocked = blockedReasons.some((reason) => reason.startsWith("resolve-review:"));
+	const applyState: ApplyState = !coreArtifactsReady || reviewBlocked
 		? "blocked"
 		: taskProgress.remaining === 0
 			? "all_done"
@@ -488,18 +541,20 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 		apply: applyState === "blocked" ? "blocked" : applyState,
 		verify: verifyState,
 		sync: syncState,
-		archive: coreArtifactsReady && verifyClean && syncClean && taskProgress.remaining === 0 ? "ready" : "blocked",
+		archive: coreArtifactsReady && verifyClean && syncClean && taskProgress.remaining === 0 && !reviewBlocked ? "ready" : "blocked",
 	};
 	const archiveReady = dependencies.archive === "ready";
-	const nextRecommended = dependencies.apply === "ready"
-		? "sdd-apply"
-		: dependencies.verify === "ready"
-			? "sdd-verify"
-			: dependencies.sync === "ready"
-				? "sdd-sync"
-				: archiveReady
-					? "sdd-archive"
-					: blockedReasons[0] ?? "Resolve blockers.";
+	const nextRecommended = reviewBlocked
+		? "resolve-review"
+		: dependencies.apply === "ready"
+			? "sdd-apply"
+			: dependencies.verify === "ready"
+				? "sdd-verify"
+				: dependencies.sync === "ready"
+					? "sdd-sync"
+					: archiveReady
+						? "sdd-archive"
+						: blockedReasons[0] ?? "Resolve blockers.";
 
 	const status: SddStatus = {
 		schemaName: "gentle-pi.sdd-status",

--- a/tests/review-authority-recovery-docs.test.ts
+++ b/tests/review-authority-recovery-docs.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const README = readFileSync("README.md", "utf8");
+const CONTROLLER = readFileSync("extensions/gentle-ai.ts", "utf8");
+
+test("recovery guidance documents the non-destructive supersession contract", () => {
+	assert.match(README, /non-destructive.*supersession/i);
+	assert.match(README, /eligible.*immutable.*graph-v1/i);
+	assert.match(README, /prepare-supersession.*supersede/i);
+	assert.match(README, /exact retr(?:y|ies).*idempotent/i);
+	assert.match(README, /conflict.*fails closed/i);
+	assert.match(README, /RESET.*RECOVER.*destructive/i);
+	assert.match(README, /append-only.*authority-supersession-v1/i);
+	assert.match(README, /rollback.*does not delete/i);
+	assert.match(README, /pre-commit.*pre-push.*pre-PR.*release/is);
+});
+
+test("controller help keeps authorization, blocked outcomes, and recovery boundaries explicit", () => {
+	assert.match(CONTROLLER, /prepare-supersession.*fresh UI approval.*never falls back to RESET or RECOVER/is);
+	assert.match(CONTROLLER, /headlessly|headless/i);
+	assert.match(CONTROLLER, /exact retry|semantic retry/i);
+	assert.match(CONTROLLER, /resolve-review/);
+});

--- a/tests/review-authority-supersession.test.ts
+++ b/tests/review-authority-supersession.test.ts
@@ -1,0 +1,581 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmodSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { canonicalJsonV1, domainHashV1 } from "../lib/review-canonical.ts";
+import {
+	createSupersessionEnvelopeV1,
+	parseSupersessionEnvelopeV1,
+	writeSupersessionRecordV1,
+	loadSupersessionChainV1,
+	ReviewAuthoritySupersessionError,
+	assertRecoverableSourceEligibilityV1,
+	assertRecoverySuccessorEquivalenceV1,
+	prepareSupersessionV1,
+	deriveIntendedUntrackedProofV1,
+	inspectApprovedCompactSuccessorV1,
+	inspectRecoverableGraphSourceV1,
+	SupersessionStoreV1,
+	resolveReviewAuthorityForChange,
+	assertLiveRecoveredSuccessorBindingV1,
+	assertLiveRecoveredSourceBindingV1,
+	hasEligibleGraphV1RecoveryAuthorityV1,
+} from "../lib/review-authority-supersession.ts";
+import { COMPACT_REVIEW_STATE, completeCompactReview, completeCompactVerification, createCompactReviewState, type CompactReviewStateV2 } from "../lib/review-compact.ts";
+import { COMPACT_STORE_OPERATION, CompactReviewStoreV2 } from "../lib/review-compact-store.ts";
+import { REVIEW_MODE, REVIEW_TRANSITION, ReviewTransactionStore, createReviewState, type ReviewBudgetV1 } from "../lib/review-transaction.ts";
+import { REVIEW_MODE as SNAPSHOT_REVIEW_MODE, REVIEW_PROJECTION, captureReviewSnapshot } from "../lib/review-snapshot.ts";
+import { REVIEW_LENS, REVIEW_ROUTE } from "../lib/review-triggers.ts";
+import { testSnapshot } from "./review-test-fixtures.ts";
+
+const digest = (digit: string) => digit.repeat(64);
+
+function body(operationId = digest("a")) {
+	return {
+		schema: "gentle-ai.review-authority-supersession/v1" as const,
+		operation_id: operationId,
+		request_hash: digest("b"),
+		sequence: 0,
+		predecessor_recovery_id: null,
+		repository: { repository_id: digest("c"), authority_id: digest("d"), common_directory_hash: digest("e"), repository_identity_hash: digest("f") },
+		change: { change_name: "recover-legacy-review-authority", change_name_hash: domainHashV1("openspec-change-name", "recover-legacy-review-authority"), change_root_relative_path: "openspec/changes/recover-legacy-review-authority" },
+		source: { format: "graph-v1" as const, lineage_id: "legacy", head_event_id: digest("2"), head_sequence: 4, reduced_state_hash: digest("3"), source_closure_hash: digest("4"), receipt_hash: digest("5"), frozen_ledger_hash: digest("6") },
+		successor: { format: "compact-v2" as const, lineage_id: "successor", authority_revision: digest("7"), state_hash: digest("8"), receipt_hash: digest("9"), ledger_hash: digest("0"), runtime_identity_hash: digest("a") },
+		equivalence: { base_tree: digest("b"), complete_snapshot_tree: digest("c"), initial_review_tree: digest("d"), final_candidate_tree: digest("e"), review_projection_hash: digest("f"), genesis_paths_hash: digest("1"), scope_digest: digest("2"), intended_untracked_hash: digest("3"), intended_untracked_proof_hash: digest("4"), policy_hash: digest("5"), policy_evidence_hash: digest("6"), source_receipt_hash: digest("7"), successor_receipt_hash: digest("8"), source_ledger_hash: digest("9"), successor_ledger_hash: digest("0") },
+		authorization_hash: digest("b"),
+	};
+}
+
+test("supersession envelopes are canonical, content-bound, and reject changed recovery IDs", () => {
+	const envelope = createSupersessionEnvelopeV1(body());
+	assert.equal(parseSupersessionEnvelopeV1(JSON.stringify(envelope)).recovery_id, envelope.recovery_id);
+	assert.throws(() => parseSupersessionEnvelopeV1(JSON.stringify({ ...envelope, recovery_id: digest("c") })), ReviewAuthoritySupersessionError);
+	assert.throws(() => parseSupersessionEnvelopeV1(JSON.stringify({ ...envelope, body: { ...envelope.body, change: { ...envelope.body.change, change_root_relative_path: "elsewhere" } } })), ReviewAuthoritySupersessionError);
+});
+
+test("supersession storage is append-only, exact retries are idempotent, and conflicts preserve source bytes", (t) => {
+	const root = mkdtempSync(join(tmpdir(), "supersession-store-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const envelope = createSupersessionEnvelopeV1(body());
+	const first = writeSupersessionRecordV1(root, envelope);
+	const second = writeSupersessionRecordV1(root, envelope);
+	assert.equal(first, second);
+	assert.equal(readFileSync(first, "utf8"), canonicalJsonV1(envelope));
+	const conflicting = createSupersessionEnvelopeV1({
+		...body(envelope.body.operation_id),
+		request_hash: digest("c"),
+	});
+	assert.throws(() => writeSupersessionRecordV1(root, conflicting), /OPERATION_CONFLICT/);
+	assert.equal(readFileSync(first, "utf8"), canonicalJsonV1(envelope));
+});
+
+test("supersession discovery derives one deterministic linear chain and rejects forks", (t) => {
+	const root = mkdtempSync(join(tmpdir(), "supersession-chain-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const first = createSupersessionEnvelopeV1(body());
+	const second = createSupersessionEnvelopeV1({
+		...body(digest("c")),
+		sequence: 1,
+		predecessor_recovery_id: first.recovery_id,
+	});
+	writeSupersessionRecordV1(root, second);
+	writeSupersessionRecordV1(root, first);
+	assert.deepEqual(loadSupersessionChainV1(root).map((entry) => entry.recovery_id), [first.recovery_id, second.recovery_id]);
+
+	const fork = createSupersessionEnvelopeV1({
+		...body(digest("d")),
+		sequence: 1,
+		predecessor_recovery_id: first.recovery_id,
+	});
+	writeSupersessionRecordV1(root, fork);
+	assert.throws(() => loadSupersessionChainV1(root), /CHAIN_AMBIGUOUS/);
+});
+
+function sourceEligibility() {
+	const record = body();
+	return {
+		repository: record.repository,
+		change: record.change,
+		source: record.source,
+		immutable: true,
+		readable: true,
+		graph_replay_valid: true,
+		receipt_valid: true,
+		frozen_ledger_valid: true,
+		identity_broken: false,
+		reset_in_progress: false,
+		mixed_authority: false,
+		duplicate_authority: false,
+	};
+}
+
+function authorityEvidence(record = body()) {
+	return {
+		repository: record.repository,
+		change: record.change,
+		source: record.source,
+		successor: record.successor,
+		source_evidence: {
+			base_tree: digest("a"), complete_snapshot_tree: digest("b"), initial_review_tree: digest("c"), final_candidate_tree: digest("d"), review_projection_hash: digest("e"), genesis_paths_hash: digest("f"), scope_digest: digest("1"), intended_untracked_hash: digest("2"), intended_untracked_proof_hash: digest("3"), policy_hash: digest("4"), policy_evidence_hash: digest("5"), receipt_hash: record.source.receipt_hash, ledger_hash: record.source.frozen_ledger_hash,
+		},
+		successor_evidence: {
+			base_tree: digest("a"), complete_snapshot_tree: digest("b"), initial_review_tree: digest("c"), final_candidate_tree: digest("d"), review_projection_hash: digest("e"), genesis_paths_hash: digest("f"), scope_digest: digest("1"), intended_untracked_hash: digest("2"), intended_untracked_proof_hash: digest("3"), policy_hash: digest("4"), policy_evidence_hash: digest("5"), receipt_hash: record.successor.receipt_hash, ledger_hash: record.successor.ledger_hash,
+		},
+	};
+}
+
+test("source eligibility accepts only immutable readable approved graph authority and canonical change identity", () => {
+	const eligible = sourceEligibility();
+	assert.deepEqual(assertRecoverableSourceEligibilityV1(eligible), eligible);
+	assert.throws(() => assertRecoverableSourceEligibilityV1({ ...eligible, mixed_authority: true }), /INELIGIBLE_SOURCE/);
+	assert.throws(() => assertRecoverableSourceEligibilityV1({ ...eligible, receipt_valid: false }), /INELIGIBLE_SOURCE/);
+	assert.throws(() => assertRecoverableSourceEligibilityV1({ ...eligible, change: { ...eligible.change, change_name_hash: digest("0") } }), /INVALID/);
+});
+
+test("successor equivalence rejects every target, path, untracked, policy, evidence, receipt, and candidate substitution while allowing distinct valid ledgers", () => {
+	const evidence = authorityEvidence();
+	assert.doesNotThrow(() => assertRecoverySuccessorEquivalenceV1(evidence));
+	for (const field of [
+		"base_tree", "complete_snapshot_tree", "initial_review_tree", "final_candidate_tree",
+		"review_projection_hash", "genesis_paths_hash", "scope_digest", "intended_untracked_hash",
+		"intended_untracked_proof_hash", "policy_hash", "policy_evidence_hash",
+	] as const) {
+		assert.throws(() => assertRecoverySuccessorEquivalenceV1({
+			...evidence,
+			successor_evidence: { ...evidence.successor_evidence, [field]: digest("9") },
+		}), /EQUIVALENCE_MISMATCH/, field);
+	}
+	assert.throws(() => assertRecoverySuccessorEquivalenceV1({ ...evidence, successor_evidence: { ...evidence.successor_evidence, receipt_hash: digest("f") } }), /EQUIVALENCE_MISMATCH/);
+	assert.throws(() => assertRecoverySuccessorEquivalenceV1({ ...evidence, successor_evidence: { ...evidence.successor_evidence, ledger_hash: digest("f") } }), /EQUIVALENCE_MISMATCH/);
+});
+
+test("prepared supersession rejects mismatched source identities and binds every successor identity mutation", () => {
+	const eligibility = sourceEligibility();
+	const equivalence = authorityEvidence();
+	const prepared = prepareSupersessionV1({ operation_id: digest("e"), eligibility, equivalence });
+	assert.match(prepared.challenge, /^SUPERSEDE REVIEW AUTHORITY /);
+	assert.equal(prepared.body.request_hash, prepared.request_hash);
+	assert.equal(prepared.body.source.lineage_id, eligibility.source.lineage_id);
+	assert.throws(() => prepareSupersessionV1({
+		operation_id: digest("e"),
+		eligibility,
+		equivalence: { ...equivalence, source: { ...equivalence.source, head_event_id: digest("f") } },
+	}), /EQUIVALENCE_MISMATCH/);
+	for (const field of ["lineage_id", "authority_revision", "state_hash", "receipt_hash", "ledger_hash", "runtime_identity_hash"] as const) {
+		const value = field === "lineage_id" ? "other-successor" : digest("f");
+		const successor = { ...equivalence.successor, [field]: value };
+		const successor_evidence = {
+			...equivalence.successor_evidence,
+			...(field === "receipt_hash" ? { receipt_hash: value } : {}),
+			...(field === "ledger_hash" ? { ledger_hash: value } : {}),
+		};
+		const changed = prepareSupersessionV1({
+			operation_id: digest("e"),
+			eligibility,
+			equivalence: { ...equivalence, successor, successor_evidence },
+		});
+		assert.notEqual(changed.request_hash, prepared.request_hash, field);
+	}
+});
+
+function proofRepository(t: test.TestContext): { root: string; git: (...args: string[]) => string } {
+	const parent = mkdtempSync(join(tmpdir(), "supersession-proof-"));
+	const root = join(parent, "repo");
+	mkdirSync(root);
+	t.after(() => rmSync(parent, { recursive: true, force: true }));
+	const git = (...args: string[]) => execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+	git("init", "-b", "main");
+	writeFileSync(join(root, "tracked.txt"), "base\n");
+	git("add", "tracked.txt");
+	git("-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-m", "base");
+	mkdirSync(join(root, "nested"));
+	return { root, git };
+}
+
+test("live intended-untracked proof accepts only all-untracked or an exact complete-index successor", (t) => {
+	const { root, git } = proofRepository(t);
+	writeFileSync(join(root, "new.txt"), "reviewed\n");
+	git("add", "new.txt");
+	const candidate = git("write-tree");
+	git("reset", "--", "new.txt");
+
+	const untracked = deriveIntendedUntrackedProofV1(join(root, "nested"), candidate, ["new.txt"]);
+	assert.equal(untracked.state, "all-untracked");
+	assert.equal(untracked.candidate_tree, candidate);
+	assert.match(untracked.proof_hash, /^[0-9a-f]{64}$/);
+
+	git("add", "new.txt");
+	const indexed = deriveIntendedUntrackedProofV1(root, candidate, ["new.txt"]);
+	assert.equal(indexed.state, "complete-index");
+	assert.equal(indexed.index_tree, candidate);
+	assert.notEqual(indexed.proof_hash, untracked.proof_hash);
+});
+
+test("live intended-untracked proof rejects mixed, ignored, extra, missing, content, mode, and index-tree mismatches", (t) => {
+	const { root, git } = proofRepository(t);
+	writeFileSync(join(root, "one.txt"), "one\n");
+	writeFileSync(join(root, "two.txt"), "two\n");
+	git("add", "one.txt", "two.txt");
+	const candidate = git("write-tree");
+	git("reset", "--", "one.txt", "two.txt");
+
+	git("add", "one.txt");
+	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
+	git("reset", "--", "one.txt");
+	writeFileSync(join(root, ".gitignore"), "one.txt\n");
+	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
+	unlinkSync(join(root, ".gitignore"));
+	writeFileSync(join(root, "extra.txt"), "extra\n");
+	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
+
+	git("clean", "-f", "extra.txt");
+	unlinkSync(join(root, "two.txt"));
+	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
+	writeFileSync(join(root, "two.txt"), "two\n");
+	writeFileSync(join(root, "one.txt"), "changed\n");
+	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
+	writeFileSync(join(root, "one.txt"), "one\n");
+	chmodSync(join(root, "one.txt"), 0o755);
+	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
+	chmodSync(join(root, "one.txt"), 0o644);
+	git("add", "one.txt", "two.txt");
+	writeFileSync(join(root, "tracked.txt"), "drift\n");
+	git("add", "tracked.txt");
+	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
+});
+
+function reviewBudget(): ReviewBudgetV1 {
+	return {
+		review_batches: 1,
+		review_actors: 1,
+		refuter_batches: 1,
+		fix_batches: 1,
+		validator_runs: 1,
+		final_verifications: 1,
+		judgment_rounds: 0,
+		judge_runs: 0,
+	};
+}
+
+function approvedGraphSource(t: test.TestContext, options: { mode?: "ordinary" | "judgment-day"; lineageId?: string; complete?: boolean } = {}) {
+	const { root, git } = proofRepository(t);
+	mkdirSync(join(root, "openspec", "changes", "recover-legacy-review-authority"), { recursive: true });
+	const baseTree = git("rev-parse", "HEAD^{tree}");
+	writeFileSync(join(root, "tracked.txt"), "reviewed\n");
+	git("add", "tracked.txt");
+	const finalTree = git("write-tree");
+	const lineageId = options.lineageId ?? "legacy-source";
+	const state = createReviewState({
+		lineageId,
+		mode: options.mode === "judgment-day" ? REVIEW_MODE.JUDGMENT_DAY : REVIEW_MODE.ORDINARY,
+		snapshot: testSnapshot(options.mode === "judgment-day"
+			? { mode: REVIEW_MODE.JUDGMENT_DAY, baseTree, completeTree: finalTree, route: REVIEW_ROUTE.TRIVIAL, lenses: [] }
+			: { mode: REVIEW_MODE.ORDINARY, baseTree, completeTree: finalTree, genesisPaths: ["tracked.txt"], route: REVIEW_ROUTE.STANDARD, lenses: [REVIEW_LENS.READABILITY] }),
+		evidenceHash: digest("a"),
+		budget: options.mode === "judgment-day"
+			? { review_batches: 1, review_actors: 2, refuter_batches: 0, fix_batches: 2, validator_runs: 0, final_verifications: 1, judgment_rounds: 2, judge_runs: 6 }
+			: reviewBudget(),
+	});
+	const store = ReviewTransactionStore.forRepository(root);
+	store.create(state, "start");
+	if (options.mode !== "judgment-day" && options.complete !== false) {
+		store.runReducerOperation({ lineageId, transition: REVIEW_TRANSITION.ORDINARY_DISCOVERY, idempotencyKey: "discover", input: { rows: [] } });
+		store.runReducerOperation({ lineageId, transition: REVIEW_TRANSITION.ORDINARY_EVIDENCE, idempotencyKey: "evidence", input: { deterministicResults: [] } });
+		store.runReducerOperation({ lineageId, transition: REVIEW_TRANSITION.ORDINARY_FINAL_VERIFICATION, idempotencyKey: "verify", input: { passed: true } });
+	}
+	return { root, git, store, lineageId };
+}
+
+function immutableFiles(root: string): Map<string, string> {
+	const files = new Map<string, string>();
+	const visit = (directory: string) => {
+		for (const entry of readdirSync(directory, { withFileTypes: true })) {
+			const path = join(directory, entry.name);
+			if (entry.isDirectory()) visit(path);
+			else if (entry.isFile()) files.set(path.slice(root.length + 1), readFileSync(path, "utf8"));
+		}
+	};
+	visit(root);
+	return files;
+}
+
+test("repository source inspection preserves source bytes and rejects reset, duplicate, unrelated, corrupt, broken-identity, and Judgment Day authority", (t) => {
+	const { root, store, lineageId } = approvedGraphSource(t);
+	const sourceBytes = immutableFiles(store.root);
+	const source = inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId);
+	assert.equal(source.source.lineage_id, lineageId);
+	assert.equal(source.source.format, "graph-v1");
+	assert.match(source.repository.common_directory_hash, /^[0-9a-f]{64}$/);
+	assert.equal(source.change.change_root_relative_path, "openspec/changes/recover-legacy-review-authority");
+	assert.deepEqual(immutableFiles(store.root), sourceBytes);
+	const authorityRoot = join(dirname(store.root), "control");
+	mkdirSync(authorityRoot, { recursive: true });
+	writeFileSync(join(authorityRoot, "reset-state.json"), "{\"body\":{\"phase\":\"quarantining\"}}");
+	assert.throws(() => inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId), /INELIGIBLE_SOURCE/);
+
+	const incomplete = approvedGraphSource(t, { complete: false, lineageId: "missing-evidence" });
+	assert.throws(() => inspectRecoverableGraphSourceV1(incomplete.root, "recover-legacy-review-authority", incomplete.lineageId), /INELIGIBLE_SOURCE/);
+	const unrelated = approvedGraphSource(t, { lineageId: "source-one" });
+	unrelated.store.create(createReviewState({
+		lineageId: "source-two",
+		mode: REVIEW_MODE.ORDINARY,
+		snapshot: testSnapshot({ baseTree: "c".repeat(40), completeTree: "d".repeat(40), route: REVIEW_ROUTE.STANDARD, lenses: [REVIEW_LENS.READABILITY] }),
+		evidenceHash: digest("a"),
+		budget: reviewBudget(),
+	}), "start-unrelated");
+	assert.equal(
+		inspectRecoverableGraphSourceV1(unrelated.root, "recover-legacy-review-authority", unrelated.lineageId).source.lineage_id,
+		unrelated.lineageId,
+	);
+
+	const corrupt = approvedGraphSource(t, { lineageId: "corrupt-source" });
+	const event = [...immutableFiles(corrupt.store.root).keys()].find((path) => path.startsWith("objects/events/sha256/"));
+	assert.ok(event, "fixture must contain an immutable graph event");
+	writeFileSync(join(corrupt.store.root, event), "corrupt");
+	assert.throws(() => inspectRecoverableGraphSourceV1(corrupt.root, "recover-legacy-review-authority", corrupt.lineageId), /INELIGIBLE_SOURCE/);
+	assert.throws(() => hasEligibleGraphV1RecoveryAuthorityV1(corrupt.root), /INELIGIBLE_SOURCE/);
+
+	const brokenIdentity = approvedGraphSource(t, { lineageId: "broken-identity" });
+	writeFileSync(join(dirname(brokenIdentity.store.root), "IDENTITY"), "broken repository identity");
+	assert.throws(() => inspectRecoverableGraphSourceV1(brokenIdentity.root, "recover-legacy-review-authority", brokenIdentity.lineageId), /INELIGIBLE_SOURCE/);
+
+	const judgmentDay = approvedGraphSource(t, { mode: "judgment-day", lineageId: "judgment-day" });
+	assert.throws(() => inspectRecoverableGraphSourceV1(judgmentDay.root, "recover-legacy-review-authority", judgmentDay.lineageId), /INELIGIBLE_SOURCE/);
+});
+
+function compactSnapshot(root: string) {
+	return captureReviewSnapshot({
+		cwd: root,
+		mode: SNAPSHOT_REVIEW_MODE.ORDINARY,
+		projection: { kind: REVIEW_PROJECTION.COMPLETE },
+		policyHash: digest("a"),
+	});
+}
+
+function approvedCompactSuccessor(root: string, lineageId = "compact-successor"): string {
+	const snapshot = compactSnapshot(root);
+	const store = CompactReviewStoreV2.forRepository(root, lineageId);
+	const reviewing = createCompactReviewState({ lineageId, snapshot, policyHash: digest("a") });
+	const start = store.replace("", COMPACT_STORE_OPERATION.START, reviewing);
+	const reviewed = completeCompactReview(reviewing, { lens_results: reviewing.selected_lenses.map(() => ({ findings: [], evidence: [] })) });
+	const review = store.replace(start, COMPACT_STORE_OPERATION.COMPLETE_REVIEW, reviewed);
+	const approved = completeCompactVerification(reviewed, "focused verification passed", true);
+	store.replace(review, COMPACT_STORE_OPERATION.COMPLETE_VERIFICATION, approved);
+	assert.equal(store.load().state.state, COMPACT_REVIEW_STATE.APPROVED);
+	store.materializeTerminalReceipt();
+	return lineageId;
+}
+
+test("successor inspection accepts exactly one approved compact-v2 claimant and rejects nonterminal, escalated, and ambiguous claimants", (t) => {
+	const { root } = proofRepository(t);
+	const lineageId = approvedCompactSuccessor(root);
+	assert.equal(inspectApprovedCompactSuccessorV1(root, lineageId).lineage_id, lineageId);
+	const nonterminal = CompactReviewStoreV2.forRepository(root, "nonterminal");
+	const reviewing = createCompactReviewState({ lineageId: "nonterminal", snapshot: compactSnapshot(root), policyHash: digest("a") });
+	nonterminal.replace("", COMPACT_STORE_OPERATION.START, reviewing);
+	assert.throws(() => inspectApprovedCompactSuccessorV1(root, "nonterminal"), /INELIGIBLE_SOURCE/);
+
+	const escalatedRoot = proofRepository(t).root;
+	const escalated = CompactReviewStoreV2.forRepository(escalatedRoot, "escalated");
+	const escalatedReview = createCompactReviewState({ lineageId: "escalated", snapshot: compactSnapshot(escalatedRoot), policyHash: digest("a") });
+	const escalatedStart = escalated.replace("", COMPACT_STORE_OPERATION.START, escalatedReview);
+	const escalatedReviewed = completeCompactReview(escalatedReview, { lens_results: escalatedReview.selected_lenses.map(() => ({ findings: [], evidence: [] })) });
+	const escalatedReviewRevision = escalated.replace(escalatedStart, COMPACT_STORE_OPERATION.COMPLETE_REVIEW, escalatedReviewed);
+	const escalatedState = completeCompactVerification(escalatedReviewed, "verification failed", false);
+	escalated.replace(escalatedReviewRevision, COMPACT_STORE_OPERATION.COMPLETE_VERIFICATION, escalatedState);
+	escalated.materializeTerminalReceipt();
+	assert.equal(escalated.load().state.state, COMPACT_REVIEW_STATE.ESCALATED);
+	assert.throws(() => inspectApprovedCompactSuccessorV1(escalatedRoot, "escalated"), /INELIGIBLE_SOURCE/);
+
+	approvedCompactSuccessor(root, "ambiguous-claimant");
+	assert.throws(() => inspectApprovedCompactSuccessorV1(root, lineageId), /INELIGIBLE_SOURCE/);
+});
+
+test("repository-backed source and successor fixtures reject each independently changed binding", (t) => {
+	const { root, git } = proofRepository(t);
+	writeFileSync(join(root, "reviewed.txt"), "reviewed\n");
+	git("add", "reviewed.txt");
+	const candidate = git("write-tree");
+	git("reset", "--", "reviewed.txt");
+	const proof = deriveIntendedUntrackedProofV1(root, candidate, ["reviewed.txt"]);
+	const record = body();
+	const binding = authorityEvidence(record);
+	const repositoryDigest = domainHashV1("repository-backed-fixture", root);
+	const candidateDigest = domainHashV1("repository-backed-candidate", candidate);
+	const proofDigest = domainHashV1("repository-backed-proof", proof);
+	const source = {
+		...binding.source_evidence,
+		base_tree: repositoryDigest,
+		complete_snapshot_tree: candidateDigest,
+		initial_review_tree: candidateDigest,
+		final_candidate_tree: candidateDigest,
+		intended_untracked_proof_hash: proofDigest,
+	};
+	const successor = {
+		...binding.successor_evidence,
+		base_tree: repositoryDigest,
+		complete_snapshot_tree: candidateDigest,
+		initial_review_tree: candidateDigest,
+		final_candidate_tree: candidateDigest,
+		intended_untracked_proof_hash: proofDigest,
+	};
+	const exact = { ...binding, source_evidence: source, successor_evidence: successor };
+	assert.doesNotThrow(() => assertRecoverySuccessorEquivalenceV1(exact));
+	for (const field of ["base_tree", "complete_snapshot_tree", "initial_review_tree", "final_candidate_tree", "intended_untracked_proof_hash", "policy_hash"] as const) {
+		assert.throws(() => assertRecoverySuccessorEquivalenceV1({
+			...exact,
+			successor_evidence: { ...exact.successor_evidence, [field]: digest("9") },
+		}), /EQUIVALENCE_MISMATCH/, field);
+	}
+});
+
+
+test("repository-anchored supersession installation serializes CAS, retries exactly, rejects divergent operations, and preserves graph source bytes", (t) => {
+	const { root, store: graphStore, lineageId } = approvedGraphSource(t);
+	const sourceBytes = immutableFiles(graphStore.root);
+	const envelope = createSupersessionEnvelopeV1({
+		...body(digest("b")),
+		repository: inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId).repository,
+		change: inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId).change,
+		source: inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId).source,
+	});
+	const supersessions = SupersessionStoreV1.forRepository(root);
+	const first = supersessions.install("recover-legacy-review-authority", envelope);
+	assert.throws(() => supersessions.install("recover-legacy-review-authority", envelope, {
+		casChecks: [{ label: "retry source", expected: digest("a"), observe: () => digest("b") }],
+	}), /STALE_AUTHORIZATION/);
+	assert.equal(supersessions.install("recover-legacy-review-authority", envelope).recovery_id, first.recovery_id);
+	assert.equal(lstatSync(join(supersessions.root, "recovery-required-v1", `${domainHashV1("openspec-change-name", "recover-legacy-review-authority")}.json`)).isFile(), true);
+	assert.equal(lstatSync(first.path).mode & 0o777, 0o600);
+	assert.deepEqual(immutableFiles(graphStore.root), sourceBytes);
+	const conflict = createSupersessionEnvelopeV1({ ...envelope.body, request_hash: digest("c") });
+	assert.throws(() => supersessions.install("recover-legacy-review-authority", conflict), /OPERATION_CONFLICT/);
+	const stale = createSupersessionEnvelopeV1({ ...body(digest("d")), repository: envelope.body.repository, change: envelope.body.change, source: envelope.body.source });
+	assert.throws(() => supersessions.install("recover-legacy-review-authority", stale), /STALE_AUTHORIZATION/);
+	for (const label of ["source", "successor", "policy", "receipt"] as const) {
+		const candidate = createSupersessionEnvelopeV1({
+			...body(digest(label === "source" ? "e" : label === "successor" ? "f" : label === "policy" ? "1" : "2")),
+			sequence: 1,
+			predecessor_recovery_id: first.recovery_id,
+			repository: envelope.body.repository,
+			change: envelope.body.change,
+			source: envelope.body.source,
+		});
+		assert.throws(() => supersessions.install("recover-legacy-review-authority", candidate, {
+			casChecks: [{ label, expected: digest("a"), observe: () => digest("b") }],
+		}), /STALE_AUTHORIZATION/, label);
+	}
+});
+
+test("repository-anchored supersession storage rejects symlink substitution and preserves zero-or-one complete record across fault windows", (t) => {
+	const { root, lineageId } = approvedGraphSource(t);
+	const source = inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId);
+	const envelope = createSupersessionEnvelopeV1({ ...body(digest("e")), repository: source.repository, change: source.change, source: source.source });
+	const crashing = SupersessionStoreV1.forRepository(root, { faultInjector: (point) => { if (point === "before-link") throw new Error("injected crash"); } });
+	assert.throws(() => crashing.install("recover-legacy-review-authority", envelope), /injected crash/);
+	const recovered = SupersessionStoreV1.forRepository(root);
+	assert.equal(recovered.load("recover-legacy-review-authority").length, 0);
+	recovered.install("recover-legacy-review-authority", envelope);
+	assert.equal(recovered.load("recover-legacy-review-authority").length, 1);
+
+	const afterLinkSource = approvedGraphSource(t, { lineageId: "after-link-source" });
+	const afterLink = inspectRecoverableGraphSourceV1(afterLinkSource.root, "recover-legacy-review-authority", afterLinkSource.lineageId);
+	const afterLinkEnvelope = createSupersessionEnvelopeV1({ ...body(digest("f")), repository: afterLink.repository, change: afterLink.change, source: afterLink.source });
+	const linkedThenInterrupted = SupersessionStoreV1.forRepository(afterLinkSource.root, { faultInjector: (point) => { if (point === "after-link") throw new Error("injected after-link crash"); } });
+	assert.throws(() => linkedThenInterrupted.install("recover-legacy-review-authority", afterLinkEnvelope), /injected after-link crash/);
+	const retryBeforeDirectoryFsync = SupersessionStoreV1.forRepository(afterLinkSource.root, { faultInjector: (point) => { if (point === "before-directory-fsync") throw new Error("exact retry reaches directory fsync"); } });
+	assert.throws(() => retryBeforeDirectoryFsync.install("recover-legacy-review-authority", afterLinkEnvelope), /exact retry reaches directory fsync/);
+	assert.equal(SupersessionStoreV1.forRepository(afterLinkSource.root).install("recover-legacy-review-authority", afterLinkEnvelope).recovery_id, afterLinkEnvelope.recovery_id);
+
+	const base = join(recovered.root, domainHashV1("openspec-change-name", "recover-legacy-review-authority"));
+	rmSync(base, { recursive: true, force: true });
+	symlinkSync(tmpdir(), base);
+	assert.throws(() => recovered.load("recover-legacy-review-authority"), /REPOSITORY_MISMATCH|symlink/i);
+});
+
+function recoveredSuccessorEquivalence(source: ReturnType<typeof inspectRecoverableGraphSourceV1>, successor: ReturnType<typeof inspectApprovedCompactSuccessorV1>, state: CompactReviewStateV2) {
+	return {
+		base_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.base_tree),
+		complete_snapshot_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.complete_snapshot_tree),
+		initial_review_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.initial_review_tree),
+		final_candidate_tree: domainHashV1("review-recovery-tree", state.current_candidate_tree),
+		review_projection_hash: domainHashV1("review-recovery-projection", state.initial_snapshot.review_projection),
+		genesis_paths_hash: domainHashV1("compact-paths", state.genesis_paths),
+		scope_digest: domainHashV1("review-recovery-scope", { base_tree: state.initial_snapshot.base_tree, complete_snapshot_tree: state.initial_snapshot.complete_snapshot_tree, initial_review_tree: state.initial_snapshot.initial_review_tree, final_candidate_tree: state.current_candidate_tree, genesis_paths: state.genesis_paths, intended_untracked: state.intended_untracked }),
+		intended_untracked_hash: domainHashV1("compact-untracked", state.intended_untracked),
+		intended_untracked_proof_hash: domainHashV1("review-recovery-empty-untracked", { candidate_tree: state.current_candidate_tree, paths: [] }),
+		policy_hash: state.policy_hash,
+		policy_evidence_hash: domainHashV1("review-recovery-policy-evidence", { policy_hash: state.policy_hash, runtime_identity_hash: state.runtime_identity.identity_hash }),
+		source_receipt_hash: source.source.receipt_hash,
+		successor_receipt_hash: successor.receipt_hash,
+		source_ledger_hash: source.source.frozen_ledger_hash,
+		successor_ledger_hash: successor.ledger_hash,
+	};
+}
+
+test("change-aware resolution requires an initial record for eligible graph authority, selects exactly the bound successor, and blocks unbound authority", (t) => {
+	const { root, lineageId } = approvedGraphSource(t);
+	assert.throws(() => resolveReviewAuthorityForChange(root, "recover-legacy-review-authority"), /CHAIN_AMBIGUOUS/);
+	const successorLineage = approvedCompactSuccessor(root);
+	const source = inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId);
+	const successor = inspectApprovedCompactSuccessorV1(root, successorLineage);
+	const envelope = createSupersessionEnvelopeV1({
+		...body(digest("7")),
+		repository: source.repository,
+		change: source.change,
+		source: source.source,
+		successor,
+		equivalence: recoveredSuccessorEquivalence(source, successor, CompactReviewStoreV2.forRepository(root, successorLineage).load().state),
+	});
+	SupersessionStoreV1.forRepository(root).install("recover-legacy-review-authority", envelope);
+	const resolved = resolveReviewAuthorityForChange(root, "recover-legacy-review-authority");
+	assert.ok(resolved);
+	assert.equal(resolved.record.state.lineage_id, successorLineage);
+	approvedCompactSuccessor(root, "unbound-claimant");
+	assert.throws(() => resolveReviewAuthorityForChange(root, "recover-legacy-review-authority"), /CHAIN_AMBIGUOUS|unbound/i);
+});
+
+test("live recovered source binding rederives source target, scope, policy, receipt, and ledger evidence", (t) => {
+	const { root, lineageId } = approvedGraphSource(t);
+	const successorLineage = approvedCompactSuccessor(root);
+	const source = inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId);
+	const successor = inspectApprovedCompactSuccessorV1(root, successorLineage);
+	const state = CompactReviewStoreV2.forRepository(root, successorLineage).load().state;
+	const expected = recoveredSuccessorEquivalence(source, successor, state);
+	const recovery = createSupersessionEnvelopeV1({ ...body(digest("c")), repository: source.repository, change: source.change, source: source.source, successor, equivalence: expected });
+	assert.doesNotThrow(() => assertLiveRecoveredSourceBindingV1(root, recovery));
+	for (const field of ["base_tree", "complete_snapshot_tree", "initial_review_tree", "final_candidate_tree", "review_projection_hash", "genesis_paths_hash", "scope_digest", "intended_untracked_hash", "intended_untracked_proof_hash", "policy_hash", "source_receipt_hash", "source_ledger_hash"] as const) {
+		assert.throws(() => assertLiveRecoveredSourceBindingV1(root, createSupersessionEnvelopeV1({ ...recovery.body, equivalence: { ...expected, [field]: digest("f") } })), /CHAIN_AMBIGUOUS|UNTRACKED_DRIFT/, field);
+	}
+});
+
+test("live recovered successor binding rejects target, paths, policy, receipt, and authority drift", (t) => {
+	const { root, lineageId } = approvedGraphSource(t);
+	const successorLineage = approvedCompactSuccessor(root);
+	const source = inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", lineageId);
+	const successor = inspectApprovedCompactSuccessorV1(root, successorLineage);
+	const state = CompactReviewStoreV2.forRepository(root, successorLineage).load().state;
+	const expected = recoveredSuccessorEquivalence(source, successor, state);
+	const recovery = createSupersessionEnvelopeV1({ ...body(digest("e")), repository: source.repository, change: source.change, source: source.source, successor, equivalence: expected });
+	assert.doesNotThrow(() => assertLiveRecoveredSuccessorBindingV1(root, recovery, state));
+	for (const field of ["final_candidate_tree", "genesis_paths_hash", "policy_hash", "policy_evidence_hash", "successor_receipt_hash", "successor_ledger_hash"] as const) {
+		assert.throws(() => assertLiveRecoveredSuccessorBindingV1(root, createSupersessionEnvelopeV1({ ...recovery.body, equivalence: { ...expected, [field]: digest("f") } }), state), /CHAIN_AMBIGUOUS|UNTRACKED_DRIFT/, field);
+	}
+});
+
+test("supersession chain rejects gaps, cycles, and duplicate heads without selecting by directory order", (t) => {
+	const root = mkdtempSync(join(tmpdir(), "supersession-invalid-chain-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const first = createSupersessionEnvelopeV1(body(digest("1")));
+	const gap = createSupersessionEnvelopeV1({ ...body(digest("2")), sequence: 2, predecessor_recovery_id: first.recovery_id });
+	writeSupersessionRecordV1(root, first);
+	writeSupersessionRecordV1(root, gap);
+	assert.throws(() => loadSupersessionChainV1(root), /CHAIN_AMBIGUOUS/);
+	rmSync(root, { recursive: true, force: true });
+	mkdirSync(root);
+	const cycle = createSupersessionEnvelopeV1({ ...body(digest("3")), sequence: 1, predecessor_recovery_id: digest("4") });
+	writeSupersessionRecordV1(root, cycle);
+	assert.throws(() => loadSupersessionChainV1(root), /CHAIN_AMBIGUOUS/);
+});

--- a/tests/review-compact-gate.test.ts
+++ b/tests/review-compact-gate.test.ts
@@ -1,12 +1,23 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import { validateCompactReviewGate } from "../lib/review-compact-gate.ts";
+import { domainHashV1 } from "../lib/review-canonical.ts";
 import { discoverCompactReview, finalizeCompactReview, startCompactReview } from "../lib/review-facade.ts";
-import { GATE_TARGET_KIND } from "../lib/review-transaction.ts";
+import {
+	createSupersessionEnvelopeV1,
+	inspectApprovedCompactSuccessorV1,
+	inspectRecoverableGraphSourceV1,
+	SupersessionStoreV1,
+} from "../lib/review-authority-supersession.ts";
+import { CompactReviewStoreV2 } from "../lib/review-compact-store.ts";
+import { REVIEW_MODE, REVIEW_TRANSITION, ReviewTransactionStore, createReviewState, type GateTargetV1 } from "../lib/review-transaction.ts";
+import { GATE_TARGET_KIND, PUSH_UPDATE_KIND, resolveConfiguredPushDestinationV1 } from "../lib/review-transaction.ts";
+import { REVIEW_LENS, REVIEW_ROUTE } from "../lib/review-triggers.ts";
+import { testSnapshot } from "./review-test-fixtures.ts";
 
 function repository(t: test.TestContext): string {
 	const parent = mkdtempSync(join(tmpdir(), "compact-gate-"));
@@ -75,7 +86,12 @@ test("compact gate is read-only and closes authority and target TOCTOU before al
 			actualIntendedCommitTree: tree,
 		};
 	};
-	const allowed = validateCompactReviewGate({ cwd: root, lineageId, deriveTarget });
+	const allowed = validateCompactReviewGate({
+		cwd: root,
+		lineageId,
+		changeName: "recover-legacy-review-authority",
+		deriveTarget,
+	});
 	assert.equal(allowed.status, "allow", allowed.reason);
 	assert.equal(allowed.actor_count, 0);
 	assert.equal(discoverCompactReview(root, lineageId, true).record.revision, before.revision);
@@ -91,6 +107,53 @@ test("compact gate is read-only and closes authority and target TOCTOU before al
 	});
 	assert.equal(denied.status, "deny");
 	assert.match(denied.reason, /changed during final authorization/i);
+});
+
+test("compact gate fails closed for a recovery-required marker without a bound change, but not an empty marker directory", (t) => {
+	const root = repository(t);
+	const lineageId = approved(root);
+	const store = SupersessionStoreV1.forRepository(root);
+	mkdirSync(join(store.root, "recovery-required-v1"), { recursive: true });
+	const emptyDirectory = validateCompactReviewGate({ cwd: root, lineageId, deriveTarget: () => deriveIntendedCommitTarget(root) });
+	assert.equal(emptyDirectory.status, "allow", emptyDirectory.reason);
+	writeFileSync(join(store.root, "recovery-required-v1", `${domainHashV1("openspec-change-name", "recover-legacy-review-authority")}.json`), "recovery-required");
+	const missingChange = validateCompactReviewGate({ cwd: root, lineageId, deriveTarget: () => deriveIntendedCommitTarget(root) });
+	assert.equal(missingChange.status, "deny", missingChange.reason);
+	const missingRecord = validateCompactReviewGate({ cwd: root, lineageId, changeName: "recover-legacy-review-authority", deriveTarget: () => deriveIntendedCommitTarget(root) });
+	assert.equal(missingRecord.status, "deny", missingRecord.reason);
+});
+
+test("eligible graph-v1 authority requires a change-bound supersession even when its OpenSpec change and marker are absent", (t) => {
+	const omitted = recoveredFixture(t);
+	const changeName = "recover-legacy-review-authority";
+	const store = SupersessionStoreV1.forRepository(omitted.root);
+	rmSync(join(omitted.root, "openspec", "changes", changeName), { recursive: true, force: true });
+	unlinkSync(join(store.root, "recovery-required-v1", `${domainHashV1("openspec-change-name", changeName)}.json`));
+	const withoutChange = validateCompactReviewGate({
+		cwd: omitted.root,
+		deriveTarget: recoveredGateTargets(omitted)["pre-commit"],
+	});
+	assert.equal(withoutChange.status, "deny", withoutChange.reason);
+	const withoutRecord = validateCompactReviewGate({
+		cwd: omitted.root,
+		changeName,
+		deriveTarget: recoveredGateTargets(omitted)["pre-commit"],
+	});
+	assert.equal(withoutRecord.status, "deny", withoutRecord.reason);
+
+	const corrupt = recoveredFixture(t);
+	const marker = join(
+		SupersessionStoreV1.forRepository(corrupt.root).root,
+		"recovery-required-v1",
+		`${domainHashV1("openspec-change-name", "recover-legacy-review-authority")}.json`,
+	);
+	writeFileSync(marker, "corrupt marker");
+	const withCorruptMarker = validateCompactReviewGate({
+		cwd: corrupt.root,
+		changeName: "recover-legacy-review-authority",
+		deriveTarget: recoveredGateTargets(corrupt)["pre-commit"],
+	});
+	assert.equal(withCorruptMarker.status, "deny", withCorruptMarker.reason);
 });
 
 test("compact pre-commit gate preserves an approved receipt across exact staging of reviewed new files", (t) => {
@@ -144,4 +207,132 @@ test("compact pre-commit gate rejects partial or additional staging around revie
 		deriveTarget: () => deriveIntendedCommitTarget(root),
 	});
 	assert.equal(additional.status, "scope-changed");
+});
+
+
+function recoveredFixture(t: test.TestContext) {
+	const root = repository(t);
+	const baseCommit = git(root, "rev-parse", "HEAD");
+	const baseTree = git(root, "rev-parse", "HEAD^{tree}");
+	const successorLineage = approved(root);
+	const successorState = CompactReviewStoreV2.forRepository(root, successorLineage).load().state;
+	const finalTree = git(root, "write-tree");
+	const graphLineage = "legacy-source";
+	const graphStore = ReviewTransactionStore.forRepository(root);
+	const graphState = createReviewState({
+		lineageId: graphLineage,
+		mode: REVIEW_MODE.ORDINARY,
+		snapshot: testSnapshot({ baseTree, completeTree: finalTree, genesisPaths: successorState.genesis_paths, route: REVIEW_ROUTE.STANDARD, lenses: [REVIEW_LENS.READABILITY] }),
+		evidenceHash: "a".repeat(64),
+		budget: { review_batches: 1, review_actors: 1, refuter_batches: 1, fix_batches: 1, validator_runs: 1, final_verifications: 1, judgment_rounds: 0, judge_runs: 0 },
+	});
+	mkdirSync(join(root, "openspec", "changes", "recover-legacy-review-authority"), { recursive: true });
+	graphStore.create(graphState, "start");
+	graphStore.runReducerOperation({ lineageId: graphLineage, transition: REVIEW_TRANSITION.ORDINARY_DISCOVERY, idempotencyKey: "discover", input: { rows: [] } });
+	graphStore.runReducerOperation({ lineageId: graphLineage, transition: REVIEW_TRANSITION.ORDINARY_EVIDENCE, idempotencyKey: "evidence", input: { deterministicResults: [] } });
+	graphStore.runReducerOperation({ lineageId: graphLineage, transition: REVIEW_TRANSITION.ORDINARY_FINAL_VERIFICATION, idempotencyKey: "verify", input: { passed: true } });
+	git(root, "-c", "user.name=Gate", "-c", "user.email=gate@example.invalid", "commit", "-m", "reviewed");
+	const finalCommit = git(root, "rev-parse", "HEAD");
+	git(root, "branch", "base", baseCommit);
+	git(root, "branch", "final", finalCommit);
+	git(root, "-c", "user.name=Gate", "-c", "user.email=gate@example.invalid", "tag", "-a", "v1.2.3", "-m", "release", finalCommit);
+	const remotePath = join(root, "remote.git");
+	execFileSync("git", ["init", "--bare", remotePath], { stdio: "ignore" });
+	git(root, "remote", "add", "origin", remotePath);
+	git(root, "push", "origin", "base:refs/heads/feature");
+	const source = inspectRecoverableGraphSourceV1(root, "recover-legacy-review-authority", graphLineage);
+	const successor = inspectApprovedCompactSuccessorV1(root, successorLineage);
+	const state = CompactReviewStoreV2.forRepository(root, successorLineage).load().state;
+	const equivalence = {
+		base_tree: (domainHashV1("review-recovery-tree", state.initial_snapshot.base_tree)),
+		complete_snapshot_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.complete_snapshot_tree),
+		initial_review_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.initial_review_tree),
+		final_candidate_tree: domainHashV1("review-recovery-tree", state.current_candidate_tree),
+		review_projection_hash: domainHashV1("review-recovery-projection", state.initial_snapshot.review_projection),
+		genesis_paths_hash: domainHashV1("compact-paths", state.genesis_paths),
+		scope_digest: domainHashV1("review-recovery-scope", { base_tree: state.initial_snapshot.base_tree, complete_snapshot_tree: state.initial_snapshot.complete_snapshot_tree, initial_review_tree: state.initial_snapshot.initial_review_tree, final_candidate_tree: state.current_candidate_tree, genesis_paths: state.genesis_paths, intended_untracked: state.intended_untracked }),
+		intended_untracked_hash: domainHashV1("compact-untracked", state.intended_untracked),
+		intended_untracked_proof_hash: domainHashV1("review-recovery-empty-untracked", { candidate_tree: state.current_candidate_tree, paths: [] }),
+		policy_hash: state.policy_hash,
+		policy_evidence_hash: domainHashV1("review-recovery-policy-evidence", { policy_hash: state.policy_hash, runtime_identity_hash: state.runtime_identity.identity_hash }),
+		source_receipt_hash: source.source.receipt_hash,
+		successor_receipt_hash: successor.receipt_hash,
+		source_ledger_hash: source.source.frozen_ledger_hash,
+		successor_ledger_hash: successor.ledger_hash,
+	};
+	SupersessionStoreV1.forRepository(root).install("recover-legacy-review-authority", createSupersessionEnvelopeV1({
+		schema: "gentle-ai.review-authority-supersession/v1", operation_id: "b".repeat(64), request_hash: "c".repeat(64), sequence: 0, predecessor_recovery_id: null,
+		repository: source.repository, change: source.change, source: source.source, successor, equivalence, authorization_hash: "d".repeat(64),
+	}));
+	return { root, graphRoot: graphStore.root, successorLineage, baseCommit, baseTree, finalCommit, finalTree, tagObject: git(root, "rev-parse", "refs/tags/v1.2.3"), remote: "origin" };
+}
+
+
+function recoveredGateTargets(fixture: ReturnType<typeof recoveredFixture>): Record<string, () => { target: GateTargetV1; actualIntendedCommitTree?: string }> {
+	const destination = resolveConfiguredPushDestinationV1(fixture.root, fixture.remote);
+	return {
+		"pre-commit": () => ({ target: { kind: GATE_TARGET_KIND.INTENDED_COMMIT, intended_commit_tree: fixture.finalTree }, actualIntendedCommitTree: fixture.finalTree }),
+		"pre-push": () => ({ target: { kind: GATE_TARGET_KIND.PUSH, remote: fixture.remote, destination_id: destination.destination_id, updates: [{ kind: PUSH_UPDATE_KIND.UPDATE, source_ref: "refs/heads/final", destination_ref: "refs/heads/feature", old_object: fixture.baseCommit, old_peeled_commit: fixture.baseCommit, old_tree: fixture.baseTree, new_object: fixture.finalCommit, new_peeled_commit: fixture.finalCommit, new_tree: fixture.finalTree }] } }),
+		"pre-PR": () => ({ target: { kind: GATE_TARGET_KIND.PULL_REQUEST, base_ref: "refs/heads/base", base_commit: fixture.baseCommit, base_tree: fixture.baseTree, head_ref: "refs/heads/final", head_commit: fixture.finalCommit, head_tree: fixture.finalTree } }),
+		release: () => ({ target: { kind: GATE_TARGET_KIND.RELEASE, tag_ref: "refs/tags/v1.2.3", tag_object: fixture.tagObject, peeled_commit: fixture.finalCommit, tree: fixture.finalTree } }),
+	};
+}
+
+function mutateRecoveredSource(fixture: ReturnType<typeof recoveredFixture>): void {
+	writeFileSync(join(dirname(fixture.graphRoot), "IDENTITY"), "corrupt source identity");
+}
+
+function assertRecoveredGateLifecycle(t: test.TestContext, gate: keyof ReturnType<typeof recoveredGateTargets>): void {
+	const exact = recoveredFixture(t);
+	const exactAllowed = validateCompactReviewGate({ cwd: exact.root, changeName: "recover-legacy-review-authority", deriveTarget: recoveredGateTargets(exact)[gate] });
+	assert.equal(exactAllowed.status, "allow", `${gate}: ${exactAllowed.reason}`);
+	assert.equal(exactAllowed.actor_count, 0);
+
+	const source = recoveredFixture(t);
+	const sourceDenied = validateCompactReviewGate({ cwd: source.root, changeName: "recover-legacy-review-authority", deriveTarget: recoveredGateTargets(source)[gate], beforeFinalRecheck: () => mutateRecoveredSource(source) });
+	assert.equal(sourceDenied.status, "deny", `${gate}: source mutation must deny`);
+	assert.equal(sourceDenied.actor_count, 0);
+
+	const authority = recoveredFixture(t);
+	const authorityDenied = validateCompactReviewGate({ cwd: authority.root, changeName: "recover-legacy-review-authority", deriveTarget: recoveredGateTargets(authority)[gate], beforeFinalRecheck: () => writeFileSync(CompactReviewStoreV2.forRepository(authority.root, authority.successorLineage).receiptPath, "corrupt compact authority") });
+	assert.equal(authorityDenied.status, "deny", `${gate}: authority mutation must deny`);
+	assert.equal(authorityDenied.actor_count, 0);
+
+	const target = recoveredFixture(t);
+	const targetDenied = validateCompactReviewGate({ cwd: target.root, changeName: "recover-legacy-review-authority", deriveTarget: recoveredGateTargets(target)[gate], beforeFinalRecheck: () => { target.finalTree = target.baseTree; } });
+	assert.equal(targetDenied.status, "deny", `${gate}: target mutation must deny`);
+	assert.equal(targetDenied.actor_count, 0);
+}
+
+test("recovered chain pre-commit gate allows exact authority and denies final-recheck drift", (t) => assertRecoveredGateLifecycle(t, "pre-commit"));
+test("recovered chain pre-push gate allows exact authority and denies final-recheck drift", (t) => assertRecoveredGateLifecycle(t, "pre-push"));
+test("recovered chain pre-PR gate allows exact authority and denies final-recheck drift", (t) => assertRecoveredGateLifecycle(t, "pre-PR"));
+test("recovered chain release gate allows exact authority and denies final-recheck drift", (t) => assertRecoveredGateLifecycle(t, "release"));
+
+test("recovered gate denies when its supersession record disappears before final recheck", (t) => {
+	const fixture = recoveredFixture(t);
+	const result = validateCompactReviewGate({
+		cwd: fixture.root,
+		changeName: "recover-legacy-review-authority",
+		deriveTarget: recoveredGateTargets(fixture)["pre-commit"],
+		beforeFinalRecheck: () => rmSync(SupersessionStoreV1.forRepository(fixture.root).root, { recursive: true, force: true }),
+	});
+	assert.equal(result.status, "deny", result.reason);
+	assert.equal(result.actor_count, 0);
+});
+
+test("recovered gate denies when its supersession state becomes unsupported before final recheck", (t) => {
+	const fixture = recoveredFixture(t);
+	const store = SupersessionStoreV1.forRepository(fixture.root);
+	const result = validateCompactReviewGate({
+		cwd: fixture.root,
+		changeName: "recover-legacy-review-authority",
+		deriveTarget: recoveredGateTargets(fixture)["pre-commit"],
+		beforeFinalRecheck: () => {
+			rmSync(store.root, { recursive: true, force: true });
+			writeFileSync(store.root, "unsupported supersession state");
+		},
+	});
+	assert.equal(result.status, "deny", result.reason);
+	assert.equal(result.actor_count, 0);
 });

--- a/tests/review-controller.test.ts
+++ b/tests/review-controller.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -9,7 +9,7 @@ import type {
 	ExtensionContext,
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
-import gentleAi from "../extensions/gentle-ai.ts";
+import gentleAi, { __testing } from "../extensions/gentle-ai.ts";
 import {
 	REVIEW_MODE,
 	REVIEW_TRANSITION,
@@ -21,7 +21,13 @@ import {
 } from "../lib/review-transaction.ts";
 import { ordinaryValidatorRequest } from "../lib/review-policy-ordinary.ts";
 import { discoverCompactReview, startCompactReview } from "../lib/review-facade.ts";
-import { domainHashV1 } from "../lib/review-canonical.ts";
+import { canonicalJsonV1, domainHashV1 } from "../lib/review-canonical.ts";
+import {
+	inspectApprovedCompactSuccessorV1,
+	inspectRecoverableGraphSourceV1,
+	resolveReviewAuthorityForChange,
+	SupersessionStoreV1,
+} from "../lib/review-authority-supersession.ts";
 import { destructiveResetReviewAuthorityV1 } from "../lib/review-reset.ts";
 import { REVIEW_LENS, REVIEW_ROUTE } from "../lib/review-triggers.ts";
 import { qualifiedReviewLockPlatform, testSnapshot } from "./review-test-fixtures.ts";
@@ -273,6 +279,7 @@ function createTerminalAuthority(fixture: RepositoryFixture, lineageId: string):
 			snapshot: testSnapshot({
 				baseTree: fixture.baseTree,
 				completeTree: fixture.finalTree,
+				genesisPaths: ["app.ts"],
 				route: REVIEW_ROUTE.STANDARD,
 				lenses: [REVIEW_LENS.READABILITY],
 			}),
@@ -294,6 +301,219 @@ function createTerminalAuthority(fixture: RepositoryFixture, lineageId: string):
 		});
 	}
 }
+
+function recoveryEvidence(
+	state: ReturnType<typeof discoverCompactReview>["record"]["state"],
+	receiptHash: string,
+	ledgerHash: string,
+) {
+	return {
+		base_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.base_tree),
+		complete_snapshot_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.complete_snapshot_tree),
+		initial_review_tree: domainHashV1("review-recovery-tree", state.initial_snapshot.initial_review_tree),
+		final_candidate_tree: domainHashV1("review-recovery-tree", state.current_candidate_tree),
+		review_projection_hash: domainHashV1("review-recovery-projection", state.initial_snapshot.review_projection),
+		genesis_paths_hash: domainHashV1("compact-paths", state.genesis_paths),
+		scope_digest: domainHashV1("review-recovery-scope", {
+			base_tree: state.initial_snapshot.base_tree,
+			complete_snapshot_tree: state.initial_snapshot.complete_snapshot_tree,
+			initial_review_tree: state.initial_snapshot.initial_review_tree,
+			final_candidate_tree: state.current_candidate_tree,
+			genesis_paths: state.genesis_paths,
+			intended_untracked: state.intended_untracked,
+		}),
+		intended_untracked_hash: domainHashV1("compact-untracked", state.intended_untracked),
+		intended_untracked_proof_hash: domainHashV1("review-recovery-empty-untracked", { candidate_tree: state.current_candidate_tree, paths: [] }),
+		policy_hash: state.policy_hash,
+		policy_evidence_hash: domainHashV1("review-recovery-policy-evidence", { policy_hash: state.policy_hash, runtime_identity_hash: state.runtime_identity.identity_hash }),
+		receipt_hash: receiptHash,
+		ledger_hash: ledgerHash,
+	};
+}
+
+function recoveryEquivalence(
+	source: ReturnType<typeof inspectRecoverableGraphSourceV1>,
+	successor: ReturnType<typeof inspectApprovedCompactSuccessorV1>,
+	state: ReturnType<typeof discoverCompactReview>["record"]["state"],
+) {
+	return {
+		repository: source.repository,
+		change: source.change,
+		source: source.source,
+		successor,
+		source_evidence: recoveryEvidence(state, source.source.receipt_hash, source.source.frozen_ledger_hash),
+		successor_evidence: recoveryEvidence(state, successor.receipt_hash, successor.ledger_hash),
+	};
+}
+
+test("controller publicly installs a supersession and exactly replays it with fresh approval", async (t) => {
+	const fixture = createRepository(t, false);
+	writeFileSync(join(fixture.repository, "app.ts"), "export const value = 2;\n");
+	git(fixture.repository, "add", "app.ts");
+	fixture.finalTree = git(fixture.repository, "write-tree");
+	const sourceLineageId = "graph-v1-source";
+	const successorLineageId = "compact-v2-successor";
+	const changeName = "recover-legacy-review-authority";
+	mkdirSync(join(fixture.repository, "openspec", "changes", changeName), { recursive: true });
+	createTerminalAuthority(fixture, sourceLineageId);
+	const { controller, toolCall } = registerRuntime();
+	await approveTrackedWorktreeTransaction(controller, extensionContext(fixture.repository), successorLineageId);
+	const source = inspectRecoverableGraphSourceV1(fixture.repository, changeName, sourceLineageId);
+	const successor = inspectApprovedCompactSuccessorV1(fixture.repository, successorLineageId);
+	const preparedInput = {
+		operation_id: domainHashV1("controller-positive-supersession", { changeName, sourceLineageId, successorLineageId }),
+		eligibility: source,
+		equivalence: recoveryEquivalence(source, successor, discoverCompactReview(fixture.repository, successorLineageId).record.state),
+	};
+	const prepareParameters = {
+		operation: "prepare-supersession",
+		input: JSON.stringify({ changeName, sourceLineageId, successorLineageId, operationId: preparedInput.operation_id, prepared: preparedInput }),
+	};
+	const prepared = await controllerCall(controller, extensionContext(fixture.repository), prepareParameters);
+	assert.equal(prepared.operation, "prepare-supersession");
+	assert.equal(typeof prepared.request_hash, "string");
+	assert.equal(typeof prepared.challenge, "string");
+	assert.equal((prepared.body as { request_hash: string }).request_hash, prepared.request_hash);
+	const supersedeParameters = {
+		operation: "supersede",
+		input: JSON.stringify({ changeName, sourceLineageId, successorLineageId, operationId: preparedInput.operation_id, prepared: preparedInput, request_hash: prepared.request_hash, challenge: prepared.challenge }),
+	};
+	let approvals = 0;
+	const approvingContext = () => extensionContext(fixture.repository, true, async (title, message) => {
+		approvals += 1;
+		assert.equal(title, "Authorize review authority SUPERSESSION?");
+		assert.ok(message.includes(`Exact challenge: ${prepared.challenge}`));
+		return true;
+	});
+	const installed = await controllerCall(controller, approvingContext(), supersedeParameters);
+	assert.equal(installed.operation, "supersede");
+	assert.equal(installed.active_authority_id, successorLineageId);
+	const recoveryId = installed.recovery_id as string;
+	const store = SupersessionStoreV1.forRepository(fixture.repository);
+	const chain = store.load(changeName);
+	assert.deepEqual(chain.map((record) => record.recovery_id), [recoveryId]);
+	const durableBytes = canonicalJsonV1(chain[0]!);
+	assert.equal(resolveReviewAuthorityForChange(fixture.repository, changeName)?.record.state.lineage_id, successorLineageId);
+
+	const command = "git commit -am recovered";
+	await assert.rejects(
+		controller.execute("missing-recovered-change", {
+			operation: "validate",
+			idempotencyKey: "missing-recovered-change",
+			command,
+			input: JSON.stringify({ scopeBudget: budget() }),
+		}, undefined, undefined, extensionContext(fixture.repository)),
+		/requires changeName and a valid supersession/i,
+	);
+	await assert.rejects(
+		controller.execute("incorrect-recovered-change", {
+			operation: "validate",
+			changeName: "incorrect-recovered-change",
+			idempotencyKey: "incorrect-recovered-change",
+			command,
+			input: JSON.stringify({ scopeBudget: budget() }),
+		}, undefined, undefined, extensionContext(fixture.repository)),
+		/recovery-required authority has no bound supersession record/i,
+	);
+	const validated = await controllerCall(controller, extensionContext(fixture.repository), {
+		operation: "validate",
+		changeName,
+		idempotencyKey: "validated-recovered-change",
+		command,
+		input: JSON.stringify({ scopeBudget: budget() }),
+	});
+	const validationResult = validated.result as Record<string, unknown>;
+	assert.equal(validationResult.status, "allow", JSON.stringify(validated));
+	assert.equal(validationResult.receipt_hash, successor.receipt_hash);
+	assert.equal(await toolCall({ toolName: "bash", input: { command } }, extensionContext(fixture.repository)), undefined);
+
+	const replayed = await controllerCall(controller, approvingContext(), supersedeParameters);
+	assert.deepEqual(replayed, installed);
+	assert.equal(approvals, 2);
+	assert.deepEqual(store.load(changeName).map((record) => record.recovery_id), [recoveryId]);
+	assert.equal(canonicalJsonV1(store.load(changeName)[0]!), durableBytes);
+
+	const changeRoot = join(fixture.repository, "openspec", "changes", changeName);
+	mkdirSync(join(changeRoot, "specs", "review"), { recursive: true });
+	writeFileSync(join(changeRoot, "proposal.md"), "# Proposal\n");
+	writeFileSync(join(changeRoot, "specs", "review", "spec.md"), "# Spec\n");
+	writeFileSync(join(changeRoot, "design.md"), "# Design\n");
+	writeFileSync(join(changeRoot, "tasks.md"), "- [x] 1.1 Done\n");
+	writeFileSync(join(changeRoot, "verify-report.md"), "PASS\n");
+	writeFileSync(join(changeRoot, "sync-report.md"), "PASS\n");
+	unlinkSync(join(store.root, "recovery-required-v1", `${domainHashV1("openspec-change-name", changeName)}.json`));
+	const status = __testing.resolveControllerSddStatus(fixture.repository, changeName, false, "openspec");
+	assert.equal(status.dependencies.archive, "blocked");
+	assert.equal(status.nextRecommended, "resolve-review");
+});
+
+test("controller SDD status treats removed OpenSpec recovery authority and deleted marker as blocking", (t) => {
+	const fixture = createRepository(t, false);
+	const changeName = "recover-legacy-review-authority";
+	const changeRoot = join(fixture.repository, "openspec", "changes", changeName);
+	mkdirSync(changeRoot, { recursive: true });
+	writeFileSync(join(fixture.repository, "app.ts"), "export const value = 2;\n");
+	git(fixture.repository, "add", "app.ts");
+	fixture.finalTree = git(fixture.repository, "write-tree");
+	createTerminalAuthority(fixture, "archived-graph-source");
+	const store = SupersessionStoreV1.forRepository(fixture.repository);
+	const marker = join(store.root, "recovery-required-v1", `${domainHashV1("openspec-change-name", changeName)}.json`);
+	mkdirSync(join(store.root, "recovery-required-v1"), { recursive: true });
+	writeFileSync(marker, "recovery-required");
+	rmSync(changeRoot, { recursive: true, force: true });
+	unlinkSync(marker);
+
+	const status = __testing.resolveControllerSddStatus(fixture.repository, changeName, false, "openspec");
+
+	assert.equal(status.dependencies.archive, "blocked");
+	assert.equal(status.nextRecommended, "resolve-review");
+	assert.match(status.blockedReasons.join("\n"), /recovery|required|graph/i);
+});
+
+test("controller SDD status blocks archive for a recovery-required marker without a supersession record", (t) => {
+	const fixture = createRepository(t, false);
+	const changeName = "recover-legacy-review-authority";
+	const changeRoot = join(fixture.repository, "openspec", "changes", changeName);
+	mkdirSync(join(changeRoot, "specs", "review"), { recursive: true });
+	writeFileSync(join(changeRoot, "proposal.md"), "# Proposal\n");
+	writeFileSync(join(changeRoot, "specs", "review", "spec.md"), "# Spec\n");
+	writeFileSync(join(changeRoot, "design.md"), "# Design\n");
+	writeFileSync(join(changeRoot, "tasks.md"), "- [x] 1.1 Done\n");
+	writeFileSync(join(changeRoot, "verify-report.md"), "PASS\n");
+	writeFileSync(join(changeRoot, "sync-report.md"), "PASS\n");
+	const store = SupersessionStoreV1.forRepository(fixture.repository);
+	const markerDirectory = join(store.root, "recovery-required-v1");
+	mkdirSync(markerDirectory, { recursive: true });
+	writeFileSync(join(markerDirectory, `${domainHashV1("openspec-change-name", changeName)}.json`), "recovery-required");
+
+	const status = __testing.resolveControllerSddStatus(fixture.repository, changeName, false, "openspec");
+
+	assert.equal(status.dependencies.archive, "blocked");
+	assert.equal(status.nextRecommended, "resolve-review");
+	assert.match(status.blockedReasons.join("\n"), /recovery-required/i);
+});
+
+test("controller rejects headless or rejected supersession approval without creating recovery authority", async (t) => {
+	const fixture = createRepository(t, false);
+	const { controller } = registerRuntime();
+	const request = {
+		operation: "supersede",
+		input: JSON.stringify({
+			challenge: "SUPERSEDE REVIEW AUTHORITY test CHANGE recovery",
+			request_hash: "a".repeat(64),
+			prepared: {},
+		}),
+	};
+	await assert.rejects(
+		controller.execute("headless-supersession", request, undefined, undefined, extensionContext(fixture.repository)),
+		/interactive Pi UI.*fails closed/i,
+	);
+	await assert.rejects(
+		controller.execute("rejected-supersession", request, undefined, undefined, extensionContext(fixture.repository, true, async () => false)),
+		/not explicitly authorized/i,
+	);
+	assert.equal(existsSync(join(fixture.repository, ".git", "gentle-ai", "reviews", "control", "authority-supersession-v1")), false);
+});
 
 test("controller keeps graph-v1 ordinary mutation read-only while preserving repository-file input confinement", async (t) => {
 	const fixture = createRepository(t, false);

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -9,6 +9,7 @@ import { discoverAndLoadExtensions } from "@earendil-works/pi-coding-agent";
 import { matchesKey } from "@earendil-works/pi-tui";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { stripAnsi } from "../lib/terminal-theme.ts";
+import { domainHashV1 } from "../lib/review-canonical.ts";
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const EXTENSIONS = [
@@ -210,6 +211,11 @@ async function run() {
 		assert.ok(tools.has(toolName), `missing quiet built-in tool renderer ${toolName}`);
 	}
 	assert.ok(tools.has("gentle_review"), "missing registered bounded review controller tool");
+	assert.deepEqual(
+		tools.get("gentle_review").parameters.properties.operation.enum.filter((operation) => operation.includes("supersession") || operation === "supersede"),
+		["prepare-supersession", "supersede"],
+		"runtime controller must expose explicit supersession operations",
+	);
 
 	for (const entry of await readdir(join(ROOT, "assets", "agents"))) {
 		if (!entry.endsWith(".md")) continue;
@@ -333,6 +339,18 @@ async function run() {
 		await commands.get("sdd-continue").handler("status-demo", continueCtx);
 		assert.match(continueCtx.ui.notifications.at(-1).message, /Native SDD Dispatcher/);
 		assert.match(continueCtx.ui.notifications.at(-1).message, /nextPhase: sdd-apply/);
+		const { execFileSync } = await import("node:child_process");
+		execFileSync("git", ["init"], { cwd: promptCwd, stdio: "ignore" });
+		const recoveryRequiredDirectory = join(promptCwd, ".git", "gentle-ai", "reviews", "control", "recovery-required-v1");
+		await mkdir(recoveryRequiredDirectory, { recursive: true });
+		await writeFile(
+			join(recoveryRequiredDirectory, `${domainHashV1("openspec-change-name", "status-demo")}.json`),
+			'{"schema":"gentle-ai.recovery-required/v1","change_name":"status-demo"}',
+		);
+		const blockedContinueCtx = createCtx(promptCwd, true);
+		await commands.get("sdd-continue").handler("status-demo", blockedContinueCtx);
+		assert.match(blockedContinueCtx.ui.notifications.at(-1).message, /resolve-review:/);
+		assert.match(blockedContinueCtx.ui.notifications.at(-1).message, /nextPhase: resolve-review/);
 	} finally {
 		await rm(promptCwd, { recursive: true, force: true });
 	}

--- a/tests/sdd-status.test.ts
+++ b/tests/sdd-status.test.ts
@@ -92,6 +92,55 @@ test("resolveSddStatus selects the only active change and counts task progress",
 	assert.match(status.instructions?.apply.join("\n") ?? "", /persisted task checkboxes/);
 });
 
+test("resolveSddStatus keeps planning-only changes read-only and blocks only an expected invalid review authority", async () => {
+	const cwd = await workspace();
+	const root = seedChange(cwd);
+	write(join(root, "tasks.md"), "# Tasks\n\n- [x] 1.1 Done\n");
+	write(join(root, "verify-report.md"), "# Verify\n\nPASS\n");
+	write(join(root, "sync-report.md"), "# Sync\n\nPASS\n");
+	let resolverCalls = 0;
+	const planning = resolveSddStatus({
+		cwd,
+		changeName: "add-auth",
+		reviewAuthority: {
+			expected: false,
+			resolve: () => {
+				resolverCalls += 1;
+				return { activeAuthorityId: "must-not-run" };
+			},
+		},
+	});
+	assert.equal(resolverCalls, 0);
+	assert.equal(planning.blockedReasons.some((reason) => reason.startsWith("resolve-review:")), false);
+
+	const invalid = resolveSddStatus({
+		cwd,
+		changeName: "add-auth",
+		reviewAuthority: {
+			expected: true,
+			resolve: () => {
+				throw new Error("stale compact successor");
+			},
+		},
+	});
+	assert.equal(invalid.applyState, "blocked");
+	assert.equal(invalid.dependencies.archive, "blocked");
+	assert.equal(invalid.nextRecommended, "resolve-review");
+	assert.match(invalid.blockedReasons.join("\n"), /^resolve-review: stale compact successor/m);
+
+	const valid = resolveSddStatus({
+		cwd,
+		changeName: "add-auth",
+		reviewAuthority: {
+			expected: true,
+			resolve: () => ({ activeAuthorityId: "validated-compact-authority" }),
+		},
+	});
+	assert.equal(valid.applyState, "all_done");
+	assert.equal(valid.dependencies.archive, "ready");
+	assert.equal(valid.blockedReasons.some((reason) => reason.startsWith("resolve-review:")), false);
+});
+
 test("resolveSddStatus marks apply all_done and verify ready when tasks are checked", async () => {
 	const cwd = await workspace();
 	const root = seedChange(cwd);


### PR DESCRIPTION
Closes #111

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds explicit, auditable graph-v1 to compact-v2 authority supersession for blocked SDD changes.
- Validates source/successor equivalence, CAS, durability, and change-scoped lifecycle gates.
- Keeps recovery-required changes fail-closed across missing, corrupt, archived, or deleted authority state.

## Changes
| Area | Change |
|------|--------|
| Review authority | Canonical append-only supersession and recovery obligation |
| Lifecycle gates | Change-scoped recovered authority validation |
| SDD status | `resolve-review` and archive blocking for unresolved recovery |
| Tests | Controller E2E, gate drift, CAS, durability, corruption, and archive coverage |

## Test plan
- [x] `pnpm test` — 539 tests plus runtime harness
- [x] Focused recovery/controller/gate suites
- [x] `git diff --check`
- [x] Bounded review receipt approved: `review-86257d6e59de9950`

## Checklist
- [x] Linked approved issue
- [x] Exactly one `type:*` label
- [x] Documentation updated
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a non-destructive review-authority supersession workflow with preparation, interactive authorization, exact retries, and change-bound validation.
  * Added recovery guidance and a dedicated resolve-review status when required review authority is missing or invalid.
  * Strengthened review gates to revalidate recovered authority and deny access when bindings or artifacts change.

* **Documentation**
  * Expanded guidance for recovery, supersession, reset safety, idempotency, and fails-closed behavior.

* **Tests**
  * Added comprehensive coverage for supersession, recovery validation, status blocking, and runtime guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->