### PR TITLE
 fix(review): preserva diagnósticos ante módulos duplicados

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -141,8 +141,10 @@ import {
 	NATIVE_REVIEW_AUTHORITY_STATUS,
 	NATIVE_REVIEW_ERROR_CODE,
 	NATIVE_REVIEW_LOCK_STATUS,
+	sanitizeForeignNativeReviewDiagnostics,
 	type NativeReviewCli,
 	type NativeFinalizeResult,
+	type NativeReviewProcessDiagnostics,
 	type NativeStartResult,
 	type NativeReviewStatusResult,
 	type NativeValidateResult,
@@ -3597,7 +3599,7 @@ async function deriveNativePrePushBinding(
 }
 
 function commitIncludesAllTracked(arguments_: readonly string[]): boolean {
-	let includesAllTracked = false;
+	const includesAllTracked = false;
 	const booleanOptions = new Set([
 		"--all",
 		"--allow-empty",
@@ -4169,9 +4171,20 @@ function nativeStatusUnsupported(operation: ReviewControllerOperation): Record<s
 	};
 }
 
+// Bundled and source module instances can coexist, making instanceof insufficient.
+function asNativeReviewCliError(error: unknown): { code: string; diagnostics: NativeReviewProcessDiagnostics } | undefined {
+	if (error instanceof NativeReviewCliError) return error;
+	if (!(error instanceof Error) || error.name !== "NativeReviewCliError") return undefined;
+	const value = error as unknown as { code?: unknown; diagnostics?: unknown };
+	if (typeof value.code !== "string") return undefined;
+	const diagnostics = sanitizeForeignNativeReviewDiagnostics(value.diagnostics);
+	return diagnostics === undefined || value.code !== diagnostics.error_code ? undefined : { code: value.code, diagnostics };
+}
+
 function nativeStatusFailed(operation: ReviewControllerOperation, error: unknown): Record<string, unknown> {
-	if (error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.VERSION_INCOMPATIBLE) return nativeStatusUnsupported(operation);
-	if (error instanceof NativeReviewCliError) {
+	const cliError = asNativeReviewCliError(error);
+	if (cliError?.code === NATIVE_REVIEW_ERROR_CODE.VERSION_INCOMPATIBLE) return nativeStatusUnsupported(operation);
+	if (cliError !== undefined) {
 		return {
 			...nativeOperationFailure(operation, error),
 			outcome: "native-status-unavailable",
@@ -4207,7 +4220,7 @@ async function nativeResetRemediationPreflight(
 		const compact = classifyCompactAuthorityApplicability(cwd);
 		return { classification: classifyNativeReviewRemediation(status, compact.lineageIds), status };
 	} catch (error) {
-		if (error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.VERSION_INCOMPATIBLE) return undefined;
+		if (asNativeReviewCliError(error)?.code === NATIVE_REVIEW_ERROR_CODE.VERSION_INCOMPATIBLE) return undefined;
 		throw error;
 	}
 }
@@ -4609,8 +4622,9 @@ function nativeOperationFailure(operation: ReviewControllerOperation, error: unk
 		};
 	}
 	const mutationOutcome = value.mutationOutcome === "unknown" ? "unknown" : "none";
-	const diagnostics = error instanceof NativeReviewCliError
-		? error.diagnostics
+	const nativeDiagnostics = asNativeReviewCliError(error)?.diagnostics;
+	const diagnostics = nativeDiagnostics?.operation === `review/${operation}`
+		? nativeDiagnostics
 		: operation === REVIEW_CONTROLLER_OPERATION.START && error instanceof CandidateViewError && value.candidateViewPreNative === true
 			? { code: error.reason, message: "candidate view rejected before native START" }
 			: undefined;

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -376,6 +376,30 @@ function parseStructuredNativeDenial(stdout: string): NativeReviewStructuredDeni
 	} catch { return undefined; }
 }
 
+// Rebuild diagnostics from a duplicated module instance before facade output.
+export function sanitizeForeignNativeReviewDiagnostics(value: unknown): NativeReviewProcessDiagnostics | undefined {
+	try {
+		const raw = exactObject(value, ["operation", "error_code", "timed_out", "output_limit_exceeded"], ["exit_code", "signal", "stderr", "denial"]);
+		const operation = enumString(raw.operation, Object.values(NATIVE_REVIEW_OPERATION)) as NativeReviewOperation;
+		const errorCode = enumString(raw.error_code, Object.values(NATIVE_REVIEW_ERROR_CODE)) as NativeReviewErrorCode;
+		const signal = raw.signal === undefined ? undefined : requiredString(raw.signal);
+		if (signal !== undefined && !/^SIG[A-Z0-9]{1,12}$/.test(signal)) return undefined;
+		return { operation, error_code: errorCode, ...(raw.exit_code === undefined ? {} : { exit_code: nonNegativeInteger(raw.exit_code) }), ...(signal === undefined ? {} : { signal: signal as NodeJS.Signals }), timed_out: booleanValue(raw.timed_out), output_limit_exceeded: booleanValue(raw.output_limit_exceeded), ...(raw.stderr === undefined ? {} : { stderr: sanitizeNativeDiagnosticText(stringValue(raw.stderr)) }), ...(raw.denial === undefined ? {} : { denial: sanitizeForeignStructuredDenial(raw.denial) }) };
+	} catch { return undefined; }
+}
+
+function sanitizeForeignStructuredDenial(value: unknown): NativeReviewStructuredDenial {
+	const parsed = exactObject(value, ["schema", "result", "action", "reason"], ["denial"]);
+	if (parsed.schema !== "gentle-ai.review-gate-result/v1") throw new Error("invalid denial schema");
+	const result = enumString(parsed.result, ["scope-changed", "invalidated", "escalated"] as const) as NativeReviewStructuredDenial["result"];
+	const action = sanitizeNativeDiagnosticText(requiredString(parsed.action), NATIVE_REVIEW_DENIAL_TEXT_LIMIT);
+	const reason = sanitizeNativeDiagnosticText(requiredString(parsed.reason), NATIVE_REVIEW_DENIAL_TEXT_LIMIT);
+	const expectedAction = { "scope-changed": "create-new-lineage", invalidated: "explicit-maintainer-action", escalated: "stop" }[result];
+	if (action !== expectedAction || !isCanonicalProcessString(action) || !isCanonicalProcessString(reason)) throw new Error("non-canonical denial evidence");
+	const denial = parsed.denial === undefined ? undefined : (() => { const nested = exactObject(parsed.denial, ["stage", "code"]); const stage = sanitizeNativeDiagnosticText(requiredString(nested.stage), NATIVE_REVIEW_DENIAL_TEXT_LIMIT); const code = sanitizeNativeDiagnosticText(requiredString(nested.code), NATIVE_REVIEW_DENIAL_TEXT_LIMIT); if (!isCanonicalProcessString(stage) || !isCanonicalProcessString(code)) throw new Error("non-canonical denial evidence"); return { stage, code }; })();
+	return { schema: "gentle-ai.review-gate-result/v1", result, action, reason, ...(denial === undefined ? {} : { denial }) };
+}
+
 function nativeProcessDiagnostics(operation: NativeReviewOperation, code: NativeReviewErrorCode, result?: ExecFileResult): NativeReviewProcessDiagnostics {
 	return {
 		operation,

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -377,6 +377,30 @@ function parseStructuredNativeDenial(stdout        )                            
 	} catch { return undefined; }
 }
 
+// Rebuild diagnostics from a duplicated module instance before facade output.
+export function sanitizeForeignNativeReviewDiagnostics(value         )                                             {
+	try {
+		const raw = exactObject(value, ["operation", "error_code", "timed_out", "output_limit_exceeded"], ["exit_code", "signal", "stderr", "denial"]);
+		const operation = enumString(raw.operation, Object.values(NATIVE_REVIEW_OPERATION))                         ;
+		const errorCode = enumString(raw.error_code, Object.values(NATIVE_REVIEW_ERROR_CODE))                         ;
+		const signal = raw.signal === undefined ? undefined : requiredString(raw.signal);
+		if (signal !== undefined && !/^SIG[A-Z0-9]{1,12}$/.test(signal)) return undefined;
+		return { operation, error_code: errorCode, ...(raw.exit_code === undefined ? {} : { exit_code: nonNegativeInteger(raw.exit_code) }), ...(signal === undefined ? {} : { signal: signal                   }), timed_out: booleanValue(raw.timed_out), output_limit_exceeded: booleanValue(raw.output_limit_exceeded), ...(raw.stderr === undefined ? {} : { stderr: sanitizeNativeDiagnosticText(stringValue(raw.stderr)) }), ...(raw.denial === undefined ? {} : { denial: sanitizeForeignStructuredDenial(raw.denial) }) };
+	} catch { return undefined; }
+}
+
+function sanitizeForeignStructuredDenial(value         )                               {
+	const parsed = exactObject(value, ["schema", "result", "action", "reason"], ["denial"]);
+	if (parsed.schema !== "gentle-ai.review-gate-result/v1") throw new Error("invalid denial schema");
+	const result = enumString(parsed.result, ["scope-changed", "invalidated", "escalated"]         )                                          ;
+	const action = sanitizeNativeDiagnosticText(requiredString(parsed.action), NATIVE_REVIEW_DENIAL_TEXT_LIMIT);
+	const reason = sanitizeNativeDiagnosticText(requiredString(parsed.reason), NATIVE_REVIEW_DENIAL_TEXT_LIMIT);
+	const expectedAction = { "scope-changed": "create-new-lineage", invalidated: "explicit-maintainer-action", escalated: "stop" }[result];
+	if (action !== expectedAction || !isCanonicalProcessString(action) || !isCanonicalProcessString(reason)) throw new Error("non-canonical denial evidence");
+	const denial = parsed.denial === undefined ? undefined : (() => { const nested = exactObject(parsed.denial, ["stage", "code"]); const stage = sanitizeNativeDiagnosticText(requiredString(nested.stage), NATIVE_REVIEW_DENIAL_TEXT_LIMIT); const code = sanitizeNativeDiagnosticText(requiredString(nested.code), NATIVE_REVIEW_DENIAL_TEXT_LIMIT); if (!isCanonicalProcessString(stage) || !isCanonicalProcessString(code)) throw new Error("non-canonical denial evidence"); return { stage, code }; })();
+	return { schema: "gentle-ai.review-gate-result/v1", result, action, reason, ...(denial === undefined ? {} : { denial }) };
+}
+
 function nativeProcessDiagnostics(operation                       , code                       , result                 )                                 {
 	return {
 		operation,

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1108,6 +1108,35 @@ test("native START preserves a candidate-view diagnostic before native invocatio
 	assert.equal(starts, 0);
 });
 
+test("ambiguous native START failure preserves rebuilt sanitized diagnostics across duplicated module instances", async (t) => {
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-controller-"));
+	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	const diagnostics = { operation: "review/start", error_code: "timeout", exit_code: 1, timed_out: true, output_limit_exceeded: false, stderr: "projection stalled token=abc123" };
+	const foreignInstance = Object.assign(new Error("native process timed out"), { name: "NativeReviewCliError", code: "timeout", mutationOutcome: "unknown", nextAction: "replay-exact-native-operation", diagnostics });
+	const { controller } = runtime(fakeNative({ start: async () => { throw foreignInstance; } }));
+	const result = await controller.execute("start", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+	assert.deepEqual(result.details, { operation: "start", status: "blocked", outcome: "native-mutation-status-required", mutation_outcome: "unknown", diagnostics: { operation: "review/start", error_code: "timeout", exit_code: 1, timed_out: true, output_limit_exceeded: false, stderr: "projection stalled token=[REDACTED]" }, replayability: "status_required", next_action: "review.status", required_status_action: "Run target-scoped review.status and follow only its declared action; never start a new review, create a new budget, launch a lens, or fall back to inventory discovery." });
+});
+
+test("foreign errors with unrecognized diagnostics shapes stay diagnostics-free", async (t) => {
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-controller-"));
+	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	const malformedShapes: Record<string, unknown>[] = [
+		{ name: "NativeReviewCliError", code: "timeout", diagnostics: { operation: "review/start", error_code: "timeout", timed_out: "yes", output_limit_exceeded: false } },
+		{ name: "NativeReviewCliError", code: "timeout", diagnostics: { operation: "review/start", error_code: "timeout", timed_out: true, output_limit_exceeded: false, unexpected: "extra" } },
+		{ name: "NativeReviewCliError", code: "timeout", diagnostics: { operation: "not-an-operation", error_code: "timeout", timed_out: true, output_limit_exceeded: false } },
+		{ name: "NativeReviewCliError", code: "timeout", diagnostics: { operation: "review/finalize", error_code: "timeout", timed_out: true, output_limit_exceeded: false } },
+		{ name: "NativeReviewCliError", code: "version-incompatible", diagnostics: { operation: "review/start", error_code: "timeout", timed_out: true, output_limit_exceeded: false } },
+		{ code: "timeout", diagnostics: { stderr: "raw unsanitized output" } },
+	];
+	for (const shape of malformedShapes) {
+		const foreignError = Object.assign(new Error("boom"), { mutationOutcome: "unknown", ...shape });
+		const { controller } = runtime(fakeNative({ start: async () => { throw foreignError; } }));
+		const result = await controller.execute("start", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+		assert.deepEqual(result.details, { operation: "start", status: "blocked", outcome: "native-mutation-status-required", mutation_outcome: "unknown", replayability: "status_required", next_action: "review.status", required_status_action: "Run target-scoped review.status and follow only its declared action; never start a new review, create a new budget, launch a lens, or fall back to inventory discovery." }, JSON.stringify(shape));
+	}
+});
+
 test("native START uses the default policy or a canonical safe policy path, and rejects unsafe policy inputs before native calls", async (t) => {
 	const cwd = repository(t);
 	const policyDirectory = join(cwd, ".gentle-ai", "policies");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native error handling when operating across multiple module instances, ensuring consistent classification and “next action” behavior.
  * Blocked responses now preserve valid diagnostic details while redacting sensitive standard-error output.
  * Malformed or unexpected diagnostics are filtered out so they no longer appear in response details.
* **Tests**
  * Added coverage for ambiguous native start failures, including cases with valid diagnostics and cases with malformed diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->