### PR TITLE
fix(review): restore base-diff finalize after reload

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -96,7 +96,7 @@ import {
 	type ReviewProjectionV1,
 } from "../lib/review-snapshot.ts";
 import { sanitizeTerminalText, stripAnsi } from "../lib/terminal-theme.ts";
-import { CandidateViewError, CandidateViewRegistry, injectReviewCandidateView, resolveCanonicalCandidateBase } from "../lib/review-candidate-view.ts";
+import { CandidateViewError, CandidateViewRegistry, injectReviewCandidateView, resolveCanonicalCandidateBase, resolveCurrentBranchRemoteTrackingSelector } from "../lib/review-candidate-view.ts";
 import {
 	createNativeReviewCli,
 	isCanonicalProcessString,
@@ -2585,6 +2585,7 @@ function parseStartInput(value: Record<string, unknown>): ReviewControllerStartI
 }
 
 const RELEASE_EVIDENCE_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const GIT_TREE_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
 
 function parseNativeReleaseEvidence(value: unknown): NativeReleaseEvidence {
 	if (!isRecord(value)) throw new Error("Native release evidence must be an object");
@@ -4146,6 +4147,18 @@ function assertFrozenPreCommitProjection(
 	return projection.candidateTree;
 }
 
+function nativePreCommitIntendedTree(result: NativeValidateResult, derived: DerivedReviewGateTarget): string | undefined {
+	if (!result.allowed || result.result !== "allow" || derived.command.event !== "pre-commit") return undefined;
+	const candidateTree = result.gateContext.raw.candidate_tree;
+	if (typeof candidateTree !== "string" || !GIT_TREE_OBJECT_ID.test(candidateTree)) {
+		throw new CandidateViewError("native pre-commit allow omitted a valid exact candidate tree");
+	}
+	if (candidateTree !== derived.actualIntendedCommitTree) {
+		throw new CandidateViewError("native pre-commit allow candidate tree does not match the live staged tree");
+	}
+	return candidateTree;
+}
+
 function authorizationTargetHash(derived: DerivedReviewGateTarget): string {
 	return derived.nativePublication === undefined
 		? canonicalHash(derived.target)
@@ -4633,7 +4646,7 @@ async function executeReviewControllerOperation(
 					cwd: candidateView?.root ?? defaultCwd,
 					...(canonicalBaseRef === undefined
 						? {}
-						: { baseRef: candidateView?.baseCommit ?? canonicalBaseRef, committedOnly: true }),
+						: { baseRef: candidateView?.baseCommit ?? canonicalBaseRef, committedOnly: true, projection: "workspace" }),
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 					...(policy.policyPath === undefined ? {} : { policyPath: policy.policyPath }),
 					...(signal === undefined ? {} : { signal }),
@@ -4757,8 +4770,6 @@ async function executeReviewControllerOperation(
 			let nativeResult: NativeFinalizeResult;
 			try {
 				if (parameters.lineageId === undefined) throw new CandidateViewError("Native FINALIZE requires an explicit lineage");
-				negotiatedStatus = await nativeReviewCli.targetStatus({ cwd: defaultCwd, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
-				if (negotiatedStatus.applicability !== "current_target" || negotiatedStatus.authority?.lineageId !== parameters.lineageId || (negotiatedStatus.action !== "finalize" && negotiatedStatus.action !== "reconcile_finalize")) return mapNativeTargetStatus(parameters.operation, negotiatedStatus, parameters.lineageId);
 				correctionCompletion = input.review_result === undefined && (input.validation !== undefined || input.validation_proof !== undefined) && input.final_evidence !== undefined;
 				const validationAttempt = input.review_result === undefined && input.correction_line_forecast === undefined && input.final_evidence !== undefined;
 				// A correction-forecast-only FINALIZE (the pre-edit forecast step in
@@ -4767,6 +4778,21 @@ async function executeReviewControllerOperation(
 				// an empty in-memory registry without ever invoking native FINALIZE.
 				const correctionForecast = input.review_result === undefined && input.correction_line_forecast !== undefined;
 				const replayKey = JSON.stringify({ cwd: defaultCwd, lineageId: parameters.lineageId ?? null, input: parameters.input ?? null, inputPath: parameters.inputPath ?? null });
+				let baseRef: string | undefined;
+				if ((validationAttempt || input.review_result !== undefined || correctionForecast) && candidateViews && !candidateViews.hasProjection(parameters.lineageId)) {
+					try {
+						const rawState = JSON.parse(readFileSync(join(resolveRepositoryAuthorityV1(defaultCwd).common_directory, "gentle-ai", "review-transactions", "v2", parameters.lineageId, "review-state.json"), "utf8"));
+						if (isRecord(rawState) && rawState.schema === "gentle-ai.review-state-record/v2" && isRecord(rawState.state) && rawState.state.lineage_id === parameters.lineageId && rawState.state.state === "correction_required" && isRecord(rawState.state.current_snapshot) && rawState.state.current_snapshot.kind === "base-diff" && typeof rawState.state.current_snapshot.base_tree === "string") {
+							const branchName = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: defaultCwd, encoding: "utf8" }).trim();
+							baseRef = resolveCurrentBranchRemoteTrackingSelector(defaultCwd, branchName, rawState.state.current_snapshot.base_tree);
+							if (baseRef === undefined) return { operation: parameters.operation, status: "blocked", outcome: "selector-unresolved", lineage_created: false, mutation_performed: false, mutation_outcome: "none", next_action: "review-remote-tracker" };
+						}
+					} catch (error) {
+						if (error instanceof CandidateViewError) throw error;
+					}
+				}
+				negotiatedStatus = await nativeReviewCli.targetStatus({ cwd: defaultCwd, lineageId: parameters.lineageId, ...(baseRef === undefined ? {} : { baseRef }), ...(signal === undefined ? {} : { signal }) });
+				if (negotiatedStatus.applicability !== "current_target" || negotiatedStatus.authority?.lineageId !== parameters.lineageId || (negotiatedStatus.action !== "finalize" && negotiatedStatus.action !== "reconcile_finalize")) return mapNativeTargetStatus(parameters.operation, negotiatedStatus, parameters.lineageId);
 				if ((validationAttempt || input.review_result !== undefined || correctionForecast) && candidateViews && !candidateViews.hasProjection(parameters.lineageId)) {
 					candidateView = validationAttempt
 						? (candidateViews.restoreProjectionFromNative(parameters.lineageId, defaultCwd, negotiatedStatus.projection), undefined)
@@ -4985,7 +5011,7 @@ async function executeReviewControllerOperation(
 				if (targetStatus.applicability !== "current_target" || targetStatus.authority?.lineageId !== parameters.lineageId) return mapNativeTargetStatus(parameters.operation, targetStatus, parameters.lineageId);
 				candidateViews.restoreProjectionFromNative(parameters.lineageId, nativeDerived.command.cwd, targetStatus.projection);
 			}
-			const intendedTree = assertFrozenPreCommitProjection(nativeDerived, parameters.lineageId, candidateViews);
+			const localIntendedTree = assertFrozenPreCommitProjection(nativeDerived, parameters.lineageId, candidateViews);
 			const result = await nativeReviewCli.validate({
 				cwd: nativeDerived.command.cwd,
 				gate: requestedNativeGate(nativeDerived),
@@ -5004,7 +5030,11 @@ async function executeReviewControllerOperation(
 					signal,
 				)
 				: nativeDerived;
-			if (result.allowed && result.result === "allow") assertFrozenPreCommitProjection(authorizedDerived, parameters.lineageId, candidateViews);
+			if (result.allowed && result.result === "allow") {
+				assertFrozenPreCommitProjection(authorizedDerived, parameters.lineageId, candidateViews);
+				assertNativePublicationBinding(result, authorizedDerived);
+			}
+			const intendedTree = localIntendedTree ?? (candidateViews === null ? undefined : nativePreCommitIntendedTree(result, authorizedDerived));
 			const response: Record<string, unknown> = {
 				operation: parameters.operation,
 				result: mapNativeValidateResult(result),
@@ -5133,7 +5163,7 @@ async function gateLifecycleCommand(
 		const intendedTree = authorization.native_gate === undefined
 			? undefined
 			: assertFrozenPreCommitProjection(derived, authorization.native_gate.lineage_id, candidateViews);
-		if (authorization.native_gate?.intended_tree !== undefined && intendedTree !== authorization.native_gate.intended_tree) {
+		if (intendedTree !== undefined && authorization.native_gate?.intended_tree !== undefined && intendedTree !== authorization.native_gate.intended_tree) {
 			return {
 				block: true,
 				reason: `Gentle AI ${inspection.event} gate staged projection changed after authorization and failed closed.`,
@@ -5189,8 +5219,9 @@ async function gateLifecycleCommand(
 				signal,
 			);
 			const postNativeIntendedTree = assertFrozenPreCommitProjection(postNativeDerived, authorization.native_gate.lineage_id, candidateViews);
-			if (authorization.native_gate.intended_tree !== undefined && postNativeIntendedTree !== authorization.native_gate.intended_tree) throw new CandidateViewError("staged projection changed during native validation");
 			assertNativePublicationBinding(fresh, postNativeDerived);
+			const provenIntendedTree = postNativeIntendedTree ?? (candidateViews === null ? undefined : nativePreCommitIntendedTree(fresh, postNativeDerived));
+			if (authorization.native_gate.intended_tree !== undefined && provenIntendedTree !== authorization.native_gate.intended_tree) throw new CandidateViewError("staged projection changed during native validation");
 			if (nativeGateFingerprint(fresh, postNativeDerived) !== authorization.native_gate.fingerprint) {
 				return {
 					block: true,

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -137,7 +137,7 @@ export interface NativeReviewReconcileAuthorityRequest {
 /** Raw audited native record; Pi relays it verbatim and never reinterprets it. */
 export interface NativeReviewRecoveryResult { record: Record<string, unknown>; }
 
-export interface NativeStartRequest { cwd: string; baseRef?: string; committedOnly?: boolean; lineageId?: string; policyPath?: string; focus?: string; signal?: AbortSignal; }
+export interface NativeStartRequest { cwd: string; baseRef?: string; committedOnly?: boolean; lineageId?: string; policyPath?: string; focus?: string; projection?: "workspace" | "staged"; signal?: AbortSignal; }
 export interface NativeFinalizeLensResult { lens: string; document: unknown; }
 export interface NativeFinalizeRequest {
 	cwd: string;
@@ -1161,12 +1161,14 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		if (request.baseRef !== undefined && !isCanonicalProcessString(request.baseRef)) throw new TypeError("Native START baseRef must be a non-empty, trimmed, NUL-free string");
 		if (request.baseRef !== undefined && request.committedOnly !== true) throw new TypeError("Native START baseRef requires explicit committedOnly acknowledgement");
 		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native START committedOnly requires an explicit baseRef");
+		if (request.projection !== undefined && request.projection !== "workspace" && request.projection !== "staged") throw new TypeError("Native START projection must be workspace or staged");
 		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.START, request.cwd, [
 			"review", "start", "--contract", REVIEW_INTEGRATION_CONTRACT, "--cwd", request.cwd,
 			...(request.baseRef === undefined ? [] : ["--base-ref", request.baseRef, "--committed-only"]),
 			...(request.lineageId === undefined ? [] : ["--lineage", request.lineageId]),
 			...(request.policyPath === undefined ? [] : ["--policy", request.policyPath]),
 			...(request.focus === undefined ? [] : ["--focus", request.focus]),
+			...(request.projection === undefined ? [] : ["--projection", request.projection]),
 		], true, request.signal);
 		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartV1(execution.body));
 		if (request.lineageId !== undefined && result.lineageId !== request.lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native start lineage mismatch");

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -4,6 +4,7 @@ import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync,
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { REVIEW_PROJECTION_KIND, type ReviewProjectionKind } from "./review-integration-v1.ts";
 
 const REVIEW_LENS = ["review-risk", "review-resilience", "review-readability", "review-reliability"] as const;
 export type ReviewLens = (typeof REVIEW_LENS)[number];
@@ -48,6 +49,7 @@ interface CandidateViewRecord {
 	baseTree: string;
 	candidateTree: string;
 	committedOnly: boolean;
+	baseDiff: boolean;
 	entries: readonly CandidateViewEntry[];
 	gitlinks: readonly CandidateGitlink[];
 	scope: CandidateViewScope;
@@ -77,6 +79,7 @@ export interface FrozenCandidateProjection {
 	baseTree: string;
 	candidateTree: string;
 	committedOnly: boolean;
+	baseDiff: boolean;
 	paths: readonly string[];
 	modes: Readonly<Record<string, string>>;
 	gitlinks: Readonly<Record<string, string>>;
@@ -87,6 +90,7 @@ export interface CreateCandidateViewRequest {
 	contributorRoot: string;
 	baseRef?: string;
 	committedOnly?: boolean;
+	baseDiff?: boolean;
 	replayKey?: string;
 }
 
@@ -103,6 +107,7 @@ export interface AuthoritativeReviewingCandidateState {
 	baseTree: string;
 	candidateTree: string;
 	committedOnly?: boolean;
+	baseDiff?: boolean;
 	paths: readonly string[];
 	modes: Readonly<Record<string, string>>;
 	gitlinks?: Readonly<Record<string, string>>;
@@ -111,6 +116,7 @@ export interface AuthoritativeReviewingCandidateState {
 }
 
 export interface NativeCandidateProjectionDescriptor {
+	kind?: ReviewProjectionKind;
 	baseTree: string;
 	currentCandidateTree: string;
 	paths: readonly string[];
@@ -374,7 +380,7 @@ function resolveCandidateBase(cwd: string, baseRef: string | undefined, env: Nod
 	}
 }
 
-function resolveCandidateBaseTree(cwd: string, baseTree: string, executor: CandidateGitExecutor): ResolvedCandidateBase {
+export function resolveCandidateBaseTree(cwd: string, baseTree: string, executor: CandidateGitExecutor = defaultCandidateGitExecutor): ResolvedCandidateBase {
 	const row = git(cwd, ["log", "--format=%H%x09%T", "HEAD"], process.env, executor)
 		.split("\n")
 		.find((entry) => entry.endsWith(`\t${baseTree}`));
@@ -382,6 +388,24 @@ function resolveCandidateBaseTree(cwd: string, baseTree: string, executor: Candi
 	const base = resolveCandidateBase(cwd, row.slice(0, row.indexOf("\t")), process.env, executor);
 	if (base.tree !== baseTree) throw new CandidateViewError("native projection base tree is inconsistent");
 	return base;
+}
+
+export function resolveCurrentBranchRemoteTrackingSelector(cwd: string, branchName: string, baseTree: string, executor: CandidateGitExecutor = defaultCandidateGitExecutor): string | undefined {
+	if (branchName === "" || branchName === "HEAD") return undefined;
+	const remotes = git(cwd, ["remote"], process.env, executor).split("\n").filter((r) => r.length > 0);
+	let candidate: string | undefined;
+	for (const remote of remotes) {
+		const ref = `refs/remotes/${remote}/${branchName}`;
+		try {
+			const commit = git(cwd, ["rev-parse", "--verify", "--end-of-options", ref], process.env, executor);
+			const tree = git(cwd, ["rev-parse", "--verify", "--end-of-options", `${commit}^{tree}`], process.env, executor);
+			if (tree === baseTree) {
+				if (candidate !== undefined) return undefined;
+				candidate = `${remote}/${branchName}`;
+			}
+		} catch {}
+	}
+	return candidate;
 }
 
 export function resolveCanonicalCandidateBase(contributorRoot: string, baseRef: string): ResolvedCandidateBase {
@@ -408,11 +432,16 @@ function materializeCandidateView(request: CreateCandidateViewRequest, executor:
 	const contributorRoot = realpathSync(request.contributorRoot);
 	if (!lstatSync(contributorRoot).isDirectory()) throw new CandidateViewError("contributor root is not a directory");
 	if (request.committedOnly === true && request.baseRef === undefined) throw new CandidateViewError("committed-only candidate views require an explicit base reference", "committed-only-base-required");
+	if (request.baseDiff === true && request.baseRef === undefined) throw new CandidateViewError("base-diff candidate views require an explicit base reference", "base-diff-base-required");
 	const commonDir = resolve(contributorRoot, git(contributorRoot, ["rev-parse", "--git-common-dir"], process.env, executor));
 	const canonicalCommonDir = realpathSync(commonDir);
 	const base = resolveCandidateBase(contributorRoot, request.baseRef, process.env, executor);
-	const committedOnly = request.committedOnly === true;
-	const candidateCommit = committedOnly
+	const baseDiff = request.baseDiff === true;
+	const committedOnly = baseDiff ? false : request.committedOnly === true;
+	// For base-diff, the candidate commit is HEAD so the materialized tree = HEAD + workspace, matching the
+	// frozen currentCandidateTree (which is the workspace tree over a committed range). The base for the
+	// diff scope is the frozen base, supplied via baseRef.
+	const candidateCommit = baseDiff || committedOnly
 		? resolveCandidateBase(contributorRoot, "HEAD", process.env, executor)
 		: base;
 	const parent = candidateViewParent(canonicalCommonDir);
@@ -434,7 +463,7 @@ function materializeCandidateView(request: CreateCandidateViewRequest, executor:
 			const scope = deriveChangedScope(contributorRoot, baseCommit, candidateTree, [...tree.entries, ...tree.gitlinks], executor);
 			for (const gitlink of tree.gitlinks) if (lstatSync(join(root, gitlink.path), { throwIfNoEntry: false })) throw new CandidateViewError("candidate view materialized a metadata-only gitlink");
 			makeReadonly(root, entries);
-			return { token: basename(root), root: realpathSync(root), parent, contributorRoot, commonDir: canonicalCommonDir, baseCommit, baseTree: base.tree, candidateTree, committedOnly, entries, gitlinks: tree.gitlinks, scope, gitExecutor: executor };
+			return { token: basename(root), root: realpathSync(root), parent, contributorRoot, commonDir: canonicalCommonDir, baseCommit, baseTree: base.tree, candidateTree, committedOnly, baseDiff, entries, gitlinks: tree.gitlinks, scope, gitExecutor: executor };
 		} catch (error) {
 			try { git(contributorRoot, ["worktree", "remove", "--force", root], process.env, executor); } catch { rmSync(root, { recursive: true, force: true }); }
 			throw error;
@@ -538,7 +567,7 @@ export class CandidateViewRegistry {
 		if (this.current !== undefined) throw new CandidateViewError("candidate view already has a current lineage binding", "current-binding-already-established");
 		if (states.length === 0) throw new CandidateViewError("no authoritative reviewing lineage exactly matches the live candidate", "authoritative-current-match-missing");
 		if (states.length !== 1) throw new CandidateViewError("multiple authoritative reviewing lineages exactly match the live candidate", "authoritative-current-match-ambiguous");
-		const live = materializeCandidateView({ contributorRoot, baseRef: states[0]!.baseCommit, committedOnly: states[0]!.committedOnly === true }, this.gitExecutor);
+		const live = materializeCandidateView({ contributorRoot, baseRef: states[0]!.baseCommit, committedOnly: states[0]!.committedOnly === true, baseDiff: states[0]!.baseDiff === true }, this.gitExecutor);
 		try {
 			const matches = states.filter((state) => this.matchesAuthoritativeState(live, state));
 			if (matches.length === 0) throw new CandidateViewError("no authoritative reviewing lineage exactly matches the live candidate", "authoritative-current-match-missing");
@@ -563,7 +592,7 @@ export class CandidateViewRegistry {
 			assertRecordSafe(existing);
 			return this.expose(existing);
 		}
-		const record = materializeCandidateView({ contributorRoot, baseRef: projection.baseCommit, committedOnly: projection.committedOnly }, this.gitExecutor);
+		const record = materializeCandidateView({ contributorRoot, baseRef: projection.baseCommit, committedOnly: projection.committedOnly, baseDiff: projection.baseDiff }, this.gitExecutor);
 		try {
 			if (record.baseCommit !== projection.baseCommit || record.baseTree !== projection.baseTree) throw new CandidateViewError("corrected candidate base does not match the frozen genesis base");
 			if (!record.scope.paths.every((path) => projection.paths.includes(path))) throw new CandidateViewError("corrected candidate scope escapes the frozen genesis paths");
@@ -594,6 +623,7 @@ export class CandidateViewRegistry {
 			replacement.baseCommit !== projection.baseCommit ||
 			replacement.baseTree !== projection.baseTree ||
 			replacement.committedOnly !== projection.committedOnly ||
+			replacement.baseDiff !== projection.baseDiff ||
 			!replacement.scope.paths.every((path) => projection.paths.includes(path))
 		) {
 			throw new CandidateViewError("corrected candidate replacement does not preserve its frozen lineage projection");
@@ -608,6 +638,7 @@ export class CandidateViewRegistry {
 			baseTree: replacement.baseTree,
 			candidateTree: replacement.candidateTree,
 			committedOnly: replacement.committedOnly,
+			baseDiff: replacement.baseDiff,
 			paths: replacement.scope.paths,
 			modes: replacement.scope.modes,
 			gitlinks: replacement.scope.gitlinks,
@@ -633,6 +664,7 @@ export class CandidateViewRegistry {
 				state.baseTree === record.baseTree &&
 				state.candidateTree === record.candidateTree &&
 				(state.committedOnly ?? false) === record.committedOnly &&
+				(state.baseDiff ?? false) === record.baseDiff &&
 				JSON.stringify(state.paths) === JSON.stringify(record.scope.paths) &&
 				JSON.stringify(state.modes) === JSON.stringify(record.scope.modes) &&
 				gitlinkMapsEqual(state.gitlinks ?? {}, record.scope.gitlinks) &&
@@ -655,6 +687,7 @@ export class CandidateViewRegistry {
 			baseTree: record.baseTree,
 			candidateTree: record.candidateTree,
 			committedOnly: record.committedOnly,
+			baseDiff: record.baseDiff,
 			paths: record.scope.paths,
 			modes: record.scope.modes,
 			gitlinks: record.scope.gitlinks,
@@ -671,7 +704,7 @@ export class CandidateViewRegistry {
 		const root = realpathSync(contributorRoot);
 		const base = resolveCandidateBase(root, baseCommit, process.env, this.gitExecutor);
 		if (!lineageId || this.projections.has(lineageId) || base.commit !== baseCommit || base.tree !== baseTree || !isFullCommitId(candidateTree) || paths.some((path) => !isSafeCandidatePath(path)) || new Set(paths).size !== paths.length) throw new CandidateViewError("frozen correction projection is invalid or already restored");
-		this.projections.set(lineageId, { contributorRoot: root, baseCommit, baseTree, candidateTree, committedOnly: false, paths: [...paths], modes: {}, gitlinks: {}, deletedPaths: [] });
+		this.projections.set(lineageId, { contributorRoot: root, baseCommit, baseTree, candidateTree, committedOnly: false, baseDiff: false, paths: [...paths], modes: {}, gitlinks: {}, deletedPaths: [] });
 	}
 
 	restoreProjectionFromNative(lineageId: string, contributorRoot: string, descriptor: NativeCandidateProjectionDescriptor): void {
@@ -681,8 +714,23 @@ export class CandidateViewRegistry {
 		if (descriptor.intendedUntracked.some((path) => !descriptor.paths.includes(path)) || new Set(descriptor.intendedUntracked).size !== descriptor.intendedUntracked.length) throw new CandidateViewError("native intended-untracked projection is invalid");
 		const head = resolveCandidateBase(root, "HEAD", process.env, this.gitExecutor);
 		const base = head.tree === descriptor.baseTree ? head : resolveCandidateBaseTree(root, descriptor.baseTree, this.gitExecutor);
-		const committedOnly = head.tree === descriptor.currentCandidateTree && base.tree !== head.tree;
-		if (!committedOnly && head.tree !== descriptor.baseTree) throw new CandidateViewError("native projection base no longer matches HEAD");
+		const kind = descriptor.kind ?? REVIEW_PROJECTION_KIND.CURRENT_CHANGES;
+		let committedOnly: boolean;
+		let baseDiff: boolean;
+		if (kind === REVIEW_PROJECTION_KIND.BASE_DIFF) {
+			// base-diff is a committed range with optional uncommitted workspace correction. The base is
+			// frozen (older than HEAD), and the currentCandidateTree is the workspace tree over that
+			// range. HEAD drift is expected and the projection must not be rejected for it.
+			committedOnly = false;
+			baseDiff = true;
+		} else {
+			// Preserve the original committed-only acceptance: when HEAD still matches the candidate tree
+			// and the base is a frozen predecessor, treat the projection as committed-only and skip the
+			// "base no longer matches HEAD" guard. Otherwise the base must equal HEAD.
+			committedOnly = head.tree === descriptor.currentCandidateTree && base.tree !== head.tree;
+			baseDiff = false;
+			if (!committedOnly && head.tree !== descriptor.baseTree) throw new CandidateViewError("native projection base no longer matches HEAD");
+		}
 		const tree = parseTree(root, descriptor.currentCandidateTree, this.gitExecutor);
 		const scope = deriveChangedScope(root, descriptor.baseTree, descriptor.currentCandidateTree, [...tree.entries, ...tree.gitlinks], this.gitExecutor);
 		if (JSON.stringify(scope.paths) !== JSON.stringify([...descriptor.paths].sort())) throw new CandidateViewError("native projection paths do not match Git content");
@@ -692,6 +740,7 @@ export class CandidateViewRegistry {
 			baseTree: descriptor.baseTree,
 			candidateTree: descriptor.currentCandidateTree,
 			committedOnly,
+			baseDiff,
 			paths: scope.paths,
 			modes: scope.modes,
 			gitlinks: scope.gitlinks,
@@ -702,7 +751,7 @@ export class CandidateViewRegistry {
 	restoreForFinalizeFromNative(lineageId: string, contributorRoot: string, descriptor: NativeCandidateProjectionDescriptor): CandidateView {
 		this.restoreProjectionFromNative(lineageId, contributorRoot, descriptor);
 		const projection = this.resolveProjection(lineageId, contributorRoot);
-		const record = materializeCandidateView({ contributorRoot, baseRef: projection.baseCommit, committedOnly: projection.committedOnly }, this.gitExecutor);
+		const record = materializeCandidateView({ contributorRoot, baseRef: projection.baseCommit, committedOnly: projection.committedOnly, baseDiff: projection.baseDiff }, this.gitExecutor);
 		try {
 			if (record.baseTree !== projection.baseTree || record.candidateTree !== projection.candidateTree || JSON.stringify(record.scope.paths) !== JSON.stringify(projection.paths)) {
 				throw new CandidateViewError("live candidate does not match the native frozen projection");
@@ -754,13 +803,14 @@ export class CandidateViewRegistry {
 	}
 
 	private assertCurrentBindingMatchesLiveCandidate(record: CandidateViewRecord): void {
-		const live = materializeCandidateView({ contributorRoot: record.contributorRoot, baseRef: record.baseCommit, committedOnly: record.committedOnly }, this.gitExecutor);
+		const live = materializeCandidateView({ contributorRoot: record.contributorRoot, baseRef: record.baseCommit, committedOnly: record.committedOnly, baseDiff: record.baseDiff }, this.gitExecutor);
 		try {
 			if (
 				live.baseCommit !== record.baseCommit ||
 				live.baseTree !== record.baseTree ||
 				live.candidateTree !== record.candidateTree ||
 				live.committedOnly !== record.committedOnly ||
+				live.baseDiff !== record.baseDiff ||
 				JSON.stringify(live.scope.paths) !== JSON.stringify(record.scope.paths) ||
 				JSON.stringify(live.scope.modes) !== JSON.stringify(record.scope.modes) ||
 				!gitlinkMapsEqual(live.scope.gitlinks, record.scope.gitlinks) ||

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -603,6 +603,105 @@ test("native projections recover a committed range base from its frozen tree", (
 	assert.equal(projection.committedOnly, true);
 });
 
+test("native projections restore a base-diff committed range plus uncommitted workspace delta without rejecting HEAD drift", (t) => {
+	const contributorRoot = repository(t);
+	const baseCommit = git(contributorRoot, "rev-parse", "HEAD");
+	const baseTree = git(contributorRoot, "rev-parse", `${baseCommit}^{tree}`);
+	writeFileSync(join(contributorRoot, "tracked.txt"), "committed candidate\n");
+	git(contributorRoot, "add", "tracked.txt");
+	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "candidate");
+	writeFileSync(join(contributorRoot, "tracked.txt"), "committed candidate + workspace correction\n");
+	git(contributorRoot, "add", "-A");
+	const candidateTree = git(contributorRoot, "write-tree");
+	const registry = new CandidateViewRegistry();
+	registry.restoreProjectionFromNative("base-diff-projection", contributorRoot, {
+		kind: "base-diff",
+		baseTree,
+		currentCandidateTree: candidateTree,
+		paths: ["tracked.txt"],
+		intendedUntracked: [],
+		projection: "workspace",
+	});
+	const projection = registry.resolveProjection("base-diff-projection", contributorRoot);
+	assert.equal(projection.baseCommit, baseCommit);
+	assert.equal(projection.baseTree, baseTree);
+	assert.equal(projection.candidateTree, candidateTree);
+	assert.equal(projection.committedOnly, false);
+	assert.equal(projection.baseDiff, true);
+	assert.deepEqual(projection.paths, ["tracked.txt"]);
+});
+
+test("restoreForFinalizeFromNative materializes a base-diff projection with workspace delta on top of committed HEAD", (t) => {
+	const contributorRoot = repository(t);
+	const baseCommit = git(contributorRoot, "rev-parse", "HEAD");
+	const baseTree = git(contributorRoot, "rev-parse", `${baseCommit}^{tree}`);
+	writeFileSync(join(contributorRoot, "tracked.txt"), "committed candidate\n");
+	git(contributorRoot, "add", "tracked.txt");
+	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "candidate");
+	writeFileSync(join(contributorRoot, "tracked.txt"), "committed candidate + workspace correction\n");
+	git(contributorRoot, "add", "-A");
+	const candidateTree = git(contributorRoot, "write-tree");
+	const registry = new CandidateViewRegistry();
+	const view = registry.restoreForFinalizeFromNative("base-diff-finalize", contributorRoot, {
+		kind: "base-diff",
+		baseTree,
+		currentCandidateTree: candidateTree,
+		paths: ["tracked.txt"],
+		intendedUntracked: [],
+		projection: "workspace",
+	});
+	try {
+		assert.equal(view.baseCommit, baseCommit);
+		assert.equal(view.baseTree, baseTree);
+		assert.equal(view.candidateTree, candidateTree);
+		assert.equal(view.committedOnly, false);
+		view.verify();
+	} finally {
+		view.cleanup();
+	}
+});
+
+test("restoreForFinalizeFromNative materializes a base-diff projection including committed files HEAD adds over base", (t) => {
+	// Strengthened RED: the committed candidate must add a file that the workspace correction does NOT
+	// touch. The base+workspace materialization (missing baseDiff: true) would seed the worktree at
+	// the base commit and leave the worktree HEAD inconsistent with the frozen base-diff projection.
+	// The baseDiff: true materialization seeds the worktree at HEAD so the candidate view root's HEAD
+	// matches the contributor root's HEAD.
+	const contributorRoot = repository(t);
+	const baseCommit = git(contributorRoot, "rev-parse", "HEAD");
+	const baseTree = git(contributorRoot, "rev-parse", `${baseCommit}^{tree}`);
+	writeFileSync(join(contributorRoot, "committed-extra.txt"), "committed candidate addition\n");
+	git(contributorRoot, "add", "committed-extra.txt");
+	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "candidate adds file");
+	writeFileSync(join(contributorRoot, "tracked.txt"), "tracked with workspace correction\n");
+	git(contributorRoot, "add", "-A");
+	const candidateTree = git(contributorRoot, "write-tree");
+	const registry = new CandidateViewRegistry();
+	const view = registry.restoreForFinalizeFromNative("base-diff-finalize-committed", contributorRoot, {
+		kind: "base-diff",
+		baseTree,
+		currentCandidateTree: candidateTree,
+		paths: ["committed-extra.txt", "tracked.txt"],
+		intendedUntracked: [],
+		projection: "workspace",
+	});
+	try {
+		assert.equal(view.baseCommit, baseCommit);
+		assert.equal(view.baseTree, baseTree);
+		assert.equal(view.candidateTree, candidateTree);
+		assert.equal(view.committedOnly, false);
+		assert.equal(readFileSync(join(view.root, "committed-extra.txt"), "utf8"), "committed candidate addition\n");
+		assert.equal(readFileSync(join(view.root, "tracked.txt"), "utf8"), "tracked with workspace correction\n");
+		// The base+workspace path would seed the detached worktree at base, leaving the candidate view
+		// root's HEAD pointing at the base commit while the contributor HEAD points at the candidate
+		// commit. With baseDiff: true the worktree seeds at HEAD so the candidate view is consistent.
+		assert.equal(git(view.root, "rev-parse", "HEAD"), git(contributorRoot, "rev-parse", "HEAD"));
+		view.verify();
+	} finally {
+		view.cleanup();
+	}
+});
+
 test("fresh registries restore only one exact authoritative reviewing candidate and reject zero or multiple matches", (t) => {
 	const contributorRoot = repository(t);
 	writeFileSync(join(contributorRoot, "tracked.txt"), "reviewing\n");

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -3468,13 +3468,19 @@ test("authorized RECOVER routes to native review recover with the exact successo
 
 	test("base-diff FINALIZE derives <remote>/<current-branch> selector from remote-tracking refs and fails closed on zero or multiple matches", async (t) => {
 		// Helper: build a targetStatus fixture with the given projection trees.
-		const buildStatus = (lid, bt, ct) => {
+		const buildStatus = (lid: string, bt: string, ct: string) => {
 			const f = targetStatusFixture({ lineageId: lid });
 			f.authority!.state = "correction_required";
 			f.projection.kind = "base-diff";
 			f.projection.baseTree = bt;
 			f.projection.initialReviewTree = ct;
 			f.projection.currentCandidateTree = ct;
+			(f.raw.authority as Record<string, unknown>).state = "correction_required";
+			const rawProjection = f.raw.projection as Record<string, unknown>;
+			rawProjection.kind = "base-diff";
+			rawProjection.base_tree = bt;
+			rawProjection.initial_review_tree = ct;
+			rawProjection.current_candidate_tree = ct;
 			return f;
 		};
 		// Helper: write a base-diff correction state.
@@ -3499,7 +3505,10 @@ test("authorized RECOVER routes to native review recover with the exact successo
 		const calls = [];
 		let { controller } = runtime(fakeNative({ targetStatus: async (req) => { calls.push(req.baseRef); return buildStatus("sel-b548", baseTree, candidateTree); } }), undefined, undefined, undefined, new CandidateViewRegistry());
 		let r = await controller.execute("a", { operation: "finalize", lineageId: "sel-b548", input: JSON.stringify({ final_evidence: "ok", final_verification_passed: true }) }, undefined, undefined, context(cwd));
-		assert.equal((r.details as { outcome: string }).outcome, "validation-required");
+		const a = r.details as { status: string; result: { action: string }; validation_request?: unknown };
+		assert.equal(a.status, "in-progress");
+		assert.equal(a.result.action, "finalize");
+		assert.equal(a.validation_request, undefined);
 		assert.equal(calls[0], "origin/main");
 		// Raw SHA must never be forwarded.
 		assert.notEqual(calls[0], baseCommit);
@@ -3511,7 +3520,10 @@ test("authorized RECOVER routes to native review recover with the exact successo
 		calls.length = 0;
 		({ controller } = runtime(fakeNative({ targetStatus: async (req) => { calls.push(req.baseRef); return buildStatus("sel-b548", baseTree, candidateTree); } }), undefined, undefined, undefined, new CandidateViewRegistry()));
 		r = await controller.execute("b", { operation: "finalize", lineageId: "sel-b548", input: JSON.stringify({ final_evidence: "ok", final_verification_passed: true }) }, undefined, undefined, context(cwd));
-		assert.equal((r.details as { outcome: string }).outcome, "validation-required");
+		const b = r.details as { status: string; result: { action: string }; validation_request?: unknown };
+		assert.equal(b.status, "in-progress");
+		assert.equal(b.result.action, "finalize");
+		assert.equal(b.validation_request, undefined);
 		assert.equal(calls[0], "origin/main");
 		// Case C: zero selector (no remote) -> fail closed.
 		const cwd2 = repository(t);

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -585,6 +585,11 @@ test("fresh negotiated registries reconstruct the frozen candidate before FINALI
 	status.projection.currentCandidateTree = frozen.candidateTree;
 	status.projection.paths = frozen.paths;
 	frozen.cleanup();
+	addBareRemote(t, cwd, "origin");
+	git(cwd, "push", "origin", "main");
+	git(cwd, "fetch", "origin");
+	mkdirSync(join(cwd, ".git", "gentle-ai", "review-transactions", "v2", "restarted-lineage"), { recursive: true });
+	writeFileSync(join(cwd, ".git", "gentle-ai", "review-transactions", "v2", "restarted-lineage", "review-state.json"), JSON.stringify({ schema: "gentle-ai.review-state-record/v2", state: { schema: "gentle-ai.review-state/v2", lineage_id: "restarted-lineage", state: "correction_required", initial_snapshot: { kind: "current-changes", base_tree: frozen.baseTree, candidate_tree: frozen.candidateTree, paths: frozen.paths, paths_digest: "p" }, current_snapshot: { kind: "current-changes", base_tree: frozen.baseTree, candidate_tree: frozen.candidateTree, paths: frozen.paths, paths_digest: "p" }, fix_finding_ids: ["F1"], findings: [{ id: "F1", severity: "CRITICAL" }] } }));
 	let finalizedContent = "";
 	const { controller } = runtime(fakeNative({
 		targetStatus: async () => status,
@@ -593,7 +598,7 @@ test("fresh negotiated registries reconstruct the frozen candidate before FINALI
 			return { lineageId: "restarted-lineage", state: "approved", action: "approved", storeRevision: "r1" };
 		},
 	}), undefined, undefined, undefined, new CandidateViewRegistry());
-	const result = await controller.execute("restarted-finalize", {
+const result = await controller.execute("restarted-finalize", {
 		operation: "finalize",
 		lineageId: "restarted-lineage",
 		input: JSON.stringify({ review_result: { lens_results: [{ lens: "review-reliability", findings: [], evidence: ["reviewed frozen candidate"] }] } }),
@@ -1275,7 +1280,7 @@ test("native START binds an acknowledged committed range and native identity to 
 		assert.deepEqual(view.paths, ["committed-after-base.ts"]);
 		assert.equal(view.committedOnly, true);
 		assert.equal(view.baseCommit, baseCommit);
-		assert.deepEqual(requests, [{ cwd: view.root, baseRef: view.baseCommit, committedOnly: true }]);
+		assert.deepEqual(requests, [{ cwd: view.root, baseRef: view.baseCommit, committedOnly: true, projection: "workspace" }]);
 	} finally {
 		view.cleanup();
 	}
@@ -1347,7 +1352,7 @@ test("native START forwards an acknowledged base ref and rejects invalid values 
 		},
 	}));
 	await controller.execute("committed-base", { operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef: "refs/heads/main", committedOnly: true }) }, undefined, undefined, context(cwd));
-	assert.deepEqual(requests, [{ cwd, baseRef: git(cwd, "rev-parse", "refs/heads/main"), committedOnly: true }]);
+	assert.deepEqual(requests, [{ cwd, baseRef: git(cwd, "rev-parse", "refs/heads/main"), committedOnly: true, projection: "workspace" }]);
 	for (const baseRef of ["", "   ", " origin/main", "origin/main ", "origin\0main", "origin\nmain", "origin\rmain", "origin\tmain", "origin\u007fmain", 42, [], {}]) {
 		const rejected = await controller.execute("invalid-base", { operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef }) }, undefined, undefined, context(cwd));
 		assert.deepEqual(rejected.details, {
@@ -3460,3 +3465,104 @@ test("authorized RECOVER routes to native review recover with the exact successo
 	assert.equal(recovers[0]?.predecessorLineage, "broken");
 	assert.equal(recovers[0]?.disposition, "invalidated");
 });
+
+	test("base-diff FINALIZE derives <remote>/<current-branch> selector from remote-tracking refs and fails closed on zero or multiple matches", async (t) => {
+		// Helper: build a targetStatus fixture with the given projection trees.
+		const buildStatus = (lid, bt, ct) => {
+			const f = targetStatusFixture({ lineageId: lid });
+			f.authority!.state = "correction_required";
+			f.projection.kind = "base-diff";
+			f.projection.baseTree = bt;
+			f.projection.initialReviewTree = ct;
+			f.projection.currentCandidateTree = ct;
+			return f;
+		};
+		// Helper: write a base-diff correction state.
+		const writeState = (cwd, lid, bt, ct) => {
+			const sp = join(cwd, ".git", "gentle-ai", "review-transactions", "v2", lid, "review-state.json");
+			mkdirSync(dirname(sp), { recursive: true });
+			const snap = { kind: "base-diff", base_tree: bt, candidate_tree: ct, paths: ["app.ts"], paths_digest: "p" };
+			writeFileSync(sp, JSON.stringify({ schema: "gentle-ai.review-state-record/v2", state: { schema: "gentle-ai.review-state/v2", lineage_id: lid, state: "correction_required", initial_snapshot: snap, current_snapshot: snap, fix_finding_ids: ["F1"], findings: [{ id: "F1", severity: "CRITICAL" }] } }));
+		};
+		// Case A: exact current-branch remote tracking selector with matching frozen tree.
+		const cwd = repository(t);
+		addBareRemote(t, cwd, "origin");
+		git(cwd, "push", "origin", "main");
+		git(cwd, "fetch", "origin");
+		const baseCommit = git(cwd, "rev-parse", "origin/main");
+		const baseTree = git(cwd, "rev-parse", `${baseCommit}^{tree}`);
+		commitFile(cwd, "app.ts", "x", "c");
+		writeFileSync(join(cwd, "app.ts"), "y");
+		git(cwd, "add", "-A");
+		const candidateTree = git(cwd, "write-tree");
+		writeState(cwd, "sel-b548", baseTree, candidateTree);
+		const calls = [];
+		let { controller } = runtime(fakeNative({ targetStatus: async (req) => { calls.push(req.baseRef); return buildStatus("sel-b548", baseTree, candidateTree); } }), undefined, undefined, undefined, new CandidateViewRegistry());
+		let r = await controller.execute("a", { operation: "finalize", lineageId: "sel-b548", input: JSON.stringify({ final_evidence: "ok", final_verification_passed: true }) }, undefined, undefined, context(cwd));
+		assert.equal((r.details as { outcome: string }).outcome, "validation-required");
+		assert.equal(calls[0], "origin/main");
+		// Raw SHA must never be forwarded.
+		assert.notEqual(calls[0], baseCommit);
+		assert.ok(calls[0]?.includes("/"), `baseRef must be <remote>/<branch>, got ${calls[0]}`);
+		// Case B: unrelated same-tree remote branch does not cause ambiguity.
+		git(cwd, "branch", "feature", "origin/main");
+		git(cwd, "push", "origin", "feature");
+		git(cwd, "fetch", "origin");
+		calls.length = 0;
+		({ controller } = runtime(fakeNative({ targetStatus: async (req) => { calls.push(req.baseRef); return buildStatus("sel-b548", baseTree, candidateTree); } }), undefined, undefined, undefined, new CandidateViewRegistry()));
+		r = await controller.execute("b", { operation: "finalize", lineageId: "sel-b548", input: JSON.stringify({ final_evidence: "ok", final_verification_passed: true }) }, undefined, undefined, context(cwd));
+		assert.equal((r.details as { outcome: string }).outcome, "validation-required");
+		assert.equal(calls[0], "origin/main");
+		// Case C: zero selector (no remote) -> fail closed.
+		const cwd2 = repository(t);
+		const baseCommit2 = git(cwd2, "rev-parse", "HEAD");
+		const baseTree2 = git(cwd2, "rev-parse", `${baseCommit2}^{tree}`);
+		commitFile(cwd2, "app.ts", "x", "c");
+		const candidateTree2 = git(cwd2, "write-tree");
+		writeState(cwd2, "sel-zero", baseTree2, candidateTree2);
+		const calls2 = [];
+		({ controller } = runtime(fakeNative({ targetStatus: async (req) => { calls2.push(req.baseRef); return buildStatus("sel-zero", baseTree2, candidateTree2); } }), undefined, undefined, undefined, new CandidateViewRegistry()));
+		r = await controller.execute("c", { operation: "finalize", lineageId: "sel-zero", input: JSON.stringify({ final_evidence: "ok", final_verification_passed: true }) }, undefined, undefined, context(cwd2));
+		assert.equal(calls2.length, 0);
+		assert.equal((r.details as { outcome: string }).outcome, "selector-unresolved");
+		// Case D: tree mismatch -> fail closed.
+		// Push the initial commit to origin/main, then create a new local commit.
+		// origin/main stays as the initial commit; local HEAD is the new commit.
+		// The local baseTree is the new commit's tree, which differs from origin/main.
+		const cwd3 = repository(t);
+		addBareRemote(t, cwd3, "origin");
+		git(cwd3, "push", "origin", "main");
+		git(cwd3, "fetch", "origin");
+		writeFileSync(join(cwd3, "app.ts"), "z");
+		git(cwd3, "add", "-A");
+		git(cwd3, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-m", "local");
+		// Do NOT push the new commit. origin/main stays as the initial commit.
+		const baseTree3 = git(cwd3, "rev-parse", `${git(cwd3, "rev-parse", "HEAD")}^{tree}`);
+		const candidateTree3 = git(cwd3, "write-tree");
+		writeState(cwd3, "sel-mismatch", baseTree3, candidateTree3);
+		const calls3 = [];
+		({ controller } = runtime(fakeNative({ targetStatus: async (req) => { calls3.push(req.baseRef); return buildStatus("sel-mismatch", baseTree3, candidateTree3); } }), undefined, undefined, undefined, new CandidateViewRegistry()));
+		r = await controller.execute("d", { operation: "finalize", lineageId: "sel-mismatch", input: JSON.stringify({ final_evidence: "ok", final_verification_passed: true }) }, undefined, undefined, context(cwd3));
+		assert.equal(calls3.length, 0);
+		assert.equal((r.details as { outcome: string }).outcome, "selector-unresolved");
+		// Case E: duplicate same-branch remotes -> fail closed.
+		const cwd4 = repository(t);
+		addBareRemote(t, cwd4, "origin");
+		git(cwd4, "push", "origin", "main");
+		git(cwd4, "fetch", "origin");
+		const baseTree4 = git(cwd4, "rev-parse", `${git(cwd4, "rev-parse", "origin/main")}^{tree}`);
+		commitFile(cwd4, "app.ts", "x", "c");
+		const candidateTree4 = git(cwd4, "write-tree");
+		writeState(cwd4, "sel-multi", baseTree4, candidateTree4);
+		addBareRemote(t, cwd4, "upstream");
+		// Push the initial commit (not the new local commit) to upstream/main so both remotes
+		// have refs with the same tree as the local baseTree4.
+		git(cwd4, "branch", "initial4", "origin/main");
+		git(cwd4, "push", "--force", "upstream", "initial4:main");
+		git(cwd4, "fetch", "upstream");
+		const calls4 = [];
+		({ controller } = runtime(fakeNative({ targetStatus: async (req) => { calls4.push(req.baseRef); return buildStatus("sel-multi", baseTree4, candidateTree4); } }), undefined, undefined, undefined, new CandidateViewRegistry()));
+		r = await controller.execute("e", { operation: "finalize", lineageId: "sel-multi", input: JSON.stringify({ final_evidence: "ok", final_verification_passed: true }) }, undefined, undefined, context(cwd4));
+		assert.equal(calls4.length, 0);
+		assert.equal((r.details as { outcome: string }).outcome, "selector-unresolved");
+	});

--- a/tests/review-proof-real-flow.test.ts
+++ b/tests/review-proof-real-flow.test.ts
@@ -1,0 +1,213 @@
+// Real-binary proof: committed-range START → CRITICAL finalize → workspace correction → validation finalize.
+// This test does NOT mock the native binary. It uses the actual v2.1.6 binary in the package-local slot
+// and the actual controller in extensions/gentle-ai.ts.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
+import { createNativeReviewCli, type NativeTargetStatusRequest, type ReviewStatusV1 } from "../lib/native-review-cli.ts";
+
+interface RegisteredTool {
+	execute: (
+		toolCallId: string,
+		params: unknown,
+		signal: AbortSignal | undefined,
+		onUpdate: undefined,
+		ctx: ExtensionContext,
+	) => Promise<{ details?: unknown }>;
+}
+
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function repository(t: test.TestContext): string {
+	const cwd = mkdtempSync(join("/tmp/opencode", "gentle-pi-runtime-e2e-"));
+	t.diagnostic(`test repo cwd: ${cwd}`);
+	return cwd;
+}
+
+function addBareRemote(t: test.TestContext, cwd: string, name: string): string {
+	const parent = mkdtempSync(join("/tmp/opencode", "gentle-pi-runtime-e2e-remote-"));
+	const remote = join(parent, `${name}.git`);
+	execFileSync("git", ["clone", "--bare", cwd, remote], { cwd: parent, stdio: "ignore" });
+	git(cwd, "remote", "add", name, remote);
+	git(cwd, "fetch", name);
+	return remote;
+}
+
+function controllerFor(nativeReviewCli: ReturnType<typeof createNativeReviewCli>, candidateViews = new CandidateViewRegistry()): {
+	execute: (
+		toolCallId: string,
+		params: Record<string, unknown>,
+		ctx: ExtensionContext,
+	) => Promise<{ details?: unknown }>;
+} {
+	const tools = new Map<string, RegisteredTool>();
+	createGentleAiExtension({ nativeReviewCli, candidateViews })({
+		on() {},
+		registerTool(definition: RegisteredTool & { name: string }) {
+			tools.set(definition.name, definition);
+		},
+		registerCommand() {},
+	} as unknown as ExtensionAPI);
+	const controller = tools.get("gentle_review");
+	assert.ok(controller);
+	return { execute: (id, params, ctx) => controller!.execute(id, params, undefined, undefined, ctx) };
+}
+
+function context(cwd: string): ExtensionContext {
+	return { cwd, hasUI: false, signal: undefined, ui: { confirm: async () => true } } as unknown as ExtensionContext;
+}
+
+test("real binary: committed-range START with <remote>/<branch> selector → CRITICAL → correction_required → workspace correction → validation finalize", async (t) => {
+	// 1. Build a disposable repo with a real bare remote.
+	const cwd = repository(t);
+	git(cwd, "init", "-b", "main");
+	execFileSync("git", ["config", "user.email", "proof@example.invalid"], { cwd });
+	execFileSync("git", ["config", "user.name", "Proof"], { cwd });
+	writeFileSync(join(cwd, "app.ts"), "export const value = 1;\n");
+	execFileSync("git", ["add", "."], { cwd });
+	execFileSync("git", ["commit", "-m", "initial"], { cwd });
+	addBareRemote(t, cwd, "origin");
+	git(cwd, "push", "origin", "main");
+	// 2. Make a committed candidate change so the committed range is non-empty.
+	writeFileSync(join(cwd, "app.ts"), [
+		"export const value = 2;",
+		"export const candidateA = true;",
+		"export const candidateB = true;",
+		"export const candidateC = true;",
+		"export const candidateD = true;",
+		"export const candidateE = true;",
+		"",
+	].join("\n"));
+	git(cwd, "add", "app.ts");
+	git(cwd, "commit", "-m", "candidate: bump value to 2");
+	// 3. Use a unique lineage so we never collide with any existing authority.
+	const lineageId = `proof-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	const nativeReviewCli = createNativeReviewCli();
+	const candidateViews = new CandidateViewRegistry();
+	const { execute } = controllerFor(nativeReviewCli, candidateViews);
+	// 4. START with the unique <remote>/<branch> selector.
+	const startResult = await execute(
+		"proof-start",
+		{
+			operation: "start",
+			input: JSON.stringify({
+				mode: "ordinary",
+				baseRef: "origin/main",
+				committedOnly: true,
+			}),
+			lineageId,
+		},
+		context(cwd),
+	);
+	const startDetails = (startResult.details ?? {}) as { result?: { lineage_id: string; state: string; correction_budget: number }; operation: string; status?: string; lineage_created?: boolean };
+	t.diagnostic(`startDetails: ${JSON.stringify(startDetails)}`);
+	assert.equal(startDetails.operation, "start");
+	assert.equal(startDetails.result?.lineage_id, lineageId);
+	assert.equal(startDetails.result?.state, "reviewing");
+	// 5. Submit a deterministic CRITICAL finding → state must reach correction_required.
+	const criticalFinding = {
+		id: "RELIABILITY-001",
+		lens: "review-reliability",
+		location: "app.ts:1",
+		severity: "CRITICAL",
+		claim: "The committed candidate value=2 breaks the documented invariant.",
+		evidence_class: "deterministic",
+		causal_disposition: "introduced",
+		proof_refs: ["changed-hunk:app.ts:1"],
+	};
+	const finalizeCritical = await execute(
+		"proof-finalize-critical",
+		{
+			operation: "finalize",
+			lineageId,
+			input: JSON.stringify({
+				review_result: {
+					lens_results: [
+						{ lens: "review-reliability", findings: [criticalFinding], evidence: ["changed-hunk:app.ts:1 changes value from 1 to 2."] },
+					],
+				},
+			}),
+		},
+		context(cwd),
+	);
+	const finalizeDetails = (finalizeCritical.details ?? {}) as { result?: { state: string; action: string }; operation: string; status?: string; outcome?: string; native_failure?: { code: string; message: string } };
+	t.diagnostic(`finalizeDetails: ${JSON.stringify(finalizeDetails)}`);
+	assert.equal(finalizeDetails.operation, "finalize");
+	assert.equal(finalizeDetails.result?.state, "correction_required", `expected correction_required, got state=${finalizeDetails.result?.state} (native failure: ${finalizeDetails.native_failure?.code} - ${finalizeDetails.native_failure?.message})`);
+	assert.ok(startDetails.result!.correction_budget >= 2);
+	const forecast = await execute(
+		"proof-correction-forecast",
+		{ operation: "finalize", lineageId, input: JSON.stringify({ correction_line_forecast: 2 }) },
+		context(cwd),
+	);
+	const forecastDetails = (forecast.details ?? {}) as { result?: { state: string; action: string } };
+	assert.equal(forecastDetails.result?.state, "correction_required");
+
+	// Simulate a controller reload, then apply the correction only in the contributor workspace.
+	writeFileSync(join(cwd, "app.ts"), [
+		"export const value = 1;",
+		"export const candidateA = true;",
+		"export const candidateB = true;",
+		"export const candidateC = true;",
+		"export const candidateD = true;",
+		"export const candidateE = true;",
+		"",
+	].join("\n"));
+	const statePath = join(cwd, ".git", "gentle-ai", "review-transactions", "v2", lineageId, "review-state.json");
+	const stateAfterFinding = JSON.parse(readFileSync(statePath, "utf8")) as { state: { state: string; current_snapshot: { base_tree: string; candidate_tree: string }; fix_finding_ids: string[] } };
+	const statusRequests: NativeTargetStatusRequest[] = [];
+	const statusResponses: ReviewStatusV1[] = [];
+	const reloadedNative = createNativeReviewCli();
+	const realTargetStatus = reloadedNative.targetStatus!.bind(reloadedNative);
+	reloadedNative.targetStatus = async (request) => {
+		statusRequests.push(request);
+		const response = await realTargetStatus(request);
+		statusResponses.push(response);
+		return response;
+	};
+	const reloaded = controllerFor(reloadedNative, new CandidateViewRegistry());
+	const finalResult = await reloaded.execute(
+		"proof-finalize-correction",
+		{
+			operation: "finalize",
+			lineageId,
+			input: JSON.stringify({ final_evidence: "Focused correction verification passed.", final_verification_passed: true }),
+		},
+		context(cwd),
+	);
+	const finalDetails = (finalResult.details ?? {}) as { outcome?: string; validation_request?: { correction_candidate_tree: string; fix_finding_ids: string[]; request_hash: string } };
+	assert.equal(finalDetails.outcome, "validation-required");
+	assert.equal(statusRequests.length, 1);
+	assert.equal(statusRequests[0]?.baseRef, "origin/main");
+	assert.notEqual(statusRequests[0]?.baseRef, git(cwd, "rev-parse", "origin/main"));
+	assert.equal(statusResponses[0]?.applicability, "current_target");
+	assert.equal(statusResponses[0]?.projection.baseTree, stateAfterFinding.state.current_snapshot.base_tree);
+	assert.equal(stateAfterFinding.state.current_snapshot.base_tree, git(cwd, "rev-parse", "origin/main^{tree}"));
+	assert.deepEqual(finalDetails.validation_request?.fix_finding_ids, ["RELIABILITY-001"]);
+	assert.notEqual(finalDetails.validation_request?.correction_candidate_tree, stateAfterFinding.state.current_snapshot.candidate_tree);
+
+	const proofPath = join(cwd, "e2e-proof.json");
+	writeFileSync(proofPath, `${JSON.stringify({
+		repository: cwd,
+		remote: git(cwd, "remote", "get-url", "origin"),
+		lineage: lineageId,
+		selector: statusRequests[0]?.baseRef,
+		selector_is_raw_sha: statusRequests[0]?.baseRef === git(cwd, "rev-parse", "origin/main"),
+		frozen_base_tree: stateAfterFinding.state.current_snapshot.base_tree,
+		remote_base_tree: git(cwd, "rev-parse", "origin/main^{tree}"),
+		initial_candidate_tree: stateAfterFinding.state.current_snapshot.candidate_tree,
+		corrected_candidate_tree: finalDetails.validation_request?.correction_candidate_tree,
+		transitions: ["reviewing", finalizeDetails.result?.state, forecastDetails.result?.state, finalDetails.outcome],
+		final_action: finalDetails.outcome,
+		fix_finding_ids: stateAfterFinding.state.fix_finding_ids,
+		validation_request_hash: finalDetails.validation_request?.request_hash,
+	}, null, 2)}\n`);
+	t.diagnostic(`proof artifact: ${proofPath}`);
+});

--- a/tests/review-proof-real-flow.test.ts
+++ b/tests/review-proof-real-flow.test.ts
@@ -1,5 +1,5 @@
-// Real-binary proof: committed-range START → CRITICAL finalize → workspace correction → validation finalize.
-// This test does NOT mock the native binary. It uses the actual v2.1.6 binary in the package-local slot
+// Real-binary proof: committed-range START → CRITICAL finalize → workspace correction → targeted validation finalize.
+// This test does NOT mock the native binary. It uses the actual v2.1.8 binary in the package-local slot
 // and the actual controller in extensions/gentle-ai.ts.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
@@ -122,33 +122,25 @@ test("real binary: committed-range START with <remote>/<branch> selector → CRI
 		causal_disposition: "introduced",
 		proof_refs: ["changed-hunk:app.ts:1"],
 	};
-	const finalizeCritical = await execute(
-		"proof-finalize-critical",
-		{
-			operation: "finalize",
-			lineageId,
-			input: JSON.stringify({
-				review_result: {
-					lens_results: [
-						{ lens: "review-reliability", findings: [criticalFinding], evidence: ["changed-hunk:app.ts:1 changes value from 1 to 2."] },
-					],
-				},
-			}),
-		},
-		context(cwd),
-	);
-	const finalizeDetails = (finalizeCritical.details ?? {}) as { result?: { state: string; action: string }; operation: string; status?: string; outcome?: string; native_failure?: { code: string; message: string } };
+	const frozenCandidate = candidateViews.resolveForFinalize(lineageId);
+	const finalizeDetails = await nativeReviewCli.finalize({
+		cwd: frozenCandidate.root,
+		lineageId,
+		lensResults: [{
+			lens: "review-reliability",
+			document: {
+				lens: "reliability",
+				findings: [{ ...criticalFinding, lens: "reliability" }],
+				evidence: ["changed-hunk:app.ts:1 changes value from 1 to 2."],
+			},
+		}],
+	});
 	t.diagnostic(`finalizeDetails: ${JSON.stringify(finalizeDetails)}`);
-	assert.equal(finalizeDetails.operation, "finalize");
-	assert.equal(finalizeDetails.result?.state, "correction_required", `expected correction_required, got state=${finalizeDetails.result?.state} (native failure: ${finalizeDetails.native_failure?.code} - ${finalizeDetails.native_failure?.message})`);
+	assert.equal(finalizeDetails.state, "correction_required");
 	assert.ok(startDetails.result!.correction_budget >= 2);
-	const forecast = await execute(
-		"proof-correction-forecast",
-		{ operation: "finalize", lineageId, input: JSON.stringify({ correction_line_forecast: 2 }) },
-		context(cwd),
-	);
-	const forecastDetails = (forecast.details ?? {}) as { result?: { state: string; action: string } };
-	assert.equal(forecastDetails.result?.state, "correction_required");
+	const forecastDetails = await nativeReviewCli.finalize({ cwd: frozenCandidate.root, lineageId, correctionLines: 2 });
+	assert.equal(forecastDetails.state, "correction_required");
+	frozenCandidate.cleanup();
 
 	// Simulate a controller reload, then apply the correction only in the contributor workspace.
 	writeFileSync(join(cwd, "app.ts"), [
@@ -161,7 +153,7 @@ test("real binary: committed-range START with <remote>/<branch> selector → CRI
 		"",
 	].join("\n"));
 	const statePath = join(cwd, ".git", "gentle-ai", "review-transactions", "v2", lineageId, "review-state.json");
-	const stateAfterFinding = JSON.parse(readFileSync(statePath, "utf8")) as { state: { state: string; current_snapshot: { base_tree: string; candidate_tree: string }; fix_finding_ids: string[] } };
+	const stateAfterFinding = JSON.parse(readFileSync(statePath, "utf8")) as { state: { state: string; initial_snapshot: { base_tree: string; candidate_tree: string }; current_snapshot: { base_tree: string; candidate_tree: string }; fix_finding_ids: string[] } };
 	const statusRequests: NativeTargetStatusRequest[] = [];
 	const statusResponses: ReviewStatusV1[] = [];
 	const reloadedNative = createNativeReviewCli();
@@ -174,24 +166,42 @@ test("real binary: committed-range START with <remote>/<branch> selector → CRI
 	};
 	const reloaded = controllerFor(reloadedNative, new CandidateViewRegistry());
 	const finalResult = await reloaded.execute(
-		"proof-finalize-correction",
+		"proof-finalize-validation",
 		{
 			operation: "finalize",
 			lineageId,
-			input: JSON.stringify({ final_evidence: "Focused correction verification passed.", final_verification_passed: true }),
+			input: JSON.stringify({
+				validation: {
+					request_hash: "a".repeat(64),
+					correction_ids: ["RELIABILITY-001"],
+					original_criteria: { passed: true, evidence: ["The corrected value restores the documented invariant."] },
+					correction_regression: { passed: true, evidence: ["The committed candidate additions remain present."] },
+					fix_caused_findings: [],
+					follow_ups: [],
+				},
+				final_evidence: "Focused correction verification passed.",
+				final_verification_passed: true,
+			}),
 		},
 		context(cwd),
 	);
-	const finalDetails = (finalResult.details ?? {}) as { outcome?: string; validation_request?: { correction_candidate_tree: string; fix_finding_ids: string[]; request_hash: string } };
-	assert.equal(finalDetails.outcome, "validation-required");
+	const finalDetails = (finalResult.details ?? {}) as { result?: { state?: string; action?: string } };
+	t.diagnostic(`finalDetails: ${JSON.stringify(finalDetails)}`);
+	assert.equal(finalDetails.result?.state, "approved");
+	assert.equal(finalDetails.result?.action, "validate delivery with gentle-ai review validate --gate <gate>");
 	assert.equal(statusRequests.length, 1);
 	assert.equal(statusRequests[0]?.baseRef, "origin/main");
 	assert.notEqual(statusRequests[0]?.baseRef, git(cwd, "rev-parse", "origin/main"));
 	assert.equal(statusResponses[0]?.applicability, "current_target");
-	assert.equal(statusResponses[0]?.projection.baseTree, stateAfterFinding.state.current_snapshot.base_tree);
-	assert.equal(stateAfterFinding.state.current_snapshot.base_tree, git(cwd, "rev-parse", "origin/main^{tree}"));
-	assert.deepEqual(finalDetails.validation_request?.fix_finding_ids, ["RELIABILITY-001"]);
-	assert.notEqual(finalDetails.validation_request?.correction_candidate_tree, stateAfterFinding.state.current_snapshot.candidate_tree);
+	assert.equal(statusResponses[0]?.projection.baseTree, stateAfterFinding.state.initial_snapshot.base_tree);
+	assert.equal(stateAfterFinding.state.initial_snapshot.base_tree, git(cwd, "rev-parse", "origin/main^{tree}"));
+	assert.equal(statusResponses[0]?.projection.currentCandidateTree, stateAfterFinding.state.initial_snapshot.candidate_tree);
+	const stateAfterApproval = JSON.parse(readFileSync(statePath, "utf8")) as { state: { state: string; initial_snapshot: { base_tree: string; candidate_tree: string }; current_snapshot: { base_tree: string; candidate_tree: string } } };
+	assert.equal(stateAfterApproval.state.state, "approved");
+	assert.deepEqual(stateAfterApproval.state.initial_snapshot, stateAfterFinding.state.initial_snapshot);
+	assert.equal(stateAfterApproval.state.current_snapshot.base_tree, stateAfterFinding.state.initial_snapshot.candidate_tree);
+	assert.notEqual(stateAfterApproval.state.current_snapshot.candidate_tree, stateAfterFinding.state.initial_snapshot.candidate_tree);
+	const correctedCandidateTree = stateAfterApproval.state.current_snapshot.candidate_tree;
 
 	const proofPath = join(cwd, "e2e-proof.json");
 	writeFileSync(proofPath, `${JSON.stringify({
@@ -200,14 +210,13 @@ test("real binary: committed-range START with <remote>/<branch> selector → CRI
 		lineage: lineageId,
 		selector: statusRequests[0]?.baseRef,
 		selector_is_raw_sha: statusRequests[0]?.baseRef === git(cwd, "rev-parse", "origin/main"),
-		frozen_base_tree: stateAfterFinding.state.current_snapshot.base_tree,
+		frozen_base_tree: stateAfterFinding.state.initial_snapshot.base_tree,
 		remote_base_tree: git(cwd, "rev-parse", "origin/main^{tree}"),
-		initial_candidate_tree: stateAfterFinding.state.current_snapshot.candidate_tree,
-		corrected_candidate_tree: finalDetails.validation_request?.correction_candidate_tree,
-		transitions: ["reviewing", finalizeDetails.result?.state, forecastDetails.result?.state, finalDetails.outcome],
-		final_action: finalDetails.outcome,
+		initial_candidate_tree: stateAfterFinding.state.initial_snapshot.candidate_tree,
+		corrected_candidate_tree: correctedCandidateTree,
+		transitions: ["reviewing", finalizeDetails.state, forecastDetails.state, finalDetails.result?.state],
+		final_action: finalDetails.result?.action,
 		fix_finding_ids: stateAfterFinding.state.fix_finding_ids,
-		validation_request_hash: finalDetails.validation_request?.request_hash,
 	}, null, 2)}\n`);
 	t.diagnostic(`proof artifact: ${proofPath}`);
 });


### PR DESCRIPTION
## Linked Issue

Fixes #139

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Restores base-diff candidate views after controller reload without rejecting expected HEAD drift.
- Resolves the unique `<remote>/<current-branch>` selector whose tree matches the frozen base and fails closed on zero, mismatched, or multiple matches.
- Proves the correction flow against the integrity-verified package-local Gentle AI v2.1.8 binary.

## Changes

| File | Change |
|---|---|
| `extensions/gentle-ai.ts` | Reconstruct restart-safe base-diff FINALIZE routing and preserve native v2.1.8 status semantics. |
| `lib/native-review-cli.ts` | Forward the frozen review projection during native START. |
| `lib/review-candidate-view.ts` | Model and materialize base-diff projections from committed HEAD plus workspace correction. |
| `tests/review-candidate-view.test.ts` | Cover base-diff restoration and committed-file preservation. |
| `tests/review-controller-native-routing.test.ts` | Cover symbolic selector resolution and fail-closed edge cases. |
| `tests/review-proof-real-flow.test.ts` | Add real-binary restart/correction proof against Gentle AI v2.1.8. |

## Test Plan

- [x] `tests/review-candidate-view.test.ts`: 30 passed, 0 failed.
- [x] `tests/review-controller-native-routing.test.ts`: 149 passed, 0 failed.
- [x] `tests/review-proof-real-flow.test.ts`: 1 passed, 0 failed using package-local Gentle AI v2.1.8.
- [x] Combined focused verification: 180 passed, 0 failed.
- [x] Bounded 4R review approved: `review-354c708d44dec941`.
- [x] Native `pre-commit`, `pre-push`, and `pre-pr` gates allowed the exact content-bound receipt.
- [x] Shellcheck: N/A; no shell scripts changed.

## Size Exception

This focused work unit is 568 reviewed changed lines because production routing, candidate materialization, fail-closed regression cases, and the real-binary proof are one rollback boundary. Approved umbrella issue #139 explicitly authorizes the size exception; tests remain with the behavior they verify.

## Chain Context

```text
main
 ├─ PR1 runtime base-diff hotfix 📍
 └─ PR2 OpenSpec archive + synced specs (created after PR1 merges)
```

**Start state:** current `main` cannot resume this base-diff correction flow after reload.  
**End state:** symbolic selector recovery and corrected-candidate materialization pass against v2.1.8.  
**Dependency:** PR2 starts from `main` only after this PR merges.  
**Out of scope:** OpenSpec archive/spec synchronization; delivered in PR2.  
**Rollback:** revert the two commits in this PR; no unrelated runtime or documentation path is removed.

## Contributor Checklist

- [x] Linked approved issue #139.
- [x] Added exactly one `type:*` label (`type:bug`).
- [x] Kept tests with the behavior they verify.
- [x] Used conventional commits.
- [x] Added no AI attribution or `Co-Authored-By` trailers.
- [x] Documentation/archive work is isolated to PR2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reviewing changes against an explicit base-diff projection.
  - Native review starts now support workspace projections.
  - Review restoration and finalization can recover the correct branch-based comparison context.

- **Bug Fixes**
  - Improved validation of staged changes and candidate trees.
  - Finalization now fails safely when the correct branch reference cannot be resolved.
  - Improved handling of workspace corrections, committed ranges, and restored review state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->