### PR TITLE
chore(release): prepare 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gentle-pi",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Turn Pi into el Gentleman: a senior-architect development harness with SDD/OpenSpec, subagents, strict TDD evidence, review guardrails, and skill discovery.",
   "license": "MIT",
   "type": "module",

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1015,9 +1015,9 @@ test("pi-pretty wrapper uses real package path resolution for pnpm symlink insta
 	assert.match(wrapper, /quietToolsEnabled/);
 });
 
-test("v1.0.5 release package and runtime stop before delivery or publication", () => {
+test("v1.0.6 release package and runtime stop before delivery or publication", () => {
 	const packageJson = readPackageJson();
-	assert.equal(packageJson.version, "1.0.5", "the release manifest must remain explicitly pinned to v1.0.5");
+	assert.equal(packageJson.version, "1.0.6", "the release manifest must remain explicitly pinned to v1.0.6");
 	assert.equal(
 		packageJson.scripts?.test,
 		"node --experimental-strip-types --test tests/*.test.ts && pnpm run test:harness",


### PR DESCRIPTION
Closes #146
Related to #147

## Summary

- Prepare `gentle-pi@1.0.6` so the safe internal-symlink fix and timeout-free native review mutations reach users.
- Keep the package manifest and explicit release invariant synchronized.
- Preserve cancellation, output limits, read-only deadlines, package contents, and publish lifecycle checks.

## Changes

| File | Change |
|------|--------|
| `package.json` | Bump the package version from 1.0.5 to 1.0.6. |
| `tests/package-manifest.test.ts` | Pin the release invariant to 1.0.6. |

## Test plan

- [x] Native review CLI tests: 42/42
- [x] Package manifest tests: 28/28
- [x] Full test suite: 816/816 plus runtime harness
- [x] Package verifier: 55 required resources
- [x] `pnpm publish --dry-run --no-git-checks`
- [x] Native bounded review approved and pre-commit, pre-push, and pre-PR gates allowed

## Release note

This PR prepares the versioned package only. Tagging and npm publication happen after merge and exact-SHA release validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release version to 1.0.6.

* **Tests**
  * Updated release validation checks to reflect version 1.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->