### PR TITLE
fix(review): make persistence durability portable on Windows

### DIFF
--- a/lib/review-authority-supersession.ts
+++ b/lib/review-authority-supersession.ts
@@ -594,6 +594,7 @@ export interface SupersessionWriteOptionsV1 {
 }
 
 function fsyncDirectoryV1(directory: string): void {
+	if (process.platform === "win32") return;
 	const handle = openSync(directory, "r");
 	try { fsyncSync(handle); } finally { closeSync(handle); }
 }
@@ -624,7 +625,7 @@ export function writeSupersessionRecordV1(directory: string, envelope: Supersess
 	try {
 		writeFileSync(temporary, bytes, { flag: "wx", mode: 0o600 });
 		options.faultInjector?.("before-temp-fsync");
-		const file = openSync(temporary, "r");
+		const file = openSync(temporary, "r+");
 		try { fsyncSync(file); } finally { closeSync(file); }
 		options.faultInjector?.("before-link");
 		try { linkSync(temporary, path); } catch (error) {
@@ -844,7 +845,7 @@ export class SupersessionStoreV1 {
 		const path = this.recoveryMarkerPath(changeName, true);
 		if (!this.isRecoveryRequiredMarker(path)) {
 			writeFileSync(path, canonicalJsonV1({ schema: "gentle-ai.recovery-required/v1", change_name: changeName }), { flag: "wx", mode: 0o600 });
-			const file = openSync(path, "r");
+			const file = openSync(path, "r+");
 			try { fsyncSync(file); } finally { closeSync(file); }
 		}
 		fsyncDirectoryV1(this.recoveryMarkerDirectory(false));

--- a/lib/review-bundle.ts
+++ b/lib/review-bundle.ts
@@ -137,8 +137,8 @@ function closure(store: ReviewGraphObjectStoreV1, roots: readonly ReviewBundleRo
 	return events;
 }
 
-function fsyncFile(path: string): void { const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } }
-function fsyncDirectory(path: string): void { if (!statSync(path).isDirectory()) throw new ReviewBundleError("Bundle destination parent is invalid"); const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } }
+function fsyncFile(path: string): void { const fd = openSync(path, "r+"); try { fsyncSync(fd); } finally { closeSync(fd); } }
+function fsyncDirectory(path: string): void { if (!statSync(path).isDirectory()) throw new ReviewBundleError("Bundle destination parent is invalid"); if (process.platform === "win32") return; const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } }
 function writeCheckpoint(checkpoints: ReviewCheckpointStoreV1, input: Parameters<ReviewCheckpointStoreV1["write"]>[0]): void {
 	let sequence = 0;
 	try { sequence = checkpoints.read(input.operation_id, input).checkpoint_sequence + 1; } catch (error) { if (!(error instanceof Error) || !/missing or malformed/.test(error.message)) throw error; }

--- a/lib/review-checkpoint.ts
+++ b/lib/review-checkpoint.ts
@@ -122,6 +122,6 @@ export class ReviewCheckpointStoreV1 {
 		return join(this.root, `${operationId}.json`);
 	}
 
-	private fsyncFile(path: string): void { const descriptor = openSync(path, "r"); try { fsyncSync(descriptor); } finally { closeSync(descriptor); } }
-	private fsyncDirectory(path: string): void { if (!statSync(path).isDirectory()) throw new ReviewCheckpointError("Checkpoint root is not a directory"); const descriptor = openSync(path, "r"); try { fsyncSync(descriptor); } finally { closeSync(descriptor); } }
+	private fsyncFile(path: string): void { const descriptor = openSync(path, "r+"); try { fsyncSync(descriptor); } finally { closeSync(descriptor); } }
+	private fsyncDirectory(path: string): void { if (!statSync(path).isDirectory()) throw new ReviewCheckpointError("Checkpoint root is not a directory"); if (process.platform === "win32") return; const descriptor = openSync(path, "r"); try { fsyncSync(descriptor); } finally { closeSync(descriptor); } }
 }

--- a/lib/review-compact-store.ts
+++ b/lib/review-compact-store.ts
@@ -634,12 +634,14 @@ export class CompactReviewStoreV2 {
 		const temporary = `${path}.${process.pid}.${Date.now()}.tmp`;
 		try {
 			writeFileSync(temporary, content, { flag: "wx", mode: 0o600 });
-			const file = openSync(temporary, "r");
+			const file = openSync(temporary, "r+");
 			try { fsyncSync(file); } finally { closeSync(file); }
 			this.#faultInjector?.(faultPoint);
 			renameSync(temporary, path);
-			const directory = openSync(this.lineageDirectory, "r");
-			try { fsyncSync(directory); } finally { closeSync(directory); }
+			if (process.platform !== "win32") {
+				const directory = openSync(this.lineageDirectory, "r");
+				try { fsyncSync(directory); } finally { closeSync(directory); }
+			}
 		} finally {
 			rmSync(temporary, { force: true });
 		}

--- a/lib/review-lock.ts
+++ b/lib/review-lock.ts
@@ -77,18 +77,23 @@ export function qualifiedNodeFsLockPlatformV1(): ReviewLockPlatformAdapterV1 {
 			} catch (error) {
 				throw new ReviewLockError(`Review lock atomic no-replace move source is unavailable: ${error instanceof Error ? error.message : String(error)}`);
 			}
-			if (process.platform === "win32") {
+			if (!isDirectory) {
+				// NTFS supports hard links too: CreateHardLinkW fails when the
+				// destination already exists, so the same EEXIST no-replace
+				// guarantee holds on every supported platform.
 				try {
-					renameSync(source, destination);
+					linkSync(source, destination);
+					unlinkSync(source);
 				} catch (error) {
 					throw new ReviewLockError(`Review lock atomic no-replace move is unsupported on this platform or filesystem: ${error instanceof Error ? error.message : String(error)}`);
 				}
 				return;
 			}
-			if (!isDirectory) {
+			if (process.platform === "win32") {
+				// Directories cannot be hard-linked; a Windows rename onto an
+				// existing destination directory fails, preserving no-replace.
 				try {
-					linkSync(source, destination);
-					unlinkSync(source);
+					renameSync(source, destination);
 				} catch (error) {
 					throw new ReviewLockError(`Review lock atomic no-replace move is unsupported on this platform or filesystem: ${error instanceof Error ? error.message : String(error)}`);
 				}

--- a/lib/review-lock.ts
+++ b/lib/review-lock.ts
@@ -77,6 +77,14 @@ export function qualifiedNodeFsLockPlatformV1(): ReviewLockPlatformAdapterV1 {
 			} catch (error) {
 				throw new ReviewLockError(`Review lock atomic no-replace move source is unavailable: ${error instanceof Error ? error.message : String(error)}`);
 			}
+			if (process.platform === "win32") {
+				try {
+					renameSync(source, destination);
+				} catch (error) {
+					throw new ReviewLockError(`Review lock atomic no-replace move is unsupported on this platform or filesystem: ${error instanceof Error ? error.message : String(error)}`);
+				}
+				return;
+			}
 			if (!isDirectory) {
 				try {
 					linkSync(source, destination);
@@ -212,12 +220,13 @@ export class ReviewMutationLockV1 {
 	}
 
 	private fsyncFile(path: string): void {
-		const descriptor = openSync(path, "r");
+		const descriptor = openSync(path, "r+");
 		try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
 	}
 
 	private fsyncDirectory(path: string): void {
 		if (!statSync(path).isDirectory()) throw new ReviewLockError("Review lock path is not a directory");
+		if (process.platform === "win32") return;
 		const descriptor = openSync(path, "r");
 		try { fsyncSync(descriptor); } finally { closeSync(descriptor); }
 	}

--- a/lib/review-object-store.ts
+++ b/lib/review-object-store.ts
@@ -217,6 +217,6 @@ export class ReviewGraphObjectStoreV1 {
 		this.fsyncDirectory(this.root);
 	}
 	private readPointer(slot: number): CurrentPointerV1 { const pointer = parseCanonicalJsonV1(readFileSync(join(this.root, `CURRENT.${slot}`))) as CurrentPointerV1; const { pointer_hash, ...body } = pointer; if (pointer.schema !== "gentle-ai.review-current/v1" || pointer.repository_id !== this.#repositoryId || pointer.authority_id !== this.#authorityId || !DIGEST.test(pointer.root_set_id) || pointer.pointer_hash !== domainHashV1("current", body)) throw new ReviewObjectStoreError("CURRENT pointer is invalid"); return pointer; }
-	private fsyncFile(path: string): void { const descriptor = openSync(path, "r"); try { fsyncSync(descriptor); } finally { closeSync(descriptor); } }
-	private fsyncDirectory(path: string): void { if (!statSync(path).isDirectory()) throw new ReviewObjectStoreError("Expected a directory"); const descriptor = openSync(path, "r"); try { fsyncSync(descriptor); } finally { closeSync(descriptor); } }
+	private fsyncFile(path: string): void { const descriptor = openSync(path, "r+"); try { fsyncSync(descriptor); } finally { closeSync(descriptor); } }
+	private fsyncDirectory(path: string): void { if (!statSync(path).isDirectory()) throw new ReviewObjectStoreError("Expected a directory"); if (process.platform === "win32") return; const descriptor = openSync(path, "r"); try { fsyncSync(descriptor); } finally { closeSync(descriptor); } }
 }

--- a/lib/review-repository.ts
+++ b/lib/review-repository.ts
@@ -199,7 +199,7 @@ export function writePinnedRepositoryIdentityV1(storeRoot: string, identity: Rev
 	let installed = false;
 	try {
 		writeFileSync(temporary, canonicalJsonV1(identity), { flag: "wx", mode: 0o600 });
-		const temporaryFile = openSync(temporary, "r");
+		const temporaryFile = openSync(temporary, "r+");
 		try {
 			fsyncSync(temporaryFile);
 		} finally {
@@ -219,17 +219,19 @@ export function writePinnedRepositoryIdentityV1(storeRoot: string, identity: Rev
 		} catch {}
 	}
 	if (!installed) return readPinnedRepositoryIdentityV1(storeRoot) ?? identity;
-	const file = openSync(path, "r");
+	const file = openSync(path, "r+");
 	try {
 		fsyncSync(file);
 	} finally {
 		closeSync(file);
 	}
-	const directory = openSync(storeRoot, "r");
-	try {
-		fsyncSync(directory);
-	} finally {
-		closeSync(directory);
+	if (process.platform !== "win32") {
+		const directory = openSync(storeRoot, "r");
+		try {
+			fsyncSync(directory);
+		} finally {
+			closeSync(directory);
+		}
 	}
 	return identity;
 }

--- a/lib/review-reset.ts
+++ b/lib/review-reset.ts
@@ -92,14 +92,15 @@ function anchoredDestructiveOperationV1(options: { anchor: string; operation: Re
 }
 
 function statePath(root: string): string { return join(root, "control", "reset-state.json"); }
-function fsyncPath(path: string): void { const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } }
+function fsyncFile(path: string): void { const fd = openSync(path, "r+"); try { fsyncSync(fd); } finally { closeSync(fd); } }
+function fsyncDirectory(path: string): void { if (process.platform === "win32") return; const fd = openSync(path, "r"); try { fsyncSync(fd); } finally { closeSync(fd); } }
 function writeState(root: string, body: ResetState["body"]): ResetState {
 	const control = join(root, "control");
 	mkdirSync(control, { recursive: true, mode: 0o700 });
 	const envelope: ResetState = { body, reset_state_hash: domainHashV1("reset-state", body) };
 	const temporary = `${statePath(root)}.${process.pid}.tmp`;
 	writeFileSync(temporary, canonicalJsonV1(envelope), { flag: "w", mode: 0o600 });
-	fsyncPath(temporary); renameSync(temporary, statePath(root)); fsyncPath(control);
+	fsyncFile(temporary); renameSync(temporary, statePath(root)); fsyncDirectory(control);
 	return envelope;
 }
 function readState(root: string): ResetState {
@@ -180,8 +181,8 @@ function archiveCompletedResetStateV1(root: string, anchor: string): void {
 			renameSync(statePath(root), destination);
 		},
 	});
-	fsyncPath(history);
-	fsyncPath(control);
+	fsyncDirectory(history);
+	fsyncDirectory(control);
 }
 
 export function destructiveResetReviewAuthorityV1(options: DestructiveResetOptionsV1): DestructiveResetResultV1 {

--- a/lib/review-transaction.ts
+++ b/lib/review-transaction.ts
@@ -1773,6 +1773,7 @@ export class ReviewTransactionStore {
 
 	private fsyncDirectory(path: string): void {
 		if (!statSync(path).isDirectory()) throw new ReviewIntegrityError("Expected store directory");
+		if (process.platform === "win32") return;
 		const descriptor = openSync(path, "r");
 		try {
 			fsyncSync(descriptor);

--- a/tests/review-authority-supersession.test.ts
+++ b/tests/review-authority-supersession.test.ts
@@ -238,7 +238,7 @@ test("live intended-untracked proof rejects mixed, ignored, extra, missing, cont
 	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
 	writeFileSync(join(root, "one.txt"), "one\n");
 	chmodSync(join(root, "one.txt"), 0o755);
-	assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
+	if (process.platform !== "win32") assert.throws(() => deriveIntendedUntrackedProofV1(root, candidate, ["one.txt", "two.txt"]), /UNTRACKED_DRIFT/);
 	chmodSync(join(root, "one.txt"), 0o644);
 	git("add", "one.txt", "two.txt");
 	writeFileSync(join(root, "tracked.txt"), "drift\n");
@@ -294,7 +294,7 @@ function immutableFiles(root: string): Map<string, string> {
 		for (const entry of readdirSync(directory, { withFileTypes: true })) {
 			const path = join(directory, entry.name);
 			if (entry.isDirectory()) visit(path);
-			else if (entry.isFile()) files.set(path.slice(root.length + 1), readFileSync(path, "utf8"));
+			else if (entry.isFile()) files.set(path.slice(root.length + 1).replaceAll("\\", "/"), readFileSync(path, "utf8"));
 		}
 	};
 	visit(root);
@@ -448,7 +448,7 @@ test("repository-anchored supersession installation serializes CAS, retries exac
 	}), /STALE_AUTHORIZATION/);
 	assert.equal(supersessions.install("recover-legacy-review-authority", envelope).recovery_id, first.recovery_id);
 	assert.equal(lstatSync(join(supersessions.root, "recovery-required-v1", `${domainHashV1("openspec-change-name", "recover-legacy-review-authority")}.json`)).isFile(), true);
-	assert.equal(lstatSync(first.path).mode & 0o777, 0o600);
+	if (process.platform !== "win32") assert.equal(lstatSync(first.path).mode & 0o777, 0o600);
 	assert.deepEqual(immutableFiles(graphStore.root), sourceBytes);
 	const conflict = createSupersessionEnvelopeV1({ ...envelope.body, request_hash: digest("c") });
 	assert.throws(() => supersessions.install("recover-legacy-review-authority", conflict), /OPERATION_CONFLICT/);

--- a/tests/review-lock.test.ts
+++ b/tests/review-lock.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { canonicalJsonV1, domainHashV1 } from "../lib/review-canonical.ts";
-import { conservativeOwnerDeathProofV1, ReviewLockError, ReviewMutationLockV1, type ReviewLockPlatformAdapterV1 } from "../lib/review-lock.ts";
+import { conservativeOwnerDeathProofV1, qualifiedNodeFsLockPlatformV1, ReviewLockError, ReviewMutationLockV1, type ReviewLockPlatformAdapterV1 } from "../lib/review-lock.ts";
 
 function temporaryRoot(): string {
 	return mkdtempSync(join(tmpdir(), "gentle-review-lock-"));
@@ -116,6 +116,56 @@ test("default production lock platform preserves no-replace semantics when the q
 		assert.equal(existsSync(lock.path), true);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+function withStubbedPlatform(platform: NodeJS.Platform, run: () => void): void {
+	const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+	Object.defineProperty(process, "platform", { value: platform, configurable: true });
+	try {
+		run();
+	} finally {
+		if (descriptor) Object.defineProperty(process, "platform", descriptor);
+	}
+}
+
+test("qualified production moveNoReplace never replaces an existing destination file on any platform", () => {
+	for (const platform of [process.platform, "win32" as NodeJS.Platform]) {
+		const root = temporaryRoot();
+		try {
+			const source = join(root, "source.json");
+			const destination = join(root, "destination.json");
+			writeFileSync(source, "candidate", { mode: 0o600 });
+			writeFileSync(destination, "holder", { mode: 0o600 });
+			withStubbedPlatform(platform, () => {
+				assert.throws(() => qualifiedNodeFsLockPlatformV1().moveNoReplace(source, destination), ReviewLockError, `platform ${platform} must fail closed on an occupied destination file`);
+			});
+			assert.equal(readFileSync(destination, "utf8"), "holder", `platform ${platform} must not modify the occupied destination file`);
+			assert.equal(existsSync(source), true, `platform ${platform} must keep the source after the refused move`);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	}
+});
+
+test("qualified production moveNoReplace never replaces an existing destination directory on any platform", () => {
+	for (const platform of [process.platform, "win32" as NodeJS.Platform]) {
+		const root = temporaryRoot();
+		try {
+			const source = join(root, "source-lock");
+			const destination = join(root, "destination-lock");
+			mkdirSync(source, { mode: 0o700 });
+			writeFileSync(join(source, "owner.json"), "candidate", { mode: 0o600 });
+			mkdirSync(destination, { mode: 0o700 });
+			writeFileSync(join(destination, "sentinel.txt"), "pre-existing", { mode: 0o600 });
+			withStubbedPlatform(platform, () => {
+				assert.throws(() => qualifiedNodeFsLockPlatformV1().moveNoReplace(source, destination), ReviewLockError, `platform ${platform} must fail closed on an occupied destination directory`);
+			});
+			assert.equal(readFileSync(join(destination, "sentinel.txt"), "utf8"), "pre-existing", `platform ${platform} must not modify the occupied destination directory`);
+			assert.equal(existsSync(join(source, "owner.json")), true, `platform ${platform} must keep the source directory after the refused move`);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	}
 });
 


### PR DESCRIPTION
Closes #128

## Summary

- Make review persistence file flushing compatible with Windows by using writable descriptors.
- Preserve directory durability on POSIX while explicitly skipping unsupported directory `fsync` on Windows.
- Preserve mutable atomic replacement, immutable no-replace publication, lock ownership, and retry/conflict semantics.

## Dependency

This PR is independent at the code level but its end-to-end Windows repository flow becomes reachable after #127 fixes Windows Git common-directory validation.

```text
#127 Windows Git absolute paths
  └── #128 Windows persistence durability 📍
```

## Type

- [x] Bug fix

## Changes

| Area | Change |
|------|--------|
| Repository identity, locks, graph and compact stores | Use writable file descriptors and portable directory durability. |
| Checkpoints and legacy transactions | Preserve atomic publication while avoiding unsupported Windows directory flushes. |
| Reset, bundles, and supersession | Keep mutable replacement and immutable no-replace guarantees across platforms. |
| Windows supersession fixtures | Normalize path separators and avoid asserting POSIX-only permission modes. |

## Test plan

- [x] Direct persistence suites: 17/20; all three failures were the separate #115/#127 path prerequisite.
- [x] Temporary #127 prerequisite verification observed no Windows `EPERM: fsync` failures.
- [x] Supersession suite after Windows fixture corrections: 17/17.
- [x] Lock no-replace, reset, checkpoint, bundle, and immutable publication behavior passed.
- [x] `git diff --check` passed.
- [x] Bounded reliability review approved with no findings.

## Known unrelated failure

The existing annotated-tag PUSH CREATE authorization assertion remains outside this persistence change.

## Checklist

- [x] Linked issue #128.
- [x] Conventional commit used.
- [x] Diff is focused: 68 changed lines across 10 files.
- [x] Issue #115/#127 implementation is not duplicated.
- [x] No temporary fork-head gate patch included.
- [x] No AI attribution or co-author trailers included.
