### PR TITLE
fix(review): support immutable gitlinks in candidate views

### DIFF
--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -18,16 +18,29 @@ const MAX_SUBAGENT_CONTEXT_LENGTH = 4_096;
 const MAX_CANDIDATE_CONTEXT_LENGTH = 4_096;
 const SUBAGENT_RUN_KEYS = new Set(["agent", "agents", "task", "context", "mode"]);
 
-interface CandidateViewEntry {
+interface CandidateTreeEntry {
 	path: string;
 	mode: string;
-	blob: string;
+	objectId: string;
+}
+
+interface CandidateViewEntry extends CandidateTreeEntry {
 	contentHash: string;
+}
+
+interface CandidateGitlink extends CandidateTreeEntry {
+	mode: "160000";
+}
+
+interface ParsedCandidateTree {
+	entries: CandidateTreeEntry[];
+	gitlinks: CandidateGitlink[];
 }
 
 interface CandidateViewScope {
 	paths: readonly string[];
 	modes: Readonly<Record<string, string>>;
+	gitlinks: Readonly<Record<string, string>>;
 	deletedPaths: readonly string[];
 }
 
@@ -42,6 +55,7 @@ interface CandidateViewRecord {
 	candidateTree: string;
 	committedOnly: boolean;
 	entries: readonly CandidateViewEntry[];
+	gitlinks: readonly CandidateGitlink[];
 	scope: CandidateViewScope;
 	lineageId?: string;
 	selectedLenses?: readonly ReviewLens[];
@@ -57,6 +71,7 @@ export interface CandidateView {
 	committedOnly: boolean;
 	paths: readonly string[];
 	modes: Readonly<Record<string, string>>;
+	gitlinks: Readonly<Record<string, string>>;
 	deletedPaths: readonly string[];
 	verify(): void;
 	cleanup(): void;
@@ -70,6 +85,7 @@ export interface FrozenCandidateProjection {
 	committedOnly: boolean;
 	paths: readonly string[];
 	modes: Readonly<Record<string, string>>;
+	gitlinks: Readonly<Record<string, string>>;
 	deletedPaths: readonly string[];
 }
 
@@ -95,6 +111,7 @@ export interface AuthoritativeReviewingCandidateState {
 	committedOnly?: boolean;
 	paths: readonly string[];
 	modes: Readonly<Record<string, string>>;
+	gitlinks?: Readonly<Record<string, string>>;
 	deletedPaths: readonly string[];
 	selectedLenses: readonly string[];
 }
@@ -135,8 +152,12 @@ function isSafeCandidatePath(path: string): boolean {
 		&& path.split("/").every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
 }
 
-function isSupportedCandidateMode(mode: string): boolean {
+function isMaterializedCandidateMode(mode: string): boolean {
 	return mode === "100644" || mode === "100755" || mode === "120000";
+}
+
+function isCanonicalObjectId(objectId: string): boolean {
+	return /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(objectId);
 }
 
 function decodeCanonicalPath(value: Buffer): string {
@@ -181,15 +202,30 @@ function splitNulTerminated(raw: Buffer, errorMessage: string): Buffer[] {
 	return tokens;
 }
 
-function parseTree(cwd: string, tree: string, executor: CandidateGitExecutor): CandidateViewEntry[] {
+function parseTree(cwd: string, tree: string, executor: CandidateGitExecutor): ParsedCandidateTree {
 	const raw = candidateGit(cwd, ["ls-tree", "-r", "-z", tree], process.env, "buffer", executor) as Buffer;
-	return splitNulTerminated(raw, "candidate tree output is not NUL-terminated").map((row) => {
+	const entries: CandidateTreeEntry[] = [];
+	const gitlinks: CandidateGitlink[] = [];
+	const paths = new Set<string>();
+	for (const row of splitNulTerminated(raw, "candidate tree output is not NUL-terminated")) {
 		const separator = row.indexOf(0x09);
-		const [mode, kind, blob] = row.subarray(0, separator).toString("ascii").split(" ");
+		if (separator < 0) throw new CandidateViewError("candidate tree contains an unsafe entry");
+		const header = row.subarray(0, separator).toString("ascii");
+		const match = /^(100644|100755|120000) blob ([0-9a-f]{40}|[0-9a-f]{64})$|^(160000) commit ([0-9a-f]{40}|[0-9a-f]{64})$/.exec(header);
 		const path = decodeCanonicalPath(row.subarray(separator + 1));
-		if (separator < 0 || kind !== "blob" || !mode || !blob || !isSupportedCandidateMode(mode)) throw new CandidateViewError("candidate tree contains an unsafe entry");
-		return { path, mode, blob, contentHash: "" };
-	});
+		if (!match || paths.has(path)) throw new CandidateViewError("candidate tree contains an unsafe entry");
+		paths.add(path);
+		const mode = match[1] ?? match[3]!;
+		const objectId = match[2] ?? match[4]!;
+		if (!isCanonicalObjectId(objectId)) throw new CandidateViewError("candidate tree contains an unsafe entry");
+		if (mode === "160000") gitlinks.push({ path, mode, objectId });
+		else if (isMaterializedCandidateMode(mode)) entries.push({ path, mode, objectId });
+		else throw new CandidateViewError("candidate tree contains an unsafe entry");
+	}
+	const comparePath = (left: CandidateTreeEntry, right: CandidateTreeEntry): number => left.path < right.path ? -1 : left.path > right.path ? 1 : 0;
+	entries.sort(comparePath);
+	gitlinks.sort(comparePath);
+	return { entries, gitlinks };
 }
 
 function gitPathTokens(cwd: string, arguments_: readonly string[], executor: CandidateGitExecutor): Buffer[] {
@@ -197,7 +233,7 @@ function gitPathTokens(cwd: string, arguments_: readonly string[], executor: Can
 	return splitNulTerminated(raw, "candidate scope Git output is not NUL-terminated");
 }
 
-function deriveChangedScope(cwd: string, baseCommit: string, candidateTree: string, entries: readonly CandidateViewEntry[], executor: CandidateGitExecutor): CandidateViewScope {
+function deriveChangedScope(cwd: string, baseCommit: string, candidateTree: string, entries: readonly CandidateTreeEntry[], executor: CandidateGitExecutor): CandidateViewScope {
 	const present = new Map(entries.map((entry) => [entry.path, entry]));
 	const paths = new Set<string>();
 	const deleted = new Set<string>();
@@ -230,11 +266,15 @@ function deriveChangedScope(cwd: string, baseCommit: string, candidateTree: stri
 	return {
 		paths: allPaths,
 		modes: Object.fromEntries(presentPaths.map((path) => [path, present.get(path)!.mode])),
+		gitlinks: Object.fromEntries(presentPaths.flatMap((path) => {
+			const entry = present.get(path)!;
+			return entry.mode === "160000" ? [[path, entry.objectId]] : [];
+		})),
 		deletedPaths,
 	};
 }
 
-function entryContentHash(root: string, entry: CandidateViewEntry): string {
+function entryContentHash(root: string, entry: CandidateTreeEntry): string {
 	const path = join(root, entry.path);
 	const item = lstatSync(path);
 	if (entry.mode === "120000") {
@@ -338,6 +378,24 @@ export function resolveCanonicalCandidateBase(contributorRoot: string, baseRef: 
 	return resolveCandidateBase(realpathSync(contributorRoot), baseRef, process.env, defaultCandidateGitExecutor);
 }
 
+function checkoutMaterializedEntries(root: string, entries: readonly CandidateTreeEntry[], executor: CandidateGitExecutor): void {
+	let batch: string[] = [];
+	let bytes = 0;
+	const flush = (): void => {
+		if (batch.length === 0) return;
+		git(root, ["checkout-index", "-f", "--", ...batch], process.env, executor);
+		batch = [];
+		bytes = 0;
+	};
+	for (const entry of entries) {
+		const entryBytes = Buffer.byteLength(entry.path, "utf8") + 1;
+		if (batch.length > 0 && bytes + entryBytes > 16_384) flush();
+		batch.push(entry.path);
+		bytes += entryBytes;
+	}
+	flush();
+}
+
 function materializeCandidateView(request: CreateCandidateViewRequest, executor: CandidateGitExecutor): CandidateViewRecord {
 	const contributorRoot = realpathSync(request.contributorRoot);
 	if (!lstatSync(contributorRoot).isDirectory()) throw new CandidateViewError("contributor root is not a directory");
@@ -362,12 +420,15 @@ function materializeCandidateView(request: CreateCandidateViewRequest, executor:
 		git(contributorRoot, ["worktree", "add", "--detach", "--no-checkout", root, candidateCommit.commit], process.env, executor);
 		try {
 			git(root, ["read-tree", candidateTree], process.env, executor);
-			git(root, ["checkout-index", "-a", "-f"], process.env, executor);
-			const treeEntries = parseTree(root, candidateTree, executor);
-			const entries = treeEntries.map((entry) => ({ ...entry, contentHash: entryContentHash(root, entry) }));
-			const scope = deriveChangedScope(contributorRoot, baseCommit, candidateTree, entries, executor);
+			const tree = parseTree(root, candidateTree, executor);
+			checkoutMaterializedEntries(root, tree.entries, executor);
+			const entries = tree.entries.map((entry) => ({ ...entry, contentHash: entryContentHash(root, entry) }));
+			const scope = deriveChangedScope(contributorRoot, baseCommit, candidateTree, [...tree.entries, ...tree.gitlinks], executor);
+			for (const gitlink of tree.gitlinks) {
+				if (lstatSync(join(root, gitlink.path), { throwIfNoEntry: false })) throw new CandidateViewError("candidate view materialized a metadata-only gitlink");
+			}
 			makeReadonly(root, entries);
-			return { token: basename(root), root: realpathSync(root), parent, contributorRoot, commonDir: canonicalCommonDir, baseCommit, baseTree: base.tree, candidateTree, committedOnly, entries, scope, gitExecutor: executor };
+			return { token: basename(root), root: realpathSync(root), parent, contributorRoot, commonDir: canonicalCommonDir, baseCommit, baseTree: base.tree, candidateTree, committedOnly, entries, gitlinks: tree.gitlinks, scope, gitExecutor: executor };
 		} catch (error) {
 			try { git(contributorRoot, ["worktree", "remove", "--force", root], process.env, executor); } catch { rmSync(root, { recursive: true, force: true }); }
 			throw error;
@@ -391,6 +452,10 @@ function assertRecordSafe(record: CandidateViewRecord): void {
 	if (gitPathTokens(root, ["ls-files", "--others", "--exclude-standard", "-z"], record.gitExecutor).length !== 0) throw new CandidateViewError("candidate view contains injected untracked entries");
 	const tree = git(root, ["write-tree"], process.env, record.gitExecutor);
 	if (tree !== record.candidateTree) throw new CandidateViewError("candidate view index no longer matches its frozen tree");
+	for (const gitlink of record.gitlinks) {
+		if (!isSafeCandidatePath(gitlink.path) || gitlink.mode !== "160000" || !isCanonicalObjectId(gitlink.objectId)) throw new CandidateViewError("candidate view gitlink metadata is unsafe");
+		if (lstatSync(join(root, gitlink.path), { throwIfNoEntry: false })) throw new CandidateViewError("candidate view contains materialized gitlink contents");
+	}
 	for (const entry of record.entries) {
 		if (!isSafeCandidatePath(entry.path)) throw new CandidateViewError("candidate view entry path is unsafe");
 		const path = join(root, entry.path);
@@ -539,6 +604,7 @@ export class CandidateViewRegistry {
 			committedOnly: replacement.committedOnly,
 			paths: replacement.scope.paths,
 			modes: replacement.scope.modes,
+			gitlinks: replacement.scope.gitlinks,
 			deletedPaths: replacement.scope.deletedPaths,
 		});
 		this.current = { lineageId, token };
@@ -563,6 +629,7 @@ export class CandidateViewRegistry {
 				(state.committedOnly ?? false) === record.committedOnly &&
 				JSON.stringify(state.paths) === JSON.stringify(record.scope.paths) &&
 				JSON.stringify(state.modes) === JSON.stringify(record.scope.modes) &&
+				JSON.stringify(state.gitlinks ?? {}) === JSON.stringify(record.scope.gitlinks) &&
 				JSON.stringify(state.deletedPaths) === JSON.stringify(record.scope.deletedPaths);
 		} catch {
 			return false;
@@ -584,6 +651,7 @@ export class CandidateViewRegistry {
 			committedOnly: record.committedOnly,
 			paths: record.scope.paths,
 			modes: record.scope.modes,
+			gitlinks: record.scope.gitlinks,
 			deletedPaths: record.scope.deletedPaths,
 		});
 		for (const [key, pendingToken] of this.replays) if (pendingToken === token) this.replays.delete(key);
@@ -597,7 +665,7 @@ export class CandidateViewRegistry {
 		const root = realpathSync(contributorRoot);
 		const base = resolveCandidateBase(root, baseCommit, process.env, this.gitExecutor);
 		if (!lineageId || this.projections.has(lineageId) || base.commit !== baseCommit || base.tree !== baseTree || !isFullCommitId(candidateTree) || paths.some((path) => !isSafeCandidatePath(path)) || new Set(paths).size !== paths.length) throw new CandidateViewError("frozen correction projection is invalid or already restored");
-		this.projections.set(lineageId, { contributorRoot: root, baseCommit, baseTree, candidateTree, committedOnly: false, paths: [...paths], modes: {}, deletedPaths: [] });
+		this.projections.set(lineageId, { contributorRoot: root, baseCommit, baseTree, candidateTree, committedOnly: false, paths: [...paths], modes: {}, gitlinks: {}, deletedPaths: [] });
 	}
 
 	resolveProjection(lineageId: string, contributorRoot: string): FrozenCandidateProjection {
@@ -646,6 +714,7 @@ export class CandidateViewRegistry {
 				live.committedOnly !== record.committedOnly ||
 				JSON.stringify(live.scope.paths) !== JSON.stringify(record.scope.paths) ||
 				JSON.stringify(live.scope.modes) !== JSON.stringify(record.scope.modes) ||
+				JSON.stringify(live.scope.gitlinks) !== JSON.stringify(record.scope.gitlinks) ||
 				JSON.stringify(live.scope.deletedPaths) !== JSON.stringify(record.scope.deletedPaths)
 			) throw new CandidateViewError("live candidate no longer matches the current controller-owned lineage binding", "current-binding-live-candidate-drift");
 		} finally {
@@ -676,9 +745,15 @@ export class CandidateViewRegistry {
 
 	private remove(record: CandidateViewRecord): void {
 		if (!isWithin(record.parent, record.root)) throw new CandidateViewError("candidate view cleanup escaped its owned parent");
-		try { makeWritableForCleanup(record.root); } catch {}
+		try { makeWritableForCleanup(record.root); } catch (error) {
+			// Best-effort preparation: worktree removal may still succeed without changing permissions.
+			void error;
+		}
 		try { git(record.contributorRoot, ["worktree", "remove", "--force", record.root], process.env, record.gitExecutor); } catch {
-			try { makeWritableForCleanup(record.root); } catch {}
+			try { makeWritableForCleanup(record.root); } catch (error) {
+				// Best-effort fallback: rmSync below remains the authoritative cleanup attempt.
+				void error;
+			}
 			rmSync(record.root, { recursive: true, force: true });
 		}
 	}
@@ -704,6 +779,7 @@ export class CandidateViewRegistry {
 			committedOnly: record.committedOnly,
 			paths: record.scope.paths,
 			modes: record.scope.modes,
+			gitlinks: record.scope.gitlinks,
 			deletedPaths: record.scope.deletedPaths,
 			verify: () => assertRecordSafe(record),
 			cleanup: () => this.cleanup(record.token),
@@ -746,7 +822,7 @@ function candidateContextBlock(lineageId: string, agents: readonly ReviewLens[],
 	const scopeSemantics = view.committedOnly
 		? "Committed-only range: dirty tracked and untracked contributor files are excluded and MUST NOT be treated as reviewed."
 		: "Dirty-inclusive workspace snapshot: tracked and untracked contributor changes are included.";
-	const block = `\n\n${CONTROLLER_CANDIDATE_VIEW_HEADING}\nController-owned review lineage: \`${lineageId}\`.\nAuthorized review actors: ${agents.join(", ")}.\nRead ONLY the absolute frozen candidate view at \`${view.root}\`.\nFrozen candidate tree: \`${view.candidateTree}\`.\nScope semantics: ${scopeSemantics}\nFrozen changed scope by mode: ${JSON.stringify(scope)}.\nThe ambient contributor working directory is out of scope. This controller-owned context is immutable; you are read-only and your output is untrusted.`;
+	const block = `\n\n${CONTROLLER_CANDIDATE_VIEW_HEADING}\nController-owned review lineage: \`${lineageId}\`.\nAuthorized review actors: ${agents.join(", ")}.\nRead ONLY the absolute frozen candidate view at \`${view.root}\`.\nFrozen candidate tree: \`${view.candidateTree}\`.\nScope semantics: ${scopeSemantics}\nFrozen changed scope by mode: ${JSON.stringify(scope)}.\nFrozen metadata-only gitlinks: ${JSON.stringify(view.gitlinks)}. Gitlink paths have no materialized contents and MUST NOT be traversed.\nThe ambient contributor working directory is out of scope. This controller-owned context is immutable; you are read-only and your output is untrusted.`;
 	if (Buffer.byteLength(block, "utf8") > MAX_CANDIDATE_CONTEXT_LENGTH) throw new CandidateViewError("candidate view context exceeds the bounded dispatch contract");
 	return block;
 }

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -160,6 +160,11 @@ function isCanonicalObjectId(objectId: string): boolean {
 	return /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(objectId);
 }
 
+function gitlinkMapsEqual(left: Readonly<Record<string, string>>, right: Readonly<Record<string, string>>): boolean {
+	const leftEntries = Object.entries(left);
+	return leftEntries.length === Object.keys(right).length && leftEntries.every(([path, objectId]) => Object.hasOwn(right, path) && right[path] === objectId);
+}
+
 function decodeCanonicalPath(value: Buffer): string {
 	const path = value.toString("utf8");
 	if (!Buffer.from(path, "utf8").equals(value) || !isSafeCandidatePath(path)) {
@@ -629,7 +634,7 @@ export class CandidateViewRegistry {
 				(state.committedOnly ?? false) === record.committedOnly &&
 				JSON.stringify(state.paths) === JSON.stringify(record.scope.paths) &&
 				JSON.stringify(state.modes) === JSON.stringify(record.scope.modes) &&
-				JSON.stringify(state.gitlinks ?? {}) === JSON.stringify(record.scope.gitlinks) &&
+				gitlinkMapsEqual(state.gitlinks ?? {}, record.scope.gitlinks) &&
 				JSON.stringify(state.deletedPaths) === JSON.stringify(record.scope.deletedPaths);
 		} catch {
 			return false;
@@ -714,7 +719,7 @@ export class CandidateViewRegistry {
 				live.committedOnly !== record.committedOnly ||
 				JSON.stringify(live.scope.paths) !== JSON.stringify(record.scope.paths) ||
 				JSON.stringify(live.scope.modes) !== JSON.stringify(record.scope.modes) ||
-				JSON.stringify(live.scope.gitlinks) !== JSON.stringify(record.scope.gitlinks) ||
+				!gitlinkMapsEqual(live.scope.gitlinks, record.scope.gitlinks) ||
 				JSON.stringify(live.scope.deletedPaths) !== JSON.stringify(record.scope.deletedPaths)
 			) throw new CandidateViewError("live candidate no longer matches the current controller-owned lineage binding", "current-binding-live-candidate-drift");
 		} finally {

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -168,6 +168,121 @@ function commitFileAfterBase(cwd: string): void {
 	git(cwd, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "committed after base");
 }
 
+function commitGitlinkAfterBase(cwd: string, path = "vendor/dependency"): { baseCommit: string; gitlinkCommit: string } {
+	const baseCommit = git(cwd, "rev-parse", "HEAD");
+	const gitlinkCommit = "0123456789abcdef0123456789abcdef01234567";
+	git(cwd, "update-index", "--add", "--cacheinfo", `160000,${gitlinkCommit},${path}`);
+	git(cwd, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "add gitlink");
+	return { baseCommit, gitlinkCommit };
+}
+
+test("candidate view freezes changed gitlinks as metadata without materializing their contents", (t) => {
+	const contributorRoot = repository(t);
+	const { baseCommit, gitlinkCommit } = commitGitlinkAfterBase(contributorRoot);
+	const registry = new CandidateViewRegistry();
+	const view = registry.create({ contributorRoot, baseRef: baseCommit, committedOnly: true });
+	try {
+		assert.deepEqual(view.paths, ["vendor/dependency"]);
+		assert.deepEqual(view.modes, { "vendor/dependency": "160000" });
+		assert.deepEqual(view.gitlinks, { "vendor/dependency": gitlinkCommit });
+		assert.equal(lstatSync(join(view.root, "vendor", "dependency"), { throwIfNoEntry: false }), undefined);
+		registry.bindCurrent({ token: view.token, lineageId: "gitlink", selectedLenses: ["review-reliability"] });
+		assert.deepEqual(registry.resolveProjection("gitlink", contributorRoot).gitlinks, { "vendor/dependency": gitlinkCommit });
+		const dispatch = { agent: "review-reliability", task: "review", mode: "task" };
+		injectReviewCandidateView(dispatch, registry);
+		assert.match(dispatch.task, new RegExp(`Frozen metadata-only gitlinks: .*${gitlinkCommit}`));
+		view.verify();
+	} finally {
+		registry.cleanup(view.token);
+	}
+});
+
+test("authoritative restore requires the exact frozen gitlink OID", (t) => {
+	const contributorRoot = repository(t);
+	const { baseCommit } = commitGitlinkAfterBase(contributorRoot);
+	const source = new CandidateViewRegistry();
+	const frozen = source.create({ contributorRoot, baseRef: baseCommit, committedOnly: true });
+	const state = {
+		lineageId: "authoritative-gitlink",
+		contributorRoot,
+		baseCommit: frozen.baseCommit,
+		baseTree: frozen.baseTree,
+		candidateTree: frozen.candidateTree,
+		committedOnly: true,
+		paths: frozen.paths,
+		modes: frozen.modes,
+		gitlinks: frozen.gitlinks,
+		deletedPaths: frozen.deletedPaths,
+		selectedLenses: ["review-reliability"],
+	};
+	const restored = new CandidateViewRegistry();
+	try {
+		assert.throws(
+			() => new CandidateViewRegistry().restoreCurrentFromAuthoritativeReviewingStates(contributorRoot, [{ ...state, gitlinks: { "vendor/dependency": "89abcdef0123456789abcdef0123456789abcdef" } }]),
+			(error: unknown) => error instanceof CandidateViewError && error.reason === "authoritative-current-match-missing",
+		);
+		restored.restoreCurrentFromAuthoritativeReviewingStates(contributorRoot, [state]);
+		assert.deepEqual(restored.resolveCurrentForLens("review-reliability").gitlinks, frozen.gitlinks);
+	} finally {
+		source.cleanup(frozen.token);
+		if (restored.hasCurrentBinding()) restored.cleanup(restored.resolveCurrentForLens("review-reliability").token);
+	}
+});
+
+test("candidate view rejects malformed tree mode-kind-OID pairings", (t) => {
+	const malformedHeaders = [
+		"160000 blob 0123456789abcdef0123456789abcdef01234567",
+		"100644 commit 0123456789abcdef0123456789abcdef01234567",
+		"100664 blob 0123456789abcdef0123456789abcdef01234567",
+		"160000 commit 0123456789abcdef0123456789abcdef0123456g",
+		"160000  commit 0123456789abcdef0123456789abcdef01234567",
+	];
+	for (const header of malformedHeaders) {
+		const contributorRoot = repository(t);
+		const executor: CandidateGitExecutor = (file, arguments_, options) => arguments_[0] === "ls-tree"
+			? Buffer.from(`${header}\tdependency\0`)
+			: execFileSync(file, arguments_, options);
+		assert.throws(() => new CandidateViewRegistry(executor).create({ contributorRoot }), CandidateViewError, header);
+	}
+});
+
+test("candidate view fails closed on gitlink materialization and frozen-index identity tampering", (t) => {
+	const contributorRoot = repository(t);
+	const { baseCommit } = commitGitlinkAfterBase(contributorRoot);
+	const view = new CandidateViewRegistry().create({ contributorRoot, baseRef: baseCommit, committedOnly: true });
+	try {
+		chmodSync(view.root, 0o755);
+		mkdirSync(join(view.root, "vendor", "dependency"), { recursive: true });
+		chmodSync(view.root, 0o555);
+		assert.throws(() => view.verify(), /gitlink/);
+		chmodSync(view.root, 0o755);
+		rmSync(join(view.root, "vendor"), { recursive: true });
+		chmodSync(view.root, 0o555);
+		git(view.root, "update-index", "--cacheinfo", "160000,89abcdef0123456789abcdef0123456789abcdef,vendor/dependency");
+		assert.throws(() => view.verify(), /frozen tree/);
+	} finally {
+		view.cleanup();
+	}
+});
+
+test("current binding detects live contributor gitlink identity drift", (t) => {
+	const contributorRoot = repository(t);
+	const { baseCommit } = commitGitlinkAfterBase(contributorRoot);
+	const registry = new CandidateViewRegistry();
+	const view = registry.create({ contributorRoot, baseRef: baseCommit, committedOnly: true });
+	registry.bindCurrent({ token: view.token, lineageId: "gitlink-drift", selectedLenses: ["review-reliability"] });
+	try {
+		git(contributorRoot, "update-index", "--cacheinfo", "160000,89abcdef0123456789abcdef0123456789abcdef,vendor/dependency");
+		git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "move gitlink");
+		assert.throws(
+			() => registry.resolveCurrentForLens("review-reliability"),
+			(error: unknown) => error instanceof CandidateViewError && error.reason === "current-binding-live-candidate-drift",
+		);
+	} finally {
+		registry.cleanup(view.token);
+	}
+});
+
 test("candidate view materializes exact tracked and initially-untracked content while contributor diverges", (t) => {
 	const contributorRoot = repository(t);
 	writeFileSync(join(contributorRoot, "tracked.txt"), "frozen tracked\n");
@@ -274,13 +389,13 @@ test("corrected views stay within frozen scope and replace projections only when
 	const registry = new CandidateViewRegistry();
 	const initial = registry.create({ contributorRoot }); registry.bind({ token: initial.token, lineageId: "correction", selectedLenses: ["review-risk"] });
 	writeFileSync(join(contributorRoot, "tracked.txt"), "corrected\n");
-	const corrected = registry.createCorrected("correction", contributorRoot);
+	const corrected = registry.createCorrected("correction", contributorRoot, "corrected-replay");
 	assert.notEqual(corrected.candidateTree, initial.candidateTree);
 	assert.equal(registry.resolveProjection("correction", contributorRoot).candidateTree, initial.candidateTree);
 	registry.promoteCorrected("correction", corrected.token);
 	assert.equal(registry.resolveProjection("correction", contributorRoot).candidateTree, corrected.candidateTree);
 	writeFileSync(join(contributorRoot, "escaped.txt"), "outside scope\n");
-	assert.throws(() => registry.createCorrected("correction", contributorRoot), /escapes the frozen genesis paths/);
+	assert.throws(() => registry.createCorrected("correction", contributorRoot, "escaped-replay"), /escapes the frozen genesis paths/);
 	registry.cleanupTerminal("correction", "approved");
 });
 

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -229,6 +229,36 @@ test("authoritative restore requires the exact frozen gitlink OID", (t) => {
 	}
 });
 
+test("authoritative restore treats gitlink maps as equal regardless of insertion order", (t) => {
+	const contributorRoot = repository(t);
+	const baseCommit = git(contributorRoot, "rev-parse", "HEAD");
+	git(contributorRoot, "update-index", "--add", "--cacheinfo", "160000,0123456789abcdef0123456789abcdef01234567,vendor/alpha");
+	git(contributorRoot, "update-index", "--add", "--cacheinfo", "160000,89abcdef0123456789abcdef0123456789abcdef,vendor/beta");
+	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "add gitlinks");
+	const source = new CandidateViewRegistry();
+	const frozen = source.create({ contributorRoot, baseRef: baseCommit, committedOnly: true });
+	const restored = new CandidateViewRegistry();
+	try {
+		restored.restoreCurrentFromAuthoritativeReviewingStates(contributorRoot, [{
+			lineageId: "reordered-authoritative-gitlinks",
+			contributorRoot,
+			baseCommit: frozen.baseCommit,
+			baseTree: frozen.baseTree,
+			candidateTree: frozen.candidateTree,
+			committedOnly: true,
+			paths: frozen.paths,
+			modes: frozen.modes,
+			gitlinks: Object.fromEntries(Object.entries(frozen.gitlinks).toReversed()),
+			deletedPaths: frozen.deletedPaths,
+			selectedLenses: ["review-reliability"],
+		}]);
+		assert.deepEqual(restored.resolveCurrentForLens("review-reliability").gitlinks, frozen.gitlinks);
+	} finally {
+		source.cleanup(frozen.token);
+		if (restored.hasCurrentBinding()) restored.cleanup(restored.resolveCurrentForLens("review-reliability").token);
+	}
+});
+
 test("candidate view rejects malformed tree mode-kind-OID pairings", (t) => {
 	const malformedHeaders = [
 		"160000 blob 0123456789abcdef0123456789abcdef01234567",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Candidate views now freeze and expose gitlink identities as metadata (without materializing their contents).
  - Restored review candidates preserve exact frozen gitlink OIDs in review context data.
- **Bug Fixes**
  - Added stronger validation to fail safely on malformed gitlink metadata.
  - Detects tampered gitlink materialization or identity changes, and rejects authoritative restores when OIDs don’t match (order-independent).
  - Improved best-effort cleanup behavior for candidate worktree removal.
- **Tests**
  - Expanded coverage for freezing, restoration, malformed input handling, tampering detection, and live identity drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->