### PR TITLE
fix(harness): avoid locale-sensitive git stderr assertion

### DIFF
--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -398,7 +398,7 @@ async function run() {
 			createCtx(toolCwd),
 		);
 		assert.equal(commitGate.block, true);
-		assert.match(commitGate.reason, /exactly derive.*not a git repository/is);
+		assert.match(commitGate.reason, /exactly derive/i);
 	} finally {
 		await rm(toolCwd, { recursive: true, force: true });
 	}


### PR DESCRIPTION
Closes #167

## Summary
- make the runtime harness test assert the commit gate reason without depending on English Git stderr text
- keep the receipt validation expectation focused on the tool gate, not the host locale
- limit the change to `tests/runtime-harness.mjs`

## Changes
| File | Change |
|------|--------|
| `tests/runtime-harness.mjs` | Relaxed the `git commit` blocked-reason assertion so the test only requires the stable guard text |

## Test Plan
- `pnpm test`
- CI: `node scripts/verify-package-files.mjs`
- CI: `pnpm run test:packed-runner`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated runtime verification to reflect the current `commitGate` blocking message.
  * No changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->