### PR TITLE
fix(review): restore pre-commit authorization

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4412,13 +4412,14 @@ interface NativePreCommitReceiptConsumption {
 async function consumeNativePreCommitReceipt(
 	command: string,
 	defaultCwd: string,
+	derivedTarget: DerivedReviewGateTarget,
 	nativeReviewCli: NativeReviewCli,
 	publicationProbe: PublicationProbe,
 	publicationProbeTimeoutMs: number,
 	signal?: AbortSignal,
 ): Promise<NativePreCommitReceiptConsumption> {
 	const derived = await deriveNativePublicationTarget(
-		deriveReviewGateTarget(command, defaultCwd),
+		derivedTarget,
 		publicationProbe,
 		publicationProbeTimeoutMs,
 		signal,
@@ -6084,10 +6085,19 @@ export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencie
 		}
 		let unmanagedPreCommit = false;
 		if (inspection.command?.event === "pre-commit" && commandAuthorizationKey !== undefined && nativeCommitAuthorization === undefined && nativeReviewCli !== null) {
+			let derived: DerivedReviewGateTarget;
+			try {
+				derived = deriveReviewGateTarget(originalCommand, ctx.cwd);
+			} catch (error) {
+				return {
+					block: true,
+					reason: `Gentle AI pre-commit gate could not exactly derive the command target and failed closed: ${error instanceof Error ? error.message : String(error)}`,
+				};
+			}
 			const deadline = AbortSignal.timeout(bashTimeRevalidationTimeoutMs);
 			const signal = ctx.signal === undefined ? deadline : AbortSignal.any([ctx.signal, deadline]);
 			try {
-				const consumed = await consumeNativePreCommitReceipt(originalCommand, ctx.cwd, nativeReviewCli, publicationProbe, publicationProbeTimeoutMs, signal);
+				const consumed = await consumeNativePreCommitReceipt(originalCommand, ctx.cwd, derived, nativeReviewCli, publicationProbe, publicationProbeTimeoutMs, signal);
 				nativeCommitAuthorization = consumed.authorization;
 				unmanagedPreCommit = consumed.delivery === "disabled/unmanaged";
 				authorizationConsumptionIdentity = nativeAuthorizationConsumptionIdentity(nativeCommitAuthorization);

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4326,10 +4326,31 @@ function assertFrozenPreCommitProjection(
 	return projection.candidateTree;
 }
 
+function reproveNativePreCommitTree(
+	derived: DerivedReviewGateTarget,
+	lineageId: string,
+	candidateViews: CandidateViewRegistry | null,
+): string | undefined {
+	return assertFrozenPreCommitProjection(derived, lineageId, candidateViews) ??
+		(derived.command.event === "pre-commit" ? derived.actualIntendedCommitTree : undefined);
+}
+
 function authorizationTargetHash(derived: DerivedReviewGateTarget): string {
 	return derived.nativePublication === undefined
 		? canonicalHash(derived.target)
 		: canonicalHash({ target: derived.target, native_publication: derived.nativePublication });
+}
+
+function nativeAuthorizationConsumptionIdentity(authorization: PendingReviewAuthorization | undefined): string | undefined {
+	if (authorization?.native_gate === undefined) return undefined;
+	return canonicalHash({
+		command_hash: authorization.command_hash,
+		target_hash: authorization.target_hash,
+		lineage_id: authorization.native_gate.lineage_id,
+		store_revision: authorization.native_gate.store_revision,
+		fingerprint: authorization.native_gate.fingerprint,
+		intended_tree: authorization.native_gate.intended_tree ?? null,
+	});
 }
 
 function assertNativePublicationBinding(result: NativeValidateResult, derived: DerivedReviewGateTarget): void {
@@ -4381,6 +4402,63 @@ async function rederiveNativePublicationTarget(
 	const fresh = await deriveNativePublicationTarget({ ...rederived, ...(expected.nativeRelease === undefined ? {} : { nativeRelease: expected.nativeRelease }) }, probe, timeoutMs, signal);
 	assertNativePublicationUnchanged(expected, fresh);
 	return fresh;
+}
+
+interface NativePreCommitReceiptConsumption {
+	authorization?: PendingReviewAuthorization;
+	delivery?: "disabled/unmanaged";
+}
+
+async function consumeNativePreCommitReceipt(
+	command: string,
+	defaultCwd: string,
+	nativeReviewCli: NativeReviewCli,
+	publicationProbe: PublicationProbe,
+	publicationProbeTimeoutMs: number,
+	signal?: AbortSignal,
+): Promise<NativePreCommitReceiptConsumption> {
+	const derived = await deriveNativePublicationTarget(
+		deriveReviewGateTarget(command, defaultCwd),
+		publicationProbe,
+		publicationProbeTimeoutMs,
+		signal,
+	);
+	if (derived.command.event !== "pre-commit" || derived.actualIntendedCommitTree === undefined) return {};
+	const result = await nativeReviewCli.validate({
+		cwd: derived.command.cwd,
+		gate: "pre-commit",
+		...(signal === undefined ? {} : { signal }),
+	});
+	assertNativePublicationBinding(result, derived);
+	const fresh = await rederiveNativePublicationTarget(
+		derived,
+		command,
+		defaultCwd,
+		publicationProbe,
+		publicationProbeTimeoutMs,
+		signal,
+	);
+	if (result.delivery === "disabled/unmanaged") return { delivery: result.delivery };
+	if (!result.allowed || result.result !== "allow") return {};
+	if (
+		result.gateContext.lineageId.length === 0 ||
+		result.gateContext.raw.candidate_tree !== derived.actualIntendedCommitTree ||
+		fresh.actualIntendedCommitTree !== derived.actualIntendedCommitTree
+	) throw new Error("Native approved receipt does not bind the exact current pre-commit tree");
+	const commandHash = reviewAuthorizationKey(command, fresh.command.cwd);
+	return {
+		authorization: {
+			command_hash: commandHash,
+			target_hash: authorizationTargetHash(fresh),
+			receipt_hash: null,
+			native_gate: {
+				lineage_id: result.gateContext.lineageId,
+				store_revision: result.gateContext.storeRevision,
+				fingerprint: nativeGateFingerprint(result, fresh),
+				intended_tree: derived.actualIntendedCommitTree,
+			},
+		},
+	};
 }
 
 interface NativeStartPolicyValidation {
@@ -5616,7 +5694,7 @@ async function gateLifecycleCommand(
 	try {
 		const intendedTree = authorization.native_gate === undefined
 			? undefined
-			: assertFrozenPreCommitProjection(derived, authorization.native_gate.lineage_id, candidateViews);
+			: reproveNativePreCommitTree(derived, authorization.native_gate.lineage_id, candidateViews);
 		if (authorization.native_gate?.intended_tree !== undefined && intendedTree !== authorization.native_gate.intended_tree) {
 			return {
 				block: true,
@@ -5672,7 +5750,7 @@ async function gateLifecycleCommand(
 				publicationProbeTimeoutMs,
 				signal,
 			);
-			const postNativeIntendedTree = assertFrozenPreCommitProjection(postNativeDerived, authorization.native_gate.lineage_id, candidateViews);
+			const postNativeIntendedTree = reproveNativePreCommitTree(postNativeDerived, authorization.native_gate.lineage_id, candidateViews);
 			if (authorization.native_gate.intended_tree !== undefined && postNativeIntendedTree !== authorization.native_gate.intended_tree) throw new CandidateViewError("staged projection changed during native validation");
 			assertNativePublicationBinding(fresh, postNativeDerived);
 			if (nativeGateFingerprint(fresh, postNativeDerived) !== authorization.native_gate.fingerprint) {
@@ -5833,6 +5911,7 @@ export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencie
 	if (!Number.isSafeInteger(bashTimeRevalidationTimeoutMs) || bashTimeRevalidationTimeoutMs <= 0) throw new TypeError("Bash-time revalidation timeout must be a positive safe integer");
 	return function gentleAi(pi: ExtensionAPI): void {
 	const pendingReviewAuthorizations = new Map<string, PendingReviewAuthorization>();
+	const consumedNativeAuthorizations = new Set<string>();
 	const pendingCommitTransactions = new Map<string, { cwd: string; transactionId: string }>();
 	const correctionEvidenceByLineage = new Map<string, CorrectionEvidence>();
 	const candidateViews = dependencies.candidateViews === undefined ? new CandidateViewRegistry() : dependencies.candidateViews;
@@ -5991,12 +6070,41 @@ export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencie
 			return undefined;
 		const originalCommand = event.input.command;
 		const inspection = inspectReviewLifecycleCommand(originalCommand, ctx.cwd);
-		const nativeCommitAuthorization = inspection.command?.event === "pre-commit"
-			? pendingReviewAuthorizations.get(reviewAuthorizationKey(originalCommand, inspection.command.cwd))
+		const commandAuthorizationKey = inspection.command?.event === "pre-commit"
+			? reviewAuthorizationKey(originalCommand, inspection.command.cwd)
 			: undefined;
+		let nativeCommitAuthorization = commandAuthorizationKey === undefined
+			? undefined
+			: pendingReviewAuthorizations.get(commandAuthorizationKey);
+		let authorizationConsumptionIdentity = nativeAuthorizationConsumptionIdentity(nativeCommitAuthorization);
+		if (authorizationConsumptionIdentity !== undefined && consumedNativeAuthorizations.has(authorizationConsumptionIdentity)) {
+			if (commandAuthorizationKey !== undefined) pendingReviewAuthorizations.delete(commandAuthorizationKey);
+			nativeCommitAuthorization = undefined;
+			authorizationConsumptionIdentity = undefined;
+		}
+		let unmanagedPreCommit = false;
+		if (inspection.command?.event === "pre-commit" && commandAuthorizationKey !== undefined && nativeCommitAuthorization === undefined && nativeReviewCli !== null) {
+			const deadline = AbortSignal.timeout(bashTimeRevalidationTimeoutMs);
+			const signal = ctx.signal === undefined ? deadline : AbortSignal.any([ctx.signal, deadline]);
+			try {
+				const consumed = await consumeNativePreCommitReceipt(originalCommand, ctx.cwd, nativeReviewCli, publicationProbe, publicationProbeTimeoutMs, signal);
+				nativeCommitAuthorization = consumed.authorization;
+				unmanagedPreCommit = consumed.delivery === "disabled/unmanaged";
+				authorizationConsumptionIdentity = nativeAuthorizationConsumptionIdentity(nativeCommitAuthorization);
+				if (authorizationConsumptionIdentity !== undefined && consumedNativeAuthorizations.has(authorizationConsumptionIdentity)) {
+					nativeCommitAuthorization = undefined;
+					authorizationConsumptionIdentity = undefined;
+				} else if (nativeCommitAuthorization !== undefined) {
+					pendingReviewAuthorizations.set(nativeCommitAuthorization.command_hash, nativeCommitAuthorization);
+				}
+			} catch (error) {
+				return { block: true, reason: `Gentle AI pre-commit receipt consumption failed closed: ${error instanceof Error ? error.message : String(error)}` };
+			}
+		}
 		const gateResult = await enforceReviewGateAndCommandSafety(
 			originalCommand,
 			(command) => {
+				if (unmanagedPreCommit) return Promise.resolve(undefined);
 				const deadline = AbortSignal.timeout(bashTimeRevalidationTimeoutMs);
 				const signal = ctx.signal === undefined ? deadline : AbortSignal.any([ctx.signal, deadline]);
 				return gateLifecycleCommand(command, ctx.cwd, pendingReviewAuthorizations, nativeReviewCli, publicationProbe, publicationProbeTimeoutMs, signal, candidateViews);
@@ -6004,6 +6112,7 @@ export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencie
 			(command) => confirmCommand(command, ctx),
 		);
 		if (gateResult) return gateResult;
+		if (authorizationConsumptionIdentity !== undefined) consumedNativeAuthorizations.add(authorizationConsumptionIdentity);
 		if (inspection.command?.event !== "pre-commit" || nativeCommitAuthorization?.native_gate === undefined) return undefined;
 		if (nativeReviewCli?.targetStatus === undefined) return undefined;
 		if (nativeCommitAuthorization.native_gate.intended_tree === undefined) {

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -798,11 +798,15 @@ export class CandidateViewRegistry {
 		const base = head.tree === descriptor.baseTree ? head : resolveCandidateBaseTree(root, descriptor.baseTree, this.gitExecutor);
 		const committedOnly = head.tree === descriptor.currentCandidateTree && base.tree !== head.tree;
 		if (!committedOnly && head.tree !== descriptor.baseTree) throw new CandidateViewError("native projection base no longer matches HEAD");
-		// The descriptor's own `projection` label ("staged" = a committed range,
-		// "workspace" = dirty-inclusive) must agree with what Pi independently
-		// derives from the base/candidate/HEAD relationship. Neither trusting
-		// nor silently overriding a mislabeled claim is safe: fail closed.
-		if ((descriptor.projection === "staged") !== committedOnly) {
+		// Native `staged` covers both a committed HEAD range and the exact current
+		// index over HEAD. Re-derive the latter from Git instead of trusting the
+		// label; this also rejects dirty-inclusive snapshots mislabeled as staged.
+		const stagedIndex = !committedOnly && descriptor.baseTree === head.tree &&
+			git(root, ["write-tree"], process.env, this.gitExecutor) === descriptor.currentCandidateTree;
+		if (
+			(descriptor.projection === "staged" && !committedOnly && !stagedIndex) ||
+			(descriptor.projection === "workspace" && committedOnly)
+		) {
 			throw new CandidateViewError("native projection commit-state does not match its declared projection kind", "projection-kind-drift");
 		}
 		const tree = parseTree(root, descriptor.currentCandidateTree, this.gitExecutor);

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -10,7 +10,7 @@ import type {
 	Theme,
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
-import gentleAi, { __testing } from "../extensions/gentle-ai.ts";
+import { __testing, createGentleAiExtension } from "../extensions/gentle-ai.ts";
 import { GATE_TARGET_KIND } from "../lib/review-publication-gate.ts";
 import {
 	REVIEW_MODE,
@@ -242,7 +242,7 @@ test("runtime lifecycle gates reject fabricated metadata while compound and wrap
 		registerCommand() {},
 		registerTool() {},
 	} as unknown as ExtensionAPI;
-	gentleAi(pi);
+	createGentleAiExtension({ nativeReviewCli: null })(pi);
 	const toolCall = handlers.get("tool_call");
 	assert.equal(typeof toolCall, "function");
 	const authority = runtimeAuthority(t);

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -584,6 +584,49 @@ test("native projections reconstruct symlink, intended-untracked, and gitlink id
 	assert.deepEqual(projection.gitlinks, { "vendor/dependency": gitlinkCommit });
 });
 
+test("native staged projections restore the exact current index over HEAD", (t) => {
+	const contributorRoot = repository(t);
+	const baseTree = git(contributorRoot, "rev-parse", "HEAD^{tree}");
+	writeFileSync(join(contributorRoot, "tracked.txt"), "staged candidate\n");
+	git(contributorRoot, "add", "tracked.txt");
+	const candidateTree = git(contributorRoot, "write-tree");
+	const registry = new CandidateViewRegistry();
+
+	registry.restoreProjectionFromNative("staged-index-projection", contributorRoot, {
+		baseTree,
+		currentCandidateTree: candidateTree,
+		paths: ["tracked.txt"],
+		intendedUntracked: [],
+		projection: "staged",
+	});
+
+	const projection = registry.resolveProjection("staged-index-projection", contributorRoot);
+	assert.equal(projection.baseTree, baseTree);
+	assert.equal(projection.candidateTree, candidateTree);
+	assert.equal(projection.committedOnly, false);
+});
+
+test("native staged projections reject a workspace snapshot that differs from the current index", (t) => {
+	const contributorRoot = repository(t);
+	const baseTree = git(contributorRoot, "rev-parse", "HEAD^{tree}");
+	writeFileSync(join(contributorRoot, "tracked.txt"), "workspace candidate\n");
+	const workspace = new CandidateViewRegistry().create({ contributorRoot });
+	try {
+		assert.throws(
+			() => new CandidateViewRegistry().restoreProjectionFromNative("workspace-as-staged", contributorRoot, {
+				baseTree,
+				currentCandidateTree: workspace.candidateTree,
+				paths: ["tracked.txt"],
+				intendedUntracked: [],
+				projection: "staged",
+			}),
+			(error: unknown) => error instanceof CandidateViewError && error.reason === "projection-kind-drift",
+		);
+	} finally {
+		workspace.cleanup();
+	}
+});
+
 test("native projections recover a committed range base from its frozen tree", (t) => {
 	const contributorRoot = repository(t);
 	const baseCommit = git(contributorRoot, "rev-parse", "HEAD");

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -287,6 +287,7 @@ function targetStatusFixture(options: {
 	baseTree?: string;
 	currentCandidateTree?: string;
 	paths?: readonly string[];
+	projection?: "workspace" | "staged";
 } = {}): ReviewStatusV3 {
 	const applicability = options.applicability ?? "current_target";
 	const action = options.action ?? (applicability === "current_target" ? "finalize" : applicability === "unrelated" ? "start" : applicability === "ambiguous" ? "select_lineage" : "repair_authority");
@@ -302,7 +303,7 @@ function targetStatusFixture(options: {
 	const projection = {
 		schema: "gentle-ai.review-integration.projection/v1" as const,
 		kind: "current-changes" as const,
-		projection: "workspace" as const,
+		projection: options.projection ?? "workspace",
 		baseTree,
 		initialReviewTree: tree,
 		currentCandidateTree: tree,
@@ -1896,7 +1897,181 @@ test("native allow registers one authorization and bash-time revalidation consum
 	assert.equal(await toolCall({ toolName: "bash", input: { command } }, interactiveContext(cwd)), undefined);
 	const replay = await toolCall({ toolName: "bash", input: { command } }, context(cwd)) as { block: boolean };
 	assert.equal(replay.block, true);
-	assert.equal(validates, 2);
+	assert.equal(validates, 3, "the replay discovers but cannot remint the consumed binding");
+});
+
+test("fresh pre-commit consumes an exact approved native receipt without START or projection restoration", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	git(cwd, "add", "--", "app.ts");
+	const tree = git(cwd, "write-tree");
+	let starts = 0;
+	const requests: Parameters<NativeReviewCli["validate"]>[0][] = [];
+	const { toolCall } = runtime(fakeNative({
+		start: async () => {
+			starts += 1;
+			throw new Error("an approved exact candidate must not start another review");
+		},
+		validate: async (request) => {
+			requests.push(request);
+			return { allowed: true, result: "allow", action: "continue", reason: "approved receipt binds the index", gateContext: nativeGateContext("approved-lineage", "r1", tree) };
+		},
+		targetStatus: async () => { throw new Error("approved receipt consumption must not reconstruct an unrelated projection"); },
+	}), undefined, undefined, undefined, new CandidateViewRegistry());
+	const command = "git commit -m approved";
+	const input = { command };
+
+	assert.equal(await toolCall({ toolName: "bash", input }, context(cwd)), undefined);
+	assert.equal(starts, 0);
+	assert.equal(requests.length, 2, "authorization and bash-time TOCTOU validation must both run");
+	assert.equal(requests[0]?.lineageId, undefined, "fresh receipt discovery is candidate-bound, not caller-selected");
+	assert.equal(requests[1]?.lineageId, "approved-lineage");
+	assert.notEqual(input.command, command, "the approved pre-commit must use the durable commit transaction");
+});
+
+test("a consumed native receipt binding cannot remint authorization for the same exact command", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	git(cwd, "add", "--", "app.ts");
+	const tree = git(cwd, "write-tree");
+	let validations = 0;
+	const { toolCall } = runtime(fakeNative({
+		validate: async () => {
+			validations += 1;
+			return { allowed: true, result: "allow", action: "continue", reason: "same approved receipt", gateContext: nativeGateContext("same-lineage", "same-revision", tree) };
+		},
+	}));
+	const command = "git commit -m same-binding";
+
+	assert.equal(await toolCall({ toolName: "bash", input: { command } }, context(cwd)), undefined);
+	const replayInput = { command };
+	const replay = await toolCall({ toolName: "bash", input: replayInput }, context(cwd)) as { block: boolean };
+	assert.equal(replay.block, true);
+	assert.equal(replayInput.command, command);
+	assert.equal(validations, 3, "the replay may discover the binding once but must not revalidate or authorize it");
+});
+
+test("a new approved candidate binding may authorize the same command and cwd later in the session", async (t) => {
+	const cwd = repository(t);
+	const command = "git commit -m reusable-command";
+	const requests: Parameters<NativeReviewCli["validate"]>[0][] = [];
+	const { toolCall } = runtime(fakeNative({
+		validate: async (request) => {
+			requests.push(request);
+			const tree = git(cwd, "write-tree");
+			const suffix = tree.slice(0, 8);
+			return { allowed: true, result: "allow", action: "continue", reason: "candidate-bound receipt", gateContext: nativeGateContext(`lineage-${suffix}`, `revision-${suffix}`, tree) };
+		},
+	}));
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	git(cwd, "add", "--", "app.ts");
+	const firstInput = { command };
+	assert.equal(await toolCall({ toolName: "bash", input: firstInput }, context(cwd)), undefined);
+	assert.notEqual(firstInput.command, command);
+
+	writeFileSync(join(cwd, "app.ts"), "export const value = 3;\n");
+	git(cwd, "add", "--", "app.ts");
+	const secondInput = { command };
+	assert.equal(await toolCall({ toolName: "bash", input: secondInput }, context(cwd)), undefined);
+	assert.notEqual(secondInput.command, command);
+	assert.equal(requests.length, 4);
+	assert.equal(requests[0]?.lineageId, undefined);
+	assert.equal(requests[1]?.lineageId?.startsWith("lineage-"), true);
+	assert.equal(requests[2]?.lineageId, undefined);
+	assert.equal(requests[3]?.lineageId?.startsWith("lineage-"), true);
+});
+
+test("a denied native discovery does not prevent a later valid receipt for the same command", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	git(cwd, "add", "--", "app.ts");
+	const tree = git(cwd, "write-tree");
+	let validations = 0;
+	const { toolCall } = runtime(fakeNative({
+		validate: async () => {
+			validations += 1;
+			return validations === 1
+				? { allowed: false, result: "scope-changed", action: "create-new-lineage", reason: "not approved yet", gateContext: nativeGateContext("", "denied", tree) }
+				: { allowed: true, result: "allow", action: "continue", reason: "now approved", gateContext: nativeGateContext("later-lineage", "later-revision", tree) };
+		},
+	}));
+	const command = "git commit -m later-approved";
+
+	assert.equal((await toolCall({ toolName: "bash", input: { command } }, context(cwd)) as { block: boolean }).block, true);
+	const approvedInput = { command };
+	assert.equal(await toolCall({ toolName: "bash", input: approvedInput }, context(cwd)), undefined);
+	assert.notEqual(approvedInput.command, command);
+	assert.equal(validations, 3);
+});
+
+test("a blocked bash-time native gate does not consume its receipt binding", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	git(cwd, "add", "--", "app.ts");
+	const tree = git(cwd, "write-tree");
+	let validations = 0;
+	const { toolCall } = runtime(fakeNative({
+		validate: async () => {
+			validations += 1;
+			if (validations === 2) return { allowed: false, result: "invalidated", action: "explicit-maintainer-action", reason: "transient authority block", gateContext: nativeGateContext("retry-lineage", "retry-revision", tree) };
+			return { allowed: true, result: "allow", action: "continue", reason: "approved", gateContext: nativeGateContext("retry-lineage", "retry-revision", tree) };
+		},
+	}));
+	const command = "git commit -m retry-binding";
+
+	assert.equal((await toolCall({ toolName: "bash", input: { command } }, context(cwd)) as { block: boolean }).block, true);
+	const retryInput = { command };
+	assert.equal(await toolCall({ toolName: "bash", input: retryInput }, context(cwd)), undefined);
+	assert.notEqual(retryInput.command, command);
+	assert.equal(validations, 4);
+});
+
+test("fresh pre-commit rejects an approved receipt for a different index tree", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	git(cwd, "add", "--", "app.ts");
+	let validations = 0;
+	const { toolCall } = runtime(fakeNative({
+		validate: async () => {
+			validations += 1;
+			return { allowed: true, result: "allow", action: "continue", reason: "stale receipt", gateContext: nativeGateContext("stale-lineage", "r1", "f".repeat(40)) };
+		},
+	}));
+	const command = "git commit -m stale";
+	const input = { command };
+
+	const result = await toolCall({ toolName: "bash", input }, context(cwd)) as { block: boolean; reason: string };
+	assert.equal(result.block, true);
+	assert.match(result.reason, /does not bind the exact current pre-commit tree/);
+	assert.equal(validations, 1);
+	assert.equal(input.command, command);
+});
+
+test("fresh pre-commit honors native disabled/unmanaged delivery without restoring stale authority", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	git(cwd, "add", "--", "app.ts");
+	let validations = 0;
+	const { toolCall } = runtime(fakeNative({
+		validate: async () => {
+			validations += 1;
+			return {
+				allowed: false,
+				result: "invalidated",
+				action: "repository-policy",
+				reason: "receipt-driven development is disabled",
+				gateContext: nativeGateContext("", "r1", git(cwd, "write-tree")),
+				delivery: "disabled/unmanaged",
+			};
+		},
+		targetStatus: async () => { throw new Error("disabled delivery must not restore stale authority"); },
+	}));
+	const command = "git commit -m unmanaged";
+	const input = { command };
+
+	assert.equal(await toolCall({ toolName: "bash", input }, context(cwd)), undefined);
+	assert.equal(validations, 1);
+	assert.equal(input.command, command, "unmanaged delivery must remain an ordinary repository command");
 });
 
 test("native VALIDATE delivery disabled/unmanaged renders as a successful skipped envelope before the maintainer-exception check, minting no authorization", async (t) => {
@@ -1965,7 +2140,7 @@ test("native pre-commit after reload delegates exact-tree validation when no loc
 			validations += 1;
 			return { allowed: true, result: "allow", action: "continue", reason: "native receipt matches", gateContext: nativeGateContext("reloaded-lineage", "r1", git(cwd, "write-tree")) };
 		},
-		targetStatus: async () => targetStatusFixture({ lineageId: "reloaded-lineage", baseTree: git(cwd, "rev-parse", "HEAD^{tree}"), currentCandidateTree: git(cwd, "write-tree"), paths: ["app.ts"] }),
+		targetStatus: async () => targetStatusFixture({ lineageId: "reloaded-lineage", baseTree: git(cwd, "rev-parse", "HEAD^{tree}"), currentCandidateTree: git(cwd, "write-tree"), paths: ["app.ts"], projection: "staged" }),
 	}), undefined, undefined, undefined, new CandidateViewRegistry());
 	const validated = await controller.execute("reload-pre-commit", { operation: "validate", lineageId: "reloaded-lineage", idempotencyKey: "reload", command: "git commit -m reload", input: "{}" }, undefined, undefined, context(cwd));
 	assert.equal(validations, 1);
@@ -3236,7 +3411,7 @@ test("native deny, target drift, and bash-time errors never restore an authoriza
 	await drifting.controller.execute("allow", { operation: "validate", lineageId: "native-lineage", idempotencyKey: "key", command, input: "{}" }, undefined, undefined, context(cwd));
 	assert.equal((await drifting.toolCall({ toolName: "bash", input: { command } }, context(cwd)) as { block: boolean }).block, true);
 	assert.equal((await drifting.toolCall({ toolName: "bash", input: { command } }, context(cwd)) as { block: boolean }).block, true);
-	assert.equal(calls, 2);
+	assert.equal(calls, 3, "a blocked gate is not consumed, so the retry performs one fresh fail-closed discovery");
 
 	const failing = runtime(fakeNative({
 		validate: async () => { throw new Error("native connection lost"); },


### PR DESCRIPTION
Closes #204
Closes #225

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Restore valid staged-index candidate projections without weakening projection drift checks.
- Consume exact approved native pre-commit receipts when Pi has no in-session authorization.
- Preserve one-shot command/cwd binding, native revalidation, TOCTOU protection, and disabled/unmanaged delivery.

## Changes

| File | Change |
|------|--------|
| `lib/review-candidate-view.ts` | Distinguish exact staged index projections from committed ranges and dirty workspace snapshots. |
| `extensions/gentle-ai.ts` | Discover and consume exact native receipt bindings while preserving durable commit transaction safety. |
| `tests/review-candidate-view.test.ts` | Cover staged index acceptance and mislabeled dirty workspace rejection. |
| `tests/review-controller-native-routing.test.ts` | Cover fresh receipt consumption, stale trees, one-shot identity, retries, and disabled delivery. |
| `tests/gentle-ai.test.ts` | Make the no-native authorization fixture explicit. |

## Chain context

```text
📍 PR 1 — pre-commit projection and authorization (#204, #225)
   └── PR 2 — candidate-scoped RDD consent and kill-switch parity (after PR 1 merges)
```

**Start state:** approved native receipts can be rejected by Pi projection restoration or remain invisible to the lifecycle interceptor.

**End state:** exact approved pre-commit targets can authorize the exact command once; drift and stale bindings still fail closed.

**Out of scope:** candidate-scoped RDD consent, localization, and stale-memory reset. Those remain the second PR in this chain.

## Test plan

- [x] `node --experimental-strip-types --test tests/review-candidate-view.test.ts` — 44 passed.
- [x] Focused native pre-commit routing regressions — 15 passed.
- [x] `node --experimental-strip-types --test tests/gentle-ai.test.ts` — 7 passed.
- [x] `node --experimental-strip-types --test tests/git-commit-transaction.test.ts` — passed.
- [x] `pnpm run check:transaction-runner` — passed.
- [x] `node scripts/verify-package-files.mjs` — passed.
- [x] `git diff --check` — passed.
- [x] Full patched and baseline suites were compared in isolated clones: both retain the same 13 pre-existing failures; this patch adds 9 passing tests and introduces zero new failures.

## Contributor checklist

- [x] Linked approved issues.
- [x] Uses conventional commit format.
- [x] Includes regression tests with the behavior change.
- [x] Preserves exact command, cwd, tree, lineage, revision, and TOCTOU bindings.
- [x] Contains no AI attribution or `Co-Authored-By` trailers.
- [x] Follow-up documentation and consent behavior are explicitly bounded to PR 2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native restoration validation for staged vs workspace projections using fresh Git write-tree comparisons, failing closed on mismatches.
  * Added native pre-commit receipt consumption with exact tree revalidation to mint pending authorizations, return disabled/unmanaged markers, or decline when bindings don’t match.
  * Updated gate lifecycle and bash-time authorization selection to prevent re-consuming the same native authorization within a session.
  * Preserved unmanaged behavior to avoid restoring stale authority.
* **Tests**
  * Expanded native receipt and bash-time gating scenarios, including deduplication, stale receipt rejection, and unmanaged/disabled delivery behavior.
  * Added staged-projection restore tests and improved test parameterization for projection type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->