### PR TITLE
fix: normalize win32 platform to windows for asset lookup

### DIFF
--- a/scripts/gentle-ai-installer.mjs
+++ b/scripts/gentle-ai-installer.mjs
@@ -42,8 +42,12 @@ function upstreamArchitecture(architecture) {
 	return architecture === "x64" ? "amd64" : architecture;
 }
 
+function upstreamPlatform(platform) {
+	return platform === "win32" ? "windows" : platform;
+}
+
 export function resolveGentleAiReleaseAsset(platform = process.platform, architecture = process.arch, releaseAssets = GENTLE_AI_RELEASE_ASSETS) {
-	const key = `${platform}/${upstreamArchitecture(architecture)}`;
+	const key = `${upstreamPlatform(platform)}/${upstreamArchitecture(architecture)}`;
 	const resolved = releaseAssets[key];
 	if (!resolved) throw new Error(`unsupported Gentle AI platform/architecture: ${platform}/${architecture}; supported pairs are darwin, linux, or windows with x64 or arm64`);
 	return resolved;

--- a/tests/gentle-ai-installer.test.ts
+++ b/tests/gentle-ai-installer.test.ts
@@ -46,6 +46,11 @@ test("release mapping selects only the supported official v2.1.4 archive and pin
 	}
 });
 
+test("win32 platform normalizes to windows for asset lookup", () => {
+	assert.equal(resolveGentleAiReleaseAsset("win32", "x64").name, "gentle-ai_2.1.4_windows_amd64.zip");
+	assert.equal(resolveGentleAiReleaseAsset("win32", "arm64").name, "gentle-ai_2.1.4_windows_arm64.zip");
+});
+
 test("unsupported platform pairs fail clearly before download", () => {
 	for (const [platform, arch] of [["freebsd", "x64"], ["linux", "ia32"], ["darwin", "ppc64"]]) {
 		assert.throws(() => resolveGentleAiReleaseAsset(platform, arch), /unsupported Gentle AI platform\/architecture/);


### PR DESCRIPTION
## Problem

\process.platform\ returns \win32\ on Windows, but the asset map in \GENTLE_AI_RELEASE_ASSETS\ uses \windows/amd64\ and \windows/arm64\ keys. This causes the installer to fail with:

\\\
unsupported Gentle AI platform/architecture: win32/x64
\\\

Even though the Windows binaries exist in the v2.1.4 release.

## Fix

Added \upstreamPlatform()\ function that normalizes \win32\ → \windows\, mirroring the existing \upstreamArchitecture()\ pattern for \x64\ → \^Gmd64\.

## Test

Added test \win32 platform normalizes to windows for asset lookup\ that verifies both \win32/x64\ and \win32/arm64\ resolve correctly.

## Verification

Tested on Windows 11 x64 — the binary downloaded and installed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows installer asset resolution so the correct release files are selected for both x64 and arm64 systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #141
