### PR TITLE
fix(tests): make cancellation-timing tests deterministic

### DIFF
--- a/tests/git-commit-transaction.test.ts
+++ b/tests/git-commit-transaction.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import {
 	COMMIT_TRANSACTION_STATE,
 	assertNoUnresolvedCommitTransaction,
@@ -167,12 +168,34 @@ test("a post-commit hook cannot replace the exact commit created by Git", async 
 test("cancellation cannot strand a commit after HEAD advances", async (t) => {
 	const cwd = repository(t);
 	stage(cwd);
-	installHook(cwd, "post-commit", "sleep 1");
+	// Deterministic cancellation ordering (issue #178): a wall-clock
+	// AbortSignal.timeout raced Git's own progress on loaded CI runners and
+	// could abort before HEAD advanced. Git only runs the post-commit hook
+	// after the commit object exists and HEAD has advanced, so the hook
+	// reports that it started and then blocks until the test releases it.
+	// Aborting between those two events guarantees the cancellation lands
+	// while the commit process is still running and strictly after HEAD
+	// advanced, on every runner.
+	const started = join(cwd, ".git", "post-commit-started");
+	const release = join(cwd, ".git", "post-commit-release");
+	installHook(cwd, "post-commit", [
+		`printf '1\\n' > ${JSON.stringify(started)}`,
+		`while [ ! -e ${JSON.stringify(release)} ]; do sleep 0.02; done`,
+	].join("\n"));
 	const before = git(cwd, "rev-parse", "HEAD");
-	const result = await runGitCommitTransaction(invocation(cwd, "commit-cancellation"), {
+	const abort = new AbortController();
+	const pending = runGitCommitTransaction(invocation(cwd, "commit-cancellation"), {
 		nativeReviewCli: native(cwd, "commit-cancellation"),
-		signal: AbortSignal.timeout(100),
+		signal: abort.signal,
 	});
+	let settled = false;
+	void pending.then(() => { settled = true; }, () => { settled = true; });
+	while (!existsSync(started) && !settled) await delay(10);
+	assert.equal(settled, false, "commit transaction finished before the post-commit hook confirmed HEAD advanced");
+	abort.abort();
+	writeFileSync(release, "release\n");
+	const result = await pending;
+	assert.equal(abort.signal.aborted, true);
 	assert.notEqual(result.head, before);
 	assert.equal(result.status, "committed");
 	assert.deepEqual(inspectCommitTransaction(cwd), { status: "clean" });

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -2890,9 +2890,14 @@ test("production tool_call forwards Pi cancellation and enforces one bash-time d
 				context(cwd, mode === "external-cancellation" ? external.signal : undefined),
 			);
 			if (mode === "external-cancellation") external.abort();
+			// Hang guard only (issue #178): cancellation itself is deterministic —
+			// the fake native validation resolves solely when its signal aborts —
+			// so this race merely catches a cancellation that never propagates.
+			// 10s keeps that guarantee without racing loaded CI runners the way a
+			// 500ms wall-clock bound did.
 			const result = await Promise.race([
 				pending,
-				new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error("production tool_call did not cancel within its aggregate deadline")), 500)),
+				new Promise<never>((_resolve, reject) => setTimeout(() => reject(new Error("production tool_call did not cancel within its aggregate deadline")), 10_000)),
 			]) as { block: boolean };
 			assert.equal(result.block, true);
 			assert.equal(receivedSignal?.aborted, true);
@@ -2923,13 +2928,26 @@ test("production post-allow pre-push remote probes obey Pi cancellation and the 
 				'if [ -f "$count_file" ]; then read -r count < "$count_file"; fi',
 				'count=$((count + 1))',
 				'printf "%s\\n" "$count" > "$count_file"',
-				'if [ -f "$stall_file" ] && [ "$count" -eq 3 ]; then exec sleep 1; fi',
+				'if [ -f "$stall_file" ] && [ "$count" -eq 3 ]; then exec sleep 20; fi',
 				`exec git upload-pack ${JSON.stringify(remote)}`,
 				"",
 			].join("\n"), { mode: 0o755 });
 			git(cwd, "config", "protocol.ext.allow", "always");
 			git(cwd, "remote", "set-url", "origin", `ext::${uploadPack}`);
 
+			// Deadline layout (issue #178): a shared 150ms aggregate deadline raced
+			// the real probe/validate process spawns on loaded CI runners and could
+			// fire before the second native validation, so cancellation triggered at
+			// the wrong point and the test flaked.
+			// - external-cancellation: cancellation is driven deterministically by
+			//   external.abort() inside the second native validation; the aggregate
+			//   deadline (30s) and per-probe timeout (30s) are far above the elapsed
+			//   bound so neither can fire first.
+			// - aggregate-deadline: the 2s aggregate deadline is the only bound able
+			//   to end the stalled post-allow probe — the stall (20s) and per-probe
+			//   timeout (30s) are far larger — while still leaving generous headroom
+			//   over pre-deadline spawn overhead on slow runners.
+			const aggregateDeadlineMs = mode === "aggregate-deadline" ? 2_000 : 30_000;
 			const external = new AbortController();
 			let validations = 0;
 			const { controller, toolCall } = runtime(fakeNative({ validate: async () => {
@@ -2938,7 +2956,7 @@ test("production post-allow pre-push remote probes obey Pi cancellation and the 
 				const gateContext = nativeGateContext();
 				gateContext.raw.gate = "pre-push";
 				return { allowed: true, result: "allow", action: "continue", reason: "ok", gateContext };
-			} }), undefined, undefined, 150);
+			} }), undefined, 30_000, aggregateDeadlineMs);
 			const command = "git push origin feature:refs/heads/feature";
 			const authorized = await controller.execute(mode, { operation: "validate", lineageId: "native-lineage", idempotencyKey: mode, command, input: "{}" }, undefined, undefined, context(cwd));
 			assert.notEqual((authorized.details as { authorization?: unknown }).authorization, undefined);
@@ -2948,7 +2966,11 @@ test("production post-allow pre-push remote probes obey Pi cancellation and the 
 			const started = Date.now();
 			const result = await toolCall({ toolName: "bash", input: { command } }, interactiveContext(cwd, external.signal)) as { block: boolean; reason: string };
 			assert.equal(result.block, true);
-			assert.ok(Date.now() - started < 300, "post-allow remote probe exceeded its cancellation deadline");
+			// 10s sits far below the 20s stall and the 30s per-probe timeout, so
+			// finishing under it proves cancellation — external abort or the 2s
+			// aggregate deadline — ended the stalled probe, without racing
+			// CI-runner process-spawn variance the way the old 300ms bound did.
+			assert.ok(Date.now() - started < 10_000, "post-allow remote probe exceeded its cancellation deadline");
 			assert.equal(validations, 2, result.reason);
 		});
 	}


### PR DESCRIPTION
Closes #178

## Summary
- The three flaky cancellation tests raced real wall-clock timers against real process spawns on loaded runners (fail on first CI attempt, pass on rerun of the identical SHA — three documented occurrences).
- Commit-transaction test: the post-commit hook now writes a start-marker and blocks on a release file, so the abort is guaranteed to land after HEAD advances on any runner; no-strand assertions unchanged plus a new ordering assertion.
- Pre-push probe tests: external-cancellation mode gets a non-firing aggregate deadline (cancellation driven solely by the deterministic abort); aggregate-deadline mode is the only bound able to end a lengthened stall, with elapsed bounds widened to headroom that still proves which bound fired. Hang-guard widened with rationale comment.

## Test Plan
- [x] Red phase: both CI failure signatures reproduced verbatim by tightening the original timers
- [x] 10/10 loops per affected file uncontended; post-rebase (over #186) 7/7 and 164/164
- [x] Full suite + runtime harness green
- [x] Native bounded review: medium tier committed-base, one reliability lens, zero findings, receipt `approved` (lineage `review-692433189159a144`); gates `allow`

## Contributor Checklist
- [x] Linked approved issue
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers