### PR TITLE
fix(review): deny omitted tools by default for read-only actors

### DIFF
--- a/assets/agents/jd-judge-a.md
+++ b/assets/agents/jd-judge-a.md
@@ -2,6 +2,7 @@
 name: jd-judge-a
 description: Judgment Day blind adversarial reviewer A. Read-only; reports findings and does not fix code.
 tools:
+  - "*": false
   - read
   - grep
   - glob

--- a/assets/agents/jd-judge-b.md
+++ b/assets/agents/jd-judge-b.md
@@ -2,6 +2,7 @@
 name: jd-judge-b
 description: Judgment Day blind adversarial reviewer B. Read-only; independently reports findings and does not fix code.
 tools:
+  - "*": false
   - read
   - grep
   - glob

--- a/assets/agents/review-readability.md
+++ b/assets/agents/review-readability.md
@@ -2,6 +2,7 @@
 name: review-readability
 description: R2 Readability reviewer — naming, complexity, intention, maintainability, review size, and context clarity.
 tools:
+  - "*": false
   - read
   - grep
   - glob

--- a/assets/agents/review-refuter.md
+++ b/assets/agents/review-refuter.md
@@ -2,6 +2,7 @@
 name: review-refuter
 description: One-shot read-only verifier for the complete inferential-severe frozen-row list.
 tools:
+  - "*": false
   - read
   - grep
   - find

--- a/assets/agents/review-reliability.md
+++ b/assets/agents/review-reliability.md
@@ -2,6 +2,7 @@
 name: review-reliability
 description: R3 Reliability reviewer — behavior-first tests, coverage value, edge cases, determinism, contracts, and regressions.
 tools:
+  - "*": false
   - read
   - grep
   - glob

--- a/assets/agents/review-resilience.md
+++ b/assets/agents/review-resilience.md
@@ -2,6 +2,7 @@
 name: review-resilience
 description: R4 Resilience reviewer — fallbacks, retry/backoff, graceful degradation, observability, load, rollback, and SLO risks.
 tools:
+  - "*": false
   - read
   - grep
   - glob

--- a/assets/agents/review-risk.md
+++ b/assets/agents/review-risk.md
@@ -2,6 +2,7 @@
 name: review-risk
 description: R1 Risk reviewer — security, privilege boundaries, data exposure, dependency risks, and merge-blocking vulnerabilities.
 tools:
+  - "*": false
   - read
   - grep
   - glob

--- a/assets/agents/review-validator.md
+++ b/assets/agents/review-validator.md
@@ -2,6 +2,7 @@
 name: review-validator
 description: Per-attempt targeted proof validator for exact frozen rows.
 tools:
+  - "*": false
   - read
   - grep
   - find

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -210,7 +210,9 @@ function readAgentDefinition(file: string): {
 	const frontmatter = readAgentFrontmatter(file);
 	const name = frontmatter.match(/^name:\s*(\S+)$/m)?.[1];
 	assert.ok(name, `${file} must declare a frontmatter name`);
-	const toolsBlock = frontmatter.match(/^tools:\n((?: {2}- [\w-]+\n?)+)/m)?.[1];
+	const toolsBlock = frontmatter.match(
+		/^tools:\n(?: {2}- "\*": false\n)?((?: {2}- [\w-]+\n?)+)/m,
+	)?.[1];
 	assert.ok(toolsBlock, `${file} must declare a YAML tool list`);
 	const tools = [...toolsBlock.matchAll(/^ {2}- ([\w-]+)$/gm)].map(
 		(match) => match[1],
@@ -336,7 +338,11 @@ test("packaged agents use YAML list syntax for tool allowlists", () => {
 			/^tools:\s*[^\n,]+(?:,\s*[^\n,]+)+$/m,
 			`${file} must not use comma-separated inline tools; pi-subagents expects a YAML list`,
 		);
-		assert.match(frontmatter, /^tools:\n(?: {2}- [\w-]+\n?)+/m, `${file} must declare tools as a YAML list`);
+		assert.match(
+			frontmatter,
+			/^tools:\n(?: {2}- "\*": false\n)?(?: {2}- [\w-]+\n?)+/m,
+			`${file} must declare tools as a YAML list`,
+		);
 	}
 });
 

--- a/tests/review-actor-tool-deny.test.ts
+++ b/tests/review-actor-tool-deny.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+// Read-only review actors must deny omitted tools by DEFAULT, not by omission
+// (parity with gentle-ai #1372). Each actor's tool map leads with the
+// deny-all rule `"*": false` before its explicit allowances so globally
+// enabled MCP namespaces and future tools stay denied unless listed.
+
+const ROOT = join(import.meta.dirname, "..");
+const ASSETS_AGENTS_DIR = join(ROOT, "assets", "agents");
+const DENY_ALL_RULE = '"*": false';
+
+const READ_ONLY_REVIEW_ACTORS = [
+	"review-risk.md",
+	"review-reliability.md",
+	"review-resilience.md",
+	"review-readability.md",
+	"review-refuter.md",
+	"review-validator.md",
+	"jd-judge-a.md",
+	"jd-judge-b.md",
+] as const;
+
+function readFrontmatter(path: string): string {
+	const text = readFileSync(path, "utf8");
+	const match = text.match(/^---\n([\s\S]*?)\n---/);
+	assert.ok(match, `${path} must have YAML frontmatter`);
+	return match[1]!;
+}
+
+function readToolEntries(path: string): string[] {
+	const lines = readFrontmatter(path).split("\n");
+	const toolsIndex = lines.findIndex((line) => line === "tools:");
+	assert.notEqual(toolsIndex, -1, `${path} must declare tools as a YAML array`);
+	const entries: string[] = [];
+	for (const line of lines.slice(toolsIndex + 1)) {
+		if (!line.startsWith("  - ")) break;
+		entries.push(line.slice(4).trim());
+	}
+	return entries;
+}
+
+// Mirrors the runtime consumption path (pi-subagents frontmatter parser +
+// pi SDK allowlist): the declared array becomes a strict allowlist, and the
+// session enables only registry tools whose exact name is declared.
+function parseScalarLikeRuntime(value: string): string {
+	const trimmed = value.trim();
+	return trimmed.replace(/^['"]|['"]$/g, "");
+}
+
+function sanitizeLikeRuntime(tools: string[]): string[] {
+	return tools.filter(
+		(tool) => !tool.startsWith("subagent_"),
+	);
+}
+
+function resolveActiveTools(
+	declaredEntries: readonly string[],
+	registry: readonly string[],
+): string[] {
+	const allowed = new Set(
+		sanitizeLikeRuntime(declaredEntries.map(parseScalarLikeRuntime)),
+	);
+	return registry.filter((name) => allowed.has(name));
+}
+
+test("every read-only review actor leads its tool map with the deny-all rule", () => {
+	for (const fileName of READ_ONLY_REVIEW_ACTORS) {
+		const path = join(ASSETS_AGENTS_DIR, fileName);
+		assert.ok(existsSync(path), `${fileName} must exist`);
+		const entries = readToolEntries(path);
+		assert.ok(entries.length >= 2, `${fileName} must declare the deny-all rule plus explicit allowances`);
+		assert.equal(
+			entries[0],
+			DENY_ALL_RULE,
+			`${fileName} must lead its tool map with ${DENY_ALL_RULE} so omitted tools are denied by default`,
+		);
+		for (const entry of entries.slice(1)) {
+			assert.match(
+				entry,
+				/^[\w-]+$/,
+				`${fileName} explicit allowance ${JSON.stringify(entry)} must be a plain tool name after the single leading deny-all rule`,
+			);
+		}
+	}
+});
+
+test("a tool absent from the allowlist resolves to denied under the deny-all rule", () => {
+	const registry = [
+		"read",
+		"grep",
+		"glob",
+		"find",
+		"edit",
+		"write",
+		"bash",
+		"mem_save",
+		"codegraph_explore",
+		"mcp__slack__slack_send_message",
+		"subagent_run",
+	] as const;
+
+	const refuterEntries = readToolEntries(join(ASSETS_AGENTS_DIR, "review-refuter.md"));
+	const refuterActive = resolveActiveTools(refuterEntries, registry);
+	assert.deepEqual(refuterActive, ["read", "grep", "find"]);
+	for (const omitted of ["edit", "write", "bash", "mem_save", "codegraph_explore", "mcp__slack__slack_send_message", "subagent_run"]) {
+		assert.ok(!refuterActive.includes(omitted), `review-refuter must deny omitted tool ${omitted}`);
+	}
+
+	const riskEntries = readToolEntries(join(ASSETS_AGENTS_DIR, "review-risk.md"));
+	const riskActive = resolveActiveTools(riskEntries, registry);
+	assert.ok(riskActive.includes("bash"), "review-risk must keep its existing explicit bash allowance");
+	assert.ok(!riskActive.includes("mem_save"), "review-risk must deny omitted memory tools");
+	assert.ok(!riskActive.includes("mcp__slack__slack_send_message"), "review-risk must deny omitted MCP-namespaced tools");
+});
+
+test("the deny-all rule never enables a tool and never empties the runtime allowlist", () => {
+	for (const fileName of READ_ONLY_REVIEW_ACTORS) {
+		const entries = readToolEntries(join(ASSETS_AGENTS_DIR, fileName));
+		const declared = sanitizeLikeRuntime(entries.map(parseScalarLikeRuntime));
+		// Non-empty declared list: the runtime must never fall back to its
+		// permissive configurable default toolset for these actors.
+		assert.ok(declared.length > 0, `${fileName} must keep a non-empty runtime tools array`);
+		// The parsed deny-all entry must not collide with any real tool name.
+		const denyParsed = parseScalarLikeRuntime(DENY_ALL_RULE);
+		assert.doesNotMatch(denyParsed, /^[\w-]+$/, "deny-all rule must not parse into a plausible tool name");
+	}
+});

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -449,6 +449,11 @@ async function run() {
 			"isolated package installation must activate only the refuter inspection tools",
 		);
 		const installedRefuterSource = await readFile(installedRefuterPath, "utf8");
+		assert.match(
+			installedRefuterSource,
+			/^tools:\n {2}- "\*": false$/m,
+			"installed refuter must lead its tool map with the deny-all rule",
+		);
 		assert.match(installedRefuterSource, /complete inferential-severe frozen-row list once/);
 		assert.match(installedRefuterSource, /refuted \| corroborated \| inconclusive/);
 		assert.doesNotMatch(installedRefuterSource, /general, correctness, impact\/exploitability, or reproducibility/);

--- a/tests/sdd-agent-tools.test.ts
+++ b/tests/sdd-agent-tools.test.ts
@@ -126,7 +126,9 @@ test("generic non-SDD agents declare exact role tool allowlists", () => {
 test("review-refuter exposes only complete-list inspection tools", () => {
 	const path = join(assetsAgentsDir, "review-refuter.md");
 	assert.ok(existsSync(path), "review-refuter.md must exist");
-	assert.deepEqual(readTools(path), REVIEW_REFUTER_TOOLS);
+	const entries = readTools(path);
+	assert.equal(entries[0], '"*": false', "review-refuter must lead with the deny-all rule");
+	assert.deepEqual(entries.slice(1), REVIEW_REFUTER_TOOLS);
 
 	const frontmatter = readFrontmatter(path);
 	assert.match(frontmatter, /^name:\s*review-refuter$/m);


### PR DESCRIPTION
Closes #175
Part of #172 (WS-B)

## Summary
- Every read-only review actor definition (4R lenses, refuter, validator, judgment-day judges) now leads its `tools:` map with an explicit deny-all rule (`"*": false`) before its unchanged allowances — parity with gentle-ai #1372.
- Under strict YAML the rule is a real deny map; under the runtime's naive frontmatter parser it degrades to an inert entry that matches no registry tool AND keeps the list non-empty, so the permissive `default_tools` fallback can never fire.
- Contract tests enumerate all 8 read-only actors and fail on any regression to allowlist-by-omission; a resolution test replicates the real pi-subagents parse + pi SDK registry-intersection semantics.

## Changes
| File | Change |
|------|--------|
| `assets/agents/review-{risk,reliability,resilience,readability}.md` | Leading deny-all rule; allowances unchanged |
| `assets/agents/review-{refuter,validator}.md`, `assets/agents/jd-judge-{a,b}.md` | Same |
| `tests/review-actor-tool-deny.test.ts` | New contract tests: enumeration lock, resolution semantics, inert-rule guards |
| `tests/sdd-agent-tools.test.ts`, `tests/package-manifest.test.ts`, `tests/runtime-harness.mjs` | Deny rule required/accepted in tool-map assertions and install path |

## Test Plan
- [x] Full suite: 849 tests, 848 pass, 1 pre-existing Windows-only skip; runtime harness green
- [x] Deny rule hand-traced through the REAL installed pi-subagents parser and pi SDK `allowedToolNames` Set semantics
- [x] Native bounded review: medium tier, one reliability lens, zero findings, receipt `approved` (lineage `review-976bd6cc296c2733`); pre-commit/pre-push/pre-pr gates `allow`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers