### PR TITLE
fix(review): fail closed when a pre-commit hook mutates the authorized tree

### DIFF
--- a/lib/git-commit-transaction.ts
+++ b/lib/git-commit-transaction.ts
@@ -645,6 +645,11 @@ export async function runGitCommitTransaction(
 		if (record.state === COMMIT_TRANSACTION_STATE.AWAITING_NATIVE || record.state === COMMIT_TRANSACTION_STATE.AWAITING_REVIEW || record.state === COMMIT_TRANSACTION_STATE.VALIDATED) {
 			const currentTree = git(binding.root, ["write-tree"]);
 			if (record.post_hook_tree !== currentTree) throw new Error("commit transaction post-hook tree changed before native validation");
+			if (currentTree !== invocation.authorization.intendedTree) {
+				const mutation = `pre-commit hook mutated the staged candidate: post-hook tree ${currentTree} is not the authorized tree ${invocation.authorization.intendedTree}; the content-bound receipt no longer covers this index; normalize sources and re-run review explicitly, or make the hook convergent, then retry the exact command; transaction ${record.transaction_id} created no commit`;
+				record = transition(binding, record, COMMIT_TRANSACTION_STATE.AWAITING_REVIEW, { error: mutation }, now);
+				throw new Error(mutation);
+			}
 			const nativeReviewCli = dependencies.nativeReviewCli ?? createNativeReviewCli();
 			let nativeResult: NativeValidateResult;
 			try {

--- a/runtime/git-commit-transaction.mjs
+++ b/runtime/git-commit-transaction.mjs
@@ -646,6 +646,11 @@ export async function runGitCommitTransaction(
 		if (record.state === COMMIT_TRANSACTION_STATE.AWAITING_NATIVE || record.state === COMMIT_TRANSACTION_STATE.AWAITING_REVIEW || record.state === COMMIT_TRANSACTION_STATE.VALIDATED) {
 			const currentTree = git(binding.root, ["write-tree"]);
 			if (record.post_hook_tree !== currentTree) throw new Error("commit transaction post-hook tree changed before native validation");
+			if (currentTree !== invocation.authorization.intendedTree) {
+				const mutation = `pre-commit hook mutated the staged candidate: post-hook tree ${currentTree} is not the authorized tree ${invocation.authorization.intendedTree}; the content-bound receipt no longer covers this index; normalize sources and re-run review explicitly, or make the hook convergent, then retry the exact command; transaction ${record.transaction_id} created no commit`;
+				record = transition(binding, record, COMMIT_TRANSACTION_STATE.AWAITING_REVIEW, { error: mutation }, now);
+				throw new Error(mutation);
+			}
 			const nativeReviewCli = dependencies.nativeReviewCli ?? createNativeReviewCli();
 			let nativeResult                      ;
 			try {

--- a/tests/git-commit-transaction.test.ts
+++ b/tests/git-commit-transaction.test.ts
@@ -12,6 +12,7 @@ import {
 	prepareCommitTransactionInvocation,
 	reconcileCommitTransaction,
 	runGitCommitTransaction,
+	verifyCommitTransactionResult,
 } from "../lib/git-commit-transaction.ts";
 import type { NativeReviewCli, NativeValidateResult } from "../lib/native-review-cli.ts";
 
@@ -101,7 +102,7 @@ test("a mutating hook creates no commit until the post-hook tree is reviewed, th
 	const before = git(cwd, "rev-parse", "HEAD");
 	await assert.rejects(
 		runGitCommitTransaction(invocation(cwd, "before-format"), { nativeReviewCli: native(cwd, "before-format", "scope-changed") }),
-		/post-hook tree/,
+		/not the authorized tree/,
 	);
 	assert.equal(git(cwd, "rev-parse", "HEAD"), before);
 	assert.equal(inspectCommitTransaction(cwd).record?.state, COMMIT_TRANSACTION_STATE.AWAITING_REVIEW);
@@ -119,6 +120,105 @@ test("a failing pre-commit hook creates no commit and leaves explicit recovery s
 	await assert.rejects(runGitCommitTransaction(invocation(cwd, "hook-failure"), { nativeReviewCli: native(cwd, "hook-failure") }), /hook failed/);
 	assert.equal(git(cwd, "rev-parse", "HEAD"), before);
 	assert.equal(inspectCommitTransaction(cwd).record?.state, COMMIT_TRANSACTION_STATE.HOOK_FAILED);
+	assert.match(inspectCommitTransaction(cwd).record?.error ?? "", /exit 23/);
+});
+
+test("a native scope-changed denial on the unmutated authorized tree awaits explicit review", async (t) => {
+	const cwd = repository(t);
+	const authorizedTree = stage(cwd);
+	const before = git(cwd, "rev-parse", "HEAD");
+	let validations = 0;
+	const denying = native(cwd, "scope-changed-denial", "scope-changed");
+	const counting = {
+		async validate(request) {
+			validations += 1;
+			return denying.validate(request);
+		},
+	} as NativeReviewCli;
+	await assert.rejects(
+		runGitCommitTransaction(invocation(cwd, "scope-changed-denial"), { nativeReviewCli: counting }),
+		/native pre-commit validation denied the post-hook tree: scope-changed/,
+	);
+	assert.equal(validations, 1, "the unmutated tree must pass the mutation guard and reach native validation");
+	assert.equal(git(cwd, "rev-parse", "HEAD"), before);
+	assert.equal(git(cwd, "write-tree"), authorizedTree, "the denied index stays exactly as authorized");
+	const inspection = inspectCommitTransaction(cwd);
+	assert.equal(inspection.record?.state, COMMIT_TRANSACTION_STATE.AWAITING_REVIEW);
+	assert.equal(inspection.record?.error, "post-hook tree differs from receipt");
+	assert.equal(typeof inspection.record?.native_result, "object", "the native denial must be recorded on the transaction");
+});
+
+test("a non-scope-changed native denial fails validation and requires explicit recovery", async (t) => {
+	const cwd = repository(t);
+	stage(cwd);
+	const before = git(cwd, "rev-parse", "HEAD");
+	await assert.rejects(
+		runGitCommitTransaction(invocation(cwd, "invalidated-denial"), { nativeReviewCli: native(cwd, "invalidated-denial", "invalidated") }),
+		/native pre-commit validation denied the post-hook tree: invalidated/,
+	);
+	assert.equal(git(cwd, "rev-parse", "HEAD"), before);
+	assert.equal(inspectCommitTransaction(cwd).record?.state, COMMIT_TRANSACTION_STATE.VALIDATION_FAILED);
+	await assert.rejects(
+		runGitCommitTransaction(invocation(cwd, "invalidated-denial"), { nativeReviewCli: native(cwd, "invalidated-denial") }),
+		/requires explicit recovery from state validation-failed/,
+	);
+});
+
+test("a mutating pre-commit hook fails closed even when native validation would allow the post-hook tree", async (t) => {
+	const cwd = repository(t);
+	const authorizedTree = stage(cwd, "unformatted\n");
+	const count = join(cwd, ".git", "hook-count");
+	installHook(cwd, "pre-commit", `printf 'formatted\\n' > tracked.txt\ngit add tracked.txt\nprintf '1\\n' >> ${JSON.stringify(count)}`);
+	const before = git(cwd, "rev-parse", "HEAD");
+	// The fake native CLI allows whatever tree the index holds, so the only
+	// defense against committing the hook-mutated tree is the transaction's
+	// own binding to the invocation's authorized tree.
+	await assert.rejects(
+		runGitCommitTransaction(invocation(cwd, "permissive-native"), { nativeReviewCli: native(cwd, "permissive-native") }),
+		/pre-commit hook mutated the staged candidate/,
+	);
+	assert.equal(git(cwd, "rev-parse", "HEAD"), before, "no commit object may be created from the mutated index");
+	assert.equal(readFileSync(count, "utf8"), "1\n", "the mutating hook must have run exactly once");
+	assert.notEqual(git(cwd, "write-tree"), authorizedTree, "the mutated index is preserved for inspection");
+	const inspection = inspectCommitTransaction(cwd);
+	assert.equal(inspection.record?.state, COMMIT_TRANSACTION_STATE.AWAITING_REVIEW);
+	assert.match(inspection.record?.error ?? "", /normalize sources and re-run review explicitly, or make the hook convergent/);
+	assert.throws(() => assertNoUnresolvedCommitTransaction(cwd), /publication is blocked/);
+});
+
+test("a convergent pre-commit hook runs exactly once and commits the exact authorized tree", async (t) => {
+	const cwd = repository(t);
+	const authorizedTree = stage(cwd, "formatted\n");
+	const count = join(cwd, ".git", "hook-count");
+	installHook(cwd, "pre-commit", `printf 'formatted\\n' > tracked.txt\ngit add tracked.txt\nprintf '1\\n' >> ${JSON.stringify(count)}`);
+	const before = git(cwd, "rev-parse", "HEAD");
+	const result = await runGitCommitTransaction(invocation(cwd, "convergent"), { nativeReviewCli: native(cwd, "convergent") });
+	assert.notEqual(result.head, before);
+	assert.equal(result.tree, authorizedTree);
+	assert.equal(git(cwd, "rev-parse", "HEAD^{tree}"), authorizedTree);
+	assert.equal(readFileSync(count, "utf8"), "1\n", "the convergent hook must have run exactly once");
+	assert.deepEqual(inspectCommitTransaction(cwd), { status: "clean" });
+});
+
+test("a repository with no hooks commits the authorized tree unchanged", async (t) => {
+	const cwd = repository(t);
+	const authorizedTree = stage(cwd);
+	const before = git(cwd, "rev-parse", "HEAD");
+	const result = await runGitCommitTransaction(invocation(cwd, "no-hooks"), { nativeReviewCli: native(cwd, "no-hooks") });
+	assert.notEqual(result.head, before);
+	assert.equal(result.tree, authorizedTree);
+	assert.equal(git(cwd, "rev-parse", "HEAD^{tree}"), authorizedTree);
+	assert.deepEqual(inspectCommitTransaction(cwd), { status: "clean" });
+});
+
+test("the Git-created HEAD tree is proven equal to the authorized tree on success", async (t) => {
+	const cwd = repository(t);
+	const authorizedTree = stage(cwd);
+	const result = await runGitCommitTransaction(invocation(cwd, "head-proof"), { nativeReviewCli: native(cwd, "head-proof") });
+	assert.equal(result.tree, authorizedTree);
+	assert.equal(git(cwd, "rev-parse", "HEAD^{tree}"), authorizedTree);
+	const verified = verifyCommitTransactionResult(cwd, result.transactionId);
+	assert.deepEqual(verified, { transactionId: result.transactionId, status: "committed", head: result.head, tree: authorizedTree });
 });
 
 test("message hooks cannot change the index after native authorization", async (t) => {


### PR DESCRIPTION
Closes #153

## Summary
- The commit transaction ran user pre-commit hooks exactly once and re-validated the post-hook tree natively, but never compared it against the tree the driving invocation actually authorized — a permissive, mismatched, or stale native authority could let a hook-mutated tree be committed under a receipt that no longer covers it (HIGH: content-bound authority bypass, proven red on base with an allow-everything native fake).
- The transaction now fails closed to `awaiting-review` before native validation whenever the post-hook tree differs from the invocation's intended tree, with an actionable message; explicit re-review recomputes the intended tree from the post-hook index, so the sanctioned exact-retry path is unchanged.
- commit-msg class stays on the existing once-only proxy (not `--no-verify`): nothing double-runs, nothing is disabled.

## Test Plan
- [x] Red-first: base-tree test proved the bypass (commit created from mutated tree); now fails closed with no commit, hook-ran-once, mutated index preserved
- [x] Matrix: convergent hook, no hooks, failing hook (surfaced unchanged), HEAD-tree == authorized-tree durable proof
- [x] Native-denial branch re-covered path-bound (validate-call counter) with disambiguated assertions after the first review pass caught the dead mock
- [x] Full suite 886 / 885 pass / 0 fail / 1 pre-existing skip; harness green; mirror parity confirmed
- [x] Native bounded review: two passes (first caught the coverage gap), receipt `approved` (lineage `review-e0cbd767af5ae460`); gates `allow`

## Contributor Checklist
- [x] Linked approved issue
- [x] Exactly one `type:*` label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to detect unexpected changes to staged content during commit recovery and validation.
  * Transactions now pause for explicit review instead of proceeding when the staged content differs from the authorized version.
  * Improved handling of native validation failures and modifying pre-commit hooks.
  * Successful commits now confirm that the committed content exactly matches the authorized content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->