### PR TITLE
fix(review): surface consent binding failures as local errors

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -105,6 +105,7 @@ import {
 	nativeReviewLegacyQuarantineAuthorization,
 	nativeReviewReconcileAuthorization,
 	NativeReviewCliError,
+	NativeReviewConsentBindingError,
 	NativeReviewConsentRequiredError,
 	NATIVE_REVIEW_ERROR_CODE,
 	NATIVE_REVIEW_LEGACY_QUARANTINE,
@@ -3917,6 +3918,14 @@ function asNativeReviewCliError(error: unknown): { code: string; diagnostics: Na
 	return diagnostics === undefined || value.code !== diagnostics.error_code ? undefined : { code: value.code, diagnostics };
 }
 
+// Same coexisting-module-instance caveat as asNativeReviewCliError above.
+function asNativeReviewConsentBindingError(error: unknown): { reason: string; message: string } | undefined {
+	if (error instanceof NativeReviewConsentBindingError) return { reason: error.reason, message: error.message };
+	if (!(error instanceof Error) || error.name !== "NativeReviewConsentBindingError") return undefined;
+	const reason = (error as unknown as { reason?: unknown }).reason;
+	return typeof reason !== "string" || reason.length === 0 ? undefined : { reason, message: error.message };
+}
+
 function nativeStatusFailed(operation: ReviewControllerOperation, error: unknown): Record<string, unknown> {
 	const cliError = asNativeReviewCliError(error);
 	if (cliError?.code === NATIVE_REVIEW_ERROR_CODE.VERSION_INCOMPATIBLE) return nativeStatusUnsupported(operation);
@@ -4621,6 +4630,23 @@ function nativeOperationFailure(operation: ReviewControllerOperation, error: unk
 					: { mutation_performed: false, mutation_outcome: "none" }),
 			...(typeof value.failureEnvelope.replayability === "string" ? { replayability: value.failureEnvelope.replayability } : {}),
 			...(typeof value.failureEnvelope.nextAction === "string" ? { next_action: value.failureEnvelope.nextAction } : {}),
+		};
+	}
+	// Every consent binding guard runs before the provider is launched, so this
+	// is a local mismatch with nothing to reconcile. Reporting it as a native
+	// operation failure hides the one fact that makes it fixable.
+	const consentBinding = asNativeReviewConsentBindingError(error);
+	if (consentBinding !== undefined) {
+		return {
+			operation,
+			status: "blocked",
+			outcome: "consent-binding-invalid",
+			native_invocation_attempted: false,
+			lineage_created: false,
+			mutation_performed: false,
+			mutation_outcome: "none" as const,
+			diagnostics: { code: consentBinding.reason, message: consentBinding.message },
+			next_action: "resolve-consent-binding",
 		};
 	}
 	const mutationOutcome = value.mutationOutcome === "unknown" ? "unknown" : "none";

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -1654,6 +1654,23 @@ export class NativeReviewConsentRequiredError extends Error {
 	}
 }
 
+// Raised when the provider-issued consent invocation no longer matches the
+// binding Pi is answering for. Every one of these guards runs before the
+// provider is launched, so the failure is local and nothing was mutated. It
+// carries its own identity precisely so callers never report it as a provider
+// outage: an opaque `native-operation-failed` here sent issue #247 chasing a
+// missing `--cwd` that Pi does forward.
+export class NativeReviewConsentBindingError extends Error {
+	readonly reason: string;
+	readonly launchAttempted = false;
+	readonly mutationOutcome = "none";
+	constructor(reason: string, message: string) {
+		super(message);
+		this.name = "NativeReviewConsentBindingError";
+		this.reason = reason;
+	}
+}
+
 function splitNativeConsentInvocation(invocation: string): readonly string[] {
 	const words: string[] = [];
 	let current = "";
@@ -1705,26 +1722,26 @@ function exactConsentOption(arguments_: readonly string[], name: string): string
 		const token = arguments_[index]!;
 		if (token === name) {
 			const value = arguments_[index + 1];
-			if (value === undefined) throw new TypeError(`Native consent invocation ${name} is missing its value`);
+			if (value === undefined) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", `Native consent invocation ${name} is missing its value`);
 			values.push(value);
 			index += 1;
 		} else if (token.startsWith(`${name}=`)) values.push(token.slice(name.length + 1));
 	}
-	if (values.length !== 1) throw new TypeError(`Native consent invocation requires exactly one ${name}`);
+	if (values.length !== 1) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", `Native consent invocation requires exactly one ${name}`);
 	return values[0]!;
 }
 
 function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): readonly string[] {
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
-	if (choice === undefined) throw new TypeError("Native consent answer must be granted or declined");
+	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
-	if (words[0] !== "gentle-ai" || words[1] !== "review" || words[2] !== "start") throw new TypeError("Native consent invocation is not a provider review START");
+	if (words[0] !== "gentle-ai" || words[1] !== "review" || words[2] !== "start") throw new NativeReviewConsentBindingError("consent-invocation-not-start", "Native consent invocation is not a provider review START");
 	const arguments_ = words.slice(1);
-	if (exactConsentOption(arguments_, "--contract") !== REVIEW_INTEGRATION_CONTRACT) throw new TypeError("Native consent invocation contract changed");
-	if (exactConsentOption(arguments_, "--cwd") !== request.cwd) throw new TypeError("Native consent invocation repository binding changed");
-	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new TypeError("Native consent invocation target binding changed");
-	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new TypeError("Native consent invocation projection binding changed");
-	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new TypeError("Native consent invocation answer binding changed");
+	if (exactConsentOption(arguments_, "--contract") !== REVIEW_INTEGRATION_CONTRACT) throw new NativeReviewConsentBindingError("consent-invocation-contract-changed", "Native consent invocation contract changed");
+	if (exactConsentOption(arguments_, "--cwd") !== request.cwd) throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
+	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
+	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
+	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");
 	return arguments_;
 }
 

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -1655,6 +1655,23 @@ export class NativeReviewConsentRequiredError extends Error {
 	}
 }
 
+// Raised when the provider-issued consent invocation no longer matches the
+// binding Pi is answering for. Every one of these guards runs before the
+// provider is launched, so the failure is local and nothing was mutated. It
+// carries its own identity precisely so callers never report it as a provider
+// outage: an opaque `native-operation-failed` here sent issue #247 chasing a
+// missing `--cwd` that Pi does forward.
+export class NativeReviewConsentBindingError extends Error {
+	         reason        ;
+	         launchAttempted = false;
+	         mutationOutcome = "none";
+	constructor(reason        , message        ) {
+		super(message);
+		this.name = "NativeReviewConsentBindingError";
+		this.reason = reason;
+	}
+}
+
 function splitNativeConsentInvocation(invocation        )                    {
 	const words           = [];
 	let current = "";
@@ -1706,26 +1723,26 @@ function exactConsentOption(arguments_                   , name        )        
 		const token = arguments_[index] ;
 		if (token === name) {
 			const value = arguments_[index + 1];
-			if (value === undefined) throw new TypeError(`Native consent invocation ${name} is missing its value`);
+			if (value === undefined) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", `Native consent invocation ${name} is missing its value`);
 			values.push(value);
 			index += 1;
 		} else if (token.startsWith(`${name}=`)) values.push(token.slice(name.length + 1));
 	}
-	if (values.length !== 1) throw new TypeError(`Native consent invocation requires exactly one ${name}`);
+	if (values.length !== 1) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", `Native consent invocation requires exactly one ${name}`);
 	return values[0] ;
 }
 
 function consentInvocationArguments(request                                  )                    {
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
-	if (choice === undefined) throw new TypeError("Native consent answer must be granted or declined");
+	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
-	if (words[0] !== "gentle-ai" || words[1] !== "review" || words[2] !== "start") throw new TypeError("Native consent invocation is not a provider review START");
+	if (words[0] !== "gentle-ai" || words[1] !== "review" || words[2] !== "start") throw new NativeReviewConsentBindingError("consent-invocation-not-start", "Native consent invocation is not a provider review START");
 	const arguments_ = words.slice(1);
-	if (exactConsentOption(arguments_, "--contract") !== REVIEW_INTEGRATION_CONTRACT) throw new TypeError("Native consent invocation contract changed");
-	if (exactConsentOption(arguments_, "--cwd") !== request.cwd) throw new TypeError("Native consent invocation repository binding changed");
-	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new TypeError("Native consent invocation target binding changed");
-	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new TypeError("Native consent invocation projection binding changed");
-	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new TypeError("Native consent invocation answer binding changed");
+	if (exactConsentOption(arguments_, "--contract") !== REVIEW_INTEGRATION_CONTRACT) throw new NativeReviewConsentBindingError("consent-invocation-contract-changed", "Native consent invocation contract changed");
+	if (exactConsentOption(arguments_, "--cwd") !== request.cwd) throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
+	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
+	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
+	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");
 	return arguments_;
 }
 

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { GENTLE_AI_VERSION } from "../lib/gentle-ai-binary.ts";
 import {
 	NativeReviewCliV216,
+	NativeReviewConsentBindingError,
 	NativeReviewConsentRequiredError,
 	clearNativeReviewCapabilitiesCacheForTesting,
 	type ExecFileAdapter,
@@ -98,6 +99,66 @@ test("consent follow-up executes the provider-named invocation exactly once and 
 		() => native.answerConsent!({ cwd: "/repo", consent: changed, answer: "declined" }),
 		/target|binding/,
 	);
+});
+
+// A binding mismatch is decided entirely inside Pi, before the provider is
+// launched, so it must not be reported as a provider failure (issue #247).
+test("a consent invocation binding mismatch is a typed pre-native error that never launches the provider", async () => {
+	const consent = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+	const queue = queuedAdapter([]);
+	await assert.rejects(
+		() => client(queue.adapter).answerConsent!({ cwd: "/repo/.git/gentle-ai/candidate-views/a1c7fdae", consent, answer: "granted" }),
+		(error: unknown) => {
+			assert.ok(error instanceof NativeReviewConsentBindingError);
+			assert.equal(error.name, "NativeReviewConsentBindingError");
+			assert.equal(error.reason, "consent-invocation-cwd-changed");
+			assert.equal(error.launchAttempted, false);
+			assert.equal(error.mutationOutcome, "none");
+			assert.match(error.message, /repository binding changed/);
+			return true;
+		},
+	);
+	assert.deepEqual(queue.calls, []);
+});
+
+// `decodeReviewConsentV2` already rejects a malformed invocation, so these
+// guards defend against a consent object that drifted after decoding. Each one
+// must still name itself rather than collapse into a generic failure.
+test("every consent invocation binding guard reports its own reason without launching the provider", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+	const drifted = (mutate: (consent: ReviewConsentV2) => void): ReviewConsentV2 => {
+		const value = structuredClone(decoded);
+		mutate(value);
+		return value;
+	};
+	const rewriteGranted = (consent: ReviewConsentV2, replace: (invocation: string) => string): void => {
+		const choice = consent.choices.find((candidate) => candidate.answer === "granted") as { invocation: string };
+		choice.invocation = replace(choice.invocation);
+	};
+	const cases = [
+		{
+			reason: "consent-answer-unknown",
+			consent: drifted((consent) => { (consent as { choices: unknown }).choices = consent.choices.filter((choice) => choice.answer !== "granted"); }),
+		},
+		{ reason: "consent-invocation-not-start", consent: drifted((consent) => rewriteGranted(consent, (value) => value.replace("review start", "review finalize"))) },
+		{ reason: "consent-invocation-contract-changed", consent: drifted((consent) => rewriteGranted(consent, (value) => value.replace("gentle-ai.review-integration/v2", "gentle-ai.review-integration/v1"))) },
+		{ reason: "consent-invocation-target-changed", consent: drifted((consent) => { (consent as { targetIdentity: string }).targetIdentity = `sha256:${"c".repeat(64)}`; }) },
+		{ reason: "consent-invocation-projection-changed", consent: drifted((consent) => { (consent as { projection: string }).projection = "staged"; }) },
+		{ reason: "consent-invocation-answer-changed", consent: drifted((consent) => rewriteGranted(consent, (value) => value.replace("--consent granted", "--consent declined"))) },
+		{ reason: "consent-invocation-option-invalid", consent: drifted((consent) => rewriteGranted(consent, (value) => `${value} --consent granted`)) },
+	] as const;
+	for (const scenario of cases) {
+		const queue = queuedAdapter([]);
+		await assert.rejects(
+			() => client(queue.adapter).answerConsent!({ cwd: "/repo", consent: scenario.consent, answer: "granted" }),
+			(error: unknown) => {
+				assert.ok(error instanceof NativeReviewConsentBindingError, `${scenario.reason} must be a typed binding error`);
+				assert.equal(error.reason, scenario.reason);
+				return true;
+			},
+		);
+		assert.deepEqual(queue.calls, [], `${scenario.reason} must not launch the provider`);
+	}
 });
 
 test("declined consent decodes the provider's explicit empty authority fields without creating a lineage", async () => {

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -9,6 +9,7 @@ import { __testing, createGentleAiExtension } from "../extensions/gentle-ai.ts";
 import {
 	NATIVE_REVIEW_ERROR_CODE,
 	NativeReviewCliError,
+	NativeReviewConsentBindingError,
 	NativeReviewConsentRequiredError,
 	NativeReviewCliV213 as NativeReviewCliV213Production,
 	setNativeCliContractForTesting,
@@ -591,6 +592,28 @@ test("explicit consent follow-up grants or declines exactly once", async (t) => 
 		}
 		await assert.rejects(() => answerConsent(controller, blocked.consent_binding, answer, headlessContext(cwd)), /unknown, expired, or already consumed/);
 	}
+});
+
+// Issue #247: a local binding mismatch was indistinguishable from a provider
+// outage, so the reporter diagnosed a missing --cwd that Pi does forward.
+test("a consent binding mismatch surfaces as an actionable local failure, not an opaque native operation failure", async (t) => {
+	const cwd = repository(t);
+	const { native, answers } = relayedConsentNative(cwd);
+	native.answerConsent = async () => {
+		throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
+	};
+	const { controller } = runtime(native);
+	const blocked = await blockedConsent(controller, "consent-binding", headlessContext(cwd));
+	const result = await answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd));
+	assert.equal(result.status, "blocked");
+	assert.equal(result.outcome, "consent-binding-invalid");
+	assert.deepEqual(result.diagnostics, { code: "consent-invocation-cwd-changed", message: "Native consent invocation repository binding changed" });
+	assert.equal(result.native_invocation_attempted, false);
+	assert.equal(result.lineage_created, false);
+	assert.equal(result.mutation_performed, false);
+	assert.equal(result.mutation_outcome, "none");
+	assert.equal(result.next_action, "resolve-consent-binding");
+	assert.deepEqual(answers, []);
 });
 
 test("consent follow-up rejects invalid token, unknown id, changed cwd, and changed target binding", async (t) => {


### PR DESCRIPTION
Closes #248

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Give consent invocation binding failures their own typed identity instead of a plain `TypeError`.
- Surface them as a local `consent-binding-invalid` result that states no native invocation was attempted.
- Keep every existing guard, message, and fail-closed behavior byte-for-byte intact.

## Context

Every guard in `consentInvocationArguments` runs *before* `negotiated(...)` launches the provider, so a mismatch there is a local defect with nothing mutated and nothing to reconcile. It was still reported as `native-operation-failed` with no diagnostics, which is exactly what a provider outage looks like.

That cost real time in #247: the reporter saw the opaque envelope and concluded `answer-consent` "did not forward the candidate-views `--cwd`". It does — `extensions/gentle-ai.ts` passes `cwd: pending.candidateView.root` and `lib/native-review-cli.ts` asserts the invocation's `--cwd` matches it. The envelope, not the binding, was the defect.

## Changes

| File | Change |
|------|--------|
| `lib/native-review-cli.ts` | Add `NativeReviewConsentBindingError` with a per-guard `reason`, `launchAttempted: false`, and `mutationOutcome: "none"`; throw it from every `consentInvocationArguments` and `exactConsentOption` guard. |
| `extensions/gentle-ai.ts` | Add a name-based detector and surface the error as `consent-binding-invalid` with typed diagnostics and `next_action: resolve-consent-binding`. |
| `runtime/native-review-cli.mjs` | Regenerate the runtime mirror from the TypeScript source. |
| `tests/native-review-consent.test.ts` | Cover the pre-native typed error, the no-launch guarantee, and one distinct reason per guard. |
| `tests/native-review-parity.test.ts` | Cover the controller-level envelope the reporter actually sees. |

Reason codes: `consent-answer-unknown`, `consent-invocation-not-start`, `consent-invocation-contract-changed`, `consent-invocation-cwd-changed`, `consent-invocation-target-changed`, `consent-invocation-projection-changed`, `consent-invocation-answer-changed`, `consent-invocation-option-invalid`.

The detector matches on `error.name` as well as `instanceof`, following `asNativeReviewCliError`, because bundled and source module instances can coexist.

## Out of scope

The candidate-views target-identity mismatch reported in #247 — the wrapper mints review authority with `cwd` set to the candidate-views worktree, so its receipt cannot govern a main-repo pre-commit. That is a design-level fix and #247 stays open for it.

## Test plan

- [x] `node --experimental-strip-types --test tests/native-review-consent.test.ts` — 5 passed (3 new).
- [x] `node --experimental-strip-types --test tests/native-review-parity.test.ts` — 34 passed (1 new).
- [x] `pnpm test` — 963 tests, 959 passing, 1 expected Windows-only skip. The 3 remaining failures are the pre-existing `tests/native-review-parity-runtime.test.ts` cases that require the global RDD switch to be on; they fail identically on `main` in the same environment and are unrelated to this change.
- [x] `pnpm run check:transaction-runner` — runtime mirror matches sources.
- [x] `node scripts/verify-package-files.mjs` — 129 files, 64 byte-identical v2.2.2 contract artifacts.
- [x] `git diff --check` — clean.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Exactly one `type:*` label.
- [x] Regression tests included with the behavior change.
- [x] Runtime mirror regenerated from source.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` or AI attribution trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or outdated consent bindings.
  * Consent mismatches now return a clear blocked status with actionable diagnostics.
  * Prevented native provider invocation and data mutations when consent details do not match.
  * Added specific detection for mismatched repository, contract, target, projection, and answer details.

* **Tests**
  * Added coverage for consent-binding drift and verified safe failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->