### PR TITLE
feat(review): support committed-base native start

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -124,6 +124,7 @@ import {
 import { sanitizeTerminalText, stripAnsi } from "../lib/terminal-theme.ts";
 import {
 	createNativeReviewCli,
+	isCanonicalProcessString,
 	type NativeReviewCli,
 	type NativeFinalizeResult,
 	type NativeStartResult,
@@ -2152,7 +2153,7 @@ const REVIEW_CONTROLLER_PARAMETERS = {
 		},
 		input: {
 			type: "string",
-			description: "A JSON-serialized object string, not a nested object. New native ordinary START uses {\"mode\":\"ordinary\"} or an optional repository-local policyPath; legacy compact START retains policyHash. FINALIZE supplies reviewer results, correction forecast, targeted validation, final evidence, and an explicit final_verification_passed boolean. Judgment Day retains graph-v1 input.",
+			description: "A JSON-serialized object string, not a nested object. New native ordinary START uses {\"mode\":\"ordinary\"} with optional baseRef and repository-local policyPath; legacy compact START retains policyHash. FINALIZE supplies reviewer results, correction forecast, targeted validation, final evidence, and an explicit final_verification_passed boolean. Judgment Day retains graph-v1 input.",
 		},
 		outputPath: { type: "string", description: "Destination path for deterministic bundle export." },
 		inputPath: { type: "string", description: "Source path for staged bundle import." },
@@ -3357,14 +3358,19 @@ function validateNativeStartPolicyPath(cwd: string, value: unknown): NativeStart
 	}
 }
 
-function nativeStartPolicyRejection(reason: string): Record<string, unknown> {
+function nativeStartRejection(reason: string, field?: string): Record<string, unknown> {
 	return {
 		operation: REVIEW_CONTROLLER_OPERATION.START,
 		status: "blocked",
 		outcome: reason === "legacy-policy-hash-unsupported"
 			? "native-start-legacy-policy-hash-unsupported"
-			: "native-start-policy-path-invalid",
+			: reason === "base-ref-invalid"
+				? "native-start-base-ref-invalid"
+				: reason === "unknown-field"
+					? "native-start-input-invalid"
+					: "native-start-policy-path-invalid",
 		reason,
+		...(field === undefined ? {} : { field }),
 		mutation_performed: false,
 		mutation_outcome: "none",
 	};
@@ -3604,14 +3610,19 @@ async function executeReviewControllerOperation(
 			) {
 				return { operation: parameters.operation, status: "blocked", outcome: "legacy-read-only", mutation_performed: false, next_action: "use-compatible-read-or-gate-route" };
 			}
-			if ("policyHash" in rawStart) return nativeStartPolicyRejection("legacy-policy-hash-unsupported");
+			if ("policyHash" in rawStart) return nativeStartRejection("legacy-policy-hash-unsupported");
+			const unknownField = Object.keys(rawStart).find((field) => !["mode", "baseRef", "policyPath"].includes(field));
+			if (unknownField !== undefined) return nativeStartRejection("unknown-field", unknownField);
 			const policy: NativeStartPolicyValidation = rawStart.policyPath === undefined
 				? {}
 				: validateNativeStartPolicyPath(defaultCwd, rawStart.policyPath);
-			if (policy.reason !== undefined) return nativeStartPolicyRejection(policy.reason);
+			if (policy.reason !== undefined) return nativeStartRejection(policy.reason);
+			const baseRef = rawStart.baseRef;
+			if (baseRef !== undefined && !isCanonicalProcessString(baseRef)) return nativeStartRejection("base-ref-invalid");
 			try {
 				const result = await nativeReviewCli.start({
 					cwd: defaultCwd,
+					...(baseRef === undefined ? {} : { baseRef }),
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 					...(policy.policyPath === undefined ? {} : { policyPath: policy.policyPath }),
 					...(signal === undefined ? {} : { signal }),
@@ -4252,7 +4263,7 @@ export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencie
 			"Inspect and recover review authority, run new native ordinary review through start/finalize/validate, preserve legacy compact compatibility reads and graph-v1 Judgment Day, and authorize one exact lifecycle command. RESET/RECOVER remain destructive; prepare-supersession/supersede require fresh interactive authorization and fail closed headlessly.",
 		promptSnippet: "Inspect authority, then use native start/finalize/validate for a new ordinary review; use graph-v1 only for explicit Judgment Day",
 		promptGuidelines: [
-			'Call {"operation":"inspect"} before START. New native ordinary START uses a JSON string such as "{\\"mode\\":\\"ordinary\\"}" or "{\\"mode\\":\\"ordinary\\",\\"policyPath\\":\\".gentle-ai/policies/team.json\\"}"; policyHash is legacy compact-only. The controller derives lineage, Git/untracked scope, tier, lenses, authored lines, and budget.',
+			'Call {"operation":"inspect"} before START. New native ordinary START uses a JSON string such as "{\\"mode\\":\\"ordinary\\"}", with optional baseRef or repository-local policyPath; policyHash is legacy compact-only. The controller derives lineage, Git/untracked scope, tier, lenses, authored lines, and budget.',
 			"For non-destructive legacy recovery, call prepare-supersession with one exact change, source, successor, operation, and prepared evidence input. Call supersede only with the returned request hash and exact English challenge after fresh UI approval; it never falls back to RESET or RECOVER. Headless, stale, conflicting, malformed, or unsupported recovery remains resolve-review blocked; exact retries are idempotent, but semantic retries require a new operation.",
 			"Run selected lenses once, then call FINALIZE with causal result JSON. FINALIZE alone records correction forecast, Git-derived correction evidence, targeted validation, and final evidence. Use ADVANCE only for explicit graph-v1 Judgment Day.",
 			"For blocked-legacy or blocked-mixed, do not call START repeatedly. Explain invalidation, request explicit user authorization for the exact reset_request challenge, then call RESET or RECOVER only after authorization. RESET and RECOVER internally INSPECT authority; require their verified clean result and next_action start-fresh-ordinary-review-after-verified-clean before continuing directly to a fresh ordinary START.",

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -44,7 +44,7 @@ export interface NativeReviewCli {
 	sddStatus(request: NativeSddStatusRequest): Promise<NativeSddStatusResult>;
 }
 
-export interface NativeStartRequest { cwd: string; lineageId?: string; policyPath?: string; focus?: string; signal?: AbortSignal; }
+export interface NativeStartRequest { cwd: string; baseRef?: string; lineageId?: string; policyPath?: string; focus?: string; signal?: AbortSignal; }
 export interface NativeFinalizeLensResult { lens: string; document: unknown; }
 export interface NativeFinalizeRequest {
 	cwd: string;
@@ -78,6 +78,10 @@ export interface NativeBindSddResult {
 	bindingRevision: string;
 }
 export interface NativeSddStatusResult { ready: boolean; [key: string]: unknown; }
+
+export function isCanonicalProcessString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0 && value.trim() === value && !/[\u0000-\u001f\u007f]/.test(value);
+}
 
 const NATIVE_RISK_LEVEL = ["low", "medium", "high"] as const;
 const NATIVE_REVIEW_LENS = ["review-risk", "review-resilience", "review-readability", "review-reliability"] as const;
@@ -193,8 +197,9 @@ export class NativeReviewCliV210 {
 	}
 
 	async start(request: NativeStartRequest): Promise<NativeStartResult> {
+		if (request.baseRef !== undefined && !isCanonicalProcessString(request.baseRef)) throw new TypeError("Native START baseRef must be a non-empty, trimmed, NUL-free string");
 		await this.verifyVersion(request.cwd, request.signal);
-		const result = await this.execute(NATIVE_REVIEW_OPERATION.START, request.cwd, ["review", "start", "--cwd", request.cwd, ...(request.lineageId ? ["--lineage", request.lineageId] : []), ...(request.policyPath ? ["--policy", request.policyPath] : []), ...(request.focus ? ["--focus", request.focus] : [])], true, request.signal);
+		const result = await this.execute(NATIVE_REVIEW_OPERATION.START, request.cwd, ["review", "start", "--cwd", request.cwd, ...(request.baseRef === undefined ? [] : ["--base-ref", request.baseRef]), ...(request.lineageId ? ["--lineage", request.lineageId] : []), ...(request.policyPath ? ["--policy", request.policyPath] : []), ...(request.focus ? ["--focus", request.focus] : [])], true, request.signal);
 		return decode(NATIVE_REVIEW_OPERATION.START, true, () => {
 			const body = exactObject(result, ["operation", "lineage_id", "state", "risk_level", "selected_lenses", "changed_files", "changed_lines", "correction_budget"]);
 			if (body.operation !== "review/start" || body.state !== "reviewing") throw new Error("wrong start discriminator");

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -7,6 +7,7 @@ import {
 	NativeReviewCliV210,
 	createNodeExecFileAdapter,
 	type ExecFileAdapter,
+	type NativeStartRequest,
 } from "../lib/native-review-cli.ts";
 
 interface QueuedResult {
@@ -43,18 +44,29 @@ const START = { stdout: JSON.stringify({ operation: "review/start", lineage_id: 
 const VALIDATE_ALLOW = { stdout: JSON.stringify({ schema: "gentle-ai.review-gate-result/v1", result: "allow", allowed: true, action: "allow", reason: "approved", gate_context: { lineage_id: "lineage-1", store_revision: "rev-1", receipt_hash: "receipt-1", target_hash: "target-1" } }) };
 
 test("native client verifies the pinned version once and uses argv without a shell", async () => {
-	const queue = queuedAdapter([VERSION, START, START, START]);
+	const queue = queuedAdapter([VERSION, START, START, START, START]);
 	const client = new NativeReviewCliV210(queue.adapter);
 	await client.start({ cwd: "/repo with spaces" });
+	await client.start({ cwd: "/repo with spaces", baseRef: "origin/main" });
 	await client.start({ cwd: "/repo with spaces", policyPath: "/repo with spaces/.gentle-ai/policies/team policy.json" });
 	await client.start({ cwd: "/repo with spaces", policyHash: "legacy-policy" } as unknown as { cwd: string; policyPath?: string });
 	assert.deepEqual(queue.calls.map((call) => call.arguments), [
 		["version"],
 		["review", "start", "--cwd", "/repo with spaces"],
+		["review", "start", "--cwd", "/repo with spaces", "--base-ref", "origin/main"],
 		["review", "start", "--cwd", "/repo with spaces", "--policy", "/repo with spaces/.gentle-ai/policies/team policy.json"],
 		["review", "start", "--cwd", "/repo with spaces"],
 	]);
 	assert.equal(queue.calls.every((call) => call.cwd === "/repo with spaces"), true);
+});
+
+test("native START rejects invalid runtime base refs before any adapter invocation", async () => {
+	for (const baseRef of ["", "   ", " origin/main", "origin/main ", "origin\0main", "origin\nmain", "origin\rmain", "origin\tmain", "origin\u007fmain", 42, [], {}]) {
+		const queue = queuedAdapter([]);
+		const request = { cwd: "/repo", baseRef } as unknown as NativeStartRequest;
+		await assert.rejects(() => new NativeReviewCliV210(queue.adapter).start(request), TypeError);
+		assert.equal(queue.calls.length, 0);
+	}
 });
 
 test("native client rejects incompatible version and malformed allow output", async () => {

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -166,6 +166,55 @@ test("native START uses the default policy or a canonical safe policy path, and 
 	assert.equal(requests.length, 2);
 });
 
+test("native START forwards a validated base ref and rejects invalid values before native calls", async (t) => {
+	const cwd = repository(t);
+	const requests: Array<{ cwd: string; baseRef?: string }> = [];
+	const { controller } = runtime(fakeNative({
+		start: async (request) => {
+			requests.push(request);
+			return { lineageId: "native-lineage", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 2, changedLines: 7, correctionBudget: 4 };
+		},
+	}));
+	await controller.execute("committed-base", { operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef: "origin/main" }) }, undefined, undefined, context(cwd));
+	assert.deepEqual(requests, [{ cwd, baseRef: "origin/main" }]);
+	for (const baseRef of ["", "   ", " origin/main", "origin/main ", "origin\0main", "origin\nmain", "origin\rmain", "origin\tmain", "origin\u007fmain", 42, [], {}]) {
+		const rejected = await controller.execute("invalid-base", { operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef }) }, undefined, undefined, context(cwd));
+		assert.deepEqual(rejected.details, {
+			operation: "start",
+			status: "blocked",
+			outcome: "native-start-base-ref-invalid",
+			reason: "base-ref-invalid",
+			mutation_performed: false,
+			mutation_outcome: "none",
+		});
+	}
+	assert.equal(requests.length, 1);
+});
+
+test("native ordinary START blocks unknown input fields before native calls", async (t) => {
+	const cwd = repository(t);
+	let starts = 0;
+	const { controller } = runtime(fakeNative({
+		start: async () => {
+			starts += 1;
+			return { lineageId: "native-lineage", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 2, changedLines: 7, correctionBudget: 4 };
+		},
+	}));
+	for (const field of ["base_ref", "unexpected"]) {
+		const rejected = await controller.execute("unknown-start-field", { operation: "start", input: JSON.stringify({ mode: "ordinary", [field]: "origin/main" }) }, undefined, undefined, context(cwd));
+		assert.deepEqual(rejected.details, {
+			operation: "start",
+			status: "blocked",
+			outcome: "native-start-input-invalid",
+			reason: "unknown-field",
+			field,
+			mutation_performed: false,
+			mutation_outcome: "none",
+		});
+	}
+	assert.equal(starts, 0);
+});
+
 test("legacy compact START retains its policyHash contract", async (t) => {
 	const cwd = repository(t);
 	const { controller } = runtime(null);


### PR DESCRIPTION
Closes #126

## Summary

- Forward optional committed-base `baseRef` through Pi's native Gentle AI v2.1.0 START adapter.
- Reject malformed process arguments and unknown ordinary START fields before any native invocation.
- Preserve absent-base, policy-path, legacy policy-hash, replay, and pre-PR behavior.

## Changes

| File | Change |
| --- | --- |
| `lib/native-review-cli.ts` | Adds optional `baseRef`, process-safe validation, and direct `--base-ref` argv forwarding. |
| `extensions/gentle-ai.ts` | Validates exact ordinary START input and forwards committed-base requests. |
| `tests/native-review-cli.test.ts` | Covers exact argv and pre-adapter malformed-input rejection. |
| `tests/review-controller-native-routing.test.ts` | Covers controller forwarding, unknown fields, controls, padding, and non-string values. |

## Test Plan

- [x] Focused native CLI and controller tests: 40/40 passed.
- [x] Full suite: `pnpm test`, 597/597 passed.
- [x] Package verification: `pnpm prepack`, 597/597 passed and 51 package files verified.
- [x] Real `execFile` harness confirmed shell-free literal argv with a spaced working directory.
- [x] `git diff --check` passed.
- [x] Four independent review lenses completed with no candidate-caused findings.

## Contributor Checklist

- [x] Linked approved issue #126.
- [x] Added exactly one `type:*` label.
- [x] Tests remain with the implementation work unit.
- [x] User-facing tool guidance reflects optional `baseRef`.
- [x] Commit follows Conventional Commits.
- [x] No `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native review starts now support an optional base reference for reviewing a specific revision or branch.
  * Repository-local policy paths are supported for native review requests.
* **Bug Fixes**
  * Invalid or unsupported review-start inputs are rejected earlier with clearer, field-specific outcomes.
  * Legacy policy-hash fields are no longer accepted in new native review-start requests.
  * Invalid base references and unexpected fields are prevented from launching a review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->