### PR TITLE
fix(review): accept and unblock released native lock entries

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -140,6 +140,7 @@ import {
 	NativeReviewCliError,
 	NATIVE_REVIEW_AUTHORITY_STATUS,
 	NATIVE_REVIEW_ERROR_CODE,
+	NATIVE_REVIEW_LOCK_STATUS,
 	type NativeReviewCli,
 	type NativeFinalizeResult,
 	type NativeStartResult,
@@ -4211,6 +4212,16 @@ async function nativeResetRemediationPreflight(
 	}
 }
 
+// gentle-ai 2.1.8 leaves review-transactions/v2/LOCK behind after ordinary
+// successful operations and inventories it as a `released` dead-owner entry
+// (#184). Only live claims — owned or ambiguous — block; released residue is
+// non-blocking and stays observable through evidence.authority_inventory.
+// The decoder keeps lock status a closed enum, so any unknown status already
+// fails closed before reaching this classification.
+function hasBlockingNativeLock(status: NativeReviewStatusResult): boolean {
+	return status.locks.some((lock) => lock.status !== NATIVE_REVIEW_LOCK_STATUS.RELEASED);
+}
+
 const NATIVE_START_PRECONDITION = {
 	CLEAN_EMPTY: "clean-empty",
 	INCOMPLETE: "incomplete",
@@ -4224,7 +4235,7 @@ function classifyNativeStartPrecondition(status: NativeReviewStatusResult): Nati
 	if (!status.complete || !status.authoritative || status.status === NATIVE_REVIEW_AUTHORITY_STATUS.INVALID || status.status === NATIVE_REVIEW_AUTHORITY_STATUS.SAME_LINEAGE_MIXED_COLLISION) {
 		return NATIVE_START_PRECONDITION.INCOMPLETE;
 	}
-	if (status.locks.length > 0) return NATIVE_START_PRECONDITION.LOCKED;
+	if (hasBlockingNativeLock(status)) return NATIVE_START_PRECONDITION.LOCKED;
 	// Readable historical inventory is not a mutation precondition. Native START
 	// owns current-lineage matching; Pi only blocks corrupt or ambiguous authority.
 	return NATIVE_START_PRECONDITION.CLEAN_EMPTY;
@@ -4260,7 +4271,7 @@ function mapNativeReviewStatus(operation: ReviewControllerOperation, result: Nat
 	if (!result.complete || !result.authoritative || result.status === "invalid") {
 		return { operation, status: "blocked", outcome: "native-authority-inventory-incomplete", mutation_performed: false, inventory_complete: false, next_action: "require-complete-native-authority-inventory", evidence };
 	}
-	if (result.locks.length > 0) {
+	if (hasBlockingNativeLock(result)) {
 		return { operation, status: "blocked", outcome: "native-authority-lock-present", mutation_performed: false, inventory_complete: true, next_action: "wait-for-native-lock-release", evidence };
 	}
 	switch (result.status) {

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -143,6 +143,12 @@ export type NativeReviewAuthorityEntryStatus = NativeReviewAuthorityStatus;
 export const NATIVE_REVIEW_LOCK_STATUS = {
 	OWNED: "owned",
 	AMBIGUOUS: "ambiguous",
+	// gentle-ai 2.1.8 leaves review-transactions/v2/LOCK behind after ordinary
+	// successful operations and inventories it as a released (dead-owner) entry
+	// (#184). This stays a closed enum: lock status routes controller blocking
+	// behavior, so unknown future statuses must keep failing closed instead of
+	// being tolerated like diagnostic-only metadata.
+	RELEASED: "released",
 } as const;
 export type NativeReviewLockStatus = (typeof NATIVE_REVIEW_LOCK_STATUS)[keyof typeof NATIVE_REVIEW_LOCK_STATUS];
 

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -144,6 +144,12 @@ export const NATIVE_REVIEW_AUTHORITY_ENTRY_STATUS = NATIVE_REVIEW_AUTHORITY_STAT
 export const NATIVE_REVIEW_LOCK_STATUS = {
 	OWNED: "owned",
 	AMBIGUOUS: "ambiguous",
+	// gentle-ai 2.1.8 leaves review-transactions/v2/LOCK behind after ordinary
+	// successful operations and inventories it as a released (dead-owner) entry
+	// (#184). This stays a closed enum: lock status routes controller blocking
+	// behavior, so unknown future statuses must keep failing closed instead of
+	// being tolerated like diagnostic-only metadata.
+	RELEASED: "released",
 }         ;
 
 

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -643,6 +643,40 @@ test("native review status uses the anticipated v2.1.5 contract, preserves Windo
 	}
 });
 
+test("native review status decodes 2.1.8 released lock residue and keeps unknown lock statuses fail-closed", async () => {
+	// gentle-ai 2.1.8 leaves review-transactions/v2/LOCK behind after ORDINARY
+	// successful operations and reports it as {"status":"released"} without
+	// owner metadata (issue #184; reproduced empirically against the system
+	// binary). The decoder must accept it or reviewStatus dead-ends with
+	// schema-incompatible on every repository that ever completed a review.
+	//
+	// Lock status stays a CLOSED enum extended by exactly `released` — unlike
+	// the cause_category widening in review-integration-v1 (diagnostic
+	// metadata nothing routes on), lock status routes blocking behavior in the
+	// controller, so an unknown future status must keep failing closed rather
+	// than being silently classified as blocking or non-blocking.
+	const releasedLock = { version: "compact-v2", path: "C:\\repo\\.git\\gentle-ai\\review-transactions\\v2\\LOCK", status: "released" };
+	const released = queuedAdapter([STATUS_VERSION, { stdout: JSON.stringify({ ...JSON.parse(REVIEW_STATUS.stdout), status: "approved", locks: [releasedLock] }) }]);
+	const decoded = await new NativeReviewCliV213(released.adapter).reviewStatus({ cwd: "C:\\repo with spaces" });
+	assert.equal(decoded.status, "approved");
+	assert.deepEqual(decoded.locks, [{ version: "compact-v2", path: "C:\\repo\\.git\\gentle-ai\\review-transactions\\v2\\LOCK", status: "released" }]);
+
+	// Residual dead-owner metadata may still accompany a released entry.
+	const releasedWithOwner = queuedAdapter([STATUS_VERSION, { stdout: JSON.stringify({ ...JSON.parse(REVIEW_STATUS.stdout), locks: [{ ...releasedLock, owner: { schema: "gentle-ai.review-store-lock/v1", owner_id: "dead-owner", pid: 1, host: "host", acquired_at: "2026-07-14T00:00:00Z" } }] }) }]);
+	assert.equal((await new NativeReviewCliV213(releasedWithOwner.adapter).reviewStatus({ cwd: "C:\\repo with spaces" })).locks[0]?.owner?.ownerId, "dead-owner");
+
+	for (const status of ["Released", "stale", "unknown-future-status", ""]) {
+		const malformed = queuedAdapter([STATUS_VERSION, { stdout: JSON.stringify({ ...JSON.parse(REVIEW_STATUS.stdout), locks: [{ ...releasedLock, status }] }) }]);
+		await assert.rejects(
+			() => new NativeReviewCliV213(malformed.adapter).reviewStatus({ cwd: "C:\\repo with spaces" }),
+			(error: unknown) => error instanceof NativeReviewCliError
+				&& error.code === NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE
+				&& error.operation === "review/status"
+				&& error.mutationOutcome === "none",
+		);
+	}
+});
+
 test("native review status accepts a canonical POSIX symlink repository identity", async (t) => {
 	if (process.platform === "win32") return t.skip("directory symlink creation requires elevated Windows privileges");
 	const repository = await mkdtemp(join(tmpdir(), "gentle-pi-native-status-"));

--- a/tests/review-controller-lock-status.test.ts
+++ b/tests/review-controller-lock-status.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import type { NativeReviewCli, NativeReviewStatusResult } from "../lib/native-review-cli.ts";
+
+// Issue #184: gentle-ai 2.1.8 leaves review-transactions/v2/LOCK behind after
+// ORDINARY successful operations and inventories it as {"status":"released"}.
+// Only live lock claims — owned or ambiguous — may block the controller;
+// released residue is dead-owner metadata already surfaced through the
+// envelope's `evidence.authority_inventory` and must never dead-end
+// INSPECT/STATUS mapping or the START precondition.
+//
+// The harness helpers below intentionally mirror (not import) the local
+// fixtures of tests/review-controller-native-routing.test.ts, which does not
+// export them and is concurrently edited on another branch.
+
+interface RegisteredTool {
+	execute: (
+		toolCallId: string,
+		params: unknown,
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	) => Promise<{ details?: unknown }>;
+}
+
+function runtime(nativeReviewCli: NativeReviewCli): RegisteredTool {
+	const tools = new Map<string, RegisteredTool>();
+	const dependencies = { nativeReviewCli, candidateViews: null } as unknown as Parameters<typeof createGentleAiExtension>[0];
+	createGentleAiExtension(dependencies)({
+		on() {},
+		registerTool(definition: RegisteredTool & { name: string }) { tools.set(definition.name, definition); },
+		registerCommand() {},
+	} as unknown as ExtensionAPI);
+	const controller = tools.get("gentle_review");
+	assert.ok(controller);
+	return controller;
+}
+
+function context(cwd: string): ExtensionContext {
+	return { cwd, hasUI: false, ui: { confirm: async () => true } } as unknown as ExtensionContext;
+}
+
+function repository(t: test.TestContext): string {
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-lock-status-"));
+	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	execFileSync("git", ["init", "-b", "main"], { cwd });
+	writeFileSync(join(cwd, "app.ts"), "export const value = 1;\n");
+	execFileSync("git", ["add", "."], { cwd });
+	execFileSync("git", ["-c", "user.name=Lock Test", "-c", "user.email=lock@example.invalid", "commit", "-m", "initial"], { cwd });
+	return cwd;
+}
+
+// Exact shape gentle-ai 2.1.8 emits for the residual entry (no owner, no
+// problem), reproduced empirically against the system binary.
+const RELEASED_LOCK = { version: "compact-v2", path: "/repo/.git/gentle-ai/review-transactions/v2/LOCK", status: "released" } as const;
+const OWNED_LOCK = { version: "compact-v2", path: "/repo/.git/gentle-ai/review-transactions/v2/LOCK", status: "owned", owner: { schema: "gentle-ai.review-store-lock/v1", ownerId: "owner", pid: 1, host: "host", acquiredAt: "2026-07-14T00:00:00Z" } } as const;
+const AMBIGUOUS_LOCK = { version: "compact-v2", path: "/repo/.git/gentle-ai/review-transactions/v2/LOCK", status: "ambiguous", problem: "unreadable owner metadata" } as const;
+
+function nativeStatus(cwd: string, status: string, locks: readonly unknown[]): NativeReviewStatusResult {
+	return {
+		repository: cwd,
+		complete: true,
+		authoritative: true,
+		status,
+		entries: [],
+		locks,
+		diagnostics: [],
+		raw: { schema: "gentle-ai.review-authority-status/v1", operation: "review/status", repository: cwd, complete: true, authoritative: true, status, entries: [], locks, diagnostics: [] },
+	} as NativeReviewStatusResult;
+}
+
+function fakeNative(status: NativeReviewStatusResult, onStart?: () => void): NativeReviewCli {
+	return {
+		start: async () => {
+			onStart?.();
+			return { lineageId: "native-lineage", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 2, correctionBudget: 1, action: "created", lensesRequired: true };
+		},
+		finalize: async () => { throw new Error("finalize must not run"); },
+		validate: async () => { throw new Error("validate must not run"); },
+		bindSdd: async () => { throw new Error("bindSdd must not run"); },
+		sddStatus: async () => ({ ready: false }),
+		reviewStatus: async () => status,
+	} as unknown as NativeReviewCli;
+}
+
+test("INSPECT treats released lock residue as non-blocking and still blocks on live lock claims", async (t) => {
+	const cwd = repository(t);
+
+	const released = await runtime(fakeNative(nativeStatus(cwd, "clean", [RELEASED_LOCK])))
+		.execute("inspect-released", { operation: "inspect" }, undefined, undefined, context(cwd));
+	const releasedDetails = released.details as Record<string, unknown>;
+	assert.equal(releasedDetails.status, "ready");
+	assert.equal(releasedDetails.inventory_complete, true);
+	assert.equal(releasedDetails.next_action, "start-native-authoritative");
+	assert.notEqual(releasedDetails.outcome, "native-authority-lock-present");
+	// The residue stays observable without new envelope fields: the raw
+	// inventory already travels in evidence.authority_inventory.
+	const inventory = (releasedDetails.evidence as Record<string, unknown>).authority_inventory as Record<string, unknown>;
+	assert.deepEqual(inventory.locks, [RELEASED_LOCK]);
+
+	for (const scenario of [
+		{ name: "owned", locks: [OWNED_LOCK] },
+		{ name: "ambiguous", locks: [AMBIGUOUS_LOCK] },
+		{ name: "released-plus-owned", locks: [RELEASED_LOCK, OWNED_LOCK] },
+	]) {
+		const blocked = await runtime(fakeNative(nativeStatus(cwd, "clean", scenario.locks)))
+			.execute(`inspect-${scenario.name}`, { operation: "inspect" }, undefined, undefined, context(cwd));
+		const details = blocked.details as Record<string, unknown>;
+		assert.equal(details.status, "blocked", scenario.name);
+		assert.equal(details.outcome, "native-authority-lock-present", scenario.name);
+		assert.equal(details.next_action, "wait-for-native-lock-release", scenario.name);
+	}
+});
+
+test("START precondition ignores released lock residue and still blocks on live lock claims", async (t) => {
+	const cwd = repository(t);
+
+	let started = 0;
+	const proceeded = await runtime(fakeNative(nativeStatus(cwd, "clean", [RELEASED_LOCK]), () => { started += 1; }))
+		.execute("start-released", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+	const proceededDetails = proceeded.details as Record<string, unknown>;
+	assert.equal(started, 1);
+	assert.equal((proceededDetails.result as Record<string, unknown>).lineage_id, "native-lineage");
+	assert.notEqual(proceededDetails.outcome, "native-authority-lock-present");
+
+	for (const scenario of [
+		{ name: "owned", locks: [OWNED_LOCK] },
+		{ name: "ambiguous", locks: [AMBIGUOUS_LOCK] },
+		{ name: "released-plus-ambiguous", locks: [RELEASED_LOCK, AMBIGUOUS_LOCK] },
+	]) {
+		let mutations = 0;
+		const blocked = await runtime(fakeNative(nativeStatus(cwd, "clean", scenario.locks), () => { mutations += 1; }))
+			.execute(`start-${scenario.name}`, { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+		const details = blocked.details as Record<string, unknown>;
+		assert.equal(mutations, 0, scenario.name);
+		assert.equal(details.status, "blocked", scenario.name);
+		assert.equal(details.outcome, "native-authority-lock-present", scenario.name);
+		assert.equal(details.next_action, "wait-for-native-lock-release", scenario.name);
+	}
+});


### PR DESCRIPTION
Closes #184

## Summary
- gentle-ai 2.1.8 leaves the review-transactions LOCK with residual dead-owner metadata after ordinary operations (empirically: appears already after START) and reports it as `"status":"released"` — Pi's decoder only accepted `owned|ambiguous`, so `reviewStatus` threw `schema-incompatible` on every repository that had ever completed a native review.
- `NATIVE_REVIEW_LOCK_STATUS` gains `released` as a **closed enum extension** (unknown statuses still fail closed — lock status routes blocking behavior, unlike the diagnostic `cause_category` widening).
- New `hasBlockingNativeLock()` at both controller call sites: only `owned`/`ambiguous` block; `released` is non-blocking. Runtime mirror regenerated.

## Test Plan
- [x] Red-first decode + controller tests (new `tests/review-controller-lock-status.test.ts`; routing test file untouched); unknown statuses still reject; mixed released+owned/ambiguous still block with zero mutations
- [x] Empirical repro against the real 2.1.8 binary: pre-fix `schema-incompatible`, post-fix decodes, released non-blocking, approved receipt maps correctly
- [x] Full suite 877 pass / 0 fail / 1 pre-existing skip; runtime harness green; `verify-package-files.mjs` passes
- [x] Native bounded review: first pass caught the unregenerated runtime mirror (deterministic BLOCKER, fixed via regeneration + amend); second pass zero findings; receipt `approved` (lineage `review-d1c0b66ec033e204`); gates `allow`

## Contributor Checklist
- [x] Linked approved issue
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Released native review locks are now treated as non-blocking residue.
  * Review inspection and starts proceed when only released locks remain.
  * Active or ambiguous locks continue to block operations and prompt users to wait for release.
  * Invalid or unknown lock statuses are rejected safely instead of being ignored.

* **Tests**
  * Added coverage for released, active, ambiguous, and unsupported lock statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->