### PR TITLE
fix(review): surface pre-pr binding failures

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4307,7 +4307,9 @@ function nativeOperationFailure(operation: ReviewControllerOperation, error: unk
 		? nativeDiagnostics
 		: operation === REVIEW_CONTROLLER_OPERATION.START && error instanceof CandidateViewError && value.candidateViewPreNative === true
 			? { code: error.reason, message: "candidate view rejected before native START" }
-			: undefined;
+			: operation === REVIEW_CONTROLLER_OPERATION.VALIDATE && mutationOutcome === "none" && error instanceof Error
+				? { code: "lifecycle-command-binding-failed", message: error.message }
+				: undefined;
 	return {
 		operation,
 		status: "blocked",

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1973,6 +1973,61 @@ test("native pre-PR validation uses and binds the exact advertised ordinary base
 	assert.equal(validates, 2);
 });
 
+test("native pre-PR validation accepts slash-containing head branch names", async (t) => {
+	const cwd = repository(t);
+	const origin = addBareRemote(t, cwd, "origin");
+	const baseCommit = git(cwd, "rev-parse", "main");
+	execFileSync("git", ["checkout", "-b", "feat/slash-head"], { cwd });
+	commitFile(cwd, "feature.ts", "export const feature = true;\n", "feature");
+	const headCommit = git(cwd, "rev-parse", "HEAD");
+	git(cwd, "push", "origin", "feat/slash-head:refs/heads/feat/slash-head");
+	git(cwd, "config", "branch.feat/slash-head.pushRemote", "origin");
+	const requests: Array<{ flags?: readonly string[] }> = [];
+	const boundary = { selector: "origin/main", remote: "origin", remoteRef: "refs/heads/main", commit: baseCommit, remoteIdentity: remoteIdentity(origin) };
+	const { controller, toolCall } = runtime(fakeNative({
+		validate: async (request) => {
+			requests.push(request);
+			return { allowed: true, result: "allow", action: "continue", reason: "ok", gateContext: nativePrePrGateContext(boundary) };
+		},
+	}));
+	const command = "gh pr create --base main --head feat/slash-head";
+	const validated = await controller.execute("slash-head", { operation: "validate", lineageId: "native-lineage", idempotencyKey: "slash-head", command, input: "{}" }, undefined, undefined, context(cwd));
+	assert.notEqual((validated.details as { authorization?: unknown }).authorization, undefined);
+	assert.deepEqual(requests[0]?.flags, ["--base-ref", "origin/main"]);
+	assert.equal(await toolCall({ toolName: "bash", input: { command } }, context(cwd)), undefined);
+	assert.equal(headCommit, git(cwd, "rev-parse", "HEAD"));
+});
+
+test("native pre-PR validation accepts slash head with repo, title, body-file, and label options", async (t) => {
+	const cwd = repository(t);
+	const origin = addBareRemote(t, cwd, "origin");
+	git(cwd, "remote", "set-url", "origin", "git@github.com:agongar-dev/itaas-workbench.git");
+	git(cwd, "config", "remote.origin.gh-resolved", "base");
+	const baseCommit = git(cwd, "rev-parse", "main");
+	execFileSync("git", ["checkout", "-b", "feat/slash-head"], { cwd });
+	commitFile(cwd, "feature.ts", "export const feature = true;\n", "feature");
+	const headCommit = git(cwd, "rev-parse", "HEAD");
+	git(cwd, "push", origin, "feat/slash-head:refs/heads/feat/slash-head");
+	git(cwd, "config", "branch.feat/slash-head.pushRemote", "origin");
+	const requests: Array<{ flags?: readonly string[] }> = [];
+	const boundary = { selector: "origin/main", remote: "origin", remoteRef: "refs/heads/main", commit: baseCommit, remoteIdentity: remoteIdentity("git@github.com:agongar-dev/itaas-workbench.git") };
+	const probe = queuedPublicationProbe({
+		["git@github.com:agongar-dev/itaas-workbench.git refs/heads/main"]: baseCommit,
+		["git@github.com:agongar-dev/itaas-workbench.git refs/heads/feat/slash-head"]: headCommit,
+	});
+	const { controller, toolCall } = runtime(fakeNative({
+		validate: async (request) => {
+			requests.push(request);
+			return { allowed: true, result: "allow", action: "continue", reason: "ok", gateContext: nativePrePrGateContext(boundary) };
+		},
+	}), probe);
+	const command = "gh pr create --repo agongar-dev/itaas-workbench --base main --head feat/slash-head --title \"feat(test): slash head\" --body-file /tmp/body.md --label type:feature";
+	const validated = await controller.execute("slash-head-full", { operation: "validate", lineageId: "native-lineage", idempotencyKey: "slash-head-full", command, input: "{}" }, undefined, undefined, context(cwd));
+	assert.notEqual((validated.details as { authorization?: unknown }).authorization, undefined);
+	assert.deepEqual(requests[0]?.flags, ["--base-ref", "origin/main"]);
+	assert.equal(await toolCall({ toolName: "bash", input: { command } }, context(cwd)), undefined);
+});
+
 test("native pre-PR derives fork and chained bases from the gh repository context", async (t) => {
 	await t.test("fork", async (t) => {
 		const cwd = repository(t);
@@ -2497,7 +2552,10 @@ test("native pre-PR rejects missing, stale, and divergent advertised remote head
 				return { allowed: true, result: "allow", action: "continue", reason: "ok", gateContext: nativeGateContext() };
 			} }));
 			const result = await controller.execute(shape, { operation: "validate", lineageId: "native-lineage", idempotencyKey: shape, command: "gh pr create --base main --head feature", input: "{}" }, undefined, undefined, context(cwd));
-			assert.equal((result.details as { authorization?: unknown }).authorization, undefined);
+			const details = result.details as { authorization?: unknown; diagnostics?: { code?: string; message?: string } };
+			assert.equal(details.authorization, undefined);
+			assert.equal(details.diagnostics?.code, "lifecycle-command-binding-failed");
+			assert.match(details.diagnostics?.message ?? "", /advertised (?:head|pull request head)/i);
 			assert.equal(validates, 0);
 		});
 	}


### PR DESCRIPTION
## Linked issue

Closes #201

Related downstream report: agongar-dev/itaas-workbench#28

## Type

- [x] Bug fix (`type:bug`)

## Summary

- Adds regression coverage proving `gh pr create --head feat/...` branch names are accepted by pre-PR lifecycle binding.
- Adds coverage for the full command shape with `--repo`, `--title`, `--body-file`, and `--label`.
- Surfaces validate-time lifecycle binding failures as structured `lifecycle-command-binding-failed` diagnostics instead of only generic `native-operation-failed`.

## Test plan

- [x] `node --experimental-strip-types --test /home/agonzalez/dev/gentle-pi/tests/review-controller-native-routing.test.ts --test-name-pattern "slash head with repo|slash-containing head|missing, stale"`
- [x] `pnpm --dir /home/agonzalez/dev/gentle-pi test`

## Reviewer notes

The original downstream hypothesis was that `/` in `--head` caused the PR lifecycle failure. The new regression tests disprove that: slash-containing head branches already authorize correctly. The actual fix is diagnostic clarity for pre-native binding failures, so the next failure reports the concrete advertised-head/topology problem.

## Contributor checklist

- [x] Linked an issue.
- [x] Conventional commit format.
- [x] PR is scoped to one reviewable work unit.
- [x] Tests/checks above pass.
- [x] No unrelated files are included.
- [x] No `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error reporting when advertised pull request branches are missing, stale, or divergent.
  * Added clear diagnostics for lifecycle command binding failures.
  * Fixed validation for branch names containing slashes, including commands with repository, title, body-file, and label options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->