### PR TITLE
fix(review): preserve absent gitlinks in snapshots

### DIFF
--- a/lib/review-snapshot.ts
+++ b/lib/review-snapshot.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
+	lstatSync,
 	mkdtempSync,
 	mkdirSync,
 	readFileSync,
@@ -153,11 +154,7 @@ export interface CorrectionSnapshotV1 {
 
 const OBJECT_ID = /^[0-9a-f]{40,64}$/;
 
-function runGit(
-	cwd: string,
-	args: readonly string[],
-	environment: GitEnvironment = {},
-): string {
+function gitEnvironment(environment: GitEnvironment): NodeJS.ProcessEnv {
 	const env = reviewGitEnvironment();
 	if (environment.indexFile) env.GIT_INDEX_FILE = environment.indexFile;
 	if (environment.objectDirectory) {
@@ -166,12 +163,34 @@ function runGit(
 	if (environment.alternateObjectDirectory) {
 		env.GIT_ALTERNATE_OBJECT_DIRECTORIES = environment.alternateObjectDirectory;
 	}
+	return env;
+}
+
+function runGit(
+	cwd: string,
+	args: readonly string[],
+	environment: GitEnvironment = {},
+	input?: Uint8Array,
+): string {
 	return execFileSync("git", args, {
 		cwd,
 		encoding: "utf8",
-		stdio: ["ignore", "pipe", "pipe"],
-		env,
+		stdio: [input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+		env: gitEnvironment(environment),
+		input,
 	}).trim();
+}
+
+function runGitBytes(
+	cwd: string,
+	args: readonly string[],
+	environment: GitEnvironment = {},
+): Buffer {
+	return execFileSync("git", args, {
+		cwd,
+		stdio: ["ignore", "pipe", "pipe"],
+		env: gitEnvironment(environment),
+	});
 }
 
 function repositoryRoot(cwd: string): string {
@@ -243,6 +262,48 @@ export function discoverReviewUntrackedPaths(cwd: string): string[] {
 	return canonicalPaths(runGit(root, ["ls-files", "--others", "--exclude-standard", "-z"]));
 }
 
+function absentLiveIndexGitlinks(root: string): Buffer[] {
+	const output = runGitBytes(root, ["ls-files", "--stage", "-z"]);
+	const records: Buffer[] = [];
+	let start = 0;
+	while (start < output.length) {
+		const end = output.indexOf(0, start);
+		if (end < 0) throw new Error("Git returned a malformed NUL-delimited index entry");
+		const entry = output.subarray(start, end);
+		start = end + 1;
+		const tab = entry.indexOf(0x09);
+		if (tab < 0) throw new Error("Git returned a malformed staged index entry");
+		const header = entry.subarray(0, tab).toString("ascii").split(" ");
+		if (header.length !== 3) throw new Error("Git returned a malformed staged index header");
+		const [mode, oid, stage] = header;
+		const path = entry.subarray(tab + 1);
+		if (mode !== "160000" || stage !== "0") continue;
+		const worktreePath = Buffer.concat([Buffer.from(`${root}${sep}`), path]);
+		if (lstatSync(worktreePath, { throwIfNoEntry: false }) !== undefined) continue;
+		records.push(Buffer.concat([Buffer.from(`${mode} ${oid}\t`), path, Buffer.from([0])]));
+	}
+	return records;
+}
+
+function stageCompleteWorkspace(
+	root: string,
+	baseTree: string,
+	environment: GitEnvironment,
+): string {
+	const absentGitlinks = absentLiveIndexGitlinks(root);
+	runGit(root, ["read-tree", baseTree], environment);
+	runGit(root, ["add", "-A", "--", "."], environment);
+	if (absentGitlinks.length > 0) {
+		runGit(
+			root,
+			["update-index", "-z", "--index-info"],
+			environment,
+			Buffer.concat(absentGitlinks),
+		);
+	}
+	return runGit(root, ["write-tree"], environment);
+}
+
 export function deriveReviewSnapshotRisk(snapshot: SnapshotV1): ReviewRiskClassification {
 	const root = repositoryRoot(snapshot.repository_root);
 	const environment: GitEnvironment = {
@@ -303,9 +364,7 @@ export function captureLiveReviewCandidateBinding(options: {
 	};
 	try {
 		const baseTree = resolveBaseTree(root);
-		runGit(root, ["read-tree", baseTree], environment);
-		runGit(root, ["add", "-A", "--", "."], environment);
-		const completeSnapshotTree = runGit(root, ["write-tree"], environment);
+		const completeSnapshotTree = stageCompleteWorkspace(root, baseTree, environment);
 		return {
 			repository_id: options.repositoryId,
 			base_tree: baseTree,
@@ -345,9 +404,7 @@ export function captureReviewSnapshot(
 		alternateObjectDirectory,
 	};
 	try {
-		runGit(root, ["read-tree", baseTree], gitEnvironment);
-		runGit(root, ["add", "-A", "--", "."], gitEnvironment);
-		const completeSnapshotTree = runGit(root, ["write-tree"], gitEnvironment);
+		const completeSnapshotTree = stageCompleteWorkspace(root, baseTree, gitEnvironment);
 		const intendedUntracked = discoverReviewUntrackedPaths(root);
 		let projection: ReviewProjectionV1;
 		let initialReviewTree: string;

--- a/tests/review-snapshot.test.ts
+++ b/tests/review-snapshot.test.ts
@@ -86,6 +86,32 @@ function createRepository(t: test.TestContext): {
 	return { repository, git };
 }
 
+function commitGitlinks(
+	git: (...args: string[]) => string,
+	entries: ReadonlyArray<{ path: string; oid: string }>,
+): void {
+	for (const entry of entries) {
+		git("update-index", "--add", "--cacheinfo", "160000", entry.oid, entry.path);
+	}
+	git(
+		"-c",
+		"user.name=Gentle Pi Tests",
+		"-c",
+		"user.email=gentle-pi@example.invalid",
+		"commit",
+		"-m",
+		"add gitlinks",
+	);
+}
+
+function treeEntry(
+	git: (...args: string[]) => string,
+	tree: string,
+	path: string,
+): string {
+	return git("ls-tree", tree, "--", path);
+}
+
 test("complete snapshot captures the repository root from a nested cwd without mutating index or worktree", (t) => {
 	const { repository, git } = createRepository(t);
 	const nested = join(repository, "packages", "app");
@@ -126,6 +152,114 @@ test("complete snapshot captures the repository root from a nested cwd without m
 	);
 	assert.deepEqual(readFileSync(indexPath), indexBefore);
 	assert.equal(git("status", "--porcelain=v1", "--untracked-files=all"), statusBefore);
+});
+
+test("complete snapshot retains multiple absent clean gitlinks without reporting them as changed", (t) => {
+	const { repository, git } = createRepository(t);
+	const gitlinkOid = git("rev-parse", "HEAD");
+	commitGitlinks(git, [
+		{ path: "vendor/alpha", oid: gitlinkOid },
+		{ path: "vendor/path with spaces", oid: gitlinkOid },
+	]);
+	writeFileSync(join(repository, "tracked.txt"), "working tree\n");
+	const indexPath = join(git("rev-parse", "--absolute-git-dir"), "index");
+	const indexBefore = readFileSync(indexPath);
+
+	const snapshot = captureReviewSnapshot({
+		cwd: repository,
+		mode: REVIEW_MODE.ORDINARY,
+		projection: { kind: REVIEW_PROJECTION.COMPLETE },
+		policyHash: "1".repeat(64),
+	});
+
+	assert.equal(
+		treeEntry(snapshotGit.bind(undefined, snapshot), snapshot.complete_snapshot_tree, "vendor/alpha"),
+		`160000 commit ${gitlinkOid}\tvendor/alpha`,
+	);
+	assert.equal(
+		treeEntry(snapshotGit.bind(undefined, snapshot), snapshot.complete_snapshot_tree, "vendor/path with spaces"),
+		`160000 commit ${gitlinkOid}\tvendor/path with spaces`,
+	);
+	assert.deepEqual(snapshot.genesis_paths, ["tracked.txt"]);
+	assert.deepEqual(readFileSync(indexPath), indexBefore);
+});
+
+test("ephemeral live candidate binding retains absent clean gitlinks", (t) => {
+	const { repository, git } = createRepository(t);
+	const gitlinkOid = git("rev-parse", "HEAD");
+	commitGitlinks(git, [
+		{ path: "vendor/alpha", oid: gitlinkOid },
+		{ path: "vendor/path with spaces", oid: gitlinkOid },
+	]);
+	const indexPath = join(git("rev-parse", "--absolute-git-dir"), "index");
+	const indexBefore = readFileSync(indexPath);
+
+	const binding = captureLiveReviewCandidateBinding({
+		cwd: repository,
+		repositoryId: "repository-authority-id",
+	});
+
+	assert.equal(binding.complete_snapshot_tree, binding.base_tree);
+	assert.deepEqual(binding.genesis_paths, []);
+	assert.deepEqual(readFileSync(indexPath), indexBefore);
+});
+
+test("staged deletion of an absent gitlink remains deleted in the complete snapshot", (t) => {
+	const { repository, git } = createRepository(t);
+	const gitlinkOid = git("rev-parse", "HEAD");
+	commitGitlinks(git, [{ path: "vendor/deleted", oid: gitlinkOid }]);
+	git("update-index", "--force-remove", "vendor/deleted");
+
+	const snapshot = captureReviewSnapshot({
+		cwd: repository,
+		mode: REVIEW_MODE.ORDINARY,
+		projection: { kind: REVIEW_PROJECTION.COMPLETE },
+		policyHash: "2".repeat(64),
+	});
+
+	assert.equal(treeEntry(snapshotGit.bind(undefined, snapshot), snapshot.complete_snapshot_tree, "vendor/deleted"), "");
+	assert.deepEqual(snapshot.genesis_paths, ["vendor/deleted"]);
+});
+
+test("present submodule checkout at another commit captures the worktree gitlink OID", (t) => {
+	const { repository, git } = createRepository(t);
+	const originalOid = git("rev-parse", "HEAD");
+	commitGitlinks(git, [{ path: "vendor/present", oid: originalOid }]);
+	const submodule = join(repository, "vendor", "present");
+	mkdirSync(submodule, { recursive: true });
+	const submoduleGit = (...args: string[]): string =>
+		execFileSync("git", args, {
+			cwd: submodule,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		}).trim();
+	submoduleGit("init", "-b", "main");
+	writeFileSync(join(submodule, "content.txt"), "new commit\n");
+	submoduleGit("add", "content.txt");
+	submoduleGit(
+		"-c",
+		"user.name=Gentle Pi Tests",
+		"-c",
+		"user.email=gentle-pi@example.invalid",
+		"commit",
+		"-m",
+		"new submodule commit",
+	);
+	const newOid = submoduleGit("rev-parse", "HEAD");
+
+	const snapshot = captureReviewSnapshot({
+		cwd: repository,
+		mode: REVIEW_MODE.ORDINARY,
+		projection: { kind: REVIEW_PROJECTION.COMPLETE },
+		policyHash: "3".repeat(64),
+	});
+
+	assert.notEqual(newOid, originalOid);
+	assert.equal(
+		treeEntry(snapshotGit.bind(undefined, snapshot), snapshot.complete_snapshot_tree, "vendor/present"),
+		`160000 commit ${newOid}\tvendor/present`,
+	);
+	assert.deepEqual(snapshot.genesis_paths, ["vendor/present"]);
 });
 
 test("ephemeral live candidate binding derives the complete candidate without retaining a snapshot", (t) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review snapshot accuracy for repositories containing gitlinks or submodules.
  * Preserved multiple absent-but-clean gitlinks in complete snapshots.
  * Correctly retained staged deletions and detected checked-out submodule revisions.
  * Ensured snapshot capture does not unintentionally alter the Git index or worktree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->