### PR TITLE
fix(review): derive blocking findings from outcomes and restore forecast-only finalize

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5320,12 +5320,17 @@ async function executeReviewControllerOperation(
 				if (candidateViews && parameters.lineageId === undefined) throw new CandidateViewError("Native FINALIZE requires an explicit candidate-view lineage");
 				correctionCompletion = input.review_result === undefined && (input.validation !== undefined || input.validation_proof !== undefined) && input.final_evidence !== undefined;
 				const validationAttempt = input.review_result === undefined && input.correction_line_forecast === undefined && input.final_evidence !== undefined;
+				// A correction-forecast-only FINALIZE (the pre-edit forecast step in
+				// correction_required) must also participate in fresh-process projection
+				// reconstruction; before #176 it skipped restoration and failed against
+				// an empty in-memory registry without ever invoking native FINALIZE.
+				const correctionForecast = input.review_result === undefined && input.correction_line_forecast !== undefined;
 				const replayKey = JSON.stringify({ cwd: defaultCwd, lineageId: parameters.lineageId ?? null, input: parameters.input ?? null, inputPath: parameters.inputPath ?? null });
-				if ((validationAttempt || input.review_result !== undefined) && candidateViews && parameters.lineageId && !candidateViews.hasProjection(parameters.lineageId)) {
+				if ((validationAttempt || input.review_result !== undefined || (correctionForecast && nativeReviewCli.targetStatus !== undefined)) && candidateViews && parameters.lineageId && !candidateViews.hasProjection(parameters.lineageId)) {
 					if (nativeReviewCli.targetStatus !== undefined) {
 						negotiatedStatus = await nativeReviewCli.targetStatus({ cwd: defaultCwd, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
 						if (negotiatedStatus.applicability !== "current_target" || negotiatedStatus.authority?.lineageId !== parameters.lineageId) return mapNativeTargetStatus(parameters.operation, negotiatedStatus, parameters.lineageId);
-						candidateView = input.review_result === undefined
+						candidateView = validationAttempt
 							? (candidateViews.restoreProjectionFromNative(parameters.lineageId, defaultCwd, negotiatedStatus.projection), undefined)
 							: candidateViews.restoreForFinalizeFromNative(parameters.lineageId, defaultCwd, negotiatedStatus.projection);
 					} else {

--- a/lib/review-compact-contract.ts
+++ b/lib/review-compact-contract.ts
@@ -230,9 +230,18 @@ export function deriveNativeValidationRequest(input: NativeValidationRequestInpu
 	const initialCandidateTree = string(initial.candidate_tree, "review/finalize.validation-request.initial_snapshot.candidate_tree");
 	const fix_finding_ids = strings(state.fix_finding_ids, "review/finalize.validation-request.fix_finding_ids");
 	if (!Array.isArray(state.findings)) fail("review/finalize.validation-request.findings", "type", "must be an array");
+	const outcomes = state.outcomes === undefined ? undefined : record(state.outcomes, "review/finalize.validation-request.outcomes");
 	const blocking_finding_ids = state.findings.flatMap((finding, index) => {
 		const row = record(finding, `review/finalize.validation-request.findings[${index}]`);
-		return row.severity === COMPACT_SEVERITY.BLOCKER || row.severity === COMPACT_SEVERITY.CRITICAL ? [string(row.id, `review/finalize.validation-request.findings[${index}].id`)] : [];
+		if (row.severity !== COMPACT_SEVERITY.BLOCKER && row.severity !== COMPACT_SEVERITY.CRITICAL) return [];
+		const id = string(row.id, `review/finalize.validation-request.findings[${index}].id`);
+		// Mirror native FINALIZE semantics (#171): only corroborated severe findings
+		// block correction validation. Severe findings classified pre-existing or
+		// base-only carry the non-blocking `info` outcome, are routed to follow-ups,
+		// and must stay inert in the targeted-validation request.
+		if (outcomes === undefined) return [id];
+		const outcome = outcomes[id] === undefined ? undefined : enumValue(outcomes[id], COMPACT_FINDING_OUTCOME, `review/finalize.validation-request.outcomes.${id}`);
+		return outcome === COMPACT_FINDING_OUTCOME.CORROBORATED ? [id] : [];
 	});
 	if (canonicalJsonV1(fix_finding_ids.toSorted()) !== canonicalJsonV1(blocking_finding_ids.toSorted())) fail("review/finalize.validation-request", "finding-ids", "fix IDs must exactly match frozen blocking findings");
 	const correction_identity = domainHashV1("compact-correction-identity", { initial_candidate_tree: initialCandidateTree, correction_candidate_tree: input.candidateTree });

--- a/tests/review-compact-contract.test.ts
+++ b/tests/review-compact-contract.test.ts
@@ -2,11 +2,64 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
 	CompactReviewContractError,
+	deriveNativeValidationRequest,
 	parseNativeCompactFinalizeInput,
 	parseCompactStartInput,
 } from "../lib/review-compact-contract.ts";
 
 const POLICY_HASH = "a".repeat(64);
+
+function correctionRequiredState(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		lineage_id: "correction-lineage",
+		state: "correction_required",
+		initial_snapshot: { candidate_tree: "c".repeat(40) },
+		fix_finding_ids: ["R4-001", "R4-002"],
+		findings: [
+			{ id: "R4-001", severity: "CRITICAL" },
+			{ id: "R4-002", severity: "BLOCKER" },
+			{ id: "RISK-XSS-001", severity: "CRITICAL" },
+		],
+		outcomes: { "R4-001": "corroborated", "R4-002": "corroborated", "RISK-XSS-001": "info" },
+		...overrides,
+	};
+}
+
+test("validation request derivation keeps severe pre-existing follow-ups inert (#171)", () => {
+	const request = deriveNativeValidationRequest({
+		lineageId: "correction-lineage",
+		candidateTree: "d".repeat(40),
+		state: correctionRequiredState(),
+	});
+	assert.deepEqual(request.blocking_finding_ids, ["R4-001", "R4-002"]);
+	assert.deepEqual(request.fix_finding_ids, ["R4-001", "R4-002"]);
+});
+
+test("validation request derivation still blocks corroborated severe findings absent from the fix set", () => {
+	assert.throws(
+		() => deriveNativeValidationRequest({
+			lineageId: "correction-lineage",
+			candidateTree: "d".repeat(40),
+			state: correctionRequiredState({
+				fix_finding_ids: ["R4-001"],
+				outcomes: { "R4-001": "corroborated", "R4-002": "corroborated", "RISK-XSS-001": "info" },
+			}),
+		}),
+		(error: unknown) => error instanceof CompactReviewContractError && error.code === "finding-ids",
+	);
+});
+
+test("validation request derivation without native outcomes keeps the severity-derived blocking set", () => {
+	const request = deriveNativeValidationRequest({
+		lineageId: "correction-lineage",
+		candidateTree: "d".repeat(40),
+		state: correctionRequiredState({
+			fix_finding_ids: ["R4-001", "R4-002", "RISK-XSS-001"],
+			outcomes: undefined,
+		}),
+	});
+	assert.deepEqual(request.blocking_finding_ids, ["R4-001", "R4-002", "RISK-XSS-001"]);
+});
 
 test("compact start parser returns canonical input and rejects widened nested projection", () => {
 	assert.deepEqual(parseCompactStartInput({

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -544,6 +544,45 @@ test("fresh negotiated registries reconstruct the frozen candidate before FINALI
 	assert.equal((result.details as { result: { state: string } }).result.state, "approved");
 });
 
+test("forecast-only FINALIZE reconstructs the frozen candidate after a fresh process (#176)", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	const status = targetStatusFixture({ lineageId: "forecast-lineage" });
+	status.projection.baseTree = frozen.baseTree;
+	status.projection.initialReviewTree = frozen.candidateTree;
+	status.projection.currentCandidateTree = frozen.candidateTree;
+	status.projection.paths = frozen.paths;
+	frozen.cleanup();
+	let statusCalls = 0;
+	let finalizedContent = "";
+	const finalizeRequests: Parameters<NativeReviewCli["finalize"]>[0][] = [];
+	const candidateViews = new CandidateViewRegistry();
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			statusCalls += 1;
+			return status;
+		},
+		finalize: async (request) => {
+			finalizeRequests.push(request);
+			finalizedContent = readFileSync(join(request.cwd, "app.ts"), "utf8");
+			return { lineageId: "forecast-lineage", state: "fixing", action: "correction-forecast-recorded", storeRevision: "r1" };
+		},
+	}), undefined, undefined, undefined, candidateViews);
+	const result = await controller.execute("forecast-only-finalize", {
+		operation: "finalize",
+		lineageId: "forecast-lineage",
+		input: JSON.stringify({ correction_line_forecast: 3 }),
+	}, undefined, undefined, context(cwd));
+	assert.equal(statusCalls, 1);
+	assert.equal(finalizeRequests.length, 1);
+	assert.equal(finalizeRequests[0]!.correctionLines, 3);
+	assert.notEqual(finalizeRequests[0]!.cwd, cwd);
+	assert.equal(finalizedContent, "export const value = 2;\n");
+	assert.equal((result.details as { result: { state: string } }).result.state, "fixing");
+	candidateViews.cleanupTerminal("forecast-lineage", "escalated");
+});
+
 test("ambiguous native START runs target status first and follows only its declared action", async (t) => {
 	const cwd = repository(t);
 	const candidateViews = new CandidateViewRegistry();


### PR DESCRIPTION
Closes #171
Closes #176

## Summary
- **#171**: `deriveNativeValidationRequest` derives `blocking_finding_ids` from corroborated outcomes instead of raw severity — severe findings classified pre-existing/base-only (outcome `info`, routed to follow-ups) no longer poison the exact-equality integrity check; corroborated severe findings still block; legacy no-outcomes states keep the severity fallback.
- **#176**: a forecast-only FINALIZE (`correction_line_forecast` without results/validation) after a process restart now restores the frozen candidate projection AND its live-verified bound record from native (`restoreForFinalizeFromNative`) before invoking finalize, instead of dead-ending on the empty in-memory registry.

## Test Plan
- [x] Red-first per fix: #171 reproduced the exact `finding-ids` contract error pre-fix; #176 reproduced the zero-status-call/zero-finalize-call restart signature pre-fix
- [x] Full suite: 875 tests, 874 pass, 0 fail, 1 pre-existing skip; runtime harness exit 0
- [x] Native bounded review: medium tier, one reliability lens, zero blocking findings; two WARNINGs routed to follow-up #185 (forecast-worktree cleanup; non-negotiated variant); receipt `approved` (lineage `review-111abe6119183dd1`); pre-commit/pre-push/pre-pr `allow`

## Contributor Checklist
- [x] Linked approved issues
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forecast-only finalization now correctly restores the candidate content after a fresh process, allowing finalization to complete with the expected correction forecast.
  * Validation requests now mark severe findings as blocking only when their outcomes confirm them. When outcome data is unavailable, existing severity-based behavior is preserved.
* **Tests**
  * Added coverage for forecast-only finalization and correction-state validation scenarios, including follow-up and corroborated findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->