### PR TITLE
fix(review): bind gentle_review to an explicit workspace root

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -2187,6 +2187,10 @@ const REVIEW_CONTROLLER_PARAMETERS = {
 		inputPath: { type: "string", description: "Source path for staged bundle import." },
 		operationId: { type: "string", description: "Identity-bound import or export operation ID." },
 		lineageIds: { type: "string", description: "Optional JSON array of graph lineage IDs to export." },
+		workspaceRoot: {
+			type: "string",
+			description: "Optional absolute Git worktree root that owns this review (for example the SDD apply worktree). It must be an existing worktree root sharing the session repository's Git common directory; validation fails closed otherwise. Absent, the session cwd is used unchanged.",
+		},
 	},
 } as const;
 
@@ -2203,6 +2207,7 @@ interface ReviewControllerParameters {
 	operationId?: string;
 	lineageIds?: string;
 	acknowledgeUntrustedBundleSource?: string;
+	workspaceRoot?: string;
 }
 
 interface SupersessionControllerInput {
@@ -2514,7 +2519,7 @@ function parseReviewControllerParameters(value: unknown): ReviewControllerParame
 		operation: value.operation,
 		...(typeof value.lineageId === "string" ? { lineageId: value.lineageId } : {}),
 	};
-	for (const key of ["changeName", "idempotencyKey", "transition", "command", "input", "outputPath", "inputPath", "operationId", "lineageIds", "acknowledgeUntrustedBundleSource"] as const) {
+	for (const key of ["changeName", "idempotencyKey", "transition", "command", "input", "outputPath", "inputPath", "operationId", "lineageIds", "acknowledgeUntrustedBundleSource", "workspaceRoot"] as const) {
 		const optional = value[key];
 		if (optional !== undefined && typeof optional !== "string") {
 			if (value.operation === REVIEW_CONTROLLER_OPERATION.START && key === "input") {
@@ -4702,9 +4707,55 @@ function nativePublicationFailure(operation: ReviewControllerOperation, error: u
 	};
 }
 
+function reviewWorkspaceGitIdentity(cwd: string): { toplevel: string; commonDir: string } {
+	const toplevel = realpathSync(runReviewGit(cwd, ["rev-parse", "--show-toplevel"]));
+	const commonDir = realpathSync(resolve(cwd, runReviewGit(cwd, ["rev-parse", "--git-common-dir"])));
+	return { toplevel, commonDir };
+}
+
+/**
+ * Resolves the workspace root every controller operation binds to. Absent an
+ * explicit workspaceRoot the session cwd is used unchanged (no new Git calls).
+ * An explicit workspaceRoot fails closed unless it is an existing Git worktree
+ * root sharing the session repository's Git common directory, so the model can
+ * never rebind review authority to an arbitrary or foreign filesystem path.
+ */
+function resolveReviewControllerWorkspaceRoot(requested: string | undefined, sessionCwd: string): string {
+	if (requested === undefined) return sessionCwd;
+	if (requested.trim().length === 0 || !isAbsolute(requested)) {
+		throw new Error(`Review controller workspaceRoot must be an absolute path to an existing Git worktree root; received ${JSON.stringify(requested)}`);
+	}
+	let resolved: string;
+	try {
+		resolved = realpathSync(requested);
+		if (!lstatSync(resolved).isDirectory()) throw new Error("not a directory");
+	} catch {
+		throw new Error(`Review controller workspaceRoot ${requested} is not an existing directory; create or adopt the worktree before binding review operations to it`);
+	}
+	let target: { toplevel: string; commonDir: string };
+	try {
+		target = reviewWorkspaceGitIdentity(resolved);
+	} catch {
+		throw new Error(`Review controller workspaceRoot ${resolved} is not inside a Git worktree; review operations bind only to real worktrees of the session repository`);
+	}
+	if (target.toplevel !== resolved) {
+		throw new Error(`Review controller workspaceRoot ${resolved} is not a worktree root (worktree root is ${target.toplevel}); pass the exact root`);
+	}
+	let session: { toplevel: string; commonDir: string };
+	try {
+		session = reviewWorkspaceGitIdentity(sessionCwd);
+	} catch {
+		throw new Error(`Review controller workspaceRoot ${resolved} cannot be validated: the session cwd ${sessionCwd} does not resolve a Git repository identity; run Pi from a worktree of the same repository`);
+	}
+	if (target.commonDir !== session.commonDir) {
+		throw new Error(`Review controller workspaceRoot ${resolved} belongs to a different repository (Git common dir ${target.commonDir}) than the session cwd ${sessionCwd} (Git common dir ${session.commonDir}); use a worktree of the session repository or start Pi from the target repository`);
+	}
+	return resolved;
+}
+
 async function executeReviewControllerOperation(
 	parametersValue: unknown,
-	defaultCwd: string,
+	sessionCwd: string,
 	pendingAuthorizations: Map<string, PendingReviewAuthorization>,
 	nativeReviewCli: NativeReviewCli | null,
 	signal?: AbortSignal,
@@ -4714,6 +4765,7 @@ async function executeReviewControllerOperation(
 	context?: ExtensionContext,
 ): Promise<Record<string, unknown>> {
 	const parameters = parseReviewControllerParameters(parametersValue);
+	const defaultCwd = resolveReviewControllerWorkspaceRoot(parameters.workspaceRoot, sessionCwd);
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.EXPORT) {
 		const outputPath = requiredControllerString(parameters, "outputPath");
 		const operationId = requiredControllerString(parameters, "operationId");
@@ -5089,7 +5141,24 @@ async function executeReviewControllerOperation(
 					else candidateViews.bindCurrent(binding);
 				} else if (candidateView && candidateViews && ((result.action === "created" && result.state === "reviewing") || result.action === "resumed" || result.action === "reuse-receipt")) candidateViews.retain(candidateView.token, result.lineageId);
 				else if (candidateView && candidateViews) candidateViews.cleanup(candidateView.token);
-				return { operation: parameters.operation, result: mapNativeStartResult(result) };
+				// The envelope always names the workspace root the lineage is bound
+				// to, and — when lenses must run — the exact frozen candidate the
+				// actors must read, so the caller can never silently launch review
+				// actors against a stale previously-active worktree (#166, #169).
+				const actorBinding = candidateView !== undefined && result.lensesRequired
+					? {
+						workspace_root: defaultCwd,
+						candidate_root: candidateView.root,
+						candidate_tree: candidateView.candidateTree,
+						candidate_paths: candidateView.paths,
+					}
+					: undefined;
+				return {
+					operation: parameters.operation,
+					result: mapNativeStartResult(result),
+					workspace_root: defaultCwd,
+					...(actorBinding === undefined ? {} : { actor_binding: actorBinding }),
+				};
 			} catch (error) {
 				if (error instanceof CandidateViewError && (error.reason === "base-ref-ambiguous" || error.reason === "base-ref-unresolvable" || error.reason === "base-ref-moved")) return nativeStartRejection(error.reason);
 				const value = error as { mutationOutcome?: unknown; nextAction?: unknown };
@@ -5271,6 +5340,9 @@ async function executeReviewControllerOperation(
 						authoritativeState = raw.state;
 					}
 				}
+				// Fail closed before any native mutation when the frozen projection
+				// belongs to a different worktree than the requested workspace (#169).
+				if (candidateViews && parameters.lineageId && candidateViews.hasProjection(parameters.lineageId)) candidateViews.resolveProjection(parameters.lineageId, defaultCwd);
 				candidateView ??= candidateViews && parameters.lineageId ? (correctionCompletion || validationAttempt) ? candidateViews.createCorrected(parameters.lineageId, defaultCwd, replayKey) : candidateViews.resolveForFinalize(parameters.lineageId) : undefined;
 				if (validationAttempt && candidateView && parameters.lineageId) {
 					if (nativeReviewCli.targetStatus !== undefined) {

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -346,7 +346,7 @@ test("new ordinary START and native-lineage FINALIZE use exactly one native call
 		},
 	}));
 	const start = await controller.execute("start", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
-	assert.deepEqual(start.details, { operation: "start", result: { lineage_id: "native-lineage", state: "reviewing", risk_tier: "medium", selected_lenses: ["review-reliability"], changed_files: 2, original_changed_lines: 7, correction_budget: 4, action: "created", lenses_required: true } });
+	assert.deepEqual(start.details, { operation: "start", result: { lineage_id: "native-lineage", state: "reviewing", risk_tier: "medium", selected_lenses: ["review-reliability"], changed_files: 2, original_changed_lines: 7, correction_budget: 4, action: "created", lenses_required: true }, workspace_root: cwd });
 	const finalize = await controller.execute("finalize", { operation: "finalize", lineageId: "native-lineage", input: JSON.stringify({ review_result: { lens_results: [{ findings: [], evidence: ["complete candidate reviewed"] }] } }) }, undefined, undefined, context(cwd));
 	assert.deepEqual(finalize.details, { operation: "finalize", result: { lineage_id: "native-lineage", state: "approved", action: "approved", store_revision: "r1", receipt_path: "/opaque/receipt" } });
 	assert.equal(starts, 1);

--- a/tests/review-controller-workspace-root.test.ts
+++ b/tests/review-controller-workspace-root.test.ts
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import type { NativeReviewCli } from "../lib/native-review-cli.ts";
+import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
+import type { ReviewStatusV1 } from "../lib/review-integration-v1.ts";
+
+interface RegisteredTool {
+	execute: (
+		toolCallId: string,
+		params: unknown,
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	) => Promise<{ details?: unknown }>;
+}
+
+type ToolCallHandler = (
+	event: { toolName: string; input: unknown },
+	ctx: ExtensionContext,
+) => Promise<unknown>;
+
+interface Runtime {
+	controller: RegisteredTool;
+	toolCall: ToolCallHandler;
+}
+
+function runtime(
+	nativeReviewCli: NativeReviewCli | null,
+	candidateViews: CandidateViewRegistry | null = null,
+): Runtime {
+	const tools = new Map<string, RegisteredTool>();
+	let toolCall: ToolCallHandler | undefined;
+	const dependencies = { nativeReviewCli, candidateViews } as unknown as Parameters<typeof createGentleAiExtension>[0];
+	createGentleAiExtension(dependencies)({
+		on(name: string, handler: ToolCallHandler) {
+			if (name === "tool_call") toolCall = handler;
+		},
+		registerTool(definition: RegisteredTool & { name: string }) { tools.set(definition.name, definition); },
+		registerCommand() {},
+	} as unknown as ExtensionAPI);
+	const controller = tools.get("gentle_review");
+	assert.ok(controller);
+	assert.ok(toolCall);
+	return { controller, toolCall };
+}
+
+function context(cwd: string): ExtensionContext {
+	return { cwd, hasUI: false, ui: { confirm: async () => true } } as unknown as ExtensionContext;
+}
+
+function repository(t: test.TestContext, prefix = "gentle-pi-workspace-root-"): string {
+	const cwd = mkdtempSync(join(tmpdir(), prefix));
+	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	execFileSync("git", ["init", "-b", "main"], { cwd });
+	writeFileSync(join(cwd, "app.ts"), "export const value = 1;\n");
+	execFileSync("git", ["add", "."], { cwd });
+	execFileSync("git", ["-c", "user.name=Workspace Test", "-c", "user.email=workspace@example.invalid", "commit", "-m", "initial"], { cwd });
+	return cwd;
+}
+
+function addWorktree(t: test.TestContext, cwd: string, branch: string): string {
+	const parent = mkdtempSync(join(tmpdir(), "gentle-pi-workspace-worktrees-"));
+	t.after(() => {
+		try { execFileSync("git", ["worktree", "remove", "--force", join(parent, branch)], { cwd }); } catch {}
+		rmSync(parent, { recursive: true, force: true });
+	});
+	const worktree = join(parent, branch);
+	execFileSync("git", ["worktree", "add", "-b", branch, worktree], { cwd });
+	return worktree;
+}
+
+function fakeNative(overrides: Partial<NativeReviewCli> = {}): NativeReviewCli {
+	return {
+		start: async () => ({ lineageId: "native-lineage", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 2, changedLines: 7, correctionBudget: 4, action: "created", lensesRequired: true }),
+		finalize: async () => ({ lineageId: "native-lineage", state: "approved", action: "approved", storeRevision: "r1", receiptPath: "/opaque/receipt" }),
+		validate: async () => { throw new Error("validate is not expected in workspace-root tests"); },
+		bindSdd: async () => { throw new Error("bind-sdd is not expected in workspace-root tests"); },
+		sddStatus: async () => ({ ready: false }),
+		reviewStatus: async () => ({ schema: "gentle-ai.review-authority-status/v1", repository: "/repo", complete: true, authoritative: true, status: "clean", entries: [], locks: [], diagnostics: [], raw: { schema: "gentle-ai.review-authority-status/v1", operation: "review/status", repository: "/repo", complete: true, authoritative: true, status: "clean", entries: [], locks: [], diagnostics: [] } }),
+		...overrides,
+	};
+}
+
+function targetStatusFixture(options: {
+	applicability?: "current_target" | "unrelated";
+	action?: ReviewStatusV1["action"];
+	lineageId?: string;
+} = {}): ReviewStatusV1 {
+	const applicability = options.applicability ?? "current_target";
+	const action = options.action ?? (applicability === "current_target" ? "finalize" : "start");
+	const lineageId = options.lineageId ?? "native-lineage";
+	const sha = `sha256:${"a".repeat(64)}`;
+	const tree = "b".repeat(40);
+	const projection = {
+		schema: "gentle-ai.review-integration.projection/v1" as const,
+		kind: "current-changes" as const,
+		projection: "workspace" as const,
+		baseTree: tree,
+		initialReviewTree: tree,
+		currentCandidateTree: tree,
+		pathsDigest: sha,
+		paths: ["app.ts"],
+		intendedUntracked: [],
+		intendedUntrackedProof: sha,
+		initialSnapshotIdentity: sha,
+		currentSnapshotIdentity: sha,
+	};
+	const raw: Record<string, unknown> = {
+		schema: "gentle-ai.review-integration.status/v1",
+		contract: "gentle-ai.review-integration/v1",
+		operation: "review.status",
+		applicability,
+		receipt: { status: applicability === "current_target" ? "expected_missing" : "not_applicable" },
+		action,
+		replayability: "not_replayable",
+		target_identity: sha,
+		projection: {
+			schema: projection.schema,
+			kind: projection.kind,
+			projection: projection.projection,
+			base_tree: tree,
+			initial_review_tree: tree,
+			current_candidate_tree: tree,
+			paths_digest: sha,
+			paths: projection.paths,
+			intended_untracked: [],
+			intended_untracked_proof: sha,
+			initial_snapshot_identity: sha,
+			current_snapshot_identity: sha,
+		},
+		candidates: [],
+	};
+	if (applicability === "current_target") {
+		raw.authority = { version: "compact-v2", lineage_id: lineageId, state: "reviewing", generation: 1, revision: sha };
+		raw.frozen = { tier: "medium", original_changed_lines: 2, correction_budget: 1 };
+	}
+	return {
+		contract: "gentle-ai.review-integration/v1",
+		applicability,
+		...(applicability === "current_target" ? { authority: { version: "compact-v2" as const, lineageId, state: "reviewing", generation: 1, revision: sha } } : {}),
+		receipt: { status: applicability === "current_target" ? "expected_missing" : "not_applicable" },
+		action,
+		replayability: "not_replayable",
+		...(applicability === "current_target" ? { frozen: { tier: "medium" as const, originalChangedLines: 2, correctionBudget: 1 } } : {}),
+		targetIdentity: sha,
+		projection,
+		candidates: [],
+		raw,
+	};
+}
+
+test("INSPECT and STATUS operate on the explicit workspace root while the session cwd stays elsewhere", async (t) => {
+	const sessionCwd = repository(t);
+	const worktree = addWorktree(t, sessionCwd, "feat-binding");
+	const observedCwds: string[] = [];
+	const { controller } = runtime(fakeNative({
+		targetStatus: async (request) => {
+			observedCwds.push(request.cwd);
+			return targetStatusFixture();
+		},
+	}));
+	await controller.execute("inspect-b", { operation: "inspect", workspaceRoot: worktree }, undefined, undefined, context(sessionCwd));
+	await controller.execute("status-b", { operation: "status", lineageId: "native-lineage", workspaceRoot: worktree }, undefined, undefined, context(sessionCwd));
+	await controller.execute("inspect-default", { operation: "inspect" }, undefined, undefined, context(sessionCwd));
+	assert.deepEqual(observedCwds, [realpathSync(worktree), realpathSync(worktree), sessionCwd]);
+});
+
+test("START freezes the candidate from the explicit workspace root and returns the actor binding envelope", async (t) => {
+	const sessionCwd = repository(t);
+	writeFileSync(join(sessionCwd, "unrelated.ts"), "export const unrelated = true;\n");
+	const worktree = addWorktree(t, sessionCwd, "feat-candidate");
+	writeFileSync(join(worktree, "app.ts"), "export const value = 2; // worktree candidate\n");
+	const candidateViews = new CandidateViewRegistry();
+	const startCwds: string[] = [];
+	const { controller, toolCall } = runtime(fakeNative({
+		start: async (request) => {
+			startCwds.push(request.cwd);
+			return { lineageId: "worktree-lineage", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: true };
+		},
+	}), candidateViews);
+	const started = await controller.execute("start-b", { operation: "start", workspaceRoot: worktree, input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(sessionCwd));
+	const details = started.details as {
+		workspace_root: string;
+		actor_binding: { workspace_root: string; candidate_root: string; candidate_tree: string; candidate_paths: readonly string[] };
+	};
+	const root = realpathSync(worktree);
+	assert.equal(details.workspace_root, root);
+	assert.equal(details.actor_binding.workspace_root, root);
+	assert.deepEqual(details.actor_binding.candidate_paths, ["app.ts"]);
+	const view = candidateViews.resolveForLens("worktree-lineage", "review-reliability");
+	assert.equal(details.actor_binding.candidate_root, view.root);
+	assert.equal(details.actor_binding.candidate_tree, view.candidateTree);
+	assert.deepEqual(startCwds, [view.root]);
+	assert.equal(readFileSync(join(view.root, "app.ts"), "utf8"), "export const value = 2; // worktree candidate\n");
+	assert.equal(view.paths.includes("unrelated.ts"), false);
+	const dispatch = { agent: "review-reliability", task: "review the change", mode: "task" };
+	assert.equal(await toolCall({ toolName: "subagent_run", input: dispatch }, context(sessionCwd)), undefined);
+	assert.match(dispatch.task, /Controller-owned review lineage: `worktree-lineage`/);
+	assert.ok(dispatch.task.includes(view.root));
+	assert.ok(dispatch.task.includes(view.candidateTree));
+	candidateViews.cleanup(view.token);
+});
+
+test("absent workspaceRoot keeps the session-cwd flow and still reports the actor binding envelope", async (t) => {
+	const sessionCwd = repository(t);
+	writeFileSync(join(sessionCwd, "app.ts"), "export const value = 3;\n");
+	const candidateViews = new CandidateViewRegistry();
+	const { controller } = runtime(fakeNative({
+		start: async () => ({ lineageId: "session-lineage", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: true }),
+	}), candidateViews);
+	const started = await controller.execute("start-session", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(sessionCwd));
+	const details = started.details as {
+		workspace_root: string;
+		actor_binding: { workspace_root: string; candidate_root: string; candidate_paths: readonly string[] };
+	};
+	assert.equal(details.workspace_root, sessionCwd);
+	assert.equal(details.actor_binding.workspace_root, sessionCwd);
+	assert.deepEqual(details.actor_binding.candidate_paths, ["app.ts"]);
+	const view = candidateViews.resolveForLens("session-lineage", "review-reliability");
+	assert.equal(details.actor_binding.candidate_root, view.root);
+	candidateViews.cleanup(view.token);
+});
+
+test("workspaceRoot fails closed before any native call for non-worktree and foreign targets", async (t) => {
+	const sessionCwd = repository(t);
+	const worktree = addWorktree(t, sessionCwd, "feat-guard");
+	const foreign = repository(t, "gentle-pi-foreign-root-");
+	const nonGit = mkdtempSync(join(tmpdir(), "gentle-pi-non-git-"));
+	t.after(() => rmSync(nonGit, { recursive: true, force: true }));
+	const nested = join(worktree, "nested");
+	mkdirSync(nested);
+	const filePath = join(worktree, "app.ts");
+	let nativeCalls = 0;
+	const counting = fakeNative({
+		start: async () => { nativeCalls += 1; throw new Error("native start must not run"); },
+		targetStatus: async () => { nativeCalls += 1; throw new Error("native status must not run"); },
+		reviewStatus: async () => { nativeCalls += 1; throw new Error("native review status must not run"); },
+	});
+	const { controller } = runtime(counting);
+	const rejected: Array<{ label: string; workspaceRoot: string; ctx: string }> = [
+		{ label: "non-git directory", workspaceRoot: nonGit, ctx: sessionCwd },
+		{ label: "missing directory", workspaceRoot: join(nonGit, "missing"), ctx: sessionCwd },
+		{ label: "file path", workspaceRoot: filePath, ctx: sessionCwd },
+		{ label: "relative path", workspaceRoot: "relative/worktree", ctx: sessionCwd },
+		{ label: "worktree subdirectory", workspaceRoot: nested, ctx: sessionCwd },
+		{ label: "foreign repository", workspaceRoot: foreign, ctx: sessionCwd },
+		{ label: "session outside a repository", workspaceRoot: worktree, ctx: nonGit },
+	];
+	for (const { label, workspaceRoot, ctx } of rejected) {
+		for (const operation of ["inspect", "start", "status"] as const) {
+			await assert.rejects(
+				controller.execute(`${operation}-${label}`, {
+					operation,
+					...(operation === "start" ? { input: JSON.stringify({ mode: "ordinary" }) } : {}),
+					...(operation === "status" ? { lineageId: "native-lineage" } : {}),
+					workspaceRoot,
+				}, undefined, undefined, context(ctx)),
+				/workspaceRoot/,
+				`${operation} must fail closed for ${label}`,
+			);
+		}
+	}
+	assert.equal(nativeCalls, 0);
+});
+
+test("workspaceRoot rejection reports both roots for a shared-common-dir mismatch", async (t) => {
+	const sessionCwd = repository(t);
+	const foreign = repository(t, "gentle-pi-foreign-report-");
+	const { controller } = runtime(fakeNative());
+	await assert.rejects(
+		controller.execute("inspect-foreign", { operation: "inspect", workspaceRoot: foreign }, undefined, undefined, context(sessionCwd)),
+		(error: Error) => {
+			assert.match(error.message, /workspaceRoot/);
+			assert.ok(error.message.includes(realpathSync(foreign)));
+			assert.ok(error.message.includes(sessionCwd));
+			return true;
+		},
+	);
+});
+
+test("FINALIZE fails closed when the frozen projection belongs to a different workspace than requested", async (t) => {
+	const sessionCwd = repository(t);
+	const worktree = addWorktree(t, sessionCwd, "feat-finalize");
+	writeFileSync(join(worktree, "app.ts"), "export const value = 4;\n");
+	const candidateViews = new CandidateViewRegistry();
+	let finalizes = 0;
+	const { controller } = runtime(fakeNative({
+		start: async () => ({ lineageId: "finalize-lineage", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: true }),
+		finalize: async () => {
+			finalizes += 1;
+			return { lineageId: "finalize-lineage", state: "approved", action: "approved", storeRevision: "r1" };
+		},
+	}), candidateViews);
+	await controller.execute("start-finalize-b", { operation: "start", workspaceRoot: worktree, input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(sessionCwd));
+	const input = JSON.stringify({ review_result: { lens_results: [{ lens: "review-reliability", findings: [], evidence: ["reviewed frozen candidate"] }] } });
+	const mismatch = await controller.execute("finalize-wrong-root", { operation: "finalize", lineageId: "finalize-lineage", input }, undefined, undefined, context(sessionCwd));
+	assert.equal((mismatch.details as { outcome?: string }).outcome, "native-operation-failed");
+	assert.equal(finalizes, 0);
+	const matched = await controller.execute("finalize-right-root", { operation: "finalize", lineageId: "finalize-lineage", workspaceRoot: worktree, input }, undefined, undefined, context(sessionCwd));
+	assert.equal((matched.details as { result?: { state?: string } }).result?.state, "approved");
+	assert.equal(finalizes, 1);
+});


### PR DESCRIPTION
Closes #169
Closes #166
Part of #172 (pulled into v1.1.0 by maintainer decision)

## Summary
- `gentle_review` gains a validated `workspaceRoot` parameter: every controller operation rebinds to the resolved root (single rebind point covering all ~30 branches), failing closed on non-root paths, worktree subdirectories, foreign common dirs, and unresolvable session identities. Absent parameter → session-cwd behavior unchanged.
- START envelopes now always carry `workspace_root` and, when lenses run, `actor_binding` (`workspace_root`, `candidate_root`, `candidate_tree`, `candidate_paths`) so the orchestrating caller can never silently target a previously-active worktree.
- FINALIZE resolves the frozen projection against the requested workspace before any native mutation, closing a lineage-only lookup hole where a review started in worktree B could be finalized from session A.

## Changes
| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | `workspaceRoot` param + fail-closed validator, controller rebind, START/actor_binding envelope, FINALIZE projection-root guard |
| `tests/review-controller-workspace-root.test.ts` | New 6-test suite with real A/B worktrees sharing one common dir (red-first) |
| `tests/review-controller-native-routing.test.ts` | START deepEqual gains `workspace_root` (new contract) |

## Test Plan
- [x] Full suite: 871 tests, 870 pass, 0 fail, 1 pre-existing skip; runtime harness green
- [x] Six red-first tests confirmed failing pre-fix on the exact target assertions
- [x] Native bounded review: medium tier, one reliability lens, zero findings, receipt `approved` (lineage `review-c0dc3247a7784ed2`); pre-commit/pre-push/pre-pr gates `allow`

## Contributor Checklist
- [x] Linked approved issues
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers