### PR TITLE
fix(review): support fork heads in pre-PR gate

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3046,19 +3046,54 @@ function commandOptionValue(arguments_: readonly string[], name: string): string
 	return matches[0]!;
 }
 
+function githubRemoteOwner(url: string): string | null {
+	const match = /^(?:https:\/\/github\.com\/|ssh:\/\/git@github\.com\/|git@github\.com:)([^/]+)\/[^/]+(?:\.git)?\/?$/i.exec(url);
+	return match?.[1] ?? null;
+}
+
+function resolvePullRequestForkHead(cwd: string, value: string): { ref: string; commit: string } | null {
+	if (!value.includes(":")) return null;
+	const match = /^([A-Za-z0-9](?:[A-Za-z0-9-]{0,38})):(.+)$/.exec(value);
+	if (!match || match[2]!.includes(":")) {
+		throw new Error("Pull request fork head must use exact owner:branch syntax");
+	}
+	const owner = match[1]!;
+	const branch = match[2]!;
+	runReviewGit(cwd, ["check-ref-format", `refs/heads/${branch}`]);
+	const remotes = runReviewGit(cwd, ["remote"]).split(/\r?\n/).filter(Boolean);
+	const ownerRemotes = remotes.filter((remote) => {
+		let urls: string;
+		try {
+			urls = runReviewGit(cwd, ["config", "--get-all", `remote.${remote}.url`]);
+		} catch {
+			return false;
+		}
+		return urls.split(/\r?\n/).some((url) => githubRemoteOwner(url)?.toLowerCase() === owner.toLowerCase());
+	});
+	if (ownerRemotes.length !== 1) {
+		throw new Error(`Pull request fork owner ${owner} must match exactly one configured GitHub remote`);
+	}
+	const ref = `refs/heads/${branch}`;
+	const lines = runReviewGit(cwd, ["ls-remote", "--refs", ownerRemotes[0]!, ref]).split(/\r?\n/).filter(Boolean);
+	if (lines.length !== 1) throw new Error(`Pull request fork branch ${owner}:${branch} is missing or ambiguous`);
+	const remoteMatch = /^([0-9a-fA-F]{40,64})\t(.+)$/.exec(lines[0]!);
+	if (!remoteMatch || remoteMatch[2] !== ref) {
+		throw new Error(`Pull request fork branch ${owner}:${branch} did not resolve to one exact remote ref`);
+	}
+	return { ref, commit: runReviewGit(cwd, ["rev-parse", "--verify", `${remoteMatch[1]}^{commit}`]) };
+}
+
 function derivePullRequestTarget(command: ReviewLifecycleCommand): GateTargetV1 {
 	const baseRef = resolveLocalFullRef(
 		command.cwd,
 		commandOptionValue(command.arguments, "--base"),
 		"Pull request base",
 	);
-	const headRef = resolveLocalFullRef(
-		command.cwd,
-		commandOptionValue(command.arguments, "--head"),
-		"Pull request head",
-	);
+	const headValue = commandOptionValue(command.arguments, "--head");
+	const forkHead = resolvePullRequestForkHead(command.cwd, headValue);
+	const headRef = forkHead?.ref ?? resolveLocalFullRef(command.cwd, headValue, "Pull request head");
 	const baseCommit = runReviewGit(command.cwd, ["rev-parse", "--verify", `${baseRef}^{commit}`]);
-	const headCommit = runReviewGit(command.cwd, ["rev-parse", "--verify", `${headRef}^{commit}`]);
+	const headCommit = forkHead?.commit ?? runReviewGit(command.cwd, ["rev-parse", "--verify", `${headRef}^{commit}`]);
 	return {
 		kind: GATE_TARGET_KIND.PULL_REQUEST,
 		base_ref: baseRef,

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -2788,12 +2788,14 @@ function runReviewGit(
 	cwd: string,
 	args: readonly string[],
 	environment: NodeJS.ProcessEnv = process.env,
+	timeout?: number,
 ): string {
 	return execFileSync("git", args, {
 		cwd,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "pipe"],
 		env: environment,
+		timeout,
 	}).trim();
 }
 
@@ -3051,7 +3053,14 @@ function githubRemoteOwner(url: string): string | null {
 	return match?.[1] ?? null;
 }
 
-function resolvePullRequestForkHead(cwd: string, value: string): { ref: string; commit: string } | null {
+type PullRequestForkHeadRemoteResolver = (cwd: string, remote: string, ref: string) => string;
+
+function resolvePullRequestForkHead(
+	cwd: string,
+	value: string,
+	resolveRemote: PullRequestForkHeadRemoteResolver = (repositoryCwd, remote, ref) =>
+		runReviewGit(repositoryCwd, ["ls-remote", "--refs", remote, ref], process.env, 10_000),
+): { ref: string; commit: string } | null {
 	if (!value.includes(":")) return null;
 	const match = /^([A-Za-z0-9](?:[A-Za-z0-9-]{0,38})):(.+)$/.exec(value);
 	if (!match || match[2]!.includes(":")) {
@@ -3074,13 +3083,13 @@ function resolvePullRequestForkHead(cwd: string, value: string): { ref: string; 
 		throw new Error(`Pull request fork owner ${owner} must match exactly one configured GitHub remote`);
 	}
 	const ref = `refs/heads/${branch}`;
-	const lines = runReviewGit(cwd, ["ls-remote", "--refs", ownerRemotes[0]!, ref]).split(/\r?\n/).filter(Boolean);
+	const lines = resolveRemote(cwd, ownerRemotes[0]!, ref).split(/\r?\n/).filter(Boolean);
 	if (lines.length !== 1) throw new Error(`Pull request fork branch ${owner}:${branch} is missing or ambiguous`);
 	const remoteMatch = /^([0-9a-fA-F]{40,64})\t(.+)$/.exec(lines[0]!);
 	if (!remoteMatch || remoteMatch[2] !== ref) {
 		throw new Error(`Pull request fork branch ${owner}:${branch} did not resolve to one exact remote ref`);
 	}
-	return { ref, commit: runReviewGit(cwd, ["rev-parse", "--verify", `${remoteMatch[1]}^{commit}`]) };
+	return { ref, commit: remoteMatch[1]! };
 }
 
 function derivePullRequestTarget(command: ReviewLifecycleCommand): GateTargetV1 {
@@ -3762,6 +3771,7 @@ export const __testing = {
 	resolveReviewLifecycleCommand,
 	inspectReviewLifecycleCommand,
 	deriveReviewGateTarget,
+	resolvePullRequestForkHead,
 	gateLifecycleCommand,
 	executeReviewControllerOperation,
 	enforceReviewGateAndCommandSafety,

--- a/tests/review-controller.test.ts
+++ b/tests/review-controller.test.ts
@@ -1176,6 +1176,31 @@ test("registered controller creates, advances, reports, and authorizes an exact 
 	assert.match(fabricated?.reason ?? "", /registered review controller authorization/i);
 });
 
+test("pull request fork heads require one exact configured remote ref", (t) => {
+	const fixture = createRepository(t, true);
+	git(fixture.repository, "remote", "add", "fork", "https://github.com/MarsSall/gentle-pi.git");
+	const ref = "refs/heads/final";
+	const commit = "a".repeat(40);
+	const resolved = __testing.resolvePullRequestForkHead(fixture.repository, "MarsSall:final", (_cwd, remote, requestedRef) => {
+		assert.equal(remote, "fork");
+		assert.equal(requestedRef, ref);
+		return `${commit}\t${ref}`;
+	});
+	assert.deepEqual(resolved, { ref, commit });
+	assert.throws(
+		() => __testing.resolvePullRequestForkHead(fixture.repository, "OtherOwner:final", () => ""),
+		/exactly one configured GitHub remote/i,
+	);
+	git(fixture.repository, "remote", "add", "fork-copy", "git@github.com:MarsSall/gentle-pi.git");
+	assert.throws(() => __testing.resolvePullRequestForkHead(fixture.repository, "MarsSall:final", () => ""), /exactly one configured GitHub remote/i);
+	git(fixture.repository, "remote", "remove", "fork-copy");
+	assert.throws(() => __testing.resolvePullRequestForkHead(fixture.repository, "MarsSall:missing", () => ""), /missing or ambiguous/i);
+	assert.throws(
+		() => __testing.resolvePullRequestForkHead(fixture.repository, "MarsSall:final", () => `${commit}\t${ref}\n${"b".repeat(40)}\t${ref}`),
+		/missing or ambiguous/i,
+	);
+});
+
 test("controller binds push, PR, and release authorization to exact command arguments", async (t) => {
 	const fixture = createRepository(t, true);
 	assert.ok(fixture.finalCommit && fixture.finalTree && fixture.tagObject);
@@ -1210,34 +1235,32 @@ test("controller binds push, PR, and release authorization to exact command argu
 	}
 
 	execFileSync("git", ["--git-dir", remotePath, "update-ref", "refs/heads/final", fixture.baseCommit]);
-	await assert.rejects(
-		controller.execute(
-			"divergent-fork-pr-head",
-			{
-				operation: "validate",
-				lineageId: "controller-targets",
-				idempotencyKey: "divergent-fork-pr-head",
-				command: "gh pr create --base base --head MarsSall:final",
-				input: JSON.stringify({ scopeBudget: budget() }),
-			},
-			undefined,
-			undefined,
-			ctx,
-		),
-	);
+	const divergentCommand = "gh pr create --base base --head MarsSall:final";
+	const divergent = await controllerCall(controller, ctx, {
+		operation: "validate",
+		lineageId: "controller-targets",
+		idempotencyKey: "divergent-fork-pr-head",
+		command: divergentCommand,
+		input: JSON.stringify({ scopeBudget: budget() }),
+	});
+	assert.equal(divergent.status, "deny");
+	assert.match(String(divergent.reason), /target|receipt|snapshot|head/i);
+	const blockedDivergent = await toolCall({ toolName: "bash", input: { command: divergentCommand } }, ctx);
+	assert.equal(blockedDivergent?.block, true);
+	assert.match(blockedDivergent?.reason ?? "", /registered review controller authorization/i);
 
-	for (const command of [
+	for (const [index, command] of [
 		"gh pr create --base base --head :final",
 		"gh pr create --base base --head MarsSall:",
 		"gh pr create --base base --head MarsSall:final:extra",
-	]) {
+	].entries()) {
 		await assert.rejects(
 			controller.execute(
 				"malformed-fork-pr-head",
 				{
 					operation: "validate",
 					lineageId: "controller-targets",
-					idempotencyKey: `malformed-fork-pr-head-${command.length}`,
+					idempotencyKey: `malformed-fork-pr-head-${index}`,
 					command,
 					input: JSON.stringify({ scopeBudget: budget() }),
 				},

--- a/tests/review-controller.test.ts
+++ b/tests/review-controller.test.ts
@@ -1186,6 +1186,8 @@ test("controller binds push, PR, and release authorization to exact command argu
 	});
 	execFileSync("git", ["--git-dir", remotePath, "update-ref", "refs/heads/main", fixture.baseCommit]);
 	git(fixture.repository, "remote", "add", "origin", remotePath);
+	git(fixture.repository, "remote", "add", "fork", "https://github.com/MarsSall/gentle-pi.git");
+	git(fixture.repository, "config", "url.file://" + remotePath.replace(/\\/g, "/") + ".insteadOf", "https://github.com/MarsSall/gentle-pi.git");
 	createTerminalAuthority(fixture, "controller-targets");
 	const { controller, toolCall } = registerRuntime();
 	const ctx = extensionContext(fixture.repository, true);
@@ -1193,6 +1195,7 @@ test("controller binds push, PR, and release authorization to exact command argu
 	for (const [command, key] of [
 		["git push origin main:main", "push"],
 		["gh pr create --base base --head final", "pr"],
+		["gh pr create --base base --head MarsSall:final", "fork-pr"],
 		["gh release create v1.2.3 --notes bounded", "release"],
 	] as const) {
 		const validated = await controllerCall(controller, ctx, {
@@ -1204,6 +1207,46 @@ test("controller binds push, PR, and release authorization to exact command argu
 		});
 		assert.equal((validated.result as Record<string, unknown>).status, "allow", command);
 		assert.equal(await toolCall({ toolName: "bash", input: { command } }, ctx), undefined, command);
+	}
+
+	execFileSync("git", ["--git-dir", remotePath, "update-ref", "refs/heads/final", fixture.baseCommit]);
+	await assert.rejects(
+		controller.execute(
+			"divergent-fork-pr-head",
+			{
+				operation: "validate",
+				lineageId: "controller-targets",
+				idempotencyKey: "divergent-fork-pr-head",
+				command: "gh pr create --base base --head MarsSall:final",
+				input: JSON.stringify({ scopeBudget: budget() }),
+			},
+			undefined,
+			undefined,
+			ctx,
+		),
+	);
+
+	for (const command of [
+		"gh pr create --base base --head :final",
+		"gh pr create --base base --head MarsSall:",
+		"gh pr create --base base --head MarsSall:final:extra",
+	]) {
+		await assert.rejects(
+			controller.execute(
+				"malformed-fork-pr-head",
+				{
+					operation: "validate",
+					lineageId: "controller-targets",
+					idempotencyKey: `malformed-fork-pr-head-${command.length}`,
+					command,
+					input: JSON.stringify({ scopeBudget: budget() }),
+				},
+				undefined,
+				undefined,
+				ctx,
+			),
+			/exact owner:branch syntax/i,
+		);
 	}
 
 	for (const command of [


### PR DESCRIPTION
Closes #129

## Summary

- Support standard GitHub fork heads using `owner:branch` in the pre-PR lifecycle gate.
- Resolve the exact fork remote branch commit instead of treating the qualified head as a local ref.
- Reject malformed, missing, ambiguous, or divergent fork-head targets.

## Changes

| File | Change |
|---|---|
| `extensions/gentle-ai.ts` | Parse fork heads, match exactly one configured GitHub owner remote, and resolve the exact remote branch commit. |
| `tests/review-controller.test.ts` | Cover valid fork authorization, divergent commits, and malformed fork-head syntax. |

## Test Plan

- [x] `git diff --cached --check`
- [x] Focused review-controller regression test: 1 passed, 0 failed
- [x] Bounded `review-reliability` review completed with no findings

## Checklist

- [x] Linked issue
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `--head owner:branch` pull request resolution using configured fork remotes, resolving the expected ref and commit uniquely.
  * Updated pull request commands to correctly interpret fork-head syntax and target the resolved commit.

* **Bug Fixes**
  * Improved validation for exact `owner:branch` formatting and disambiguation when remotes are missing or ambiguous.
  * Added an optional timeout for underlying git operations used during review.

* **Tests**
  * Added unit coverage for fork-head resolution and expanded controller authorization scenarios, including divergence and malformed input cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->