### PR TITLE
feat(review): enhance diagnostic propagation for negotiated failures

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -105,6 +105,7 @@ import {
 	nativeReviewLegacyQuarantineAuthorization,
 	nativeReviewReconcileAuthorization,
 	NativeReviewCliError,
+	NativeReviewIntegrationError,
 	NATIVE_REVIEW_ERROR_CODE,
 	NATIVE_REVIEW_LEGACY_QUARANTINE,
 	NATIVE_REVIEW_LEGACY_ALIAS_REPAIR,
@@ -3836,11 +3837,13 @@ function nativeStatusUnsupported(operation: ReviewControllerOperation): Record<s
 // Bundled and source module instances can coexist, making instanceof insufficient.
 function asNativeReviewCliError(error: unknown): { code: string; diagnostics: NativeReviewProcessDiagnostics } | undefined {
 	if (error instanceof NativeReviewCliError) return error;
-	if (!(error instanceof Error) || error.name !== "NativeReviewCliError") return undefined;
+	if (error instanceof NativeReviewIntegrationError) return { code: error.diagnostics.error_code, diagnostics: error.diagnostics };
+	if (!(error instanceof Error) || !["NativeReviewCliError", "NativeReviewIntegrationError"].includes(error.name)) return undefined;
 	const value = error as unknown as { code?: unknown; diagnostics?: unknown };
-	if (typeof value.code !== "string") return undefined;
 	const diagnostics = sanitizeForeignNativeReviewDiagnostics(value.diagnostics);
-	return diagnostics === undefined || value.code !== diagnostics.error_code ? undefined : { code: value.code, diagnostics };
+	if (diagnostics === undefined) return undefined;
+	if (error.name === "NativeReviewIntegrationError") return { code: diagnostics.error_code, diagnostics };
+	return typeof value.code === "string" && value.code === diagnostics.error_code ? { code: value.code, diagnostics } : undefined;
 }
 
 function nativeStatusFailed(operation: ReviewControllerOperation, error: unknown): Record<string, unknown> {
@@ -4387,28 +4390,28 @@ function nativeStartRejection(reason: string, field?: string): Record<string, un
 
 function nativeOperationFailure(operation: ReviewControllerOperation, error: unknown): Record<string, unknown> {
 	const value = error as { mutationOutcome?: unknown; nextAction?: unknown; diagnostics?: unknown; auditRecord?: unknown; launchAttempted?: unknown; candidateViewPreNative?: unknown; failureEnvelope?: { raw?: unknown; mutationOutcome?: unknown; replayability?: unknown; nextAction?: unknown } };
-	if (isRecord(value.failureEnvelope) && isRecord(value.failureEnvelope.raw)) {
-		const mutationOutcome = value.failureEnvelope.mutationOutcome;
-		return {
-			operation,
-			status: "blocked",
-			native_failure: value.failureEnvelope.raw,
-			...(mutationOutcome === "committed"
-				? { mutation_performed: true, mutation_outcome: "committed" }
-				: mutationOutcome === "unknown"
-					? { mutation_outcome: "unknown" }
-					: { mutation_performed: false, mutation_outcome: "none" }),
-			...(typeof value.failureEnvelope.replayability === "string" ? { replayability: value.failureEnvelope.replayability } : {}),
-			...(typeof value.failureEnvelope.nextAction === "string" ? { next_action: value.failureEnvelope.nextAction } : {}),
-		};
-	}
-	const mutationOutcome = value.mutationOutcome === "unknown" ? "unknown" : "none";
 	const nativeDiagnostics = asNativeReviewCliError(error)?.diagnostics;
 	const diagnostics = nativeDiagnostics?.operation === `review/${operation}`
 		? nativeDiagnostics
 		: operation === REVIEW_CONTROLLER_OPERATION.START && error instanceof CandidateViewError && value.candidateViewPreNative === true
 			? { code: error.reason, message: "candidate view rejected before native START" }
 			: undefined;
+	if (isRecord(value.failureEnvelope) && isRecord(value.failureEnvelope.raw)) {
+		const mutationOutcome = value.failureEnvelope.mutationOutcome;
+		return {
+			operation,
+			status: "blocked",
+			...(mutationOutcome === "committed"
+				? { mutation_performed: true, mutation_outcome: "committed" }
+				: mutationOutcome === "unknown"
+					? { mutation_outcome: "unknown" }
+					: { mutation_performed: false, mutation_outcome: "none" }),
+			...(diagnostics === undefined ? {} : { diagnostics }),
+			...(typeof value.failureEnvelope.replayability === "string" ? { replayability: value.failureEnvelope.replayability } : {}),
+			...(typeof value.failureEnvelope.nextAction === "string" ? { next_action: value.failureEnvelope.nextAction } : {}),
+		};
+	}
+	const mutationOutcome = value.mutationOutcome === "unknown" ? "unknown" : "none";
 	return {
 		operation,
 		status: "blocked",

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -1182,13 +1182,15 @@ export class NativeReviewIntegrationError extends Error {
 	readonly failureEnvelope: ReviewFailureV1;
 	readonly mutationOutcome: ReviewFailureV1["mutationOutcome"];
 	readonly nextAction: string;
+	readonly diagnostics: NativeReviewProcessDiagnostics;
 	readonly launchAttempted = true;
-	constructor(failure: ReviewFailureV1) {
+	constructor(failure: ReviewFailureV1, diagnostics: NativeReviewProcessDiagnostics) {
 		super(failure.message);
 		this.name = "NativeReviewIntegrationError";
 		this.failureEnvelope = failure;
 		this.mutationOutcome = failure.mutationOutcome;
 		this.nextAction = failure.nextAction;
+		this.diagnostics = diagnostics;
 	}
 }
 
@@ -1285,7 +1287,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
 		if (result.exitCode !== 0) {
 			try {
-				throw new NativeReviewIntegrationError(decodeReviewFailureV1(body));
+				throw new NativeReviewIntegrationError(decodeReviewFailureV1(body), diagnostics);
 			} catch (error) {
 				if (error instanceof NativeReviewIntegrationError) throw error;
 				throw nativeError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, operation, mutating, "native negotiated operation failed without a valid failure envelope", result);

--- a/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/README.md
+++ b/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/README.md
@@ -1,0 +1,37 @@
+# Review diagnostic propagation handoff
+
+The Pi adapter repair is proven: after verified package-local Gentle AI v2.1.11 provisioning, local provider inspection succeeds and an authorized fresh ordinary START returns a sanitized provider diagnostic. The raw negotiated failure payload is not exposed.
+
+## Review first
+
+1. Read `patch.diff` for the four-file repair.
+2. Run the test-only reproduction in `reproduction.md` from a source checkout.
+3. Check `validation.md` before treating the installed package as validated.
+
+## Impact and decision
+
+| Topic | Maintainer conclusion |
+| --- | --- |
+| Impact | A caller receives the operation-scoped, sanitized provider diagnostic needed to explain a failed negotiated START reconciliation. |
+| Pi adapter conclusion | Repaired and proven: the post-install ordinary START reports only the sanitized `review/start` diagnostic captured in `observed-start-failure.json`. |
+| Remaining native root failure | Gentle AI v2.1.11 emits only the generic `non-zero` / `operation_outcome_unknown` diagnostic. Native maintainers must add stage-level sanitized failure evidence. |
+| Repair invariant | For a negotiated unknown START reconciled to `start` with no lineage, expose only sanitized diagnostics for `review/start`; never expose `native_failure` or raw payload content. |
+| Source base | `v1.2.0` at `113906a34c1b527ba2d65806b7638bff32b8e916`. |
+| Source branch | `fix/review-diagnostic-propagation` at `4d5214b410d352712be20917e81f9ce5974d039a`, with the repair present as working-tree changes. |
+
+## Evidence boundary
+
+**Proven:** the focused source regression passes; package-local Gentle AI v2.1.11 provisioning was verified; local provider inspection succeeds; and the authorized fresh ordinary START returned the sanitized diagnostic recorded in `observed-start-failure.json`.
+
+**Native escalation required:** the remaining native failure is generic (`non-zero` / `operation_outcome_unknown`) and lacks stage-level sanitized failure evidence. Native maintainers must add that evidence before the root cause can be diagnosed.
+
+**Authority boundary:** status reconciliation reports no lineage and action `start`. No replay is safe, and this evidence cannot authorize a commit. This bundle does not authorize creating, replaying, or inspecting a real review lineage.
+
+## Tracker paths
+
+- Upstream tracker #122: [`../122-receipt-tree-path-diagnostics.md`](../122-receipt-tree-path-diagnostics.md)
+- Gentle AI #1248 mapping: [`../README.md`](../README.md) (the #122 row)
+
+## Safety statement
+
+This bundle contains no private authority material, credentials, tokens, native receipts, real review snapshots, target values, repository identities, or user identities. `patch.diff` redacts a test-only sentinel value and excludes this handoff directory, so it is a review artifact rather than an apply-ready patch.

--- a/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/manifest.json
+++ b/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/manifest.json
@@ -1,0 +1,49 @@
+{
+  "schema": "gentle-pi.maintainer-handoff/v1",
+  "purpose": "Sanitized evidence bundle for review diagnostic propagation",
+  "source": {
+    "base_ref": "v1.2.0",
+    "base_revision": "113906a34c1b527ba2d65806b7638bff32b8e916",
+    "branch": "fix/review-diagnostic-propagation",
+    "head_revision": "4d5214b410d352712be20917e81f9ce5974d039a"
+  },
+  "files": [
+    {
+      "path": "README.md",
+      "sha256": "56841d9ce241ace7ff72e254c21e0eb209f063e77795e9b2b648f056d5369450"
+    },
+    {
+      "path": "reproduction.md",
+      "sha256": "16a7cf27845836964ad1226e83716a633fa91840119e3229c154de5f710aab3c"
+    },
+    {
+      "path": "validation.md",
+      "sha256": "9064474c6af33db2818cc24e615c1ad54c5ce5bbafa59355dbcee80b53b15543"
+    },
+    {
+      "path": "observed-start-failure.json",
+      "sha256": "c2cc93f07cc7a4189a4e041876446cdba7c73551d777963859f997d88849a4ae"
+    },
+    {
+      "path": "patch.diff",
+      "sha256": "04adf42c47708da212ba011b81764782629fa173ce9ee42552cbc8202379cbea"
+    },
+    {
+      "path": "reference/failure.schema.json",
+      "sha256": "11284601a00e0192c41b1f3aab0b153635e28ad57ec5f1e2e90a69d129296c44"
+    },
+    {
+      "path": "reference/failure.fixture.json",
+      "sha256": "e72b6ab5e3c529abac47bd324444f84ca90f67ef0a67189f5fd8d24d199a2759"
+    }
+  ],
+  "exclusions": [
+    "The handoff directory itself is excluded from patch.diff.",
+    "Untracked files and dependency directories are excluded from patch.diff.",
+    "manifest.json is excluded from the digest list because self-hashing is recursive.",
+    "No user paths, Git remotes, private authority data, real snapshots, credentials, or tokens are included.",
+    "The test-only sensitive sentinel in patch.diff is redacted; patch.diff is not apply-ready."
+  ],
+  "expected_invariant": "For a negotiated unknown review/start failure reconciled to start without a lineage, return only sanitized review/start diagnostics and never expose native_failure or raw failure-envelope content.",
+  "installed_validation": "Verified package-local Gentle AI v2.1.11 provisioning permits successful local provider inspection. A fresh ordinary START returned only the sanitized review/start non-zero operation_outcome_unknown diagnostic in observed-start-failure.json; reconciliation reported no lineage and action start. This proves Pi adapter propagation, not the native root cause. No replay is safe and this evidence cannot authorize a commit."
+}

--- a/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/observed-start-failure.json
+++ b/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/observed-start-failure.json
@@ -1,0 +1,14 @@
+{
+  "provider_diagnostic": {
+    "operation": "review/start",
+    "error_code": "non-zero",
+    "exit_code": 1,
+    "timeout": false,
+    "output_limit": false,
+    "stderr": "Error: The negotiated review operation failed without authoritative mutation evidence. [operation_outcome_unknown]"
+  },
+  "status_reconciliation": {
+    "lineage": null,
+    "action": "start"
+  }
+}

--- a/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/patch.diff
+++ b/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/patch.diff
@@ -1,0 +1,166 @@
+diff --git a/extensions/gentle-ai.ts b/extensions/gentle-ai.ts
+index c6c7ac91..dc2f1439 100644
+--- a/extensions/gentle-ai.ts
++++ b/extensions/gentle-ai.ts
+@@ -105,6 +105,7 @@ import {
+ 	nativeReviewLegacyQuarantineAuthorization,
+ 	nativeReviewReconcileAuthorization,
+ 	NativeReviewCliError,
++	NativeReviewIntegrationError,
+ 	NATIVE_REVIEW_ERROR_CODE,
+ 	NATIVE_REVIEW_LEGACY_QUARANTINE,
+ 	NATIVE_REVIEW_LEGACY_ALIAS_REPAIR,
+@@ -3836,11 +3837,13 @@ function nativeStatusUnsupported(operation: ReviewControllerOperation): Record<s
+ // Bundled and source module instances can coexist, making instanceof insufficient.
+ function asNativeReviewCliError(error: unknown): { code: string; diagnostics: NativeReviewProcessDiagnostics } | undefined {
+ 	if (error instanceof NativeReviewCliError) return error;
+-	if (!(error instanceof Error) || error.name !== "NativeReviewCliError") return undefined;
++	if (error instanceof NativeReviewIntegrationError) return { code: error.diagnostics.error_code, diagnostics: error.diagnostics };
++	if (!(error instanceof Error) || !["NativeReviewCliError", "NativeReviewIntegrationError"].includes(error.name)) return undefined;
+ 	const value = error as unknown as { code?: unknown; diagnostics?: unknown };
+-	if (typeof value.code !== "string") return undefined;
+ 	const diagnostics = sanitizeForeignNativeReviewDiagnostics(value.diagnostics);
+-	return diagnostics === undefined || value.code !== diagnostics.error_code ? undefined : { code: value.code, diagnostics };
++	if (diagnostics === undefined) return undefined;
++	if (error.name === "NativeReviewIntegrationError") return { code: diagnostics.error_code, diagnostics };
++	return typeof value.code === "string" && value.code === diagnostics.error_code ? { code: value.code, diagnostics } : undefined;
+ }
+ 
+ function nativeStatusFailed(operation: ReviewControllerOperation, error: unknown): Record<string, unknown> {
+@@ -4387,28 +4390,28 @@ function nativeStartRejection(reason: string, field?: string): Record<string, un
+ 
+ function nativeOperationFailure(operation: ReviewControllerOperation, error: unknown): Record<string, unknown> {
+ 	const value = error as { mutationOutcome?: unknown; nextAction?: unknown; diagnostics?: unknown; auditRecord?: unknown; launchAttempted?: unknown; candidateViewPreNative?: unknown; failureEnvelope?: { raw?: unknown; mutationOutcome?: unknown; replayability?: unknown; nextAction?: unknown } };
++	const nativeDiagnostics = asNativeReviewCliError(error)?.diagnostics;
++	const diagnostics = nativeDiagnostics?.operation === `review/${operation}`
++		? nativeDiagnostics
++		: operation === REVIEW_CONTROLLER_OPERATION.START && error instanceof CandidateViewError && value.candidateViewPreNative === true
++			? { code: error.reason, message: "candidate view rejected before native START" }
++			: undefined;
+ 	if (isRecord(value.failureEnvelope) && isRecord(value.failureEnvelope.raw)) {
+ 		const mutationOutcome = value.failureEnvelope.mutationOutcome;
+ 		return {
+ 			operation,
+ 			status: "blocked",
+-			native_failure: value.failureEnvelope.raw,
+ 			...(mutationOutcome === "committed"
+ 				? { mutation_performed: true, mutation_outcome: "committed" }
+ 				: mutationOutcome === "unknown"
+ 					? { mutation_outcome: "unknown" }
+ 					: { mutation_performed: false, mutation_outcome: "none" }),
++			...(diagnostics === undefined ? {} : { diagnostics }),
+ 			...(typeof value.failureEnvelope.replayability === "string" ? { replayability: value.failureEnvelope.replayability } : {}),
+ 			...(typeof value.failureEnvelope.nextAction === "string" ? { next_action: value.failureEnvelope.nextAction } : {}),
+ 		};
+ 	}
+ 	const mutationOutcome = value.mutationOutcome === "unknown" ? "unknown" : "none";
+-	const nativeDiagnostics = asNativeReviewCliError(error)?.diagnostics;
+-	const diagnostics = nativeDiagnostics?.operation === `review/${operation}`
+-		? nativeDiagnostics
+-		: operation === REVIEW_CONTROLLER_OPERATION.START && error instanceof CandidateViewError && value.candidateViewPreNative === true
+-			? { code: error.reason, message: "candidate view rejected before native START" }
+-			: undefined;
+ 	return {
+ 		operation,
+ 		status: "blocked",
+diff --git a/lib/native-review-cli.ts b/lib/native-review-cli.ts
+index 76846e64..ba49d137 100644
+--- a/lib/native-review-cli.ts
++++ b/lib/native-review-cli.ts
+@@ -1182,13 +1182,15 @@ export class NativeReviewIntegrationError extends Error {
+ 	readonly failureEnvelope: ReviewFailureV1;
+ 	readonly mutationOutcome: ReviewFailureV1["mutationOutcome"];
+ 	readonly nextAction: string;
++	readonly diagnostics: NativeReviewProcessDiagnostics;
+ 	readonly launchAttempted = true;
+-	constructor(failure: ReviewFailureV1) {
++	constructor(failure: ReviewFailureV1, diagnostics: NativeReviewProcessDiagnostics) {
+ 		super(failure.message);
+ 		this.name = "NativeReviewIntegrationError";
+ 		this.failureEnvelope = failure;
+ 		this.mutationOutcome = failure.mutationOutcome;
+ 		this.nextAction = failure.nextAction;
++		this.diagnostics = diagnostics;
+ 	}
+ }
+ 
+@@ -1285,7 +1287,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
+ 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
+ 		if (result.exitCode !== 0) {
+ 			try {
+-				throw new NativeReviewIntegrationError(decodeReviewFailureV1(body));
++				throw new NativeReviewIntegrationError(decodeReviewFailureV1(body), diagnostics);
+ 			} catch (error) {
+ 				if (error instanceof NativeReviewIntegrationError) throw error;
+ 				throw nativeError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, operation, mutating, "native negotiated operation failed without a valid failure envelope", result);
+diff --git a/runtime/native-review-cli.mjs b/runtime/native-review-cli.mjs
+index 07243444..dc075af4 100644
+--- a/runtime/native-review-cli.mjs
++++ b/runtime/native-review-cli.mjs
+@@ -1183,13 +1183,15 @@ export class NativeReviewIntegrationError extends Error {
+ 	         failureEnvelope                 ;
+ 	         mutationOutcome                                    ;
+ 	         nextAction        ;
++	         diagnostics                                ;
+ 	         launchAttempted = true;
+-	constructor(failure                 ) {
++	constructor(failure                 , diagnostics                                ) {
+ 		super(failure.message);
+ 		this.name = "NativeReviewIntegrationError";
+ 		this.failureEnvelope = failure;
+ 		this.mutationOutcome = failure.mutationOutcome;
+ 		this.nextAction = failure.nextAction;
++		this.diagnostics = diagnostics;
+ 	}
+ }
+ 
+@@ -1286,7 +1288,7 @@ export class NativeReviewCliV216                            {
+ 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
+ 		if (result.exitCode !== 0) {
+ 			try {
+-				throw new NativeReviewIntegrationError(decodeReviewFailureV1(body));
++				throw new NativeReviewIntegrationError(decodeReviewFailureV1(body), diagnostics);
+ 			} catch (error) {
+ 				if (error instanceof NativeReviewIntegrationError) throw error;
+ 				throw nativeError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, operation, mutating, "native negotiated operation failed without a valid failure envelope", result);
+diff --git a/tests/review-controller-native-routing.test.ts b/tests/review-controller-native-routing.test.ts
+index 8e6261be..797f7b3a 100644
+--- a/tests/review-controller-native-routing.test.ts
++++ b/tests/review-controller-native-routing.test.ts
+@@ -1157,6 +1157,36 @@ test("ambiguous native START failure preserves rebuilt sanitized diagnostics acr
+ 	assert.equal((details.reconciliation_failure as { outcome?: string }).outcome, "native-operation-failed");
+ });
+ 
++test("negotiated unknown START reconciled to start without lineage exposes only sanitized diagnostics", async (t) => {
++	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-controller-"));
++	t.after(() => rmSync(cwd, { recursive: true, force: true }));
++	const error = Object.assign(new Error("native negotiated START failed"), {
++		name: "NativeReviewIntegrationError",
++		mutationOutcome: "unknown",
++		nextAction: "review.status",
++		diagnostics: { operation: "review/start", error_code: "non-zero", exit_code: 1, timed_out: false, output_limit_exceeded: false, stderr: "native failure sensitive-value=[REDACTED_TEST_VALUE]" },
++		failureEnvelope: {
++			raw: { message: "raw negotiated failure sensitive-value=[REDACTED_TEST_VALUE]", stdout: "must never be public" },
++			mutationOutcome: "unknown",
++			replayability: "status_required",
++			nextAction: "review.status",
++		},
++	});
++	const { controller } = runtime(fakeNative({
++		start: async () => { throw error; },
++		targetStatus: async () => targetStatusFixture({ applicability: "unrelated", action: "start" }),
++	}));
++	const result = await controller.execute("start", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
++	const details = result.details as Record<string, unknown>;
++	assert.equal(details.outcome, "native-mutation-status-reconciled");
++	assert.equal(details.mutation_outcome, "unknown");
++	assert.equal(details.next_action, "start");
++	assert.deepEqual(details.diagnostics, { operation: "review/start", error_code: "non-zero", exit_code: 1, timed_out: false, output_limit_exceeded: false, stderr: "native failure sensitive-value=[REDACTED]" });
++	assert.equal("native_failure" in details, false);
++	assert.equal(JSON.stringify(details).includes("[REDACTED_TEST_VALUE]"), false);
++	assert.equal(JSON.stringify(details).includes("must never be public"), false);
++});
++
+ test("foreign errors with unrecognized diagnostics shapes stay diagnostics-free", async (t) => {
+ 	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-controller-"));
+ 	t.after(() => rmSync(cwd, { recursive: true, force: true }));

--- a/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/reference/failure.fixture.json
+++ b/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/reference/failure.fixture.json
@@ -1,0 +1,47 @@
+{
+  "schema": "gentle-ai.review-integration.failure/v1",
+  "contract": "gentle-ai.review-integration/v1",
+  "operation": "review.validate",
+  "phase": "preflight",
+  "code": "gate_scope_changed",
+  "message": "The review delivery gate denied the current target.",
+  "mutation_outcome": "not_started",
+  "authority_applicability": "current_target",
+  "retry_safe": false,
+  "replayability": "manual_action_required",
+  "lineage_id": "review-failure-fixture",
+  "required_inputs": [
+    "predecessor_lineage_id",
+    "expected_predecessor_revision",
+    "successor_lineage_id",
+    "disposition",
+    "reason",
+    "actor"
+  ],
+  "next_action": "explicit-maintainer-action",
+  "context": {
+    "scope_change": {
+      "expected": {
+        "candidate_tree": "2222222222222222222222222222222222222222",
+        "paths_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "actual": {
+        "candidate_tree": "3333333333333333333333333333333333333333",
+        "paths_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "differing_path_count": 1,
+      "differing_paths_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+      "predecessor_lineage_id": "review-failure-fixture",
+      "predecessor_revision": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "recovery_operation": "review.recover",
+      "recovery_required_inputs": [
+        "predecessor_lineage_id",
+        "expected_predecessor_revision",
+        "successor_lineage_id",
+        "disposition",
+        "reason",
+        "actor"
+      ]
+    }
+  }
+}

--- a/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/reference/failure.schema.json
+++ b/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/reference/failure.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gentle-ai.dev/contracts/review-integration/v1/schemas/failure.schema.json",
+  "title": "Gentle AI negotiated review failure",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "contract",
+    "operation",
+    "phase",
+    "code",
+    "message",
+    "mutation_outcome",
+    "authority_applicability",
+    "retry_safe",
+    "replayability",
+    "required_inputs",
+    "next_action"
+  ],
+  "properties": {
+    "schema": {"const": "gentle-ai.review-integration.failure/v1"},
+    "contract": {"const": "gentle-ai.review-integration/v1"},
+    "operation": {
+      "enum": ["review.capabilities", "review.start", "review.status", "review.finalize", "review.validate", "review.bind_sdd"]
+    },
+    "phase": {"enum": ["preflight", "pre_native", "native_running", "native_committed", "reconciliation"]},
+    "code": {"type": "string", "pattern": "^[a-z0-9]+(?:_[a-z0-9]+)*$"},
+    "message": {"type": "string", "minLength": 1, "maxLength": 240, "pattern": "^[^\\r\\n]+$"},
+    "mutation_outcome": {"enum": ["not_started", "unknown", "committed"]},
+    "authority_applicability": {"enum": ["current_target", "unrelated", "ambiguous", "corrupted", "not_evaluated"]},
+    "retry_safe": {"type": "boolean"},
+    "replayability": {"enum": ["not_replayable", "exact_replay_safe", "status_required", "manual_action_required"]},
+    "lineage_id": {"type": "string", "maxLength": 128, "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+    "request_digest": {"$ref": "#/$defs/sha256"},
+    "required_inputs": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "lineage_id",
+          "change",
+          "expected_binding_revision",
+          "predecessor_lineage_id",
+          "expected_predecessor_revision",
+          "successor_lineage_id",
+          "disposition",
+          "reason",
+          "actor"
+        ]
+      }
+    },
+    "next_action": {"enum": ["correct_request", "retry", "retry_with_bounded_backoff", "review.status", "review.finalize", "review.bind_sdd", "explicit-maintainer-action", "stop"]},
+    "cause_category": {"enum": ["inventory_io_or_layout", "lock_ambiguous", "reset_residue", "record_or_graph_invalid", "inventory_incomplete"]},
+    "context": {"$ref": "#/$defs/gate_context"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "tree": {"type": "string", "pattern": "^[0-9a-f]{40}(?:[0-9a-f]{24})?$"},
+    "target_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["candidate_tree", "paths_digest"],
+      "properties": {
+        "candidate_tree": {"$ref": "#/$defs/tree"},
+        "paths_digest": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "scope_change": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expected",
+        "actual",
+        "differing_path_count",
+        "differing_paths_digest",
+        "predecessor_lineage_id",
+        "predecessor_revision",
+        "recovery_operation",
+        "recovery_required_inputs"
+      ],
+      "properties": {
+        "expected": {"$ref": "#/$defs/target_evidence"},
+        "actual": {"$ref": "#/$defs/target_evidence"},
+        "differing_path_count": {"type": "integer", "minimum": 0, "maximum": 1000000},
+        "differing_paths_digest": {"$ref": "#/$defs/sha256"},
+        "predecessor_lineage_id": {"type": "string", "maxLength": 128, "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+        "predecessor_revision": {"$ref": "#/$defs/sha256"},
+        "recovery_operation": {"const": "review.recover"},
+        "recovery_required_inputs": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "prefixItems": [
+            {"const": "predecessor_lineage_id"},
+            {"const": "expected_predecessor_revision"},
+            {"const": "successor_lineage_id"},
+            {"const": "disposition"},
+            {"const": "reason"},
+            {"const": "actor"}
+          ],
+          "items": false
+        }
+      }
+    },
+    "gate_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope_change"
+      ],
+      "properties": {
+        "scope_change": {"$ref": "#/$defs/scope_change"}
+      }
+    }
+  }
+}

--- a/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/reproduction.md
+++ b/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/reproduction.md
@@ -1,0 +1,26 @@
+# Test-only reproduction
+
+Use a source checkout on `fix/review-diagnostic-propagation`. These steps exercise a synthetic error only.
+
+> **Do not replay or create a real failed START.** Do not call a review lifecycle command, inspect authority state, or use a real lineage. The regression supplies its own fake native error and temporary test directory.
+
+## Steps
+
+1. Confirm the source base is `v1.2.0` and the repair is present on `fix/review-diagnostic-propagation`.
+2. Run only the regression:
+
+   ```shell
+   node --experimental-strip-types --test --test-name-pattern="negotiated unknown START reconciled to start without lineage exposes only sanitized diagnostics" tests/review-controller-native-routing.test.ts
+   ```
+
+3. Confirm the single selected test passes.
+4. Confirm the assertions establish all of the following:
+   - reconciled outcome is `native-mutation-status-reconciled`;
+   - mutation outcome remains `unknown` and the next action is `start`;
+   - diagnostics are scoped to `review/start` and redact the synthetic value;
+   - `native_failure` is absent; and
+   - raw synthetic payload text is absent.
+
+## Expected result
+
+The synthetic negotiated failure retains the safe diagnostic summary but cannot disclose its raw failure envelope. No real native authority, receipt, snapshot, or START result participates.

--- a/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/validation.md
+++ b/openspec/changes/consolidate-review-parity-runtime/upstream-trackers/handoff-122-review-diagnostic-propagation/validation.md
@@ -1,0 +1,26 @@
+# Validation record
+
+## Result at a glance
+
+| Surface | Result | Meaning |
+| --- | --- | --- |
+| Source focused regression | PASS | The repaired behavior is demonstrated in the source checkout. |
+| Source package-resource verifier | PASS | Required package resources and pinned contract artifacts match. |
+| Package-local Gentle AI v2.1.11 provisioning | VERIFIED | The package-local provider was provisioned before post-install observation. |
+| Local provider inspect | PASS | Provider inspection succeeds after that verified provisioning. |
+| Authorized fresh ordinary START | OBSERVED | Returns the sanitized provider diagnostic in `observed-start-failure.json`; reconciliation reports no lineage and action `start`. |
+| Pi adapter diagnostic propagation | PROVEN | The adapter preserves and exposes the sanitized `review/start` diagnostic rather than raw negotiated failure content. |
+| Native Gentle AI root cause | UNRESOLVED | v2.1.11 emits only generic `non-zero` / `operation_outcome_unknown`; native maintainers must add stage-level sanitized failure evidence. |
+
+## RED / GREEN evidence
+
+- **RED:** not observed. The repair already existed when this handoff began, so a pre-repair failure was not run or reconstructed.
+- **GREEN:** source command passed: `node --experimental-strip-types --test --test-name-pattern="negotiated unknown START reconciled to start without lineage exposes only sanitized diagnostics" tests/review-controller-native-routing.test.ts` (1 pass, 0 failures).
+- **TRIANGULATE:** source command passed: `node scripts/verify-package-files.mjs` (`84 files; 19 exact byte-identical v2.1.11 contract artifacts`).
+- **REFACTOR:** not performed; this handoff only packages the existing repair and evidence.
+
+## Post-install evidence and authority boundary
+
+The provider diagnostic is intentionally limited to operation `review/start`, error code `non-zero`, exit code `1`, timeout `false`, output limit `false`, and the sanitized stderr string in `observed-start-failure.json`. It contains no target, repository, user, lineage, receipt, credential, or raw negotiated payload value.
+
+Status reconciliation reports no lineage and action `start`. Therefore no replay is safe, and this evidence cannot authorize a commit. The generic native diagnostic is sufficient to prove Pi adapter propagation but insufficient to identify the native failure stage; native maintainers must add stage-level sanitized failure evidence.

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -1183,13 +1183,15 @@ export class NativeReviewIntegrationError extends Error {
 	         failureEnvelope                 ;
 	         mutationOutcome                                    ;
 	         nextAction        ;
+	         diagnostics                                ;
 	         launchAttempted = true;
-	constructor(failure                 ) {
+	constructor(failure                 , diagnostics                                ) {
 		super(failure.message);
 		this.name = "NativeReviewIntegrationError";
 		this.failureEnvelope = failure;
 		this.mutationOutcome = failure.mutationOutcome;
 		this.nextAction = failure.nextAction;
+		this.diagnostics = diagnostics;
 	}
 }
 
@@ -1286,7 +1288,7 @@ export class NativeReviewCliV216                            {
 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
 		if (result.exitCode !== 0) {
 			try {
-				throw new NativeReviewIntegrationError(decodeReviewFailureV1(body));
+				throw new NativeReviewIntegrationError(decodeReviewFailureV1(body), diagnostics);
 			} catch (error) {
 				if (error instanceof NativeReviewIntegrationError) throw error;
 				throw nativeError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, operation, mutating, "native negotiated operation failed without a valid failure envelope", result);

--- a/tests/native-review-integration-v1.test.ts
+++ b/tests/native-review-integration-v1.test.ts
@@ -16,6 +16,7 @@ const fixture = (name: string): Record<string, unknown> => JSON.parse(readFileSy
 
 interface Result {
 	stdout: string;
+	stderr?: string;
 	exitCode?: number;
 }
 
@@ -27,7 +28,7 @@ function queued(results: Result[]): { adapter: ExecFileAdapter; calls: readonly 
 			calls.push({ arguments: request.arguments, timeoutMs: request.timeoutMs });
 			const result = results.shift();
 			if (result === undefined) throw new Error("unexpected native invocation");
-			return { stdout: result.stdout, stderr: "", exitCode: result.exitCode ?? 0, signal: null, timedOut: false, outputLimitExceeded: false };
+			return { stdout: result.stdout, stderr: result.stderr ?? "", exitCode: result.exitCode ?? 0, signal: null, timedOut: false, outputLimitExceeded: false };
 		},
 	};
 }
@@ -52,17 +53,24 @@ test("v2.1.7 negotiates once per verified digest and binds every operation argv"
 	assert.equal(queue.calls[1]?.timeoutMs, undefined);
 });
 
-test("v2.1.7 preserves the native uniform failure envelope", async () => {
+test("v2.1.7 attaches diagnostics to a non-zero native failure envelope before controller sanitization", async () => {
 	clearNativeReviewCapabilitiesCacheForTesting();
 	const digest = "dcc846103b16d365eaeeb9d7f289c23fc4f2897f23def1cb3fe7f05557b64705";
 	const queue = queued([
 		{ stdout: JSON.stringify(fixture("capabilities.fixture.json")) },
-		{ stdout: JSON.stringify(fixture("failure.fixture.json")), exitCode: 1 },
+		{ stdout: JSON.stringify(fixture("failure.fixture.json")), stderr: "native transport token=super-secret", exitCode: 1 },
 	]);
 	const client = new NativeReviewCliV216(queue.adapter, "/package/gentle-ai", 321, 654, undefined, () => digest);
 	await assert.rejects(
 		() => client.finalize({ cwd: "/repo", lineageId: "review-failure-fixture" }),
-		(error: unknown) => error instanceof NativeReviewIntegrationError && error.failureEnvelope.code === "gate_scope_changed" && error.mutationOutcome === "not_started" && error.nextAction === "explicit-maintainer-action",
+		(error: unknown) => {
+			if (!(error instanceof NativeReviewIntegrationError)) return false;
+			assert.equal(error.failureEnvelope.code, "gate_scope_changed");
+			assert.equal(error.mutationOutcome, "not_started");
+			assert.equal(error.nextAction, "explicit-maintainer-action");
+			assert.deepEqual(error.diagnostics, { operation: "review/finalize", error_code: NATIVE_REVIEW_ERROR_CODE.NON_ZERO, exit_code: 1, timed_out: false, output_limit_exceeded: false, stderr: "native transport token=[REDACTED]", denial: undefined });
+			return true;
+		},
 	);
 });
 

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1157,6 +1157,36 @@ test("ambiguous native START failure preserves rebuilt sanitized diagnostics acr
 	assert.equal((details.reconciliation_failure as { outcome?: string }).outcome, "native-operation-failed");
 });
 
+test("negotiated unknown START reconciled to start without lineage exposes only sanitized diagnostics", async (t) => {
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-controller-"));
+	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	const error = Object.assign(new Error("native negotiated START failed"), {
+		name: "NativeReviewIntegrationError",
+		mutationOutcome: "unknown",
+		nextAction: "review.status",
+		diagnostics: { operation: "review/start", error_code: "non-zero", exit_code: 1, timed_out: false, output_limit_exceeded: false, stderr: "native failure token=super-secret" },
+		failureEnvelope: {
+			raw: { message: "raw negotiated failure token=super-secret", stdout: "must never be public" },
+			mutationOutcome: "unknown",
+			replayability: "status_required",
+			nextAction: "review.status",
+		},
+	});
+	const { controller } = runtime(fakeNative({
+		start: async () => { throw error; },
+		targetStatus: async () => targetStatusFixture({ applicability: "unrelated", action: "start" }),
+	}));
+	const result = await controller.execute("start", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+	const details = result.details as Record<string, unknown>;
+	assert.equal(details.outcome, "native-mutation-status-reconciled");
+	assert.equal(details.mutation_outcome, "unknown");
+	assert.equal(details.next_action, "start");
+	assert.deepEqual(details.diagnostics, { operation: "review/start", error_code: "non-zero", exit_code: 1, timed_out: false, output_limit_exceeded: false, stderr: "native failure token=[REDACTED]" });
+	assert.equal("native_failure" in details, false);
+	assert.equal(JSON.stringify(details).includes("super-secret"), false);
+	assert.equal(JSON.stringify(details).includes("must never be public"), false);
+});
+
 test("foreign errors with unrecognized diagnostics shapes stay diagnostics-free", async (t) => {
 	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-controller-"));
 	t.after(() => rmSync(cwd, { recursive: true, force: true }));

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -7,7 +7,7 @@ import { basename, dirname, join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { __testing, createGentleAiExtension } from "../extensions/gentle-ai.ts";
-import { NATIVE_REVIEW_ERROR_CODE, NATIVE_REVIEW_OPERATION, NativeReviewCliError, NativeReviewCliV214 as NativeReviewCliV214Production, type NativeReviewCli, type NativeReviewStatusResult } from "../lib/native-review-cli.ts";
+import { NATIVE_REVIEW_ERROR_CODE, NATIVE_REVIEW_OPERATION, NativeReviewCliError, NativeReviewIntegrationError, NativeReviewCliV214 as NativeReviewCliV214Production, type NativeReviewCli, type NativeReviewStatusResult } from "../lib/native-review-cli.ts";
 
 // Queued-adapter clients never execute a real process; default to a fixed absolute
 // package-local path so these tests do not depend on an installed binary
@@ -23,7 +23,7 @@ import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
 import { inspectLegacyReviewAuthorityV1 } from "../lib/review-legacy-detector.ts";
 import { resolveRepositoryAuthorityV1 } from "../lib/review-repository.ts";
 import { NATIVE_REVIEW_REMEDIATION, classifyNativeReviewRemediation } from "../lib/native-review-remediation.ts";
-import type { ReviewStatusV1 } from "../lib/review-integration-v1.ts";
+import { decodeReviewFailureV1, type ReviewStatusV1 } from "../lib/review-integration-v1.ts";
 
 interface RegisteredTool {
 	execute: (
@@ -1160,18 +1160,20 @@ test("ambiguous native START failure preserves rebuilt sanitized diagnostics acr
 test("negotiated unknown START reconciled to start without lineage exposes only sanitized diagnostics", async (t) => {
 	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-controller-"));
 	t.after(() => rmSync(cwd, { recursive: true, force: true }));
-	const error = Object.assign(new Error("native negotiated START failed"), {
-		name: "NativeReviewIntegrationError",
-		mutationOutcome: "unknown",
-		nextAction: "review.status",
-		diagnostics: { operation: "review/start", error_code: "non-zero", exit_code: 1, timed_out: false, output_limit_exceeded: false, stderr: "native failure token=super-secret" },
-		failureEnvelope: {
-			raw: { message: "raw negotiated failure token=super-secret", stdout: "must never be public" },
-			mutationOutcome: "unknown",
-			replayability: "status_required",
-			nextAction: "review.status",
-		},
-	});
+	const error = new NativeReviewIntegrationError(decodeReviewFailureV1({
+		schema: "gentle-ai.review-integration.failure/v1",
+		contract: "gentle-ai.review-integration/v1",
+		operation: "review.start",
+		phase: "native_running",
+		code: "native_failure",
+		message: "raw negotiated failure token=super-secret",
+		mutation_outcome: "unknown",
+		authority_applicability: "current_target",
+		retry_safe: false,
+		replayability: "status_required",
+		required_inputs: [],
+		next_action: "review.status",
+	}), { operation: "review/start", error_code: "non-zero", exit_code: 1, timed_out: false, output_limit_exceeded: false, stderr: "native failure token=[REDACTED]" });
 	const { controller } = runtime(fakeNative({
 		start: async () => { throw error; },
 		targetStatus: async () => targetStatusFixture({ applicability: "unrelated", action: "start" }),


### PR DESCRIPTION
# Review diagnostic propagation handoff

The Pi adapter repair is proven: after verified package-local Gentle AI v2.1.11 provisioning, local provider inspection succeeds and an authorized fresh ordinary START returns a sanitized provider diagnostic. The raw negotiated failure payload is not exposed.

## Review first

1. Read `patch.diff` for the four-file repair.
2. Run the test-only reproduction in `reproduction.md` from a source checkout.
3. Check `validation.md` before treating the installed package as validated.

## Impact and decision

| Topic | Maintainer conclusion |
| --- | --- |
| Impact | A caller receives the operation-scoped, sanitized provider diagnostic needed to explain a failed negotiated START reconciliation. |
| Pi adapter conclusion | Repaired and proven: the post-install ordinary START reports only the sanitized `review/start` diagnostic captured in `observed-start-failure.json`. |
| Remaining native root failure | Gentle AI v2.1.11 emits only the generic `non-zero` / `operation_outcome_unknown` diagnostic. Native maintainers must add stage-level sanitized failure evidence. |
| Repair invariant | For a negotiated unknown START reconciled to `start` with no lineage, expose only sanitized diagnostics for `review/start`; never expose `native_failure` or raw payload content. |
| Source base | `v1.2.0` at `113906a34c1b527ba2d65806b7638bff32b8e916`. |
| Source branch | `fix/review-diagnostic-propagation` at `4d5214b410d352712be20917e81f9ce5974d039a`, with the repair present as working-tree changes. |

## Evidence boundary

**Proven:** the focused source regression passes; package-local Gentle AI v2.1.11 provisioning was verified; local provider inspection succeeds; and the authorized fresh ordinary START returned the sanitized diagnostic recorded in `observed-start-failure.json`.

**Native escalation required:** the remaining native failure is generic (`non-zero` / `operation_outcome_unknown`) and lacks stage-level sanitized failure evidence. Native maintainers must add that evidence before the root cause can be diagnosed.

**Authority boundary:** status reconciliation reports no lineage and action `start`. No replay is safe, and this evidence cannot authorize a commit. This bundle does not authorize creating, replaying, or inspecting a real review lineage.

## Tracker paths

- Upstream tracker #122: [`../122-receipt-tree-path-diagnostics.md`](../122-receipt-tree-path-diagnostics.md)
- Gentle AI #1248 mapping: [`../README.md`](../README.md) (the #122 row)

## Safety statement

This bundle contains no private authority material, credentials, tokens, native receipts, real review snapshots, target values, repository identities, or user identities. `patch.diff` redacts a test-only sentinel value and excludes this handoff directory, so it is a review artifact rather than an apply-ready patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of native operation failures so sanitized process diagnostics are consistently captured and surfaced in responses.
  * Updated failure mapping to compute diagnostics earlier and avoid exposing raw integration failure details.
  * Ensured native START failure reconciliation preserves correct outcome/next-action values while redacting sensitive stderr content.
* **Tests**
  * Added/updated integration and routing tests to verify diagnostics attachment timing, redaction behavior, and absence of raw failure fields in returned details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->