### PR TITLE
fix(codegraph): add injectable shell-free runner

### DIFF
--- a/extensions/codegraph-tools.ts
+++ b/extensions/codegraph-tools.ts
@@ -42,6 +42,7 @@ interface CodeGraphFallbackDetails {
 	status: CodeGraphStatus;
 	operation: CodeGraphOperation;
 	cwd: string;
+	args: string[];
 	fallback: string;
 }
 
@@ -67,6 +68,30 @@ const MAX_OUTPUT_CHARS = 100_000;
 const PROCESS_MAX_BUFFER = MAX_OUTPUT_CHARS * 2;
 const FALLBACK_INSTRUCTIONS = "Use read, grep, and find for this exploration.";
 const execFileAsync = promisify(execFile);
+
+type ExecFileResult = Promise<CodeGraphCommandResult>;
+type ExecFileFunction = (
+	file: string,
+	args: string[],
+	options: { cwd: string; signal?: AbortSignal; maxBuffer: number },
+) => ExecFileResult;
+
+interface CodeGraphRunnerDependencies {
+	execFile?: ExecFileFunction;
+}
+
+export function createCodeGraphRunner(
+	dependencies: CodeGraphRunnerDependencies = {},
+): CodeGraphRunner {
+	const execute =
+		dependencies.execFile ?? (execFileAsync as unknown as ExecFileFunction);
+	return async (args, options) =>
+		execute("codegraph", [...args], {
+			cwd: options.cwd,
+			signal: options.signal,
+			maxBuffer: options.maxBuffer,
+		});
+}
 
 function resolveWorkspaceCwd(cwd: string): string {
 	const resolved = realpathSync(cwd);
@@ -163,12 +188,13 @@ function codeGraphFailureDetails(
 	error: unknown,
 	operation: CodeGraphOperation,
 	cwd: string,
+	args: readonly string[],
 ): CodeGraphFallbackDetails {
 	const status =
 		typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT"
 			? CODEGRAPH_STATUS.UNAVAILABLE
 			: CODEGRAPH_STATUS.FAILED;
-	return { status, operation, cwd, fallback: FALLBACK_INSTRUCTIONS };
+	return { status, operation, cwd, args: [...args], fallback: FALLBACK_INSTRUCTIONS };
 }
 
 function codeGraphFailureMessage(status: CodeGraphStatus): string {
@@ -177,14 +203,7 @@ function codeGraphFailureMessage(status: CodeGraphStatus): string {
 		: `CodeGraph failed to run. ${FALLBACK_INSTRUCTIONS}`;
 }
 
-const runCodeGraphCommand: CodeGraphRunner = async (args, options) => {
-	const result = await execFileAsync("codegraph", [...args], {
-		cwd: options.cwd,
-		signal: options.signal,
-		maxBuffer: options.maxBuffer,
-	});
-	return { stdout: result.stdout, stderr: result.stderr };
-};
+const runCodeGraphCommand = createCodeGraphRunner();
 
 export function createCodeGraphTool(runner: CodeGraphRunner = runCodeGraphCommand) {
 	return {
@@ -217,7 +236,7 @@ export function createCodeGraphTool(runner: CodeGraphRunner = runCodeGraphComman
 					details: { operation: parameters.operation, cwd, args },
 				};
 			} catch (error: unknown) {
-				const details = codeGraphFailureDetails(error, parameters.operation, cwd);
+				const details = codeGraphFailureDetails(error, parameters.operation, cwd, args);
 				return {
 					content: [{ type: "text" as const, text: codeGraphFailureMessage(details.status) }],
 					details,

--- a/tests/codegraph-tools.test.ts
+++ b/tests/codegraph-tools.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import codeGraphTools, {
+	createCodeGraphRunner,
 	createCodeGraphTool,
 	type CodeGraphRunner,
 } from "../extensions/codegraph-tools.ts";
@@ -16,6 +17,23 @@ function workspace(t: test.TestContext): string {
 	t.after(() => rmSync(cwd, { recursive: true, force: true }));
 	return cwd;
 }
+
+test("runner preserves direct shell-free Unix execution", async () => {
+	const signal = new AbortController().signal;
+	const calls: Array<{ file: string; args: string[]; options: Record<string, unknown> }> = [];
+	const runner = createCodeGraphRunner({
+		execFile: async (file, args, options) => {
+			calls.push({ file, args, options });
+			return { stdout: "ok", stderr: "" };
+		},
+	});
+
+	await runner(["query", "--", "a;b"], { cwd: "/repo", signal, maxBuffer: 99 });
+	assert.deepEqual(calls, [
+		{ file: "codegraph", args: ["query", "--", "a;b"], options: { cwd: "/repo", signal, maxBuffer: 99 } },
+	]);
+	assert.equal(calls[0]?.options.signal, signal);
+});
 
 test("CodeGraph tool rejects non-project, nested-project, HOME, and temporary workspaces before init", async (t) => {
 	const nonProject = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-codegraph-non-project-")));
@@ -128,6 +146,7 @@ test("CodeGraph tool returns structured fallback instructions when the binary is
 		status: "unavailable",
 		operation: "query",
 		cwd,
+		args: ["query", "--path", cwd, "--limit", "10", "--", "symbol"],
 		fallback: "Use read, grep, and find for this exploration.",
 	});
 });
@@ -149,6 +168,7 @@ test("CodeGraph tool returns fallback instructions when CodeGraph fails", async 
 		status: "failed",
 		operation: "explore",
 		cwd,
+		args: ["explore", "--path", cwd, "--max-files", "10", "--", "call path"],
 		fallback: "Use read, grep, and find for this exploration.",
 	});
 });


### PR DESCRIPTION
## Summary

- Introduce an injectable, shell-free CodeGraph runner without changing existing Unix execution behavior.
- Preserve argument boundaries and forward `cwd`, cancellation signals, and output-buffer limits.
- Include structured command arguments in fallback diagnostics.

Part of #160. The follow-up PR will add the Windows npm-entry resolution and close the issue.

## Changes

| File | Change |
|------|--------|
| `extensions/codegraph-tools.ts` | Adds the injectable runner and structured fallback arguments. |
| `tests/codegraph-tools.test.ts` | Covers direct shell-free execution and forwarded process options. |

## Test plan

- [x] `node --experimental-strip-types --test tests/codegraph-tools.test.ts` — 14/14 passing on the completed stack.
- [x] PR1 focused snapshot passed 10/10 tests.
- [x] `git diff --check` passed.
- [x] Independent bounded reliability review approved.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Windows CodeGraph runner |
| Tracker PR | Not needed |
| Position | 1 of 2 |
| Base | `main` |
| Depends on | None |
| Follow-up | `fix/windows-codegraph-npm-entry` after this PR merges |
| Review budget | 286 / 400 changed lines |
| Starts at | `main` at `1fbaf829` |
| Ends with | Injectable shell-free runner foundation |

### Chain Overview

```text
main
 └── 📍 PR 1: runner foundation
      └── PR 2: safe Windows npm entry resolution
```

### Scope

- Includes: runner injection, Unix behavior preservation, process-option forwarding, fallback argv diagnostics.
- Excludes: Windows npm package-entry resolution and Windows-specific security checks.

### Autonomy

- [x] CI is expected to pass for this PR branch.
- [x] This PR has one deliverable scope.
- [x] This PR can be rolled back without unrelated changes.
- [x] Tests cover this unit.

## Contributor checklist

- [x] Links the implementation issue.
- [x] Uses a conventional commit.
- [x] Contains no `Co-Authored-By` trailer.
- [x] Keeps implementation and tests in the same review unit.
- [x] Adds exactly one `type:*` label after PR creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Code Graph command execution reliability and error reporting.
  * Failure details now include the exact command arguments used.
  * Command execution continues to support cancellation, working directories, output limits, and output truncation.

* **Tests**
  * Added coverage for command execution options, cancellation handling, working directories, and output limits.
  * Enhanced validation of truncated output and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->