### PR TITLE
fix(review): accept absolute Windows Git common directories

### DIFF
--- a/lib/review-repository.ts
+++ b/lib/review-repository.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { closeSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, statSync, unlinkSync, writeFileSync, fsyncSync } from "node:fs";
-import { join, relative, resolve, sep } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { canonicalJsonV1, domainHashV1, parseCanonicalJsonV1 } from "./review-canonical.ts";
 
 const OBJECT_FORMAT = /^(sha1|sha256)$/;
@@ -243,7 +243,7 @@ interface LiveRepositoryProbeV1 {
 
 function probeLiveRepositoryV1(cwd: string): LiveRepositoryProbeV1 {
 	const commonDirectory = oneGitLine(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
-	if (!commonDirectory.startsWith("/")) throw new ReviewRepositoryError("Git common directory is not absolute");
+	if (!isAbsolute(commonDirectory)) throw new ReviewRepositoryError("Git common directory is not absolute");
 	let canonicalCommonDirectory: string;
 	try {
 		canonicalCommonDirectory = realpathSync(commonDirectory);

--- a/tests/review-repository.test.ts
+++ b/tests/review-repository.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { cpSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import test from "node:test";
 import { resolveRepositoryAuthorityV1, setReviewRepositoryIdentityRetryHookForTesting } from "../lib/review-repository.ts";
 import { REVIEW_MODE, ReviewTransactionStore, createReviewState, setReviewMutationLockPlatformForTesting } from "../lib/review-transaction.ts";
@@ -48,6 +48,20 @@ function addOrphanRoot(root: string, branch: string, file: string): void {
 	git(root, "commit", "-m", `orphan root on ${branch}`);
 	git(root, "checkout", "main");
 }
+
+test("a Windows drive-letter Git common directory resolves repository authority", { skip: process.platform !== "win32" }, (t) => {
+	const root = repository(t);
+	const commonDirectory = git(root, "rev-parse", "--path-format=absolute", "--git-common-dir");
+	assert.match(commonDirectory, /^[A-Za-z]:[\\/]/);
+	const storeRoot = join(commonDirectory, "gentle-ai", "reviews");
+	mkdirSync(storeRoot, { recursive: true });
+	writeFileSync(join(storeRoot, "IDENTITY"), JSON.stringify({
+		object_format: "sha1",
+		root_commit_ids: [git(root, "rev-list", "--max-parents=0", "--all")],
+		schema: "gentle-ai.review-repository/v1",
+	}));
+	assert.equal(resolveRepositoryAuthorityV1(root).common_directory, resolve(commonDirectory));
+});
 
 test("linked worktrees resolve one common-directory authority", (t) => {
 	const root = repository(t);


### PR DESCRIPTION
Closes #115

## Summary

- Accept platform-native absolute Git common-directory paths using Node's `path.isAbsolute`.
- Add a Windows regression covering drive-letter Git common directories.

## Type

- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `lib/review-repository.ts` | Replace the POSIX-only leading-slash check with platform-aware absolute-path validation. |
| `tests/review-repository.test.ts` | Verify repository authority resolution with a Windows drive-letter common directory. |

## Test plan

- [x] Focused Windows regression passes.
- [x] Staged diff validation passes.
- [x] Bounded reliability review approved.

## Checklist

- [x] Linked issue #115.
- [x] Conventional commit used.
- [x] No unrelated fsync portability changes included.
- [x] No AI attribution or co-author trailers included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository validation to correctly recognize absolute paths across operating systems, including Windows drive-letter paths.
  * Repository identity information is now resolved correctly for Windows-based Git configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->