### PR TITLE
fix(install): build trusted Windows runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Most coding-agent sessions fail for operational reasons, not model reasons:
 | **Skill creation workflow**    | Provides the `gentle-ai-skill-creator`/`gentle-ai-skill-improver` skills, `/skill-creation` prompt, and packaged style guide for LLM-first skills. |
 | **Delivery skills**            | Includes issue-first PRs, chained PRs, work-unit commits, cognitive docs, comment writing, and Judgment Day review.                           |
 | **Bounded native review**      | Freezes one candidate, dispatches only controller-selected lenses, records native authority, and reuses the same content-bound receipt at delivery gates. |
-| **Verified native runtime**    | Provisions the exact package-local Gentle AI v2.2.1 binary, verifies pinned archive/binary integrity, negotiates `review-integration/v1` today, and rejects PATH, global, sibling, symlink, and mode fallbacks. `review-integration/v2`'s immutable `base_tree`/`candidate_tree` transport is staged for a separate release-gated cutover (see [Native Authority Architecture](docs/native-authority-architecture.md)). |
+| **Verified native runtime**    | Provisions the exact package-local Gentle AI v2.2.2 runtime: signed archives on Darwin/Linux and a Go SumDB-verified source build on Windows x64/arm64. It validates package-local integrity and rejects PATH, global, sibling, symlink, and mode fallbacks. |
 | **Runtime safety**             | Blocks destructive shell commands, asks for confirmation for sensitive operations, and blocks direct read/write/edit access to sensitive paths. |
 
 ## Install
@@ -79,7 +79,7 @@ pi install npm:gentle-pi@0.14.0
 pi install npm:gentle-pi@latest
 ```
 
-The latest RDD package downloads its pinned platform-specific Gentle AI binary into the package's private `.gentle-ai/` directory and verifies archive and executable SHA-256 values before extraction. It never uses `PATH` or a global `gentle-ai` installation. For development or offline installs only, set `GENTLE_PI_SKIP_GENTLE_AI_INSTALL=1`; native review operations then fail closed with an actionable `package-local-binary-missing` error until the package is reinstalled normally.
+The latest RDD package installs Gentle AI only into its private `.gentle-ai/` directory. Darwin and Linux use pinned signed archives with archive and executable SHA-256 verification. Windows x64 and arm64 build the exact `v2.2.2` source tag with a local Go 1.25.10+ toolchain, a sealed Go environment, `GOTOOLCHAIN=local`, and `GOSUMDB=sum.golang.org`; it does not download Go automatically. Windows provenance is Go-toolchain plus SumDB evidence and postinstall tamper detection, **not** Authenticode or protection against a malicious joint binary-and-manifest replacement. Package-private locks coordinate cooperative concurrent or crashed installers; their tombstones fail closed. A malicious same-user process with write access to package-private `node_modules` is outside that protocol because it can already replace package code, binary, or manifest, and portable Node has no pathname-delete CAS. It never uses `PATH` or a global `gentle-ai` installation. For development or offline installs only, set `GENTLE_PI_SKIP_GENTLE_AI_INSTALL=1`; native review operations then fail closed with an actionable `package-local-binary-missing` error until the package is reinstalled normally.
 
 Recommended companion packages:
 
@@ -660,7 +660,7 @@ Memory contract for SDD delegation:
 | `lib/review-canonical.ts`      | Permanent Pi-owned canonical JSON and domain-hash primitives for consumer-side identities.                   |
 | `lib/review-repository.ts`     | Permanent Pi-owned Git common-directory identity, safe Git environment, and authority-root binding.          |
 | `lib/gentle-ai-binary.ts`      | Resolves and verifies the confined package-local Gentle AI runtime without global or PATH fallback.          |
-| `scripts/gentle-ai-installer.mjs` | Downloads, verifies, extracts, and atomically promotes the pinned native runtime for six platform targets. |
+| `scripts/gentle-ai-installer.mjs` | Installs signed Darwin/Linux archives or exact Go SumDB-verified Windows source builds into the package-local runtime. |
 | `contracts/review-integration/v1/` | Byte-identical provider schemas and conformance fixtures for contract `review-integration/v1`, hash-checked before packaging; retained on disk permanently because `/v2`'s schemas `$ref` into these fragments. |
 | `contracts/review-integration/v2/` | Byte-identical provider schemas and conformance fixtures for contract `review-integration/v2` (immutable `base_tree`/`candidate_tree`, ordered `changed_path_manifest`, no inline candidate diff), hash-checked before packaging. |
 | `extensions/startup-banner.ts` | Shows and configures the startup intro, color presets, compact runtime panel, and collaboration credit.     |

--- a/lib/gentle-ai-binary.ts
+++ b/lib/gentle-ai-binary.ts
@@ -1,7 +1,16 @@
 import { createHash } from "node:crypto";
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { resolveGentleAiReleaseAsset } from "../scripts/gentle-ai-installer.mjs";
+import {
+	GENTLE_AI_INSTALL_METHOD,
+	GENTLE_AI_WINDOWS_SOURCE_MODULE,
+	GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
+	GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH,
+	GENTLE_AI_WINDOWS_SOURCE_TAG,
+	isGentleAiWindowsGoVersionSupported,
+	isWindowsGoSumdbSourceTarget,
+	resolveGentleAiReleaseAsset,
+} from "../scripts/gentle-ai-installer.mjs";
 import { fileURLToPath } from "node:url";
 
 export const GENTLE_AI_BINARY_MISSING_CODE = "package-local-binary-missing";
@@ -49,6 +58,50 @@ function assertPosixExecutable(path: string, platform: string): void {
 	}
 }
 
+function signedReleaseManifest(asset: { name: string; sha256: string; binarySha256: string }): Record<string, string> {
+	return { version: GENTLE_AI_VERSION, asset: asset.name, assetSha256: asset.sha256, binarySha256: asset.binarySha256 };
+}
+
+function windowsSourceManifest(manifest: Record<string, unknown>, binarySha256: string, platform: string): Record<string, string> {
+	if (!isWindowsGoSumdbSourceTarget(platform, process.arch)) throw new Error("unsupported Windows source architecture");
+	const architecture = process.arch === "x64" ? "x64" : "arm64";
+	const goVersion = manifest.goVersion;
+	if (manifest.moduleChecksum !== GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM || typeof goVersion !== "string" || !isGentleAiWindowsGoVersionSupported(goVersion)) throw new Error("invalid Windows source provenance");
+	return {
+		version: GENTLE_AI_VERSION,
+		method: GENTLE_AI_INSTALL_METHOD.GO_SUMDB_SOURCE_BUILD,
+		package: GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH,
+		module: GENTLE_AI_WINDOWS_SOURCE_MODULE,
+		tag: GENTLE_AI_WINDOWS_SOURCE_TAG,
+		architecture,
+		binarySha256,
+		moduleChecksum: GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
+		goVersion,
+		goos: "windows",
+		goarch: process.arch === "x64" ? "amd64" : "arm64",
+		buildMode: "exe",
+		compiler: "gc",
+		cgoEnabled: "0",
+	};
+}
+
+function expectedRuntimeManifest(platform: string, binarySha256: string, manifest: Record<string, unknown>): Record<string, string> {
+	if (platform === "win32") return windowsSourceManifest(manifest, binarySha256, platform);
+	const asset = resolveGentleAiReleaseAsset(platform, process.arch);
+	if (binarySha256 !== asset.binarySha256) throw new Error("runtime binary does not match pinned release digest");
+	return signedReleaseManifest(asset);
+}
+
+function isCanonicalManifest(contents: string, manifest: Record<string, unknown>, expected: Record<string, string>): boolean {
+	return contents === `${JSON.stringify(expected)}\n`
+		&& Object.keys(manifest).length === Object.keys(expected).length
+		&& Object.entries(expected).every(([key, value]) => manifest[key] === value);
+}
+
+function sameFile(before: ReturnType<typeof lstatSync>, after: ReturnType<typeof lstatSync>): boolean {
+	return before.dev === after.dev && before.ino === after.ino && before.size === after.size && before.mtimeMs === after.mtimeMs;
+}
+
 export function resolveGentleAiBinary(
 	packageRoot = dirname(dirname(fileURLToPath(import.meta.url))),
 	platform = process.platform,
@@ -66,22 +119,16 @@ export function resolveGentleAiBinary(
 		assertRegularNonSymlink(binaryPath);
 		assertPosixExecutable(binaryPath, platform);
 		assertRegularNonSymlink(manifestPath);
-		const before = lstatSync(binaryPath);
-		const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, unknown>;
-		const asset = resolveGentleAiReleaseAsset(platform, process.arch);
-		if (
-			Object.keys(manifest).length !== 4 ||
-			["version", "asset", "assetSha256", "binarySha256"].some((key) => !(key in manifest)) ||
-			manifest.version !== GENTLE_AI_VERSION ||
-			manifest.asset !== asset.name ||
-			manifest.assetSha256 !== asset.sha256 ||
-			typeof manifest.binarySha256 !== "string" ||
-			manifest.binarySha256 !== asset.binarySha256 ||
-			!/^[0-9a-f]{64}$/.test(manifest.binarySha256) ||
-			sha256(readBinary(binaryPath)) !== manifest.binarySha256
-		) throw new Error("invalid runtime integrity manifest");
-		const after = lstatSync(binaryPath);
-		if (before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || before.mtimeMs !== after.mtimeMs) throw new Error("runtime replaced during verification");
+		const beforeBinary = lstatSync(binaryPath);
+		const beforeManifest = lstatSync(manifestPath);
+		const manifestContents = readFileSync(manifestPath, "utf8");
+		const manifest = JSON.parse(manifestContents) as Record<string, unknown>;
+		const binarySha256 = sha256(readBinary(binaryPath));
+		const expected = expectedRuntimeManifest(platform, binarySha256, manifest);
+		if (!isCanonicalManifest(manifestContents, manifest, expected)) throw new Error("invalid runtime integrity manifest");
+		const afterBinary = lstatSync(binaryPath);
+		const afterManifest = lstatSync(manifestPath);
+		if (!sameFile(beforeBinary, afterBinary) || !sameFile(beforeManifest, afterManifest)) throw new Error("runtime replaced during verification");
 		assertPosixExecutable(binaryPath, platform);
 		return binaryPath;
 	} catch {

--- a/runtime/gentle-ai-binary.mjs
+++ b/runtime/gentle-ai-binary.mjs
@@ -2,7 +2,16 @@
 import { createHash } from "node:crypto";
 import { existsSync, lstatSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { resolveGentleAiReleaseAsset } from "../scripts/gentle-ai-installer.mjs";
+import {
+	GENTLE_AI_INSTALL_METHOD,
+	GENTLE_AI_WINDOWS_SOURCE_MODULE,
+	GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
+	GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH,
+	GENTLE_AI_WINDOWS_SOURCE_TAG,
+	isGentleAiWindowsGoVersionSupported,
+	isWindowsGoSumdbSourceTarget,
+	resolveGentleAiReleaseAsset,
+} from "../scripts/gentle-ai-installer.mjs";
 import { fileURLToPath } from "node:url";
 
 export const GENTLE_AI_BINARY_MISSING_CODE = "package-local-binary-missing";
@@ -50,6 +59,50 @@ function assertPosixExecutable(path        , platform        )       {
 	}
 }
 
+function signedReleaseManifest(asset                                                        )                         {
+	return { version: GENTLE_AI_VERSION, asset: asset.name, assetSha256: asset.sha256, binarySha256: asset.binarySha256 };
+}
+
+function windowsSourceManifest(manifest                         , binarySha256        , platform        )                         {
+	if (!isWindowsGoSumdbSourceTarget(platform, process.arch)) throw new Error("unsupported Windows source architecture");
+	const architecture = process.arch === "x64" ? "x64" : "arm64";
+	const goVersion = manifest.goVersion;
+	if (manifest.moduleChecksum !== GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM || typeof goVersion !== "string" || !isGentleAiWindowsGoVersionSupported(goVersion)) throw new Error("invalid Windows source provenance");
+	return {
+		version: GENTLE_AI_VERSION,
+		method: GENTLE_AI_INSTALL_METHOD.GO_SUMDB_SOURCE_BUILD,
+		package: GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH,
+		module: GENTLE_AI_WINDOWS_SOURCE_MODULE,
+		tag: GENTLE_AI_WINDOWS_SOURCE_TAG,
+		architecture,
+		binarySha256,
+		moduleChecksum: GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
+		goVersion,
+		goos: "windows",
+		goarch: process.arch === "x64" ? "amd64" : "arm64",
+		buildMode: "exe",
+		compiler: "gc",
+		cgoEnabled: "0",
+	};
+}
+
+function expectedRuntimeManifest(platform        , binarySha256        , manifest                         )                         {
+	if (platform === "win32") return windowsSourceManifest(manifest, binarySha256, platform);
+	const asset = resolveGentleAiReleaseAsset(platform, process.arch);
+	if (binarySha256 !== asset.binarySha256) throw new Error("runtime binary does not match pinned release digest");
+	return signedReleaseManifest(asset);
+}
+
+function isCanonicalManifest(contents        , manifest                         , expected                        )          {
+	return contents === `${JSON.stringify(expected)}\n`
+		&& Object.keys(manifest).length === Object.keys(expected).length
+		&& Object.entries(expected).every(([key, value]) => manifest[key] === value);
+}
+
+function sameFile(before                              , after                              )          {
+	return before.dev === after.dev && before.ino === after.ino && before.size === after.size && before.mtimeMs === after.mtimeMs;
+}
+
 export function resolveGentleAiBinary(
 	packageRoot = dirname(dirname(fileURLToPath(import.meta.url))),
 	platform = process.platform,
@@ -67,22 +120,16 @@ export function resolveGentleAiBinary(
 		assertRegularNonSymlink(binaryPath);
 		assertPosixExecutable(binaryPath, platform);
 		assertRegularNonSymlink(manifestPath);
-		const before = lstatSync(binaryPath);
-		const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))                           ;
-		const asset = resolveGentleAiReleaseAsset(platform, process.arch);
-		if (
-			Object.keys(manifest).length !== 4 ||
-			["version", "asset", "assetSha256", "binarySha256"].some((key) => !(key in manifest)) ||
-			manifest.version !== GENTLE_AI_VERSION ||
-			manifest.asset !== asset.name ||
-			manifest.assetSha256 !== asset.sha256 ||
-			typeof manifest.binarySha256 !== "string" ||
-			manifest.binarySha256 !== asset.binarySha256 ||
-			!/^[0-9a-f]{64}$/.test(manifest.binarySha256) ||
-			sha256(readBinary(binaryPath)) !== manifest.binarySha256
-		) throw new Error("invalid runtime integrity manifest");
-		const after = lstatSync(binaryPath);
-		if (before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size || before.mtimeMs !== after.mtimeMs) throw new Error("runtime replaced during verification");
+		const beforeBinary = lstatSync(binaryPath);
+		const beforeManifest = lstatSync(manifestPath);
+		const manifestContents = readFileSync(manifestPath, "utf8");
+		const manifest = JSON.parse(manifestContents)                           ;
+		const binarySha256 = sha256(readBinary(binaryPath));
+		const expected = expectedRuntimeManifest(platform, binarySha256, manifest);
+		if (!isCanonicalManifest(manifestContents, manifest, expected)) throw new Error("invalid runtime integrity manifest");
+		const afterBinary = lstatSync(binaryPath);
+		const afterManifest = lstatSync(manifestPath);
+		if (!sameFile(beforeBinary, afterBinary) || !sameFile(beforeManifest, afterManifest)) throw new Error("runtime replaced during verification");
 		assertPosixExecutable(binaryPath, platform);
 		return binaryPath;
 	} catch {

--- a/scripts/gentle-ai-installer.mjs
+++ b/scripts/gentle-ai-installer.mjs
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { createWriteStream, existsSync } from "node:fs";
 import {
 	chmod,
@@ -13,7 +13,7 @@ import {
 	writeFile,
 } from "node:fs/promises";
 import https from "node:https";
-import { dirname, isAbsolute, join, relative, win32 } from "node:path";
+import { dirname, isAbsolute, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -23,7 +23,34 @@ const RELEASE_BASE_URL = "https://github.com/Gentleman-Programming/gentle-ai/rel
 const MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
 const MAX_REDIRECTS = 3;
 const DOWNLOAD_TIMEOUTS = { headers: 10_000, body: 30_000, attempts: 2, retryDelay: 100 };
+const GO_COMMAND_TIMEOUT_MS = 120_000;
+const GO_COMMAND_MAX_BUFFER = 1024 * 1024;
+const WINDOWS_SYSTEM_ROOT = "C:\\Windows";
 export const INSTALLER_VERSION = "2.2.2";
+export const GENTLE_AI_INSTALL_METHOD = Object.freeze({
+	SIGNED_RELEASE_ASSET: "signed-release-asset",
+	GO_SUMDB_SOURCE_BUILD: "go-sumdb-source-build",
+});
+export const GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH = "github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai";
+export const GENTLE_AI_WINDOWS_SOURCE_MODULE = "github.com/gentleman-programming/gentle-ai/v2";
+export const GENTLE_AI_WINDOWS_SOURCE_TAG = "v2.2.2";
+// `go mod download -json github.com/gentleman-programming/gentle-ai/v2@v2.2.2`
+// with GOSUMDB=sum.golang.org reports this exact module SumDB checksum.
+export const GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM = "h1:YZcI5dRvoHm82I2CULvgBkB2M3UQQGarYO/u/Nt5LSc=";
+export const GENTLE_AI_WINDOWS_SOURCE_PACKAGE = `${GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH}@${GENTLE_AI_WINDOWS_SOURCE_TAG}`;
+export const GENTLE_AI_WINDOWS_MINIMUM_GO_VERSION = "1.25.10";
+export const GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE_CODE = "GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE";
+export const GENTLE_AI_GO_TOOLCHAIN_TOO_OLD_CODE = "GENTLE_AI_GO_TOOLCHAIN_TOO_OLD";
+export const GENTLE_AI_GO_INSTALL_FAILED_CODE = "GENTLE_AI_GO_INSTALL_FAILED";
+export const GENTLE_AI_VERSION_MISMATCH_CODE = "GENTLE_AI_VERSION_MISMATCH";
+
+export class GentleAiInstallerError extends Error {
+	constructor(code, message, cause) {
+		super(message, cause === undefined ? undefined : { cause });
+		this.code = code;
+		this.name = "GentleAiInstallerError";
+	}
+}
 
 // Sentinel used while a re-pinned gentle-ai release is not yet published. A
 // sentinel digest can never match a real SHA-256, so installation fails closed,
@@ -38,12 +65,11 @@ function asset(name, sha256, binarySha256, executable) {
 	return Object.freeze({ name, sha256, binarySha256, executable, url: `${RELEASE_BASE_URL}${name}` });
 }
 
-// Windows is absent on purpose. gentle-ai stopped distributing Windows builds
-// in c4b764d0 ("omit unsigned Windows distribution"), so v2.2.2 publishes only
-// darwin and linux archives and there is nothing to pin. A Windows caller now
-// gets resolveGentleAiReleaseAsset's unsupported-platform error, which is the
-// truth: Pi cannot install a binary that upstream does not publish. Restore
-// both rows the moment gentle-ai ships signed Windows assets again.
+// Windows is absent from signed release archives on purpose. gentle-ai stopped
+// distributing unsigned Windows builds in c4b764d0, so v2.2.2 publishes signed
+// Darwin/Linux archives only. Windows x64/arm64 uses the separately verified
+// exact-tag Go SumDB source-build path below; restore archive rows only when
+// upstream ships signed Windows assets.
 export const GENTLE_AI_RELEASE_ASSETS = Object.freeze({
 	"darwin/amd64": asset("gentle-ai_2.2.2_darwin_amd64.tar.gz", "5ca67829903bf4c6b14665664f80f9d8216c84b10c8e50870d297f452cefb9dc", "9b239423450562d026384f482bbd2f1e3f2820431a84f0921743ac3df9d632de", "gentle-ai"),
 	"darwin/arm64": asset("gentle-ai_2.2.2_darwin_arm64.tar.gz", "0193e1a284444dccee2863d31b8dbb76a982e8f9111955908d6a9131c1a5490e", "149b97248552c5e03ebc4d991f86b1360fb847a40fc315555a8aa256f95baca0", "gentle-ai"),
@@ -59,10 +85,19 @@ function upstreamPlatform(platform) {
 	return platform === "win32" ? "windows" : platform;
 }
 
+export function isWindowsGoSumdbSourceTarget(platform = process.platform, architecture = process.arch) {
+	return platform === "win32" && ["x64", "arm64"].includes(architecture);
+}
+
 export function resolveGentleAiReleaseAsset(platform = process.platform, architecture = process.arch, releaseAssets = GENTLE_AI_RELEASE_ASSETS) {
 	const key = `${upstreamPlatform(platform)}/${upstreamArchitecture(architecture)}`;
 	const resolved = releaseAssets[key];
-	if (!resolved) throw new Error(`unsupported Gentle AI platform/architecture: ${platform}/${architecture}; supported pairs are darwin, linux, or windows with x64 or arm64`);
+	if (!resolved) {
+		const windowsSource = isWindowsGoSumdbSourceTarget(platform, architecture)
+			? "; Windows x64/arm64 use Go SumDB source installation because no signed Windows archive is published"
+			: "";
+		throw new Error(`unsupported Gentle AI platform/architecture: ${platform}/${architecture}; signed archive pairs are darwin/x64, darwin/arm64, linux/x64, and linux/arm64${windowsSource}`);
+	}
 	return resolved;
 }
 
@@ -172,73 +207,421 @@ function isConfined(path, directory) {
 	return value !== "" && !value.startsWith("..") && !isAbsolute(value);
 }
 
-async function existingBinaryMatches(binaryPath, manifestPath, asset, platform) {
-	try {
-		const runtimeDirectory = dirname(binaryPath);
-		const packageRuntimeDirectory = dirname(runtimeDirectory);
-		if (!isConfined(binaryPath, runtimeDirectory) || !isConfined(manifestPath, runtimeDirectory)) return false;
-		const [parent, runtime, binary, manifestFile, manifest] = await Promise.all([
-			lstat(packageRuntimeDirectory), lstat(runtimeDirectory), lstat(binaryPath), lstat(manifestPath), readFile(manifestPath, "utf8"),
-		]);
-		const parsed = JSON.parse(manifest);
-		return parent.isDirectory() && !parent.isSymbolicLink()
-			&& runtime.isDirectory() && !runtime.isSymbolicLink()
-			&& binary.isFile() && !binary.isSymbolicLink()
-			&& (platform === "win32" || (binary.mode & 0o111) !== 0)
-			&& manifestFile.isFile() && !manifestFile.isSymbolicLink()
-			&& typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-			&& Object.keys(parsed).length === 4
-			&& ["version", "asset", "assetSha256", "binarySha256"].every((key) => key in parsed)
-			&& parsed.version === INSTALLER_VERSION
-			&& parsed.asset === asset.name
-			&& parsed.assetSha256 === asset.sha256
-			&& typeof parsed.binarySha256 === "string"
-			&& /^[0-9a-f]{64}$/.test(parsed.binarySha256)
-			&& (!asset.binarySha256 || parsed.binarySha256 === asset.binarySha256)
-			&& parsed.binarySha256 === await sha256File(binaryPath);
-	} catch {
-		return false;
+function signedReleaseManifest(asset, binarySha256) {
+	return { version: INSTALLER_VERSION, asset: asset.name, assetSha256: asset.sha256, binarySha256 };
+}
+
+function windowsSourceManifest(metadata, binarySha256, architecture) {
+	return {
+		version: INSTALLER_VERSION,
+		method: GENTLE_AI_INSTALL_METHOD.GO_SUMDB_SOURCE_BUILD,
+		package: GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH,
+		module: GENTLE_AI_WINDOWS_SOURCE_MODULE,
+		tag: GENTLE_AI_WINDOWS_SOURCE_TAG,
+		architecture,
+		binarySha256,
+		moduleChecksum: GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
+		goVersion: metadata.goVersion,
+		goos: metadata.goos,
+		goarch: metadata.goarch,
+		buildMode: metadata.buildMode,
+		compiler: metadata.compiler,
+		cgoEnabled: metadata.cgoEnabled,
+	};
+}
+
+function canonicalManifest(manifest) { return `${JSON.stringify(manifest)}\n`; }
+
+function isCanonicalManifest(contents, parsed, expected) {
+	return contents === canonicalManifest(expected)
+		&& typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+		&& Object.keys(parsed).length === Object.keys(expected).length
+		&& Object.entries(expected).every(([key, value]) => parsed[key] === value);
+}
+
+function commandOutput(result) { return typeof result?.stdout === "string" ? result.stdout : ""; }
+
+function commandOptions(env, cwd) {
+	return { cwd, env, shell: false, windowsHide: true, timeout: GO_COMMAND_TIMEOUT_MS, maxBuffer: GO_COMMAND_MAX_BUFFER };
+}
+
+function outputVersion(output) {
+	const match = /^go version go(\d+)\.(\d+)\.(\d+)(?:\s|$)/.exec(output);
+	return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
+}
+
+function isVersionAtLeast(actual, minimum) {
+	return actual[0] > minimum[0] || (actual[0] === minimum[0] && (actual[1] > minimum[1] || (actual[1] === minimum[1] && actual[2] >= minimum[2])));
+}
+
+export function isGentleAiWindowsGoVersionSupported(goVersion) {
+	const match = /^go(\d+)\.(\d+)\.(\d+)$/.exec(goVersion);
+	return match !== null && isVersionAtLeast(match.slice(1).map(Number), GENTLE_AI_WINDOWS_MINIMUM_GO_VERSION.split(".").map(Number));
+}
+
+function expectedGoArchitecture(architecture) { return architecture === "x64" ? "amd64" : "arm64"; }
+
+function sealedGoEnvironment(goPath, buildDirectory, architecture) {
+	const goDirectory = dirname(goPath);
+	const tempDirectory = join(buildDirectory, "tmp");
+	return {
+		GOENV: "off", GOFLAGS: "", GOWORK: "off", GOTOOLCHAIN: "local", GOSUMDB: "sum.golang.org",
+		GONOSUMDB: "", GOPRIVATE: "", GONOPROXY: "", GOINSECURE: "", GOPROXY: "https://proxy.golang.org",
+		GOOS: "windows", GOARCH: expectedGoArchitecture(architecture), CGO_ENABLED: "0",
+		GOBIN: join(buildDirectory, "gobin"), GOPATH: join(buildDirectory, "gopath"), GOMODCACHE: join(buildDirectory, "gomodcache"), GOCACHE: join(buildDirectory, "gocache"),
+		SystemRoot: WINDOWS_SYSTEM_ROOT, WINDIR: WINDOWS_SYSTEM_ROOT, ComSpec: join(WINDOWS_SYSTEM_ROOT, "System32", "cmd.exe"),
+		TEMP: tempDirectory, TMP: tempDirectory, PATHEXT: ".COM;.EXE;.BAT;.CMD",
+		PATH: [goDirectory, join(WINDOWS_SYSTEM_ROOT, "System32"), WINDOWS_SYSTEM_ROOT].join(";"),
+	};
+}
+
+async function runCommand(execute, file, arguments_, options) { return execute(file, arguments_, options); }
+
+async function resolveWindowsGoExecutable(options) {
+	let resolved;
+	if (options.resolveGoExecutable) resolved = await options.resolveGoExecutable();
+	else {
+		try {
+			const result = await execFileAsync(join(WINDOWS_SYSTEM_ROOT, "System32", "where.exe"), ["go.exe"], { shell: false, windowsHide: true, timeout: GO_COMMAND_TIMEOUT_MS, maxBuffer: GO_COMMAND_MAX_BUFFER });
+			resolved = commandOutput(result).split(/\r?\n/).find((value) => isAbsolute(value));
+		} catch (error) {
+			throw new GentleAiInstallerError(GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE_CODE, `Windows source installation requires local Go ${GENTLE_AI_WINDOWS_MINIMUM_GO_VERSION} or newer; install Go and retry (automatic Go toolchain download is disabled).`, error);
+		}
 	}
+	if (typeof resolved !== "string" || !isAbsolute(resolved)) throw new GentleAiInstallerError(GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE_CODE, "Windows source installation could not resolve an absolute local Go executable.");
+	try {
+		const details = await lstat(resolved);
+		if (!details.isFile() || details.isSymbolicLink()) throw new Error("not a regular non-symlink file");
+	} catch (error) {
+		throw new GentleAiInstallerError(GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE_CODE, "Windows source installation requires a regular non-symlink local Go executable.", error);
+	}
+	return resolved;
+}
+
+async function assertGoToolchain(execute, goPath, environment, cwd) {
+	let result;
+	try { result = await runCommand(execute, goPath, ["version"], commandOptions(environment, cwd)); }
+	catch (error) { throw new GentleAiInstallerError(GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE_CODE, `Windows source installation requires local Go ${GENTLE_AI_WINDOWS_MINIMUM_GO_VERSION} or newer; install Go and retry (automatic Go toolchain download is disabled).`, error); }
+	const version = outputVersion(commandOutput(result));
+	const minimum = GENTLE_AI_WINDOWS_MINIMUM_GO_VERSION.split(".").map(Number);
+	if (!version || !isVersionAtLeast(version, minimum)) throw new GentleAiInstallerError(GENTLE_AI_GO_TOOLCHAIN_TOO_OLD_CODE, `Windows source installation requires local Go ${GENTLE_AI_WINDOWS_MINIMUM_GO_VERSION} or newer; found ${commandOutput(result).trim() || "an unrecognized Go version"}.`);
+}
+
+function parseGoBuildMetadata(output, architecture) {
+	const fields = new Map();
+	const lines = output.split(/\r?\n/).filter(Boolean);
+	const goVersion = /:\s+(go\d+\.\d+\.\d+)$/.exec(lines[0] ?? "")?.[1];
+	for (const line of lines.slice(1)) {
+		const [kind, ...values] = line.trimStart().split(/\s+/);
+		if (kind === "path") fields.set("path", values[0]);
+		else if (kind === "mod") { fields.set("module", values[0]); fields.set("tag", values[1]); fields.set("moduleChecksum", values[2]); }
+		else if (kind === "build") { const [key, value] = (values[0] ?? "").split("="); fields.set(key, value); }
+	}
+	const metadata = {
+		goVersion, path: fields.get("path"), module: fields.get("module"), tag: fields.get("tag"), moduleChecksum: fields.get("moduleChecksum"),
+		goos: fields.get("GOOS"), goarch: fields.get("GOARCH"), buildMode: fields.get("-buildmode"), compiler: fields.get("-compiler"), cgoEnabled: fields.get("CGO_ENABLED"),
+	};
+	if (metadata.path !== GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH || metadata.module !== GENTLE_AI_WINDOWS_SOURCE_MODULE || metadata.tag !== GENTLE_AI_WINDOWS_SOURCE_TAG || metadata.moduleChecksum !== GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM || !isGentleAiWindowsGoVersionSupported(metadata.goVersion ?? "") || metadata.goos !== "windows" || metadata.goarch !== expectedGoArchitecture(architecture) || metadata.buildMode !== "exe" || metadata.compiler !== "gc" || metadata.cgoEnabled !== "0") throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, "Gentle AI source build metadata does not match the pinned Windows provenance.");
+	return metadata;
+}
+
+async function verifyGoBuildMetadata(execute, goPath, binaryPath, environment, cwd, architecture) {
+	try { return parseGoBuildMetadata(commandOutput(await runCommand(execute, goPath, ["version", "-m", binaryPath], commandOptions(environment, cwd))), architecture); }
+	catch (error) { if (error instanceof GentleAiInstallerError) throw error; throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, "Gentle AI source build metadata could not be verified.", error); }
+}
+
+async function assertExactGentleAiVersion(execute, binaryPath, environment, cwd) {
+	let result;
+	try { result = await runCommand(execute, binaryPath, ["version"], commandOptions(environment, cwd)); }
+	catch (error) { throw new GentleAiInstallerError(GENTLE_AI_VERSION_MISMATCH_CODE, `Gentle AI source build at ${binaryPath} could not report its version.`, error); }
+	if (!/^gentle-ai 2\.2\.2\r?\n?$/.test(commandOutput(result))) throw new GentleAiInstallerError(GENTLE_AI_VERSION_MISMATCH_CODE, `Gentle AI source build reported ${JSON.stringify(commandOutput(result).trim())}; expected gentle-ai ${INSTALLER_VERSION}.`);
+}
+
+function sameFile(before, after) { return before.dev === after.dev && before.ino === after.ino && before.size === after.size && before.mtimeMs === after.mtimeMs; }
+
+async function safeRemoveDirectory(path) {
+	try {
+		const details = await lstat(path);
+		if (!details.isDirectory() || details.isSymbolicLink()) throw new Error("not a real directory");
+		await rm(path, { recursive: true, force: true });
+	} catch (error) { if (!(error && typeof error === "object" && error.code === "ENOENT")) throw error; }
+}
+
+async function existingSignedBundleMatches(directory, asset, platform) {
+	try {
+		const binaryPath = join(directory, asset.executable), manifestPath = join(directory, "integrity.json");
+		const [bundle, binary, manifestFile, contents] = await Promise.all([lstat(directory), lstat(binaryPath), lstat(manifestPath), readFile(manifestPath, "utf8")]);
+		const binarySha256 = await sha256File(binaryPath);
+		return bundle.isDirectory() && !bundle.isSymbolicLink() && binary.isFile() && !binary.isSymbolicLink() && (platform === "win32" || (binary.mode & 0o111) !== 0) && manifestFile.isFile() && !manifestFile.isSymbolicLink() && (!asset.binarySha256 || asset.binarySha256 === binarySha256) && isCanonicalManifest(contents, JSON.parse(contents), signedReleaseManifest(asset, binarySha256));
+	} catch { return false; }
+}
+
+async function existingWindowsSourceBundleMatches(directory, execute, goPath, environment, architecture) {
+	try {
+		const binaryPath = join(directory, "gentle-ai.exe"), manifestPath = join(directory, "integrity.json");
+		const [bundle, binary, manifestFile, contents] = await Promise.all([lstat(directory), lstat(binaryPath), lstat(manifestPath), readFile(manifestPath, "utf8")]);
+		if (!bundle.isDirectory() || bundle.isSymbolicLink() || !binary.isFile() || binary.isSymbolicLink() || !manifestFile.isFile() || manifestFile.isSymbolicLink()) return false;
+		const parsed = JSON.parse(contents);
+		if (typeof parsed?.binarySha256 !== "string" || !/^[0-9a-f]{64}$/.test(parsed.binarySha256)) return false;
+		const beforeBinary = await lstat(binaryPath), beforeManifest = await lstat(manifestPath);
+		const metadata = await verifyGoBuildMetadata(execute, goPath, binaryPath, environment, directory, architecture);
+		if ((await sha256File(binaryPath)) !== parsed.binarySha256 || !isCanonicalManifest(contents, parsed, windowsSourceManifest(metadata, parsed.binarySha256, architecture))) return false;
+		await assertExactGentleAiVersion(execute, binaryPath, environment, directory);
+		return sameFile(beforeBinary, await lstat(binaryPath)) && sameFile(beforeManifest, await lstat(manifestPath));
+	} catch { return false; }
+}
+
+function lockIdentity(details) { return `${details.dev}:${details.ino}`; }
+
+function validInstallLockOwner(owner) {
+	return typeof owner === "object" && owner !== null
+		&& Number.isSafeInteger(owner.createdAt)
+		&& typeof owner.nonce === "string"
+		&& /^[0-9a-f]{64}$/.test(owner.nonce);
+}
+
+async function inspectInstallLock(lockPath) {
+	const details = await lstat(lockPath);
+	if (!details.isDirectory() || details.isSymbolicLink()) throw new Error("Gentle AI install lock is not a real directory");
+	let owner;
+	try {
+		const ownerPath = join(lockPath, "owner.json");
+		const ownerDetails = await lstat(ownerPath);
+		if (ownerDetails.isFile() && !ownerDetails.isSymbolicLink()) {
+			const parsed = JSON.parse(await readFile(ownerPath, "utf8"));
+			if (validInstallLockOwner(parsed)) owner = parsed;
+		}
+	} catch (error) {
+		if (!(error && typeof error === "object" && error.code === "ENOENT") && !(error instanceof SyntaxError)) throw error;
+	}
+	return { details, identity: lockIdentity(details), owner };
+}
+
+function installLockBlockedError(path) {
+	return new Error(`Gentle AI package-private installation lock or tombstone exists at ${path}. Confirm no installer is active, then remove this package-private path manually before retrying.`);
+}
+
+function installTombstonePrefix() { return `.v${INSTALLER_VERSION}.install.tombstone-`; }
+
+function installTombstonePath(runtimeRoot, nonce) {
+	const path = join(runtimeRoot, `${installTombstonePrefix()}${nonce}`);
+	if (!isConfined(path, runtimeRoot)) throw new Error("Gentle AI install tombstone escaped the package-private runtime directory");
+	return path;
+}
+
+async function existingInstallTombstone(runtimeRoot) {
+	for (const entry of await readdir(runtimeRoot, { withFileTypes: true })) {
+		if (!entry.name.startsWith(installTombstonePrefix())) continue;
+		const path = join(runtimeRoot, entry.name);
+		const details = await lstat(path);
+		if (!details.isDirectory() || details.isSymbolicLink()) throw installLockBlockedError(path);
+		return path;
+	}
+	return undefined;
+}
+
+async function assertNoInstallTombstones(runtimeRoot) {
+	const tombstone = await existingInstallTombstone(runtimeRoot);
+	if (tombstone) throw installLockBlockedError(tombstone);
+}
+
+async function releaseInstallLock(runtimeRoot, lockPath, owner, options) {
+	try {
+		const observed = await inspectInstallLock(lockPath);
+		if (observed.identity !== owner.identity || observed.owner?.nonce !== owner.owner?.nonce) return;
+		await options.beforeInstallLockReleaseRename?.(lockPath);
+		const tombstonePath = installTombstonePath(runtimeRoot, randomBytes(32).toString("hex"));
+		await (options.rename ?? rename)(lockPath, tombstonePath);
+		const tombstone = await inspectInstallLock(tombstonePath);
+		if (tombstone.identity !== owner.identity || tombstone.owner?.nonce !== owner.owner?.nonce) throw installLockBlockedError(tombstonePath);
+		await safeRemoveDirectory(tombstonePath);
+	} catch (error) {
+		if (!(error && typeof error === "object" && error.code === "ENOENT")) throw error;
+	}
+}
+
+// This coordinates cooperative installers only. A malicious same-user package
+// writer can already replace package code, binaries, or manifests; Node has no
+// pathname-delete CAS. Tombstones make rename auditable: only a matching owned
+// tombstone is deleted automatically. Any other tombstone requires a maintainer
+// to confirm no installer is active before manual package-private cleanup.
+async function acquireInstallLock(runtimeRoot, options) {
+	const lockPath = join(runtimeRoot, `.v${INSTALLER_VERSION}.install.lock`);
+	await assertNoInstallTombstones(runtimeRoot);
+	await options.afterInstallLockFirstTombstoneScan?.(runtimeRoot);
+	const nonce = randomBytes(32).toString("hex");
+	try {
+		await mkdir(lockPath, { mode: 0o700 });
+		await writeFile(join(lockPath, "owner.json"), canonicalManifest({ createdAt: (options.now ?? Date.now)(), nonce }), { mode: 0o600, flag: "wx" });
+	} catch (error) {
+		if (error && typeof error === "object" && error.code === "EEXIST") throw installLockBlockedError(lockPath);
+		throw error;
+	}
+	const owner = await inspectInstallLock(lockPath);
+	if (owner.owner?.nonce !== nonce) throw installLockBlockedError(lockPath);
+	try {
+		await assertNoInstallTombstones(runtimeRoot);
+	} catch (error) {
+		await releaseInstallLock(runtimeRoot, lockPath, owner, options);
+		throw error;
+	}
+	return async () => releaseInstallLock(runtimeRoot, lockPath, owner, options);
+}
+
+function bundleRecoveryError(runtimeRoot, reason) {
+	return new Error(`Gentle AI package-local bundle recovery requires manual intervention in ${runtimeRoot}: ${reason}. Confirm no installer is active before changing package-private bundle paths.`);
+}
+
+function versionBundlePath(runtimeRoot) { return join(runtimeRoot, `v${INSTALLER_VERSION}`); }
+function bundleBackupPrefix() { return `.v${INSTALLER_VERSION}.backup-`; }
+function bundleStagingPrefix() { return `.v${INSTALLER_VERSION}.staging-`; }
+
+async function realBundleDirectory(path, runtimeRoot, label) {
+	if (!isConfined(path, runtimeRoot)) throw bundleRecoveryError(runtimeRoot, `${label} escaped the version parent`);
+	try {
+		const details = await lstat(path);
+		if (!details.isDirectory() || details.isSymbolicLink()) throw bundleRecoveryError(runtimeRoot, `${label} is not a real directory at ${path}`);
+		return true;
+	} catch (error) {
+		if (error && typeof error === "object" && error.code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+async function backupBundlePaths(runtimeRoot) {
+	const backups = [];
+	for (const entry of await readdir(runtimeRoot, { withFileTypes: true })) {
+		if (!entry.name.startsWith(bundleBackupPrefix())) continue;
+		const path = join(runtimeRoot, entry.name);
+		if (!await realBundleDirectory(path, runtimeRoot, "backup bundle")) throw bundleRecoveryError(runtimeRoot, `backup bundle disappeared at ${path}`);
+		backups.push(path);
+	}
+	return backups;
+}
+
+async function recoverInterruptedPublication(runtimeRoot, bundleIsValid, options) {
+	const backups = await backupBundlePaths(runtimeRoot);
+	if (backups.length === 0) return;
+	if (backups.length !== 1) throw bundleRecoveryError(runtimeRoot, `found ${backups.length} backup bundle candidates`);
+	const [backup] = backups;
+	if (!await bundleIsValid(backup)) throw bundleRecoveryError(runtimeRoot, `backup bundle is invalid at ${backup}`);
+	const live = versionBundlePath(runtimeRoot);
+	const liveExists = await realBundleDirectory(live, runtimeRoot, "live bundle");
+	if (!liveExists) {
+		try { await (options.rename ?? rename)(backup, live); }
+		catch (error) { throw bundleRecoveryError(runtimeRoot, `could not restore valid backup ${backup}: ${error instanceof Error ? error.message : String(error)}`); }
+		return;
+	}
+	if (!await bundleIsValid(live)) throw bundleRecoveryError(runtimeRoot, `live bundle is invalid while valid backup remains at ${backup}`);
+	await safeRemoveDirectory(backup);
+}
+
+async function cleanupStaleStagingBundles(runtimeRoot) {
+	for (const entry of await readdir(runtimeRoot, { withFileTypes: true })) {
+		if (!entry.name.startsWith(bundleStagingPrefix())) continue;
+		const path = join(runtimeRoot, entry.name);
+		if (!await realBundleDirectory(path, runtimeRoot, "staging bundle")) throw bundleRecoveryError(runtimeRoot, `staging bundle disappeared at ${path}`);
+		await safeRemoveDirectory(path);
+	}
+}
+
+async function publishBundle(runtimeRoot, stagingDirectory, options) {
+	const versionDirectory = join(runtimeRoot, `v${INSTALLER_VERSION}`), renameFile = options.rename ?? rename;
+	const backupDirectory = join(runtimeRoot, `.v${INSTALLER_VERSION}.backup-${process.pid}-${Date.now()}`);
+	let movedPrior = false;
+	try {
+		try {
+			const current = await lstat(versionDirectory);
+			if (!current.isDirectory() || current.isSymbolicLink()) throw new Error("Gentle AI package-local version directory must be a real directory");
+			await renameFile(versionDirectory, backupDirectory);
+			movedPrior = true;
+		} catch (error) { if (!(error && typeof error === "object" && error.code === "ENOENT")) throw error; }
+		await renameFile(stagingDirectory, versionDirectory);
+	} catch (error) {
+		if (movedPrior) {
+			try { await renameFile(backupDirectory, versionDirectory); }
+			catch (rollbackError) { throw new Error("Gentle AI bundle publication failed and rollback could not restore the prior bundle", { cause: rollbackError }); }
+		}
+		throw error;
+	}
+	if (movedPrior) await safeRemoveDirectory(backupDirectory);
+	return versionDirectory;
+}
+
+async function withInstallLock(packageRoot, options, install) {
+	const runtimeRoot = join(packageRoot, ".gentle-ai");
+	await mkdir(packageRoot, { recursive: true });
+	await mkdir(runtimeRoot, { recursive: true, mode: 0o700 });
+	await assertRuntimeDirectory(runtimeRoot);
+	const release = await acquireInstallLock(runtimeRoot, options);
+	try { return await install(runtimeRoot); }
+	finally { await release(); }
+}
+
+async function installWindowsGentleAiFromGoSumdb(options, packageRoot, architecture) {
+	const execute = options.execFile ?? execFileAsync;
+	return withInstallLock(packageRoot, options, async (runtimeRoot) => {
+		await cleanupStaleStagingBundles(runtimeRoot);
+		const stagingDirectory = await mkdtemp(join(runtimeRoot, `.v${INSTALLER_VERSION}.staging-`));
+		try {
+			await chmod(stagingDirectory, 0o700);
+			const buildDirectory = join(stagingDirectory, ".build");
+			await mkdir(buildDirectory, { recursive: true, mode: 0o700 });
+			const goPath = await resolveWindowsGoExecutable(options);
+			const environment = sealedGoEnvironment(goPath, buildDirectory, architecture);
+			for (const directory of [environment.GOBIN, environment.GOPATH, environment.GOMODCACHE, environment.GOCACHE, environment.TEMP]) await mkdir(directory, { recursive: true, mode: 0o700 });
+			await recoverInterruptedPublication(runtimeRoot, (directory) => existingWindowsSourceBundleMatches(directory, execute, goPath, environment, architecture), options);
+			const existing = versionBundlePath(runtimeRoot);
+			if (await existingWindowsSourceBundleMatches(existing, execute, goPath, environment, architecture)) return { installed: false, binaryPath: join(existing, "gentle-ai.exe"), method: GENTLE_AI_INSTALL_METHOD.GO_SUMDB_SOURCE_BUILD };
+			await assertGoToolchain(execute, goPath, environment, stagingDirectory);
+			try { await runCommand(execute, goPath, ["install", GENTLE_AI_WINDOWS_SOURCE_PACKAGE], commandOptions(environment, stagingDirectory)); }
+			catch (error) { throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, `Gentle AI Go SumDB source installation failed for ${GENTLE_AI_WINDOWS_SOURCE_PACKAGE}.`, error); }
+			const builtBinary = join(environment.GOBIN, "gentle-ai.exe"), binaryPath = join(stagingDirectory, "gentle-ai.exe");
+			const details = await lstat(builtBinary);
+			if (!details.isFile() || details.isSymbolicLink()) throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, "Gentle AI Go installation produced a non-regular gentle-ai.exe.");
+			await copyFile(builtBinary, binaryPath);
+			const metadata = await verifyGoBuildMetadata(execute, goPath, binaryPath, environment, stagingDirectory, architecture);
+			await assertExactGentleAiVersion(execute, binaryPath, environment, stagingDirectory);
+			const binarySha256 = await sha256File(binaryPath);
+			await writeFile(join(stagingDirectory, "integrity.json"), canonicalManifest(windowsSourceManifest(metadata, binarySha256, architecture)), { mode: 0o600 });
+			await safeRemoveDirectory(buildDirectory);
+			const published = await publishBundle(runtimeRoot, stagingDirectory, options);
+			return { installed: true, binaryPath: join(published, "gentle-ai.exe"), method: GENTLE_AI_INSTALL_METHOD.GO_SUMDB_SOURCE_BUILD };
+		} finally { await safeRemoveDirectory(stagingDirectory); }
+	});
+}
+
+async function installSignedRelease(options, packageRoot, platform, arch, asset) {
+	return withInstallLock(packageRoot, options, async (runtimeRoot) => {
+		await recoverInterruptedPublication(runtimeRoot, (directory) => existingSignedBundleMatches(directory, asset, platform), options);
+		await cleanupStaleStagingBundles(runtimeRoot);
+		const existing = versionBundlePath(runtimeRoot);
+		if (await existingSignedBundleMatches(existing, asset, platform)) return { installed: false, binaryPath: join(existing, asset.executable), asset };
+		const stagingDirectory = await mkdtemp(join(runtimeRoot, `.v${INSTALLER_VERSION}.staging-`));
+		try {
+			const archive = join(stagingDirectory, asset.name);
+			await (options.download ?? downloadGentleAiAsset)(asset.url, archive);
+			if ((await sha256File(archive)) !== asset.sha256) throw new Error(`Gentle AI archive checksum mismatch for ${asset.name}`);
+			const extracted = join(stagingDirectory, "extracted");
+			await (options.extractArchive ?? extractGentleAiArchive)(archive, extracted);
+			const source = await expectedRegularFile(extracted, asset.executable);
+			if (asset.binarySha256 && (await sha256File(source)) !== asset.binarySha256) throw new Error(`Gentle AI binary checksum mismatch for ${asset.name}`);
+			const binaryPath = join(stagingDirectory, asset.executable);
+			await copyFile(source, binaryPath);
+			if (platform !== "win32") await chmod(binaryPath, 0o700);
+			await writeFile(join(stagingDirectory, "integrity.json"), canonicalManifest(signedReleaseManifest(asset, await sha256File(binaryPath))), { mode: 0o600 });
+			await safeRemoveDirectory(extracted);
+			await rm(archive, { force: true });
+			const published = await publishBundle(runtimeRoot, stagingDirectory, options);
+			return { installed: true, binaryPath: join(published, asset.executable), asset };
+		} finally { await safeRemoveDirectory(stagingDirectory); }
+	});
 }
 
 export async function installGentleAi(options = {}) {
 	const packageRoot = options.packageRoot ?? resolveGentleAiInstallerPackageRoot();
-	const platform = options.platform ?? process.platform;
-	const arch = options.arch ?? process.arch;
-	const releaseAssets = options.releaseAssets ?? GENTLE_AI_RELEASE_ASSETS;
-	const asset = resolveGentleAiReleaseAsset(platform, arch, releaseAssets);
-	const installDirectory = join(packageRoot, ".gentle-ai", `v${INSTALLER_VERSION}`);
-	const binaryPath = join(installDirectory, asset.executable);
-	const manifestPath = join(installDirectory, "integrity.json");
-	await assertRuntimeDirectory(join(packageRoot, ".gentle-ai"));
-	await assertRuntimeDirectory(installDirectory);
-	if (await existingBinaryMatches(binaryPath, manifestPath, asset, platform)) return { installed: false, binaryPath, asset };
-
-	await mkdir(packageRoot, { recursive: true });
-	const temporaryDirectory = await mkdtemp(join(packageRoot, ".gentle-ai-install-"));
-	try {
-		await chmod(temporaryDirectory, 0o700);
-		const archive = join(temporaryDirectory, asset.name);
-		await (options.download ?? downloadGentleAiAsset)(asset.url, archive);
-		const digest = await sha256File(archive);
-		if (digest !== asset.sha256) throw new Error(`Gentle AI archive checksum mismatch for ${asset.name}`);
-		const extracted = join(temporaryDirectory, "extracted");
-		await (options.extractArchive ?? extractGentleAiArchive)(archive, extracted);
-		const source = await expectedRegularFile(extracted, asset.executable);
-		if (asset.binarySha256 && (await sha256File(source)) !== asset.binarySha256) throw new Error(`Gentle AI binary checksum mismatch for ${asset.name}`);
-		await mkdir(installDirectory, { recursive: true, mode: 0o700 });
-		await assertRuntimeDirectory(join(packageRoot, ".gentle-ai"));
-		await assertRuntimeDirectory(installDirectory);
-		const temporaryBinary = join(installDirectory, `.${asset.executable}.${process.pid}.${Date.now()}.tmp`);
-		const temporaryManifest = join(installDirectory, `.integrity.${process.pid}.${Date.now()}.tmp`);
-		await copyFile(source, temporaryBinary);
-		if (platform !== "win32") await chmod(temporaryBinary, 0o700);
-		const binarySha256 = await sha256File(temporaryBinary);
-		await writeFile(temporaryManifest, `${JSON.stringify({ version: INSTALLER_VERSION, asset: asset.name, assetSha256: asset.sha256, binarySha256 })}\n`, { mode: 0o600 });
-		await rename(temporaryBinary, binaryPath);
-		await rename(temporaryManifest, manifestPath);
-		return { installed: true, binaryPath, asset };
-	} finally {
-		await rm(temporaryDirectory, { recursive: true, force: true }).catch(() => undefined);
-	}
+	const platform = options.platform ?? process.platform, arch = options.arch ?? process.arch;
+	if (isWindowsGoSumdbSourceTarget(platform, arch)) return installWindowsGentleAiFromGoSumdb(options, packageRoot, arch);
+	const asset = resolveGentleAiReleaseAsset(platform, arch, options.releaseAssets ?? GENTLE_AI_RELEASE_ASSETS);
+	return installSignedRelease(options, packageRoot, platform, arch, asset);
 }

--- a/scripts/test-packed-runner.mjs
+++ b/scripts/test-packed-runner.mjs
@@ -44,7 +44,7 @@ try {
 	if (packed.length !== 1 || typeof packed[0]?.filename !== "string") throw new Error("npm pack did not return one tarball");
 	const tarball = join(packDirectory, packed[0].filename);
 	writeFileSync(join(installDirectory, "package.json"), JSON.stringify({ name: "gentle-pi-packed-runner-test", private: true }), "utf8");
-	runNpm(["install", "--no-audit", "--no-fund", "--package-lock=false", "--omit=dev", "--legacy-peer-deps", tarball], {
+	runNpm(["install", "--ignore-scripts=false", "--no-audit", "--no-fund", "--package-lock=false", "--omit=dev", "--legacy-peer-deps", tarball], {
 		cwd: installDirectory,
 		stdio: "inherit",
 	});

--- a/tests/gentle-ai-binary.test.ts
+++ b/tests/gentle-ai-binary.test.ts
@@ -12,13 +12,13 @@ import {
 	resolveGentleAiBinary,
 } from "../lib/gentle-ai-binary.ts";
 import { NativeReviewCliV213, createNativeReviewCli, type ExecFileAdapter } from "../lib/native-review-cli.ts";
-import { resolveGentleAiReleaseAsset } from "../scripts/gentle-ai-installer.mjs";
+import { GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM, resolveGentleAiReleaseAsset } from "../scripts/gentle-ai-installer.mjs";
 import { requireNativeBinary } from "./support/native-binary-gate.ts";
 
 const VERSION = { stdout: `gentle-ai ${GENTLE_AI_VERSION}\n`, stderr: "", exitCode: 0, signal: null, timedOut: false, outputLimitExceeded: false } as const;
 const RUNTIME_DIRECTORY = `v${GENTLE_AI_VERSION}`;
 const repoRuntimeBinary = join(import.meta.dirname, "..", ".gentle-ai", RUNTIME_DIRECTORY, process.platform === "win32" ? "gentle-ai.exe" : "gentle-ai");
-const releaseDigestsPinned = /^[0-9a-f]{64}$/.test(resolveGentleAiReleaseAsset(process.platform, process.arch).sha256);
+const releaseDigestsPinned = process.platform === "win32" || /^[0-9a-f]{64}$/.test(resolveGentleAiReleaseAsset(process.platform, process.arch).sha256);
 // These integrity tests need the published official binary; they skip while a
 // re-pinned release's archives and digest table are still pending.
 const nativeBinaryGate = requireNativeBinary({
@@ -27,7 +27,7 @@ const nativeBinaryGate = requireNativeBinary({
 	env: process.env,
 });
 if (!nativeBinaryGate.run) console.log(`gentle-ai-binary: ${nativeBinaryGate.reason}`);
-const verifiedBinaryTest = nativeBinaryGate.run ? test : test.skip;
+const verifiedBinaryTest = nativeBinaryGate.run && process.platform !== "win32" ? test : test.skip;
 
 async function writeVerifiedBinary(packageRoot: string, platform = process.platform): Promise<string> {
 	const asset = resolveGentleAiReleaseAsset(platform, process.arch);
@@ -37,6 +37,31 @@ async function writeVerifiedBinary(packageRoot: string, platform = process.platf
 	if (platform !== "win32") await chmod(binaryPath, 0o700);
 	await writeFile(join(packageRoot, ".gentle-ai", RUNTIME_DIRECTORY, "integrity.json"), `${JSON.stringify({ version: GENTLE_AI_VERSION, asset: asset.name, assetSha256: asset.sha256, binarySha256: asset.binarySha256 })}\n`);
 	return binaryPath;
+}
+
+async function writeWindowsSourceBinary(packageRoot: string): Promise<{ binaryPath: string; manifestPath: string }> {
+	const binaryPath = join(packageRoot, ".gentle-ai", RUNTIME_DIRECTORY, "gentle-ai.exe");
+	const manifestPath = join(packageRoot, ".gentle-ai", RUNTIME_DIRECTORY, "integrity.json");
+	const binary = "verified Windows source build";
+	await mkdir(join(packageRoot, ".gentle-ai", RUNTIME_DIRECTORY), { recursive: true });
+	await writeFile(binaryPath, binary);
+	await writeFile(manifestPath, `${JSON.stringify({
+		version: GENTLE_AI_VERSION,
+		method: "go-sumdb-source-build",
+		package: "github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai",
+		module: "github.com/gentleman-programming/gentle-ai/v2",
+		tag: "v2.2.2",
+		architecture: process.arch === "x64" ? "x64" : "arm64",
+		binarySha256: createHash("sha256").update(binary).digest("hex"),
+		moduleChecksum: GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
+		goVersion: "go1.25.10",
+		goos: "windows",
+		goarch: process.arch === "x64" ? "amd64" : "arm64",
+		buildMode: "exe",
+		compiler: "gc",
+		cgoEnabled: "0",
+	})}\n`);
+	return { binaryPath, manifestPath };
 }
 
 verifiedBinaryTest("runtime resolves an absolute package-local binary path without PATH fallback", async () => {
@@ -50,6 +75,40 @@ verifiedBinaryTest("runtime resolves an absolute package-local binary path witho
 	assert.equal(basename(resolved), executable);
 	assert.doesNotMatch(resolved, /(^|[/\\])PATH($|[/\\])/i);
 });
+
+test("runtime validates a Windows Go SumDB source manifest and rejects tampering, symlinks, and PATH injection", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-windows-source-runtime-"));
+	const { binaryPath, manifestPath } = await writeWindowsSourceBinary(packageRoot);
+	assert.equal(resolveGentleAiBinary(packageRoot, "win32"), binaryPath);
+
+	const valid = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<string, string>;
+	for (const manifest of [
+		{ ...valid, method: "signed-release-asset" },
+		{ ...valid, module: "example.invalid/gentle-ai" },
+		{ ...valid, tag: "v2.2.1" },
+		{ ...valid, binarySha256: "0".repeat(64) },
+		{ ...valid, moduleChecksum: "h1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" },
+		{ ...valid, goVersion: "go1.25.9" },
+		{ ...valid, goVersion: "go1.25" },
+	]) {
+		await writeFile(manifestPath, `${JSON.stringify(manifest)}\n`);
+		assert.throws(() => resolveGentleAiBinary(packageRoot, "win32"), /package-local-binary-missing/);
+	}
+	await writeFile(manifestPath, `${JSON.stringify(valid)}\n`);
+	await writeFile(binaryPath, "tampered Windows source build");
+	assert.throws(() => resolveGentleAiBinary(packageRoot, "win32"), /package-local-binary-missing/);
+	await writeFile(binaryPath, "verified Windows source build");
+	await rm(binaryPath);
+	const ambient = join(packageRoot, "ambient-gentle-ai.exe");
+	await writeFile(ambient, "ambient executable");
+	await symlink(ambient, binaryPath);
+	assert.throws(() => resolveGentleAiBinary(packageRoot, "win32"), /package-local-binary-missing/);
+	assert.doesNotMatch(gentleAiBinaryPathForTest(packageRoot), /(^|[/\\])PATH($|[/\\])/i);
+});
+
+function gentleAiBinaryPathForTest(packageRoot: string): string {
+	return join(packageRoot, ".gentle-ai", RUNTIME_DIRECTORY, "gentle-ai.exe");
+}
 
 test("runtime rejects an unverified binary, a symlinked manifest, and ambient executable injection", async () => {
 	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-binary-integrity-"));
@@ -94,6 +153,14 @@ verifiedBinaryTest("runtime rejects malformed, unknown, wrong, and symlinked int
 	const directoryRoot = await mkdtemp(join(tmpdir(), "gentle-pi-binary-directory-"));
 	await symlink(join(packageRoot, ".gentle-ai"), join(directoryRoot, ".gentle-ai"));
 	assert.throws(() => resolveGentleAiBinary(directoryRoot, process.platform), /package-local-binary-missing/);
+});
+
+verifiedBinaryTest("runtime rejects a binary-only tamper while its canonical pinned manifest remains unchanged", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-binary-pinned-manifest-tamper-"));
+	const binaryPath = await writeVerifiedBinary(packageRoot);
+	await writeFile(binaryPath, "binary-only tamper");
+	if (process.platform !== "win32") await chmod(binaryPath, 0o700);
+	assert.throws(() => resolveGentleAiBinary(packageRoot, process.platform), /package-local-binary-missing/);
 });
 
 verifiedBinaryTest("runtime rejects an arbitrary binary even when a forged manifest matches its digest", async () => {

--- a/tests/gentle-ai-installer.test.ts
+++ b/tests/gentle-ai-installer.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { chmod, mkdtemp, mkdir, readFile, readdir, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdtemp, mkdir, readFile, readdir, rename, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import {
 	GENTLE_AI_PENDING_DIGEST,
 	GENTLE_AI_RELEASE_ASSETS,
+	GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
 	downloadGentleAiAsset,
 	installGentleAi,
 	resolveGentleAiInstallerPackageRoot,
@@ -69,13 +70,548 @@ test("release digests are all-or-none and install fails closed while any digest 
 	}
 });
 
-test("win32 is rejected with the same clear error as any other unsupported platform", () => {
-	// v2.2.2 publishes no Windows archive, so there is nothing honest to
-	// resolve. Failing here, by name, beats resolving an asset that would 404
-	// at download time and blame the network for a packaging decision.
+interface WindowsGoCall {
+	file: string;
+	arguments_: string[];
+	options: {
+		env?: NodeJS.ProcessEnv;
+		shell?: boolean;
+		timeout?: number;
+		maxBuffer?: number;
+	};
+}
+
+interface WindowsGoFixtureOptions {
+	goVersion?: string;
+	goVersionError?: Error;
+	reportedVersion?: string;
+	installError?: Error;
+	goArchitecture?: "amd64" | "arm64";
+}
+
+function windowsGoFixture(fixtureOptions: WindowsGoFixtureOptions = {}) {
+	const calls: WindowsGoCall[] = [];
+	let goExecutable = "go";
+	const metadata = [
+		"gentle-ai.exe: go1.25.10",
+		"\tpath\tgithub.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai",
+		`\tmod\tgithub.com/gentleman-programming/gentle-ai/v2\tv2.2.2\t${GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM}`,
+		"\tbuild\t-buildmode=exe", "\tbuild\t-compiler=gc", "\tbuild\tCGO_ENABLED=0", `\tbuild\tGOARCH=${fixtureOptions.goArchitecture ?? "amd64"}`, "\tbuild\tGOOS=windows",
+	].join("\n");
+	const run = async (file: string, arguments_: string[], options: WindowsGoCall["options"]) => {
+		calls.push({ file, arguments_, options });
+		if (file === goExecutable && arguments_.length === 1 && arguments_[0] === "version") {
+			if (fixtureOptions.goVersionError) throw fixtureOptions.goVersionError;
+			return { stdout: fixtureOptions.goVersion ?? "go version go1.25.10 windows/amd64\n", stderr: "" };
+		}
+		if (file === goExecutable && arguments_[0] === "install") {
+			if (fixtureOptions.installError) throw fixtureOptions.installError;
+			const gobin = options.env?.GOBIN;
+			assert.ok(gobin, "go install must receive an explicit staging GOBIN");
+			await mkdir(gobin, { recursive: true });
+			await writeFile(join(gobin, "gentle-ai.exe"), "trusted Windows source build");
+			return { stdout: "", stderr: "" };
+		}
+		if (file === goExecutable && arguments_[0] === "version" && arguments_[1] === "-m") return { stdout: metadata, stderr: "" };
+		if (arguments_.length === 1 && arguments_[0] === "version") return { stdout: fixtureOptions.reportedVersion ?? "gentle-ai 2.2.2\n", stderr: "" };
+		throw new Error(`unexpected command: ${file} ${arguments_.join(" ")}`);
+	};
+	return { calls, run, setGoExecutable: (path: string) => { goExecutable = path; } };
+}
+
+test("win32 x64 and arm64 install the exact Go SumDB source tag without archive lookup", async () => {
+	for (const [arch, goArchitecture] of [["x64", "amd64"], ["arm64", "arm64"]] as const) {
+		const packageRoot = await mkdtemp(join(tmpdir(), `gentle-pi-installer-windows-${arch}-`));
+		const fixture = windowsGoFixture({ goArchitecture });
+		const goPath = join(packageRoot, "go.exe");
+		await writeFile(goPath, "trusted local Go executable");
+		fixture.setGoExecutable(goPath);
+		const result = await installGentleAi({ packageRoot, platform: "win32", arch, execFile: fixture.run, resolveGoExecutable: async () => goPath });
+		assert.equal(result.installed, true);
+		assert.deepEqual(fixture.calls.filter((call) => call.file === goPath).map((call) => call.arguments_.slice(0, 2)), [
+			["version"], ["install", "github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.2.2"], ["version", "-m"],
+		]);
+	}
+});
+
+test("Windows source install reports missing or too-old Go without publishing a binary", async () => {
+	for (const fixtureOptions of [
+		{ goVersion: "go version go1.25.9 windows/amd64\n", expectedCode: "GENTLE_AI_GO_TOOLCHAIN_TOO_OLD" },
+		{ goVersionError: Object.assign(new Error("go was not found"), { code: "ENOENT" }), expectedCode: "GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE" },
+	] as const) {
+		const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-windows-go-"));
+		const fixture = windowsGoFixture(fixtureOptions);
+		const goPath = join(packageRoot, "go.exe");
+		await writeFile(goPath, "trusted local Go executable");
+		fixture.setGoExecutable(goPath);
+		await assert.rejects(
+			() => installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: async () => goPath }),
+			(error: unknown) => error instanceof Error && "code" in error && error.code === fixtureOptions.expectedCode,
+		);
+		assert.equal(existsSync(join(packageRoot, ".gentle-ai", "v2.2.2", "gentle-ai.exe")), false);
+		assert.deepEqual((await readdir(packageRoot)).filter((entry) => entry.includes("install-")), []);
+	}
+});
+
+test("Windows source install cleans staging after Go failure or wrong built version", async () => {
+	for (const fixtureOptions of [
+		{ installError: Object.assign(new Error("go install timed out"), { code: "ETIMEDOUT" }), expectedCode: "GENTLE_AI_GO_INSTALL_FAILED" },
+		{ reportedVersion: "gentle-ai 2.2.1\n", expectedCode: "GENTLE_AI_VERSION_MISMATCH" },
+	] as const) {
+		const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-windows-cleanup-"));
+		const fixture = windowsGoFixture(fixtureOptions);
+		const goPath = join(packageRoot, "go.exe");
+		await writeFile(goPath, "trusted local Go executable");
+		fixture.setGoExecutable(goPath);
+		await assert.rejects(
+			() => installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: async () => goPath }),
+			(error: unknown) => error instanceof Error && "code" in error && error.code === fixtureOptions.expectedCode,
+		);
+		const runtimeDirectory = join(packageRoot, ".gentle-ai", "v2.2.2");
+		assert.ok(fixture.calls.some((call) => call.arguments_[0] === "install"));
+		assert.equal(existsSync(join(runtimeDirectory, "gentle-ai.exe")), false);
+		assert.equal(existsSync(runtimeDirectory) && (await readdir(runtimeDirectory)).some((entry) => entry.startsWith(".go-install-") || entry.endsWith(".tmp")), false);
+	}
+});
+
+test("Windows source installs reuse only a fully verified package-local binary", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-windows-reuse-"));
+	const goPath = join(packageRoot, "go.exe");
+	await writeFile(goPath, "trusted local Go executable");
+	const initial = windowsGoFixture();
+	initial.setGoExecutable(goPath);
+	await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: initial.run, resolveGoExecutable: async () => goPath });
+
+	const reuse = windowsGoFixture();
+	reuse.setGoExecutable(goPath);
+	const reused = await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: reuse.run, resolveGoExecutable: async () => goPath });
+	assert.equal(reused.installed, false);
+	assert.ok(reuse.calls.every((call) => call.file !== "gentle-ai"), "the installer must never fall back to ambient gentle-ai on PATH");
+
+	await writeFile(join(packageRoot, ".gentle-ai", "v2.2.2", "integrity.json"), "{}\n");
+	const repaired = windowsGoFixture();
+	repaired.setGoExecutable(goPath);
+	assert.equal((await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: repaired.run, resolveGoExecutable: async () => goPath })).installed, true);
+	assert.ok(repaired.calls.some((call) => call.arguments_[0] === "install"));
+});
+
+interface HardenedGoCall {
+	file: string;
+	arguments_: string[];
+	options: WindowsGoCall["options"] & { cwd?: string };
+}
+
+const GO_ARCHITECTURE = {
+	AMD64: "amd64",
+	ARM64: "arm64",
+} as const;
+
+type GoArchitecture = (typeof GO_ARCHITECTURE)[keyof typeof GO_ARCHITECTURE];
+
+interface HardenedGoFixtureOptions {
+	architecture?: GoArchitecture;
+	blockInstall?: boolean;
+	metadataOverride?: string;
+}
+
+async function hardenedWindowsGoFixture(packageRoot: string, fixtureOptions: HardenedGoFixtureOptions = {}) {
+	const goDirectory = join(packageRoot, "trusted-go");
+	const goPath = join(goDirectory, "go.exe");
+	await mkdir(goDirectory, { recursive: true });
+	await writeFile(goPath, "trusted local Go executable");
+	const calls: HardenedGoCall[] = [];
+	let resolveCalls = 0;
+	let signalInstallStarted: (() => void) | undefined;
+	const installStarted = new Promise<void>((resolve) => { signalInstallStarted = resolve; });
+	let releaseInstall: (() => void) | undefined;
+	const installGate = fixtureOptions.blockInstall
+		? new Promise<void>((resolve) => { releaseInstall = resolve; })
+		: undefined;
+	const metadata = fixtureOptions.metadataOverride ?? [
+		"gentle-ai.exe: go1.25.10",
+		"\tpath\tgithub.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai",
+		`\tmod\tgithub.com/gentleman-programming/gentle-ai/v2\tv2.2.2\t${GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM}`,
+		"\tbuild\t-buildmode=exe",
+		"\tbuild\t-compiler=gc",
+		"\tbuild\tCGO_ENABLED=0",
+		`\tbuild\tGOARCH=${fixtureOptions.architecture ?? "amd64"}`,
+		"\tbuild\tGOOS=windows",
+	].join("\n");
+	const run = async (file: string, arguments_: string[], options: HardenedGoCall["options"]) => {
+		calls.push({ file, arguments_, options });
+		if (file === goPath && arguments_.length === 1 && arguments_[0] === "version") return { stdout: "go version go1.25.10 windows/amd64\n", stderr: "" };
+		if (file === goPath && arguments_[0] === "install") {
+			signalInstallStarted?.();
+			await installGate;
+			const gobin = options.env?.GOBIN;
+			assert.ok(gobin);
+			await mkdir(gobin, { recursive: true });
+			await writeFile(join(gobin, "gentle-ai.exe"), "trusted Windows source build");
+			return { stdout: "", stderr: "" };
+		}
+		if (file === goPath && arguments_[0] === "version" && arguments_[1] === "-m") return { stdout: metadata, stderr: "" };
+		if (arguments_.length === 1 && arguments_[0] === "version") return { stdout: "gentle-ai 2.2.2\n", stderr: "" };
+		throw new Error(`unexpected command: ${file} ${arguments_.join(" ")}`);
+	};
+	return {
+		calls,
+		goPath,
+		resolveGoExecutable: async () => { resolveCalls += 1; return goPath; },
+		resolveCalls: () => resolveCalls,
+		waitForInstall: () => installStarted,
+		releaseInstall: () => releaseInstall?.(),
+		run,
+	};
+}
+
+test("Windows source installation resolves one validated Go executable and seals hostile Go environment", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-hardened-go-"));
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	await installGentleAi({
+		packageRoot,
+		platform: "win32",
+		arch: "x64",
+		execFile: fixture.run,
+		resolveGoExecutable: fixture.resolveGoExecutable,
+		env: {
+			GOENV: "C:\\attacker\\goenv",
+			GOFLAGS: "-mod=mod",
+			GOWORK: "C:\\attacker\\go.work",
+			GOPROXY: "http://attacker.invalid",
+			GOBIN: "C:\\attacker\\bin",
+			GOPATH: "C:\\attacker\\path",
+			GOMODCACHE: "C:\\attacker\\mods",
+			GOCACHE: "C:\\attacker\\cache",
+			GOOS: "linux",
+			GOARCH: "386",
+			PATH: "C:\\attacker",
+			UNRELATED_SECRET: "must-not-reach-go",
+		},
+	});
+	assert.equal(fixture.resolveCalls(), 1);
+	const goCalls = fixture.calls.filter((call) => call.file === fixture.goPath);
+	assert.deepEqual(goCalls.map((call) => call.arguments_.slice(0, 2)), [
+		["version"],
+		["install", "github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.2.2"],
+		["version", "-m"],
+	]);
+	for (const call of goCalls) {
+		assert.equal(call.options.shell, false);
+		assert.equal(call.options.env?.GOENV, "off");
+		assert.equal(call.options.env?.GOFLAGS, "");
+		assert.equal(call.options.env?.GOWORK, "off");
+		assert.equal(call.options.env?.GOTOOLCHAIN, "local");
+		assert.equal(call.options.env?.GOSUMDB, "sum.golang.org");
+		assert.equal(call.options.env?.GONOSUMDB, "");
+		assert.equal(call.options.env?.GOPRIVATE, "");
+		assert.equal(call.options.env?.GONOPROXY, "");
+		assert.equal(call.options.env?.GOINSECURE, "");
+		assert.equal(call.options.env?.GOPROXY, "https://proxy.golang.org");
+		assert.equal(call.options.env?.GOOS, "windows");
+		assert.equal(call.options.env?.GOARCH, "amd64");
+		assert.equal(call.options.env?.UNRELATED_SECRET, undefined);
+		assert.doesNotMatch(call.options.env?.PATH ?? "", /attacker/i);
+	}
+});
+
+test("Windows source manifest binds verified Go metadata and architecture", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-provenance-"));
+	const fixture = await hardenedWindowsGoFixture(packageRoot, { architecture: "arm64" });
+	const result = await installGentleAi({ packageRoot, platform: "win32", arch: "arm64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable });
+	const manifest = JSON.parse(await readFile(join(packageRoot, ".gentle-ai", "v2.2.2", "integrity.json"), "utf8")) as Record<string, string>;
+	assert.equal(result.installed, true);
+	assert.deepEqual(manifest, {
+		version: "2.2.2",
+		method: "go-sumdb-source-build",
+		package: "github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai",
+		module: "github.com/gentleman-programming/gentle-ai/v2",
+		tag: "v2.2.2",
+		architecture: "arm64",
+		binarySha256: createHash("sha256").update("trusted Windows source build").digest("hex"),
+		moduleChecksum: GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
+		goVersion: "go1.25.10",
+		goos: "windows",
+		goarch: "arm64",
+		buildMode: "exe",
+		compiler: "gc",
+		cgoEnabled: "0",
+	});
+});
+
+test("Windows source installation rejects Go metadata for a different architecture", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-provenance-architecture-"));
+	const fixture = await hardenedWindowsGoFixture(packageRoot, { architecture: "arm64" });
+	await assert.rejects(
+		() => installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable }),
+		(error: unknown) => error instanceof Error && "code" in error && error.code === "GENTLE_AI_GO_INSTALL_FAILED",
+	);
+	assert.equal(existsSync(join(packageRoot, ".gentle-ai", "v2.2.2", "gentle-ai.exe")), false);
+});
+
+test("Windows source installation treats a fresh ownerless lock as active", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-ownerless-lock-"));
+	const lockPath = join(packageRoot, ".gentle-ai", ".v2.2.2.install.lock");
+	await mkdir(lockPath, { recursive: true });
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	await assertManualLockRecoveryRequired(packageRoot, fixture);
+});
+
+test("Windows source installation preserves a lock whose owner nonce changed before release", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-owner-lock-"));
+	const lockOwnerPath = join(packageRoot, ".gentle-ai", ".v2.2.2.install.lock", "owner.json");
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	let replacedOwner = false;
+	const run = async (...arguments_: Parameters<typeof fixture.run>) => {
+		const result = await fixture.run(...arguments_);
+		if (!replacedOwner && arguments_[0] !== fixture.goPath && arguments_[1].length === 1 && arguments_[1][0] === "version") {
+			replacedOwner = true;
+			await writeFile(lockOwnerPath, `${JSON.stringify({ createdAt: Date.now(), nonce: "1".repeat(64) })}\n`);
+		}
+		return result;
+	};
+	await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: run, resolveGoExecutable: fixture.resolveGoExecutable });
+	assert.equal(replacedOwner, true);
+	assert.equal((await readFile(lockOwnerPath, "utf8")).includes("1".repeat(64)), true);
+});
+
+async function assertManualLockRecoveryRequired(packageRoot: string, fixture: Awaited<ReturnType<typeof hardenedWindowsGoFixture>>, options: Record<string, unknown> = {}) {
+	const lockPath = join(packageRoot, ".gentle-ai", ".v2.2.2.install.lock");
+	await assert.rejects(
+		() => installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable, ...options }),
+		(error: unknown) => error instanceof Error && error.message.includes(lockPath) && /confirm no installer is active.*remove.*manually/i.test(error.message),
+	);
+	assert.equal(fixture.calls.some((call) => call.arguments_[0] === "install"), false);
+	assert.equal(existsSync(lockPath), true);
+}
+
+function tombstonePath(packageRoot: string, nonce: string): string {
+	return join(packageRoot, ".gentle-ai", `.v2.2.2.install.tombstone-${nonce}`);
+}
+
+async function tombstones(packageRoot: string): Promise<string[]> {
+	const runtimeRoot = join(packageRoot, ".gentle-ai");
+	return existsSync(runtimeRoot)
+		? (await readdir(runtimeRoot)).filter((entry) => entry.startsWith(".v2.2.2.install.tombstone-"))
+		: [];
+}
+
+function backupBundlePath(packageRoot: string, nonce: string): string {
+	return join(packageRoot, ".gentle-ai", `.v2.2.2.backup-${nonce}`);
+}
+
+async function copyWindowsBundle(source: string, destination: string): Promise<void> {
+	await mkdir(destination, { recursive: true });
+	await copyFile(join(source, "gentle-ai.exe"), join(destination, "gentle-ai.exe"));
+	await copyFile(join(source, "integrity.json"), join(destination, "integrity.json"));
+}
+
+test("Windows source installation fails closed for an ownerless lock even after the stale threshold", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-ownerless-stale-lock-"));
+	const lockPath = join(packageRoot, ".gentle-ai", ".v2.2.2.install.lock");
+	await mkdir(lockPath, { recursive: true });
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	await assertManualLockRecoveryRequired(packageRoot, fixture, { now: () => Date.now() + 10 * 60_000 });
+});
+
+test("Windows source installation fails closed for a stale owner lock", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-stale-lock-"));
+	const lockPath = join(packageRoot, ".gentle-ai", ".v2.2.2.install.lock");
+	await mkdir(lockPath, { recursive: true });
+	await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ createdAt: 0, nonce: "0".repeat(64) })}\n`);
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	await assertManualLockRecoveryRequired(packageRoot, fixture);
+});
+
+test("Windows source release moves a replacement lock to a preserved tombstone", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-release-tombstone-"));
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	const replacementNonce = "2".repeat(64);
+	await assert.rejects(
+		() => installGentleAi({
+			packageRoot,
+			platform: "win32",
+			arch: "x64",
+			execFile: fixture.run,
+			resolveGoExecutable: fixture.resolveGoExecutable,
+			beforeInstallLockReleaseRename: async (lockPath: string) => writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ createdAt: Date.now(), nonce: replacementNonce })}\n`),
+		}),
+		/package-private installation lock or tombstone exists/,
+	);
+	const preserved = await tombstones(packageRoot);
+	assert.equal(preserved.length, 1);
+	const preservedPath = join(packageRoot, ".gentle-ai", preserved[0]);
+	assert.equal((await readFile(join(preservedPath, "owner.json"), "utf8")).includes(replacementNonce), true);
+	const retry = await hardenedWindowsGoFixture(packageRoot);
+	await assert.rejects(
+		() => installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: retry.run, resolveGoExecutable: retry.resolveGoExecutable }),
+		(error: unknown) => error instanceof Error && error.message.includes(preservedPath),
+	);
+});
+
+test("Windows source acquisition fails closed when a tombstone appears after its first scan", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-acquire-tombstone-"));
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	const foreignTombstone = tombstonePath(packageRoot, "3".repeat(64));
+	await assert.rejects(
+		() => installGentleAi({
+			packageRoot,
+			platform: "win32",
+			arch: "x64",
+			execFile: fixture.run,
+			resolveGoExecutable: fixture.resolveGoExecutable,
+			afterInstallLockFirstTombstoneScan: async () => {
+				await mkdir(foreignTombstone, { recursive: true });
+				await writeFile(join(foreignTombstone, "owner.json"), `${JSON.stringify({ createdAt: Date.now(), nonce: "3".repeat(64) })}\n`);
+			},
+		}),
+		(error: unknown) => error instanceof Error && error.message.includes(foreignTombstone),
+	);
+	assert.equal(existsSync(foreignTombstone), true);
+	assert.equal(existsSync(join(packageRoot, ".gentle-ai", ".v2.2.2.install.lock")), false);
+	assert.equal(fixture.calls.some((call) => call.arguments_[0] === "install"), false);
+});
+
+test("Windows source release deletes its matching tombstone and allows reuse", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-owned-lock-release-"));
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable });
+	assert.equal(existsSync(join(packageRoot, ".gentle-ai", ".v2.2.2.install.lock")), false);
+	assert.deepEqual(await tombstones(packageRoot), []);
+	const reuse = await hardenedWindowsGoFixture(packageRoot);
+	assert.equal((await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: reuse.run, resolveGoExecutable: reuse.resolveGoExecutable })).installed, false);
+});
+
+test("Windows source recovers a valid backup after a crash between publication renames before any build", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-backup-crash-"));
+	const initial = await hardenedWindowsGoFixture(packageRoot);
+	await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: initial.run, resolveGoExecutable: initial.resolveGoExecutable });
+	const live = join(packageRoot, ".gentle-ai", "v2.2.2");
+	const backup = backupBundlePath(packageRoot, "crash");
+	await rename(live, backup);
+	const recovery = await hardenedWindowsGoFixture(packageRoot);
+	let buildAttempted = false;
+	const run = async (...arguments_: Parameters<typeof recovery.run>) => {
+		if (arguments_[1][0] === "install") { buildAttempted = true; throw new Error("recovery must precede a new build"); }
+		return recovery.run(...arguments_);
+	};
+	assert.equal((await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: run, resolveGoExecutable: recovery.resolveGoExecutable })).installed, false);
+	assert.equal(existsSync(live), true);
+	assert.equal(existsSync(backup), false);
+	assert.equal(buildAttempted, false);
+});
+
+test("Windows source fails closed for multiple or invalid backup candidates", async () => {
+	for (const setup of ["multiple", "invalid"] as const) {
+		const packageRoot = await mkdtemp(join(tmpdir(), `gentle-pi-installer-backup-${setup}-`));
+		const first = backupBundlePath(packageRoot, "first");
+		await mkdir(first, { recursive: true });
+		if (setup === "multiple") await mkdir(backupBundlePath(packageRoot, "second"), { recursive: true });
+		else await writeFile(join(first, "not-a-bundle"), "invalid");
+		const fixture = await hardenedWindowsGoFixture(packageRoot);
+		await assert.rejects(
+			() => installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable }),
+			/bundle recovery.*manual/i,
+		);
+		assert.equal(existsSync(first), true);
+		assert.equal(fixture.calls.some((call) => call.arguments_[0] === "install"), false);
+	}
+});
+
+test("Windows source cleans one validated backup only when the live bundle is valid", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-backup-valid-live-"));
+	const initial = await hardenedWindowsGoFixture(packageRoot);
+	await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: initial.run, resolveGoExecutable: initial.resolveGoExecutable });
+	const live = join(packageRoot, ".gentle-ai", "v2.2.2");
+	const backup = backupBundlePath(packageRoot, "valid");
+	await copyWindowsBundle(live, backup);
+	const reuse = await hardenedWindowsGoFixture(packageRoot);
+	assert.equal((await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: reuse.run, resolveGoExecutable: reuse.resolveGoExecutable })).installed, false);
+	assert.equal(existsSync(live), true);
+	assert.equal(existsSync(backup), false);
+});
+
+test("Windows source preserves a valid backup when the live bundle is invalid", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-backup-invalid-live-"));
+	const initial = await hardenedWindowsGoFixture(packageRoot);
+	await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: initial.run, resolveGoExecutable: initial.resolveGoExecutable });
+	const live = join(packageRoot, ".gentle-ai", "v2.2.2");
+	const backup = backupBundlePath(packageRoot, "valid");
+	await copyWindowsBundle(live, backup);
+	await writeFile(join(live, "integrity.json"), "{}\n");
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	await assert.rejects(
+		() => installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable }),
+		/bundle recovery.*manual/i,
+	);
+	assert.equal(existsSync(backup), true);
+	assert.equal(fixture.calls.some((call) => call.arguments_[0] === "install"), false);
+});
+
+test("Windows concurrent installs fail closed until normal release, then reuse the published bundle", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-concurrent-"));
+	const fixture = await hardenedWindowsGoFixture(packageRoot, { blockInstall: true });
+	const first = installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable });
+	await fixture.waitForInstall();
+	const lockPath = join(packageRoot, ".gentle-ai", ".v2.2.2.install.lock");
+	await assert.rejects(
+		() => installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable }),
+		(error: unknown) => error instanceof Error && error.message.includes(lockPath),
+	);
+	assert.equal(fixture.calls.filter((call) => call.file === fixture.goPath && call.arguments_[0] === "install").length, 1);
+	fixture.releaseInstall();
+	assert.equal((await first).installed, true);
+	assert.equal((await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: fixture.resolveGoExecutable })).installed, false);
+	assert.equal(fixture.calls.filter((call) => call.file === fixture.goPath && call.arguments_[0] === "install").length, 1);
+});
+
+test("Windows source publication rolls back a prior bundle when final directory swap fails", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-rollback-"));
+	const versionDirectory = join(packageRoot, ".gentle-ai", "v2.2.2");
+	await mkdir(versionDirectory, { recursive: true });
+	await writeFile(join(versionDirectory, "old.txt"), "previous bundle");
+	const fixture = await hardenedWindowsGoFixture(packageRoot);
+	await assert.rejects(
+		() => installGentleAi({
+			packageRoot,
+			platform: "win32",
+			arch: "x64",
+			execFile: fixture.run,
+			resolveGoExecutable: fixture.resolveGoExecutable,
+			rename: async (from: string, to: string) => {
+				if (to === versionDirectory && from.includes(".staging-")) throw new Error("simulated final swap failure");
+				await rename(from, to);
+			},
+		}),
+		/simulated final swap failure/,
+	);
+	assert.equal(await readFile(join(versionDirectory, "old.txt"), "utf8"), "previous bundle");
+});
+
+test("Darwin/Linux signed bundles retain their four-field manifest and reusable compatibility", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-signed-compatibility-"));
+	const payload = Buffer.from("signed archive fixture");
+	const asset = { name: "gentle-ai_2.2.2_linux_amd64.tar.gz", sha256: createHash("sha256").update(payload).digest("hex"), url: "https://example.invalid/gentle-ai.tar.gz", executable: "gentle-ai" };
+	const options = {
+		packageRoot,
+		platform: "linux",
+		arch: "x64",
+		releaseAssets: { "linux/amd64": asset },
+		download: async (_url: string, destination: string) => writeFile(destination, payload),
+		extractArchive: async (_archive: string, destination: string) => {
+			await mkdir(destination, { recursive: true });
+			await writeFile(join(destination, "gentle-ai"), "signed binary");
+		},
+	};
+	await installGentleAi(options);
+	const manifestPath = join(packageRoot, ".gentle-ai", "v2.2.2", "integrity.json");
+	const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as Record<string, string>;
+	assert.deepEqual(Object.keys(manifest), ["version", "asset", "assetSha256", "binarySha256"]);
+	assert.equal((await installGentleAi({ ...options, download: async () => { throw new Error("signed bundle must be reused"); } })).installed, false);
+});
+
+test("Windows archive lookup remains unsupported and names Go SumDB source installation", () => {
 	for (const arch of ["x64", "arm64"]) {
-		assert.throws(() => resolveGentleAiReleaseAsset("win32", arch), /unsupported Gentle AI platform\/architecture/);
-		assert.throws(() => resolveGentleAiReleaseAsset("windows", arch), /unsupported Gentle AI platform\/architecture/);
+		assert.throws(() => resolveGentleAiReleaseAsset("win32", arch), /Go SumDB source installation/);
 	}
 });
 

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -212,7 +212,8 @@ test("installed commit transaction runner loads JavaScript only and has determin
 	assert.equal(packageJson.scripts?.["test:packed-runner"], "node scripts/test-packed-runner.mjs");
 	assert.match(packageJson.scripts?.prepublishOnly ?? "", /pnpm run test:packed-runner/);
 	assert.match(ci, /pnpm run test:packed-runner/);
-	assert.doesNotMatch(packedRunner, /\["install"[^\]]*"--ignore-scripts"/s);
+	assert.match(packedRunner, /\["install"[^\]]*"--ignore-scripts=false"/s, "packed install must explicitly enable postinstall");
+	assert.doesNotMatch(packedRunner, /\["install"[^\]]*"--ignore-scripts"(?!\=false)/s);
 	assert.match(packedRunner, /execFileSync\("where\.exe", \["npm"\]/);
 	assert.match(packedRunner, /could not resolve npm-cli\.js without a command shell/);
 	assert.doesNotMatch(packedRunner, /ComSpec|cmd\.exe/);
@@ -275,7 +276,13 @@ test("package verification binds the published Gentle AI v2.2.2 runtime pin", ()
 	const verifier = readFileSync(join(PACKAGE_ROOT, "scripts", "verify-package-files.mjs"), "utf8");
 
 	assert.match(installer, /INSTALLER_VERSION = "2\.2\.2"/);
+	assert.match(installer, /GENTLE_AI_WINDOWS_SOURCE_PACKAGE.*GENTLE_AI_WINDOWS_SOURCE_MODULE/);
+	assert.match(installer, /GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM = "h1:YZcI5dRvoHm82I2CULvgBkB2M3UQQGarYO\/u\/Nt5LSc="/);
+	assert.match(installer, /GOTOOLCHAIN: "local"/);
+	assert.match(installer, /GOSUMDB: "sum\.golang\.org"/);
 	assert.match(binary, /GENTLE_AI_VERSION = "2\.2\.2"/);
+	assert.match(binary, /GO_SUMDB_SOURCE_BUILD/);
+	assert.match(binary, /GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM/);
 	assert.match(verifier, /v2\.2\.2/);
 });
 


### PR DESCRIPTION
Closes #240

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Build the exact `gentle-ai` v2.2.2 Windows runtime from the trusted Go module when upstream signed Windows assets are unavailable.
- Seal the Go build environment, bind source provenance to the pinned SumDB checksum, and verify module metadata, architecture, version, and executable hash.
- Publish only package-local validated bundles with cooperative installer locking, rollback/crash recovery, and no ambient `gentle-ai` fallback.

## Changes

| File | Change |
|------|--------|
| `scripts/gentle-ai-installer.mjs` | Adds exact-tag Windows source installation, provenance checks, sealed build environment, and transactional package-local publication. |
| `lib/gentle-ai-binary.ts` | Validates Windows source manifests and preserves pinned Darwin/Linux digest verification. |
| `runtime/gentle-ai-binary.mjs` | Regenerates the package runtime mirror. |
| `scripts/test-packed-runner.mjs` | Runs package lifecycle scripts in the packed-install harness. |
| `tests/gentle-ai-installer.test.ts` | Covers Go environment isolation, metadata, architectures, locks, rollback, crash recovery, and failure modes. |
| `tests/gentle-ai-binary.test.ts` | Covers package-local runtime integrity and source-manifest tampering. |
| `tests/package-manifest.test.ts` | Verifies packaged installer and provenance constants. |
| `README.md` | Documents Windows source-build trust and its explicit limitations. |

## Test Plan

- [x] `node --experimental-strip-types --test tests/gentle-ai-installer.test.ts tests/gentle-ai-binary.test.ts` — 47/47 passed
- [x] `node --experimental-strip-types --test tests/package-manifest.test.ts` — 32/32 passed
- [x] `pnpm run test:packed-runner`
- [x] `node scripts/verify-package-files.mjs`
- [x] `pnpm run check:transaction-runner`
- [x] `git diff --check`

## Trust Boundary

Windows source builds rely on the local Go toolchain plus Go SumDB verification for the exact module/tag and pinned checksum. This is not equivalent to Authenticode or a signed upstream archive, and it does not protect against a malicious same-user process jointly replacing package code, binary, and manifest.

## Review Workload

`size:exception` was explicitly approved for this security-sensitive installer work so implementation, tests, runtime mirror, and documentation remain one atomic review unit.

## Contributor Checklist

- [x] Linked approved issue #240
- [x] Exactly one `type:*` label will be applied
- [x] Relevant automated checks passed
- [x] Runtime/package behavior tested in the packed harness
- [x] Documentation updated for changed behavior
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Windows support for installing the verified Gentle AI runtime on x64 and arm64 systems.
  - Runtime installation now uses signed packages on macOS/Linux and verified source builds on Windows.
  - Installations are stored in a package-local runtime directory with recovery support for interrupted updates.

- **Bug Fixes**
  - Strengthened runtime integrity checks to detect tampered binaries, manifests, and replacement files.
  - Installations now fail safely when required verification or toolchain checks cannot be completed.

- **Documentation**
  - Expanded installation, verification, platform support, and security documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->