### PR TITLE
fix(review): harden blocking failure paths

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -109,6 +109,7 @@ import {
 	NativeReviewConsentBindingError,
 	NativeReviewConsentRequiredError,
 	NATIVE_REVIEW_ERROR_CODE,
+	NATIVE_REVIEW_OPERATION,
 	NATIVE_REVIEW_LEGACY_QUARANTINE,
 	NATIVE_REVIEW_LEGACY_ALIAS_REPAIR,
 	NATIVE_REVIEW_MODE_OPERATION,
@@ -3927,9 +3928,22 @@ function asNativeReviewConsentBindingError(error: unknown): { reason: string; me
 	return typeof reason !== "string" || reason.length === 0 ? undefined : { reason, message: error.message };
 }
 
+function nativeStatusPackageBinaryMissing(operation: ReviewControllerOperation, diagnostics: NativeReviewProcessDiagnostics): Record<string, unknown> {
+	return {
+		operation,
+		status: "blocked",
+		outcome: "native-status-package-binary-missing",
+		...(operation === REVIEW_CONTROLLER_OPERATION.START ? nativeStartPreAuthorityRejection() : { lineage_created: false, mutation_performed: false, mutation_outcome: "none" }),
+		inventory_complete: false,
+		diagnostics,
+		next_action: "reinstall-package-local-gentle-ai",
+	};
+}
+
 function nativeStatusFailed(operation: ReviewControllerOperation, error: unknown): Record<string, unknown> {
 	const cliError = asNativeReviewCliError(error);
 	if (cliError?.code === NATIVE_REVIEW_ERROR_CODE.VERSION_INCOMPATIBLE) return nativeStatusUnsupported(operation);
+	if (cliError?.code === NATIVE_REVIEW_ERROR_CODE.PACKAGE_BINARY_MISSING) return nativeStatusPackageBinaryMissing(operation, cliError.diagnostics);
 	if (cliError !== undefined) {
 		return {
 			...nativeOperationFailure(operation, error),
@@ -4665,12 +4679,18 @@ function nativeOperationFailure(operation: ReviewControllerOperation, error: unk
 		};
 	}
 	const mutationOutcome = value.mutationOutcome === "unknown" ? "unknown" : "none";
-	const nativeDiagnostics = asNativeReviewCliError(error)?.diagnostics;
+	const nativeCliError = asNativeReviewCliError(error);
+	if (nativeCliError?.code === NATIVE_REVIEW_ERROR_CODE.PACKAGE_BINARY_MISSING) return nativeStatusPackageBinaryMissing(operation, nativeCliError.diagnostics);
+	const nativeDiagnostics = nativeCliError?.diagnostics;
+	// A target-status probe verifies `version` before it invokes `review/status`.
+	// Preserve either already-sanitized diagnostic on every controller route rather
+	// than relabeling an actionable failure as an opaque controller failure.
+	const preservesNativeTargetStatusDiagnostic = nativeDiagnostics?.operation === NATIVE_REVIEW_OPERATION.VERSION || nativeDiagnostics?.operation === NATIVE_REVIEW_OPERATION.STATUS;
 	const diagnostics = operation === REVIEW_CONTROLLER_OPERATION.START && error instanceof CandidateViewError && value.candidateViewPreNative === true
-		? { code: error.reason, message: "candidate view rejected before native START" }
+		? error.diagnostics ?? { code: error.reason, message: "candidate view rejected before native START" }
 		: error instanceof CandidateViewError
 			? { code: error.reason, message: error.message }
-			: nativeDiagnostics?.operation === `review/${operation}`
+			: nativeDiagnostics?.operation === `review/${operation}` || preservesNativeTargetStatusDiagnostic
 		? nativeDiagnostics
 		: undefined;
 	return {
@@ -5030,7 +5050,12 @@ async function executeReviewControllerOperation(
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.REPAIR) {
 		if (nativeReviewCli?.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
-		const status = await nativeReviewCli.targetStatus({ cwd: defaultCwd, ...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }), ...(signal === undefined ? {} : { signal }) });
+		let status: ReviewStatusV3;
+		try {
+			status = await nativeReviewCli.targetStatus({ cwd: defaultCwd, ...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }), ...(signal === undefined ? {} : { signal }) });
+		} catch (error) {
+			return nativeStatusFailed(parameters.operation, error);
+		}
 		if (status.authority?.version === "compact-v2") return { operation: parameters.operation, repaired: false, compact_authority: "immutable-untouched", status: mapNativeTargetStatus(parameters.operation, status, parameters.lineageId) };
 		if (status.authority?.version !== "legacy-v1") return mapNativeTargetStatus(parameters.operation, status, parameters.lineageId);
 		const store = ReviewTransactionStore.forRepository(defaultCwd);
@@ -5174,6 +5199,7 @@ async function executeReviewControllerOperation(
 				try {
 					canonicalBaseRef = resolveCanonicalCandidateBase(defaultCwd, baseRef).commit;
 				} catch (error) {
+					if (error instanceof CandidateViewError && error.diagnostics !== undefined) return nativeOperationFailure(parameters.operation, Object.assign(error, { candidateViewPreNative: true }));
 					if (error instanceof CandidateViewError && (error.reason === "base-ref-ambiguous" || error.reason === "base-ref-unresolvable" || error.reason === "base-ref-moved")) return nativeStartRejection(error.reason);
 					return nativeStartRejection("base-ref-unresolvable");
 				}
@@ -5236,6 +5262,7 @@ async function executeReviewControllerOperation(
 				}
 				return completeNativeStart(parameters.operation, result, defaultCwd, candidateView, candidateViews);
 			} catch (error) {
+				if (error instanceof CandidateViewError && error.diagnostics !== undefined) return nativeOperationFailure(parameters.operation, Object.assign(error, { candidateViewPreNative: true }));
 				if (error instanceof CandidateViewError && (error.reason === "base-ref-ambiguous" || error.reason === "base-ref-unresolvable" || error.reason === "base-ref-moved")) return nativeStartRejection(error.reason);
 				const value = error as { mutationOutcome?: unknown; nextAction?: unknown };
 				const provenNoMutation = value.mutationOutcome === "none";

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -25,6 +25,23 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+// Negotiated review/status responses can carry a complete authority inventory.
+// Keep the production default large enough for that payload while retaining a
+// hard 64 MiB ceiling even when GENTLE_PI_REVIEW_MAX_BUFFER_BYTES is set.
+export const NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+const NATIVE_REVIEW_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+const NATIVE_REVIEW_MAX_BUFFER_BYTES_ENV = "GENTLE_PI_REVIEW_MAX_BUFFER_BYTES";
+const NATIVE_REVIEW_MAX_BUFFER_CONFIGURATION_HINT = "Inspect native review state before any new START; GENTLE_PI_REVIEW_MAX_BUFFER_BYTES accepts a positive decimal up to 67108864.";
+
+function resolveNativeReviewMaxBufferBytes(environment: NodeJS.ProcessEnv = process.env): number {
+	const value = environment[NATIVE_REVIEW_MAX_BUFFER_BYTES_ENV];
+	if (value === undefined || !/^[1-9]\d*$/.test(value)) return NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES;
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) && parsed <= NATIVE_REVIEW_MAX_BUFFER_BYTES
+		? parsed
+		: NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES;
+}
+
 export const NATIVE_REVIEW_OPERATION = {
 	VERSION: "version",
 	START: "review/start",
@@ -697,6 +714,8 @@ export interface NativeReviewProcessDiagnostics {
 	signal?: NodeJS.Signals;
 	timed_out: boolean;
 	output_limit_exceeded: boolean;
+	max_buffer_bytes?: number;
+	configuration_hint?: string;
 	stderr?: string;
 	denial?: NativeReviewStructuredDenial;
 }
@@ -732,7 +751,8 @@ export function createNodeExecFileAdapter(): ExecFileAdapter {
 		} catch (error) {
 			const detail = error as NodeJS.ErrnoException & { stdout?: string; stderr?: string; code?: string | number; signal?: NodeJS.Signals; killed?: boolean };
 			if (detail.code === "ENOENT" || detail.code === "EACCES" || detail.name === "AbortError") throw error;
-			return { stdout: detail.stdout ?? "", stderr: detail.stderr ?? "", exitCode: typeof detail.code === "number" ? detail.code : 1, signal: detail.signal ?? null, timedOut: detail.killed === true, outputLimitExceeded: detail.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" };
+			const outputLimitExceeded = detail.code === "ENOBUFS" || detail.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+			return { stdout: detail.stdout ?? "", stderr: detail.stderr ?? "", exitCode: typeof detail.code === "number" ? detail.code : 1, signal: detail.signal ?? null, timedOut: !outputLimitExceeded && detail.killed === true, outputLimitExceeded };
 		}
 	};
 }
@@ -808,12 +828,28 @@ function parseStructuredNativeDenial(stdout: string): NativeReviewStructuredDeni
 // Rebuild diagnostics from a duplicated module instance before facade output.
 export function sanitizeForeignNativeReviewDiagnostics(value: unknown): NativeReviewProcessDiagnostics | undefined {
 	try {
-		const raw = exactObject(value, ["operation", "error_code", "timed_out", "output_limit_exceeded"], ["exit_code", "signal", "stderr", "denial"]);
+		const raw = exactObject(value, ["operation", "error_code", "timed_out", "output_limit_exceeded"], ["exit_code", "signal", "max_buffer_bytes", "configuration_hint", "stderr", "denial"]);
 		const operation = enumString(raw.operation, Object.values(NATIVE_REVIEW_OPERATION)) as NativeReviewOperation;
 		const errorCode = enumString(raw.error_code, Object.values(NATIVE_REVIEW_ERROR_CODE)) as NativeReviewErrorCode;
 		const signal = raw.signal === undefined ? undefined : requiredString(raw.signal);
-		if (signal !== undefined && !/^SIG[A-Z0-9]{1,12}$/.test(signal)) return undefined;
-		return { operation, error_code: errorCode, ...(raw.exit_code === undefined ? {} : { exit_code: nonNegativeInteger(raw.exit_code) }), ...(signal === undefined ? {} : { signal: signal as NodeJS.Signals }), timed_out: booleanValue(raw.timed_out), output_limit_exceeded: booleanValue(raw.output_limit_exceeded), ...(raw.stderr === undefined ? {} : { stderr: sanitizeNativeDiagnosticText(stringValue(raw.stderr)) }), ...(raw.denial === undefined ? {} : { denial: sanitizeForeignStructuredDenial(raw.denial) }) };
+		const maxBufferBytes = raw.max_buffer_bytes === undefined ? undefined : positiveInteger(raw.max_buffer_bytes);
+		const configurationHint = raw.configuration_hint === undefined ? undefined : stringValue(raw.configuration_hint);
+		if (
+			(signal !== undefined && !/^SIG[A-Z0-9]{1,12}$/.test(signal)) ||
+			(maxBufferBytes === undefined) !== (configurationHint === undefined) ||
+			(configurationHint !== undefined && (errorCode !== NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT || configurationHint !== NATIVE_REVIEW_MAX_BUFFER_CONFIGURATION_HINT))
+		) return undefined;
+		return {
+			operation,
+			error_code: errorCode,
+			...(raw.exit_code === undefined ? {} : { exit_code: nonNegativeInteger(raw.exit_code) }),
+			...(signal === undefined ? {} : { signal: signal as NodeJS.Signals }),
+			timed_out: booleanValue(raw.timed_out),
+			output_limit_exceeded: booleanValue(raw.output_limit_exceeded),
+			...(maxBufferBytes === undefined ? {} : { max_buffer_bytes: maxBufferBytes, configuration_hint: configurationHint! }),
+			...(raw.stderr === undefined ? {} : { stderr: sanitizeNativeDiagnosticText(stringValue(raw.stderr)) }),
+			...(raw.denial === undefined ? {} : { denial: sanitizeForeignStructuredDenial(raw.denial) }),
+		};
 	} catch { return undefined; }
 }
 
@@ -829,14 +865,18 @@ function sanitizeForeignStructuredDenial(value: unknown): NativeReviewStructured
 	return { schema: "gentle-ai.review-gate-result/v1", result, action, reason, ...(denial === undefined ? {} : { denial }) };
 }
 
-function nativeProcessDiagnostics(operation: NativeReviewOperation, code: NativeReviewErrorCode, result?: ExecFileResult): NativeReviewProcessDiagnostics {
+function nativeProcessDiagnostics(operation: NativeReviewOperation, code: NativeReviewErrorCode, result?: ExecFileResult, maxBufferBytes?: number): NativeReviewProcessDiagnostics {
+	const outputLimitExceeded = result?.outputLimitExceeded === true;
 	return {
 		operation,
 		error_code: code,
 		...(result === undefined ? {} : { exit_code: result.exitCode }),
 		...(result?.signal === null || result?.signal === undefined ? {} : { signal: result.signal }),
-		timed_out: result?.timedOut === true,
-		output_limit_exceeded: result?.outputLimitExceeded === true,
+		timed_out: !outputLimitExceeded && result?.timedOut === true,
+		output_limit_exceeded: outputLimitExceeded,
+		...(code === NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT && maxBufferBytes !== undefined
+			? { max_buffer_bytes: maxBufferBytes, configuration_hint: NATIVE_REVIEW_MAX_BUFFER_CONFIGURATION_HINT }
+			: {}),
 		...(result?.stderr.trim() ? { stderr: sanitizeNativeDiagnosticText(result.stderr) } : {}),
 		...(result === undefined ? {} : { denial: parseStructuredNativeDenial(result.stdout) }),
 	};
@@ -1154,8 +1194,8 @@ function hasValidLensesRequired(action: NativeStartAction, state: string, riskLe
 	return !lensesRequired;
 }
 
-function nativeError(code: NativeReviewErrorCode, operation: NativeReviewOperation, mutating: boolean, message: string, result?: ExecFileResult, launchAttempted = true, auditRecord?: Record<string, unknown>): NativeReviewCliError {
-	return new NativeReviewCliError(code, operation, launchAttempted, mutating, message, nativeProcessDiagnostics(operation, code, result), auditRecord);
+function nativeError(code: NativeReviewErrorCode, operation: NativeReviewOperation, mutating: boolean, message: string, result?: ExecFileResult, launchAttempted = true, auditRecord?: Record<string, unknown>, maxBufferBytes?: number): NativeReviewCliError {
+	return new NativeReviewCliError(code, operation, launchAttempted, mutating, message, nativeProcessDiagnostics(operation, code, result, maxBufferBytes), auditRecord);
 }
 
 interface NativeJsonExecution {
@@ -1170,7 +1210,7 @@ export class NativeReviewCliV214 {
 	private readonly timeoutMs: number;
 	private readonly maxBufferBytes: number;
 	private readonly cleanupDirectory: (directory: string) => Promise<void>;
-	constructor(adapter: ExecFileAdapter, executable: string | (() => string) = resolveGentleAiBinary, timeoutMs = 30_000, maxBufferBytes = 1024 * 1024, cleanupDirectory = (directory: string) => rm(directory, { recursive: true, force: true })) {
+	constructor(adapter: ExecFileAdapter, executable: string | (() => string) = resolveGentleAiBinary, timeoutMs = 30_000, maxBufferBytes = resolveNativeReviewMaxBufferBytes(), cleanupDirectory = (directory: string) => rm(directory, { recursive: true, force: true })) {
 		if (typeof executable === "string" && (!isAbsolute(executable) || executable === "gentle-ai")) throw new TypeError("Native review requires an absolute package-local executable");
 		this.adapter = adapter;
 		this.executable = executable;
@@ -1207,8 +1247,8 @@ export class NativeReviewCliV214 {
 			throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNAVAILABLE, operation, mutating, "native process could not start");
 		}
 		const diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.NON_ZERO, result);
+		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, operation, mutating, "native process output exceeded limit", result, true, undefined, this.maxBufferBytes);
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, operation, mutating, "native process timed out", result);
-		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, operation, mutating, "native process output exceeded limit", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, operation, mutating, "native process was signalled", result);
 		const structuredValidateDenial = operation === NATIVE_REVIEW_OPERATION.VALIDATE && result.exitCode === 1;
 		const maintenancePartialFailure = [NATIVE_REVIEW_OPERATION.ABANDON, NATIVE_REVIEW_OPERATION.QUARANTINE_LEGACY, NATIVE_REVIEW_OPERATION.RECONCILE_AUTHORITY, NATIVE_REVIEW_OPERATION.REPAIR_LEGACY_ALIAS].includes(operation) && result.exitCode !== 0;
@@ -1226,8 +1266,8 @@ export class NativeReviewCliV214 {
 			if (error instanceof Error && error.name === "AbortError") throw nativeError(NATIVE_REVIEW_ERROR_CODE.CANCELLED, NATIVE_REVIEW_OPERATION.VERSION, false, "version process was cancelled");
 			throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNAVAILABLE, NATIVE_REVIEW_OPERATION.VERSION, false, "gentle-ai is unavailable");
 		}
+		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, NATIVE_REVIEW_OPERATION.VERSION, false, "version process output exceeded limit", result, true, undefined, this.maxBufferBytes);
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, NATIVE_REVIEW_OPERATION.VERSION, false, "version process timed out", result);
-		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, NATIVE_REVIEW_OPERATION.VERSION, false, "version process output exceeded limit", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, NATIVE_REVIEW_OPERATION.VERSION, false, "version process was signalled", result);
 		if (result.exitCode !== 0) throw nativeError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, NATIVE_REVIEW_OPERATION.VERSION, false, "version process failed", result);
 		const version = /^gentle-ai ([0-9]+\.[0-9]+\.[0-9]+)\n$/.exec(result.stdout.replace(/\r\n$/, "\n"))?.[1];
@@ -1750,7 +1790,30 @@ function exactConsentOption(arguments_: readonly string[], name: string): string
 	return values[0]!;
 }
 
-function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): readonly string[] {
+function optionalConsentLineageOption(arguments_: readonly string[]): string | undefined {
+	const values: string[] = [];
+	for (let index = 0; index < arguments_.length; index += 1) {
+		const token = arguments_[index]!;
+		if (token === "--lineage") {
+			const value = arguments_[index + 1];
+			if (value === undefined || value.startsWith("--")) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation --lineage is missing its value");
+			values.push(value);
+			index += 1;
+		} else if (token.startsWith("--lineage=")) values.push(token.slice("--lineage=".length));
+	}
+	if (values.length > 1) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation permits at most one --lineage");
+	if (values.length === 0) return undefined;
+	const lineageId = values[0]!;
+	if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(lineageId)) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation --lineage is malformed");
+	return lineageId;
+}
+
+interface ConsentInvocation {
+	arguments_: readonly string[];
+	lineageId?: string;
+}
+
+function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): ConsentInvocation {
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
 	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
@@ -1760,8 +1823,9 @@ function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): 
 	if (exactConsentOption(arguments_, "--cwd") !== request.cwd) throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
+	const lineageId = optionalConsentLineageOption(arguments_);
 	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");
-	return arguments_;
+	return { arguments_, ...(lineageId === undefined ? {} : { lineageId }) };
 }
 
 function decodeDeclinedConsentStart(value: unknown, expected: NativeReviewConsentAnswerRequest): NativeReviewConsentDeclinedResult {
@@ -1846,7 +1910,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		adapter: ExecFileAdapter,
 		executable: string | (() => string) = resolveGentleAiBinary,
 		timeoutMs = 30_000,
-		maxBufferBytes = 1024 * 1024,
+		maxBufferBytes = resolveNativeReviewMaxBufferBytes(),
 		cleanupDirectory: (directory: string) => Promise<void> = (directory) => rm(directory, { recursive: true, force: true }),
 		executableDigest: NativeExecutableDigestResolver = defaultExecutableDigest,
 	) {
@@ -1896,8 +1960,8 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			if (error instanceof Error && error.name === "AbortError") throw nativeError(NATIVE_REVIEW_ERROR_CODE.CANCELLED, operation, mutating, "native process was cancelled");
 			throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNAVAILABLE, operation, mutating, "native process could not start");
 		}
+		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, operation, mutating, "native process output exceeded limit", result, true, undefined, this.maxBufferBytes);
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, operation, mutating, "native process timed out", result);
-		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, operation, mutating, "native process output exceeded limit", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, operation, mutating, "native process was signalled", result);
 		const diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.NON_ZERO, result);
 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
@@ -2036,16 +2100,15 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 	}
 
 	async answerConsent(request: NativeReviewConsentAnswerRequest): Promise<NativeReviewConsentAnswerResult> {
-		const arguments_ = consentInvocationArguments(request);
-		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.START, request.cwd, arguments_, true, request.signal);
+		const invocation = consentInvocationArguments(request);
+		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.START, request.cwd, invocation.arguments_, true, request.signal);
 		if (request.answer === NATIVE_REVIEW_CONSENT_ANSWER.DECLINED) {
 			return decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeDeclinedConsentStart(execution.body, request));
 		}
 		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartV3(execution.body));
 		const answeredTarget = result.targetIdentity ?? result.repositoryContext?.targetIdentity;
 		if (answeredTarget !== request.consent.targetIdentity) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer target mismatch");
-		const lineageId = exactConsentOption(arguments_, "--lineage");
-		if (result.lineageId !== lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer lineage mismatch");
+		if (invocation.lineageId !== undefined && result.lineageId !== invocation.lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer lineage mismatch");
 		return { kind: "started", start: {
 			lineageId: result.lineageId,
 			state: result.state as NativeStartResult["state"],

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -8,6 +8,46 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "nod
 const REVIEW_LENS = ["review-risk", "review-resilience", "review-readability", "review-reliability"] as const;
 export type ReviewLens = (typeof REVIEW_LENS)[number];
 const CANDIDATE_GIT_TIMEOUT_MS = 10_000;
+const CANDIDATE_GIT_TIMEOUT_MAX_MS = 120_000;
+const CANDIDATE_GIT_TIMEOUT_ENV = "GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS";
+const CANDIDATE_GIT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
+// Candidate views may materialize full repository trees. Large repositories can
+// raise this bounded deadline without creating an unbounded child process.
+function resolveCandidateGitTimeoutMs(environment: NodeJS.ProcessEnv = process.env): number {
+	const value = environment[CANDIDATE_GIT_TIMEOUT_ENV];
+	if (value === undefined || !/^[1-9]\d*$/.test(value)) return CANDIDATE_GIT_TIMEOUT_MS;
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) && parsed <= CANDIDATE_GIT_TIMEOUT_MAX_MS
+		? parsed
+		: CANDIDATE_GIT_TIMEOUT_MS;
+}
+
+function isCandidateGitTimeoutMs(value: number): boolean {
+	return Number.isSafeInteger(value) && value > 0 && value <= CANDIDATE_GIT_TIMEOUT_MAX_MS;
+}
+const CANDIDATE_VIEW_DIAGNOSTIC_PHASE = "candidate-view";
+const CANDIDATE_VIEW_GIT_FAILURE_CATEGORY = {
+	TIMEOUT: "timeout",
+	OUTPUT_LIMIT: "output-limit",
+	GIT_FAILURE: "git-failure",
+} as const;
+export type CandidateViewGitFailureCategory = (typeof CANDIDATE_VIEW_GIT_FAILURE_CATEGORY)[keyof typeof CANDIDATE_VIEW_GIT_FAILURE_CATEGORY];
+const CANDIDATE_GIT_SUBCOMMAND = {
+	ADD: "add",
+	CHECKOUT_INDEX: "checkout-index",
+	DIFF: "diff",
+	FOR_EACH_REF: "for-each-ref",
+	LOG: "log",
+	LS_FILES: "ls-files",
+	LS_TREE: "ls-tree",
+	READ_TREE: "read-tree",
+	REV_PARSE: "rev-parse",
+	WORKTREE: "worktree",
+	WRITE_TREE: "write-tree",
+	OTHER: "other",
+} as const;
+type CandidateGitSubcommand = (typeof CANDIDATE_GIT_SUBCOMMAND)[keyof typeof CANDIDATE_GIT_SUBCOMMAND];
 
 export type CandidateGitExecutor = (file: string, arguments_: readonly string[], options: ExecFileSyncOptions) => string | Buffer;
 const defaultCandidateGitExecutor: CandidateGitExecutor = (file, arguments_, options) => execFileSync(file, arguments_, options);
@@ -130,22 +170,96 @@ export interface NativeCandidateProjectionDescriptor {
 	providerManifestHashVerified?: true;
 }
 
+export interface CandidateViewDiagnostic {
+	phase: typeof CANDIDATE_VIEW_DIAGNOSTIC_PHASE;
+	category: CandidateViewGitFailureCategory;
+	git_subcommand: CandidateGitSubcommand;
+	timeout_ms: number;
+	max_buffer_bytes: number;
+	message: string;
+}
+
 export class CandidateViewError extends Error {
 	readonly reason: string;
-	constructor(message: string, reason = "candidate-view-invalid") {
+	readonly diagnostics?: CandidateViewDiagnostic;
+	constructor(message: string, reason = "candidate-view-invalid", diagnostics?: CandidateViewDiagnostic) {
 		super(message);
 		this.name = "CandidateViewError";
 		this.reason = reason;
+		this.diagnostics = diagnostics === undefined ? undefined : sanitizeCandidateViewDiagnostic(diagnostics);
 	}
 }
 
+function candidateGitSubcommand(arguments_: readonly string[]): CandidateGitSubcommand {
+	switch (arguments_[0]) {
+		case CANDIDATE_GIT_SUBCOMMAND.ADD: return CANDIDATE_GIT_SUBCOMMAND.ADD;
+		case CANDIDATE_GIT_SUBCOMMAND.CHECKOUT_INDEX: return CANDIDATE_GIT_SUBCOMMAND.CHECKOUT_INDEX;
+		case CANDIDATE_GIT_SUBCOMMAND.DIFF: return CANDIDATE_GIT_SUBCOMMAND.DIFF;
+		case CANDIDATE_GIT_SUBCOMMAND.FOR_EACH_REF: return CANDIDATE_GIT_SUBCOMMAND.FOR_EACH_REF;
+		case CANDIDATE_GIT_SUBCOMMAND.LOG: return CANDIDATE_GIT_SUBCOMMAND.LOG;
+		case CANDIDATE_GIT_SUBCOMMAND.LS_FILES: return CANDIDATE_GIT_SUBCOMMAND.LS_FILES;
+		case CANDIDATE_GIT_SUBCOMMAND.LS_TREE: return CANDIDATE_GIT_SUBCOMMAND.LS_TREE;
+		case CANDIDATE_GIT_SUBCOMMAND.READ_TREE: return CANDIDATE_GIT_SUBCOMMAND.READ_TREE;
+		case CANDIDATE_GIT_SUBCOMMAND.REV_PARSE: return CANDIDATE_GIT_SUBCOMMAND.REV_PARSE;
+		case CANDIDATE_GIT_SUBCOMMAND.WORKTREE: return CANDIDATE_GIT_SUBCOMMAND.WORKTREE;
+		case CANDIDATE_GIT_SUBCOMMAND.WRITE_TREE: return CANDIDATE_GIT_SUBCOMMAND.WRITE_TREE;
+		default: return CANDIDATE_GIT_SUBCOMMAND.OTHER;
+	}
+}
+
+function candidateGitDiagnosticMessage(category: CandidateViewGitFailureCategory, subcommand: CandidateGitSubcommand, timeoutMs: number): string {
+	if (category === CANDIDATE_VIEW_GIT_FAILURE_CATEGORY.TIMEOUT) return `candidate-view Git command ${subcommand} timed out after ${timeoutMs}ms; inspect the candidate state before any new START`;
+	if (category === CANDIDATE_VIEW_GIT_FAILURE_CATEGORY.OUTPUT_LIMIT) return `candidate-view Git command ${subcommand} exceeded the ${CANDIDATE_GIT_MAX_BUFFER_BYTES}-byte output limit; inspect the candidate state before any new START`;
+	return `candidate-view Git command ${subcommand} failed; inspect the candidate state before any new START`;
+}
+
+function candidateGitDiagnostic(category: CandidateViewGitFailureCategory, arguments_: readonly string[], timeoutMs: number): CandidateViewDiagnostic {
+	const git_subcommand = candidateGitSubcommand(arguments_);
+	return Object.freeze({
+		phase: CANDIDATE_VIEW_DIAGNOSTIC_PHASE,
+		category,
+		git_subcommand,
+		timeout_ms: timeoutMs,
+		max_buffer_bytes: CANDIDATE_GIT_MAX_BUFFER_BYTES,
+		message: candidateGitDiagnosticMessage(category, git_subcommand, timeoutMs),
+	});
+}
+
+function sanitizeCandidateViewDiagnostic(diagnostics: CandidateViewDiagnostic): CandidateViewDiagnostic | undefined {
+	const { phase, category, git_subcommand, timeout_ms, max_buffer_bytes, message } = diagnostics;
+	if (
+		phase !== CANDIDATE_VIEW_DIAGNOSTIC_PHASE ||
+		!Object.values(CANDIDATE_VIEW_GIT_FAILURE_CATEGORY).includes(category) ||
+		!Object.values(CANDIDATE_GIT_SUBCOMMAND).includes(git_subcommand) ||
+		!isCandidateGitTimeoutMs(timeout_ms) ||
+		max_buffer_bytes !== CANDIDATE_GIT_MAX_BUFFER_BYTES ||
+		message !== candidateGitDiagnosticMessage(category, git_subcommand, timeout_ms)
+	) return undefined;
+	return Object.freeze({ phase, category, git_subcommand, timeout_ms, max_buffer_bytes, message });
+}
+
+function candidateGitFailure(category: CandidateViewGitFailureCategory, arguments_: readonly string[], timeoutMs: number): CandidateViewError {
+	const diagnostics = candidateGitDiagnostic(category, arguments_, timeoutMs);
+	return new CandidateViewError(diagnostics.message, `candidate-view-${category}`, diagnostics);
+}
+
 function candidateGit(cwd: string, arguments_: readonly string[], env: NodeJS.ProcessEnv, encoding: "utf8" | "buffer", executor: CandidateGitExecutor): string | Buffer {
+	const timeoutMs = resolveCandidateGitTimeoutMs(env);
 	try {
-		return executor("git", arguments_, { cwd, encoding, env, stdio: ["ignore", "pipe", "pipe"], timeout: CANDIDATE_GIT_TIMEOUT_MS, windowsHide: true });
+		return executor("git", arguments_, {
+			cwd,
+			encoding,
+			env,
+			stdio: ["ignore", "pipe", "pipe"],
+			timeout: timeoutMs,
+			maxBuffer: CANDIDATE_GIT_MAX_BUFFER_BYTES,
+			windowsHide: true,
+		});
 	} catch (error) {
-		const detail = error as NodeJS.ErrnoException & { stderr?: Buffer; killed?: boolean };
-		if (detail.code === "ETIMEDOUT" || detail.killed === true) throw new CandidateViewError(`candidate view Git operation timed out after ${CANDIDATE_GIT_TIMEOUT_MS}ms`);
-		throw new CandidateViewError(`candidate view Git operation failed: ${detail.stderr?.toString("utf8").trim() || detail.message || "unknown Git error"}`);
+		const detail = error as NodeJS.ErrnoException & { killed?: boolean };
+		if (detail.code === "ENOBUFS" || detail.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") throw candidateGitFailure(CANDIDATE_VIEW_GIT_FAILURE_CATEGORY.OUTPUT_LIMIT, arguments_, timeoutMs);
+		if (detail.code === "ETIMEDOUT" || detail.killed === true) throw candidateGitFailure(CANDIDATE_VIEW_GIT_FAILURE_CATEGORY.TIMEOUT, arguments_, timeoutMs);
+		throw candidateGitFailure(CANDIDATE_VIEW_GIT_FAILURE_CATEGORY.GIT_FAILURE, arguments_, timeoutMs);
 	}
 }
 
@@ -484,7 +598,7 @@ function resolveCandidateBase(cwd: string, baseRef: string | undefined, env: Nod
 		if (tree !== confirmedTree) throw new CandidateViewError("candidate base tree changed during resolution", "base-ref-moved");
 		return { commit: confirmedCommit, tree: confirmedTree };
 	} catch (error) {
-		if (error instanceof CandidateViewError && (error.reason === "base-ref-ambiguous" || error.reason === "base-ref-moved" || error.reason === "base-ref-unresolvable")) throw error;
+		if (error instanceof CandidateViewError && (error.diagnostics !== undefined || error.reason === "base-ref-ambiguous" || error.reason === "base-ref-moved" || error.reason === "base-ref-unresolvable")) throw error;
 		throw new CandidateViewError("candidate base reference is unresolvable", "base-ref-unresolvable");
 	}
 }

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -26,6 +26,23 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+// Negotiated review/status responses can carry a complete authority inventory.
+// Keep the production default large enough for that payload while retaining a
+// hard 64 MiB ceiling even when GENTLE_PI_REVIEW_MAX_BUFFER_BYTES is set.
+export const NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+const NATIVE_REVIEW_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+const NATIVE_REVIEW_MAX_BUFFER_BYTES_ENV = "GENTLE_PI_REVIEW_MAX_BUFFER_BYTES";
+const NATIVE_REVIEW_MAX_BUFFER_CONFIGURATION_HINT = "Inspect native review state before any new START; GENTLE_PI_REVIEW_MAX_BUFFER_BYTES accepts a positive decimal up to 67108864.";
+
+function resolveNativeReviewMaxBufferBytes(environment = process.env) {
+	const value = environment[NATIVE_REVIEW_MAX_BUFFER_BYTES_ENV];
+	if (value === undefined || !/^[1-9]\d*$/.test(value)) return NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES;
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) && parsed <= NATIVE_REVIEW_MAX_BUFFER_BYTES
+		? parsed
+		: NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES;
+}
+
 export const NATIVE_REVIEW_OPERATION = {
 	VERSION: "version",
 	START: "review/start",
@@ -733,7 +750,8 @@ export function createNodeExecFileAdapter()                  {
 		} catch (error) {
 			const detail = error                                                                                                                                   ;
 			if (detail.code === "ENOENT" || detail.code === "EACCES" || detail.name === "AbortError") throw error;
-			return { stdout: detail.stdout ?? "", stderr: detail.stderr ?? "", exitCode: typeof detail.code === "number" ? detail.code : 1, signal: detail.signal ?? null, timedOut: detail.killed === true, outputLimitExceeded: detail.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" };
+			const outputLimitExceeded = detail.code === "ENOBUFS" || detail.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+			return { stdout: detail.stdout ?? "", stderr: detail.stderr ?? "", exitCode: typeof detail.code === "number" ? detail.code : 1, signal: detail.signal ?? null, timedOut: !outputLimitExceeded && detail.killed === true, outputLimitExceeded };
 		}
 	};
 }
@@ -809,12 +827,28 @@ function parseStructuredNativeDenial(stdout        )                            
 // Rebuild diagnostics from a duplicated module instance before facade output.
 export function sanitizeForeignNativeReviewDiagnostics(value         )                                             {
 	try {
-		const raw = exactObject(value, ["operation", "error_code", "timed_out", "output_limit_exceeded"], ["exit_code", "signal", "stderr", "denial"]);
+		const raw = exactObject(value, ["operation", "error_code", "timed_out", "output_limit_exceeded"], ["exit_code", "signal", "max_buffer_bytes", "configuration_hint", "stderr", "denial"]);
 		const operation = enumString(raw.operation, Object.values(NATIVE_REVIEW_OPERATION))                         ;
 		const errorCode = enumString(raw.error_code, Object.values(NATIVE_REVIEW_ERROR_CODE))                         ;
 		const signal = raw.signal === undefined ? undefined : requiredString(raw.signal);
-		if (signal !== undefined && !/^SIG[A-Z0-9]{1,12}$/.test(signal)) return undefined;
-		return { operation, error_code: errorCode, ...(raw.exit_code === undefined ? {} : { exit_code: nonNegativeInteger(raw.exit_code) }), ...(signal === undefined ? {} : { signal: signal                   }), timed_out: booleanValue(raw.timed_out), output_limit_exceeded: booleanValue(raw.output_limit_exceeded), ...(raw.stderr === undefined ? {} : { stderr: sanitizeNativeDiagnosticText(stringValue(raw.stderr)) }), ...(raw.denial === undefined ? {} : { denial: sanitizeForeignStructuredDenial(raw.denial) }) };
+		const maxBufferBytes = raw.max_buffer_bytes === undefined ? undefined : positiveInteger(raw.max_buffer_bytes);
+		const configurationHint = raw.configuration_hint === undefined ? undefined : stringValue(raw.configuration_hint);
+		if (
+			(signal !== undefined && !/^SIG[A-Z0-9]{1,12}$/.test(signal)) ||
+			(maxBufferBytes === undefined) !== (configurationHint === undefined) ||
+			(configurationHint !== undefined && (errorCode !== NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT || configurationHint !== NATIVE_REVIEW_MAX_BUFFER_CONFIGURATION_HINT))
+		) return undefined;
+		return {
+			operation,
+			error_code: errorCode,
+			...(raw.exit_code === undefined ? {} : { exit_code: nonNegativeInteger(raw.exit_code) }),
+			...(signal === undefined ? {} : { signal: signal                   }),
+			timed_out: booleanValue(raw.timed_out),
+			output_limit_exceeded: booleanValue(raw.output_limit_exceeded),
+			...(maxBufferBytes === undefined ? {} : { max_buffer_bytes: maxBufferBytes, configuration_hint: configurationHint }),
+			...(raw.stderr === undefined ? {} : { stderr: sanitizeNativeDiagnosticText(stringValue(raw.stderr)) }),
+			...(raw.denial === undefined ? {} : { denial: sanitizeForeignStructuredDenial(raw.denial) }),
+		};
 	} catch { return undefined; }
 }
 
@@ -830,14 +864,18 @@ function sanitizeForeignStructuredDenial(value         )                        
 	return { schema: "gentle-ai.review-gate-result/v1", result, action, reason, ...(denial === undefined ? {} : { denial }) };
 }
 
-function nativeProcessDiagnostics(operation                       , code                       , result                 )                                 {
+function nativeProcessDiagnostics(operation                       , code                       , result                 , maxBufferBytes          )                                 {
+	const outputLimitExceeded = result?.outputLimitExceeded === true;
 	return {
 		operation,
 		error_code: code,
 		...(result === undefined ? {} : { exit_code: result.exitCode }),
 		...(result?.signal === null || result?.signal === undefined ? {} : { signal: result.signal }),
-		timed_out: result?.timedOut === true,
-		output_limit_exceeded: result?.outputLimitExceeded === true,
+		timed_out: !outputLimitExceeded && result?.timedOut === true,
+		output_limit_exceeded: outputLimitExceeded,
+		...(code === NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT && maxBufferBytes !== undefined
+			? { max_buffer_bytes: maxBufferBytes, configuration_hint: NATIVE_REVIEW_MAX_BUFFER_CONFIGURATION_HINT }
+			: {}),
 		...(result?.stderr.trim() ? { stderr: sanitizeNativeDiagnosticText(result.stderr) } : {}),
 		...(result === undefined ? {} : { denial: parseStructuredNativeDenial(result.stdout) }),
 	};
@@ -1155,8 +1193,8 @@ function hasValidLensesRequired(action                   , state        , riskLe
 	return !lensesRequired;
 }
 
-function nativeError(code                       , operation                       , mutating         , message        , result                 , launchAttempted = true, auditRecord                          )                       {
-	return new NativeReviewCliError(code, operation, launchAttempted, mutating, message, nativeProcessDiagnostics(operation, code, result), auditRecord);
+function nativeError(code                       , operation                       , mutating         , message        , result                 , launchAttempted = true, auditRecord                          , maxBufferBytes          )                       {
+	return new NativeReviewCliError(code, operation, launchAttempted, mutating, message, nativeProcessDiagnostics(operation, code, result, maxBufferBytes), auditRecord);
 }
 
 
@@ -1171,7 +1209,7 @@ export class NativeReviewCliV214 {
 	                 timeoutMs        ;
 	                 maxBufferBytes        ;
 	                 cleanupDirectory                                      ;
-	constructor(adapter                 , executable                          = resolveGentleAiBinary, timeoutMs = 30_000, maxBufferBytes = 1024 * 1024, cleanupDirectory = (directory        ) => rm(directory, { recursive: true, force: true })) {
+	constructor(adapter                 , executable                          = resolveGentleAiBinary, timeoutMs = 30_000, maxBufferBytes = resolveNativeReviewMaxBufferBytes(), cleanupDirectory = (directory        ) => rm(directory, { recursive: true, force: true })) {
 		if (typeof executable === "string" && (!isAbsolute(executable) || executable === "gentle-ai")) throw new TypeError("Native review requires an absolute package-local executable");
 		this.adapter = adapter;
 		this.executable = executable;
@@ -1208,8 +1246,8 @@ export class NativeReviewCliV214 {
 			throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNAVAILABLE, operation, mutating, "native process could not start");
 		}
 		const diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.NON_ZERO, result);
+		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, operation, mutating, "native process output exceeded limit", result, true, undefined, this.maxBufferBytes);
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, operation, mutating, "native process timed out", result);
-		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, operation, mutating, "native process output exceeded limit", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, operation, mutating, "native process was signalled", result);
 		const structuredValidateDenial = operation === NATIVE_REVIEW_OPERATION.VALIDATE && result.exitCode === 1;
 		const maintenancePartialFailure = [NATIVE_REVIEW_OPERATION.ABANDON, NATIVE_REVIEW_OPERATION.QUARANTINE_LEGACY, NATIVE_REVIEW_OPERATION.RECONCILE_AUTHORITY, NATIVE_REVIEW_OPERATION.REPAIR_LEGACY_ALIAS].includes(operation) && result.exitCode !== 0;
@@ -1227,8 +1265,8 @@ export class NativeReviewCliV214 {
 			if (error instanceof Error && error.name === "AbortError") throw nativeError(NATIVE_REVIEW_ERROR_CODE.CANCELLED, NATIVE_REVIEW_OPERATION.VERSION, false, "version process was cancelled");
 			throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNAVAILABLE, NATIVE_REVIEW_OPERATION.VERSION, false, "gentle-ai is unavailable");
 		}
+		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, NATIVE_REVIEW_OPERATION.VERSION, false, "version process output exceeded limit", result, true, undefined, this.maxBufferBytes);
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, NATIVE_REVIEW_OPERATION.VERSION, false, "version process timed out", result);
-		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, NATIVE_REVIEW_OPERATION.VERSION, false, "version process output exceeded limit", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, NATIVE_REVIEW_OPERATION.VERSION, false, "version process was signalled", result);
 		if (result.exitCode !== 0) throw nativeError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, NATIVE_REVIEW_OPERATION.VERSION, false, "version process failed", result);
 		const version = /^gentle-ai ([0-9]+\.[0-9]+\.[0-9]+)\n$/.exec(result.stdout.replace(/\r\n$/, "\n"))?.[1];
@@ -1751,6 +1789,24 @@ function exactConsentOption(arguments_                   , name        )        
 	return values[0] ;
 }
 
+function optionalConsentLineageOption(arguments_) {
+	const values = [];
+	for (let index = 0; index < arguments_.length; index += 1) {
+		const token = arguments_[index];
+		if (token === "--lineage") {
+			const value = arguments_[index + 1];
+			if (value === undefined || value.startsWith("--")) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation --lineage is missing its value");
+			values.push(value);
+			index += 1;
+		} else if (token.startsWith("--lineage=")) values.push(token.slice("--lineage=".length));
+	}
+	if (values.length > 1) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation permits at most one --lineage");
+	if (values.length === 0) return undefined;
+	const lineageId = values[0];
+	if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(lineageId)) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation --lineage is malformed");
+	return lineageId;
+}
+
 function consentInvocationArguments(request                                  )                    {
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
 	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
@@ -1761,8 +1817,9 @@ function consentInvocationArguments(request                                  )  
 	if (exactConsentOption(arguments_, "--cwd") !== request.cwd) throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
+	const lineageId = optionalConsentLineageOption(arguments_);
 	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");
-	return arguments_;
+	return { arguments_, ...(lineageId === undefined ? {} : { lineageId }) };
 }
 
 function decodeDeclinedConsentStart(value         , expected                                  )                                    {
@@ -1847,7 +1904,7 @@ export class NativeReviewCliV216                            {
 		adapter                 ,
 		executable                          = resolveGentleAiBinary,
 		timeoutMs = 30_000,
-		maxBufferBytes = 1024 * 1024,
+		maxBufferBytes = resolveNativeReviewMaxBufferBytes(),
 		cleanupDirectory                                       = (directory) => rm(directory, { recursive: true, force: true }),
 		executableDigest                                 = defaultExecutableDigest,
 	) {
@@ -1897,8 +1954,8 @@ export class NativeReviewCliV216                            {
 			if (error instanceof Error && error.name === "AbortError") throw nativeError(NATIVE_REVIEW_ERROR_CODE.CANCELLED, operation, mutating, "native process was cancelled");
 			throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNAVAILABLE, operation, mutating, "native process could not start");
 		}
+		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, operation, mutating, "native process output exceeded limit", result, true, undefined, this.maxBufferBytes);
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, operation, mutating, "native process timed out", result);
-		if (result.outputLimitExceeded) throw nativeError(NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT, operation, mutating, "native process output exceeded limit", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, operation, mutating, "native process was signalled", result);
 		const diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.NON_ZERO, result);
 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
@@ -2037,16 +2094,15 @@ export class NativeReviewCliV216                            {
 	}
 
 	async answerConsent(request                                  )                                           {
-		const arguments_ = consentInvocationArguments(request);
-		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.START, request.cwd, arguments_, true, request.signal);
+		const invocation = consentInvocationArguments(request);
+		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.START, request.cwd, invocation.arguments_, true, request.signal);
 		if (request.answer === NATIVE_REVIEW_CONSENT_ANSWER.DECLINED) {
 			return decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeDeclinedConsentStart(execution.body, request));
 		}
 		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartV3(execution.body));
 		const answeredTarget = result.targetIdentity ?? result.repositoryContext?.targetIdentity;
 		if (answeredTarget !== request.consent.targetIdentity) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer target mismatch");
-		const lineageId = exactConsentOption(arguments_, "--lineage");
-		if (result.lineageId !== lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer lineage mismatch");
+		if (invocation.lineageId !== undefined && result.lineageId !== invocation.lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer lineage mismatch");
 		return { kind: "started", start: {
 			lineageId: result.lineageId,
 			state: result.state                              ,

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -34,7 +34,7 @@ const NATIVE_REVIEW_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 const NATIVE_REVIEW_MAX_BUFFER_BYTES_ENV = "GENTLE_PI_REVIEW_MAX_BUFFER_BYTES";
 const NATIVE_REVIEW_MAX_BUFFER_CONFIGURATION_HINT = "Inspect native review state before any new START; GENTLE_PI_REVIEW_MAX_BUFFER_BYTES accepts a positive decimal up to 67108864.";
 
-function resolveNativeReviewMaxBufferBytes(environment = process.env) {
+function resolveNativeReviewMaxBufferBytes(environment                    = process.env)         {
 	const value = environment[NATIVE_REVIEW_MAX_BUFFER_BYTES_ENV];
 	if (value === undefined || !/^[1-9]\d*$/.test(value)) return NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES;
 	const parsed = Number(value);
@@ -719,6 +719,8 @@ function resolvedNativeCliContract(version        )                             
 
 
 
+
+
 export class NativeReviewCliError extends Error {
 	         code                       ;
 	         operation                       ;
@@ -845,7 +847,7 @@ export function sanitizeForeignNativeReviewDiagnostics(value         )          
 			...(signal === undefined ? {} : { signal: signal                   }),
 			timed_out: booleanValue(raw.timed_out),
 			output_limit_exceeded: booleanValue(raw.output_limit_exceeded),
-			...(maxBufferBytes === undefined ? {} : { max_buffer_bytes: maxBufferBytes, configuration_hint: configurationHint }),
+			...(maxBufferBytes === undefined ? {} : { max_buffer_bytes: maxBufferBytes, configuration_hint: configurationHint  }),
 			...(raw.stderr === undefined ? {} : { stderr: sanitizeNativeDiagnosticText(stringValue(raw.stderr)) }),
 			...(raw.denial === undefined ? {} : { denial: sanitizeForeignStructuredDenial(raw.denial) }),
 		};
@@ -864,7 +866,7 @@ function sanitizeForeignStructuredDenial(value         )                        
 	return { schema: "gentle-ai.review-gate-result/v1", result, action, reason, ...(denial === undefined ? {} : { denial }) };
 }
 
-function nativeProcessDiagnostics(operation                       , code                       , result                 , maxBufferBytes          )                                 {
+function nativeProcessDiagnostics(operation                       , code                       , result                 , maxBufferBytes         )                                 {
 	const outputLimitExceeded = result?.outputLimitExceeded === true;
 	return {
 		operation,
@@ -1193,7 +1195,7 @@ function hasValidLensesRequired(action                   , state        , riskLe
 	return !lensesRequired;
 }
 
-function nativeError(code                       , operation                       , mutating         , message        , result                 , launchAttempted = true, auditRecord                          , maxBufferBytes          )                       {
+function nativeError(code                       , operation                       , mutating         , message        , result                 , launchAttempted = true, auditRecord                          , maxBufferBytes         )                       {
 	return new NativeReviewCliError(code, operation, launchAttempted, mutating, message, nativeProcessDiagnostics(operation, code, result, maxBufferBytes), auditRecord);
 }
 
@@ -1789,10 +1791,10 @@ function exactConsentOption(arguments_                   , name        )        
 	return values[0] ;
 }
 
-function optionalConsentLineageOption(arguments_) {
-	const values = [];
+function optionalConsentLineageOption(arguments_                   )                     {
+	const values           = [];
 	for (let index = 0; index < arguments_.length; index += 1) {
-		const token = arguments_[index];
+		const token = arguments_[index] ;
 		if (token === "--lineage") {
 			const value = arguments_[index + 1];
 			if (value === undefined || value.startsWith("--")) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation --lineage is missing its value");
@@ -1802,10 +1804,15 @@ function optionalConsentLineageOption(arguments_) {
 	}
 	if (values.length > 1) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation permits at most one --lineage");
 	if (values.length === 0) return undefined;
-	const lineageId = values[0];
+	const lineageId = values[0] ;
 	if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(lineageId)) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", "Native consent invocation --lineage is malformed");
 	return lineageId;
 }
+
+
+
+
+
 
 function consentInvocationArguments(request                                  )                    {
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -4,13 +4,19 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+	NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES,
 	NATIVE_REVIEW_ERROR_CODE,
 	NativeReviewCliError,
 	NativeReviewCliV213 as NativeReviewCliV213Production,
+	NativeReviewCliV216,
 	createNodeExecFileAdapter,
 	type ExecFileAdapter,
 	type NativeStartRequest,
 } from "../lib/native-review-cli.ts";
+import {
+	NativeReviewCliV214 as RuntimeNativeReviewCliV214,
+	NativeReviewCliV216 as RuntimeNativeReviewCliV216,
+} from "../runtime/native-review-cli.mjs";
 
 // The queued-adapter unit tests never execute a real process; default to a fixed
 // absolute package-local path so they do not depend on an installed binary
@@ -260,6 +266,23 @@ test("version process failures retain their typed failure code", async () => {
 	}
 });
 
+test("native output limits dominate killed timeout signals and expose the bounded configuration guidance", async () => {
+	const assertOutputLimit = (error: unknown): boolean => {
+		const value = error as { name?: unknown; code?: unknown; diagnostics?: { timed_out?: unknown; output_limit_exceeded?: unknown; max_buffer_bytes?: unknown; configuration_hint?: unknown } };
+		const diagnostics = value.diagnostics;
+		return value.name === "NativeReviewCliError"
+			&& value.code === NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT
+			&& diagnostics?.timed_out === false
+			&& diagnostics?.output_limit_exceeded === true
+			&& diagnostics?.max_buffer_bytes === NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES
+			&& diagnostics?.configuration_hint === "Inspect native review state before any new START; GENTLE_PI_REVIEW_MAX_BUFFER_BYTES accepts a positive decimal up to 67108864.";
+	};
+	const queue = queuedAdapter([VERSION, { stdout: "", timedOut: true, outputLimitExceeded: true }]);
+	await assert.rejects(() => new NativeReviewCliV213(queue.adapter).start({ cwd: "/repo" }), assertOutputLimit);
+	const runtimeQueue = queuedAdapter([VERSION, { stdout: "", timedOut: true, outputLimitExceeded: true }]);
+	await assert.rejects(() => new RuntimeNativeReviewCliV214(runtimeQueue.adapter).start({ cwd: "/repo" }), assertOutputLimit);
+});
+
 test("native mutation uncertainty requires target status before any replay decision", async () => {
 	const queue = queuedAdapter([VERSION, { stdout: "", timedOut: true }]);
 	await assert.rejects(
@@ -269,6 +292,39 @@ test("native mutation uncertainty requires target status before any replay decis
 			&& error.mutationOutcome === "unknown"
 			&& error.nextAction === "review.status",
 	);
+});
+
+test("native clients resolve a bounded review output buffer override at construction and propagate it to child processes", async () => {
+	const expectedDefault = 16 * 1024 * 1024;
+	const override = "2097152";
+	const invalidOverrides = ["", "0", "-1", "1.5", "not-a-number", "67108865"];
+	const withOverride = <T>(value: string | undefined, callback: () => T): T => {
+		const previous = process.env.GENTLE_PI_REVIEW_MAX_BUFFER_BYTES;
+		try {
+			if (value === undefined) delete process.env.GENTLE_PI_REVIEW_MAX_BUFFER_BYTES;
+			else process.env.GENTLE_PI_REVIEW_MAX_BUFFER_BYTES = value;
+			return callback();
+		} finally {
+			if (previous === undefined) delete process.env.GENTLE_PI_REVIEW_MAX_BUFFER_BYTES;
+			else process.env.GENTLE_PI_REVIEW_MAX_BUFFER_BYTES = previous;
+		}
+	};
+	for (const [name, overrideValue, expected] of [
+		["default", undefined, expectedDefault],
+		["valid override", override, Number(override)],
+		...invalidOverrides.map((value) => [`invalid override ${JSON.stringify(value)}`, value, expectedDefault] as const),
+	] as const) {
+		const queue = queuedAdapter([VERSION, START]);
+		const client = withOverride(overrideValue, () => new NativeReviewCliV213(queue.adapter));
+		const v216 = withOverride(overrideValue, () => new NativeReviewCliV216(queue.adapter, "/package/.gentle-ai/gentle-ai"));
+		const runtimeV214 = withOverride(overrideValue, () => new RuntimeNativeReviewCliV214(queue.adapter, "/package/.gentle-ai/gentle-ai"));
+		const runtimeV216 = withOverride(overrideValue, () => new RuntimeNativeReviewCliV216(queue.adapter, "/package/.gentle-ai/gentle-ai"));
+		assert.equal(Reflect.get(v216, "maxBufferBytes"), expected, name);
+		assert.equal(Reflect.get(runtimeV214, "maxBufferBytes"), expected, `${name} runtime v214`);
+		assert.equal(Reflect.get(runtimeV216, "maxBufferBytes"), expected, `${name} runtime v216`);
+		await client.start({ cwd: "/repo" });
+		assert.deepEqual(queue.calls.map((call) => call.maxBufferBytes), [expected, expected], name);
+	}
 });
 
 test("native mutating commands omit the automatic timeout while preserving output caps", async () => {

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -10,6 +10,10 @@ import {
 	clearNativeReviewCapabilitiesCacheForTesting,
 	type ExecFileAdapter,
 } from "../lib/native-review-cli.ts";
+import {
+	NativeReviewCliV216 as RuntimeNativeReviewCliV216,
+	clearNativeReviewCapabilitiesCacheForTesting as clearRuntimeNativeReviewCapabilitiesCacheForTesting,
+} from "../runtime/native-review-cli.mjs";
 import type { ReviewConsentV2 } from "../lib/review-integration-v2.ts";
 
 const fixtureRoot = join(process.cwd(), "contracts", "review-integration", "v2", "fixtures");
@@ -58,6 +62,11 @@ function client(adapter: ExecFileAdapter): NativeReviewCliV216 {
 	return new NativeReviewCliV216(adapter, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024, async () => undefined, () => executableDigest);
 }
 
+function runtimeClient(adapter: ExecFileAdapter): RuntimeNativeReviewCliV216 {
+	clearRuntimeNativeReviewCapabilitiesCacheForTesting();
+	return new RuntimeNativeReviewCliV216(adapter, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024, async () => undefined, () => executableDigest);
+}
+
 test("negotiated ordinary START declares relay and preserves the complete target-bound consent envelope", async () => {
 	const consent = fixture<Record<string, unknown>>("consent.fixture.json");
 	const target = String(consent.target_identity);
@@ -97,17 +106,39 @@ test("controller-prebound START target is used without projecting a second works
 	assert.equal(queue.calls.some((arguments_) => arguments_[1] === "status"), false, "a prebound START target must not be projected again");
 });
 
-test("consent follow-up executes the provider-named invocation exactly once and refuses a changed target binding", async () => {
+test("consent follow-up executes the provider-named invocation exactly once and refuses changed lineage or target bindings", async () => {
 	const consent = fixture<ReviewConsentV2 extends never ? never : Record<string, unknown>>("consent.fixture.json");
 	const decodedConsent = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(consent);
-	const started = JSON.parse(JSON.stringify(fixture<Record<string, unknown>>("start.fixture.json"))
-		.replaceAll("review-start-fixture", "review-consent-fixture")) as Record<string, unknown>;
+	const preboundLineage = "Review.Lineage_42";
+	for (const choice of decodedConsent.choices) {
+		choice.invocation = choice.invocation.replace("review-consent-fixture", preboundLineage);
+	}
+	const started = fixture<Record<string, unknown>>("start.fixture.json");
+	started.lineage_id = preboundLineage;
+	started.artifact_subjects = [];
 	const queue = queuedAdapter([capabilities(), started]);
 	const native = client(queue.adapter);
 	const result = await native.answerConsent!({ cwd: "/repo", consent: decodedConsent, answer: "granted" });
 	assert.equal(result.kind, "started");
+	assert.ok(result.kind === "started");
+	assert.equal(result.start.lineageId, preboundLineage);
 	assert.deepEqual(queue.calls.at(-1), decodedConsent.choices[0].invocation.split(" ").slice(1));
 	assert.equal(queue.calls.filter((arguments_) => arguments_.includes("granted")).length, 1);
+
+	const runtimeQueue = queuedAdapter([capabilities(), structuredClone(started)]);
+	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd: "/repo", consent: decodedConsent, answer: "granted" });
+	assert.equal(runtimeResult.kind, "started");
+	assert.ok(runtimeResult.kind === "started");
+	assert.equal(runtimeResult.start.lineageId, preboundLineage);
+	assert.equal(runtimeQueue.calls.filter((arguments_) => arguments_.includes("granted")).length, 1);
+
+	const changedLineage = JSON.parse(JSON.stringify(started).replaceAll(preboundLineage, "different-lineage")) as Record<string, unknown>;
+	const lineageQueue = queuedAdapter([capabilities(), changedLineage]);
+	await assert.rejects(
+		() => client(lineageQueue.adapter).answerConsent!({ cwd: "/repo", consent: decodedConsent, answer: "granted" }),
+		/lineage mismatch/,
+	);
+	assert.equal(lineageQueue.calls.filter((arguments_) => arguments_[0] === "review" && arguments_[1] === "start").length, 1);
 
 	const changed = structuredClone(decodedConsent);
 	changed.targetIdentity = `sha256:${"b".repeat(64)}`;
@@ -174,6 +205,68 @@ test("every consent invocation binding guard reports its own reason without laun
 			},
 		);
 		assert.deepEqual(queue.calls, [], `${scenario.reason} must not launch the provider`);
+	}
+});
+
+test("fresh consent START accepts the strictly decoded provider-created lineage and rejects a mismatched target", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+	const freshConsent = structuredClone(decoded);
+	for (const choice of freshConsent.choices) {
+		choice.invocation = choice.invocation.replace(" --lineage review-consent-fixture", "");
+	}
+	const freshStart = JSON.parse(JSON.stringify(fixture<Record<string, unknown>>("start.fixture.json"))
+		.replaceAll("review-start-fixture", "provider-created-lineage")) as Record<string, unknown>;
+	const queue = queuedAdapter([capabilities(), freshStart]);
+	const result = await client(queue.adapter).answerConsent!({ cwd: "/repo", consent: freshConsent, answer: "granted" });
+	assert.equal(result.kind, "started");
+	assert.ok(result.kind === "started");
+	assert.equal(result.start.lineageId, "provider-created-lineage");
+	assert.equal(queue.calls.filter((arguments_) => arguments_[0] === "review" && arguments_[1] === "start").length, 1);
+	assert.equal(queue.calls.at(-1)?.includes("--lineage"), false);
+
+	const runtimeQueue = queuedAdapter([capabilities(), structuredClone(freshStart)]);
+	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd: "/repo", consent: freshConsent, answer: "granted" });
+	assert.equal(runtimeResult.kind, "started");
+	assert.ok(runtimeResult.kind === "started");
+	assert.equal(runtimeResult.start.lineageId, "provider-created-lineage");
+	assert.equal(runtimeQueue.calls.filter((arguments_) => arguments_[0] === "review" && arguments_[1] === "start").length, 1);
+	assert.equal(runtimeQueue.calls.at(-1)?.includes("--lineage"), false);
+
+	const mismatchedTarget = structuredClone(freshStart);
+	((mismatchedTarget.repository_context as Record<string, unknown>).target_identity as string) = `sha256:${"b".repeat(64)}`;
+	const mismatchQueue = queuedAdapter([capabilities(), mismatchedTarget]);
+	await assert.rejects(
+		() => client(mismatchQueue.adapter).answerConsent!({ cwd: "/repo", consent: freshConsent, answer: "granted" }),
+		/target mismatch/,
+	);
+	assert.equal(mismatchQueue.calls.filter((arguments_) => arguments_[0] === "review" && arguments_[1] === "start").length, 1);
+});
+
+test("duplicate, empty, missing, and malformed consent lineages fail before provider launch", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+	const drifted = (replace: (invocation: string) => string): ReviewConsentV2 => {
+		const consent = structuredClone(decoded);
+		const choice = consent.choices.find((candidate) => candidate.answer === "granted") as { invocation: string };
+		choice.invocation = replace(choice.invocation);
+		return consent;
+	};
+	const cases = [
+		{ label: "duplicate", consent: drifted((value) => `${value} --lineage duplicate-lineage`) },
+		{ label: "empty", consent: drifted((value) => value.replace("--lineage review-consent-fixture", "--lineage=")) },
+		{ label: "missing", consent: drifted((value) => value.replace("--lineage review-consent-fixture", "--lineage")) },
+		{ label: "malformed", consent: drifted((value) => value.replace("--lineage review-consent-fixture", "--lineage invalid/lineage")) },
+	] as const;
+	for (const scenario of cases) {
+		const queue = queuedAdapter([]);
+		await assert.rejects(
+			() => client(queue.adapter).answerConsent!({ cwd: "/repo", consent: scenario.consent, answer: "granted" }),
+			(error: unknown) => {
+				assert.ok(error instanceof NativeReviewConsentBindingError, `${scenario.label} lineage must be a typed binding error`);
+				assert.equal(error.reason, "consent-invocation-option-invalid");
+				return true;
+			},
+		);
+		assert.deepEqual(queue.calls, [], `${scenario.label} lineage must not launch the provider`);
 	}
 });
 

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -28,12 +28,145 @@ function repository(t: test.TestContext): string {
 	return cwd;
 }
 
-test("candidate view Git commands have a finite timeout and block materialization before worktree execution", (t) => {
-	const calls: Array<{ arguments: readonly string[]; timeout: number | undefined }> = [];
-	const executor: CandidateGitExecutor = (_file, arguments_, options) => { calls.push({ arguments: arguments_, timeout: options.timeout }); throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT", killed: true }); };
-	assert.throws(() => new CandidateViewRegistry(executor).create({ contributorRoot: repository(t) }), (error: unknown) => error instanceof CandidateViewError && /timed out/.test(error.message));
-	assert.deepEqual(calls, [{ arguments: ["rev-parse", "--git-common-dir"], timeout: 10_000 }]);
+test("candidate view Git commands classify bounded timeouts and block materialization before worktree execution", (t) => {
+	const calls: Array<{ arguments: readonly string[]; timeout: number | undefined; maxBuffer: number | undefined }> = [];
+	const executor: CandidateGitExecutor = (_file, arguments_, options) => { calls.push({ arguments: arguments_, timeout: options.timeout, maxBuffer: options.maxBuffer }); throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT", killed: true }); };
+	let failure: unknown;
+	try {
+		new CandidateViewRegistry(executor).create({ contributorRoot: repository(t) });
+	} catch (error) {
+		failure = error;
+	}
+	assert.ok(failure instanceof CandidateViewError);
+	assert.equal(failure.reason, "candidate-view-timeout");
+	assert.deepEqual((failure as CandidateViewError & { diagnostics?: unknown }).diagnostics, {
+		phase: "candidate-view",
+		category: "timeout",
+		git_subcommand: "rev-parse",
+		timeout_ms: 10_000,
+		max_buffer_bytes: 64 * 1024 * 1024,
+		message: "candidate-view Git command rev-parse timed out after 10000ms; inspect the candidate state before any new START",
+	});
+	assert.deepEqual(calls, [{ arguments: ["rev-parse", "--git-common-dir"], timeout: 10_000, maxBuffer: 64 * 1024 * 1024 }]);
 	assert.equal(calls.some((call) => call.arguments[0] === "worktree"), false);
+});
+
+test("candidate-view Git timeouts use a bounded strict-decimal override with safe fallback", (t) => {
+	const withTimeout = <T>(value: string | undefined, callback: () => T): T => {
+		const previous = process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS;
+		try {
+			if (value === undefined) delete process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS;
+			else process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS = value;
+			return callback();
+		} finally {
+			if (previous === undefined) delete process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS;
+			else process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS = previous;
+		}
+	};
+	for (const [name, value, expected] of [
+		["default", undefined, 10_000],
+		["valid override", "45000", 45_000],
+		...(["", "0", "0010", "-1", "1.5", "not-a-number", "120001", "Infinity"] as const).map((value) => [`invalid override ${JSON.stringify(value)}`, value, 10_000] as const),
+	] as const) {
+		const timeouts: Array<number | undefined> = [];
+		let failure: unknown;
+		withTimeout(value, () => {
+			try {
+				new CandidateViewRegistry((_file, _arguments, options) => {
+					timeouts.push(options.timeout);
+					throw Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
+				}).create({ contributorRoot: repository(t) });
+			} catch (error) {
+				failure = error;
+			}
+		});
+		assert.ok(failure instanceof CandidateViewError, name);
+		assert.equal(timeouts[0], expected, name);
+		assert.equal((failure as CandidateViewError & { diagnostics?: { timeout_ms?: unknown } }).diagnostics?.timeout_ms, expected, name);
+	}
+});
+
+test("explicit base resolution preserves structured for-each-ref output-limit diagnostics", (t) => {
+	const contributorRoot = repository(t);
+	const executor: CandidateGitExecutor = (file, arguments_, options) => {
+		if (arguments_[0] === "for-each-ref") throw Object.assign(new Error("sensitive base-reference output"), { code: "ENOBUFS", killed: true, stderr: Buffer.from("sensitive base-reference output") });
+		return execFileSync(file, arguments_, options);
+	};
+	let failure: unknown;
+	try {
+		new CandidateViewRegistry(executor).create({ contributorRoot, baseRef: "refs/heads/main", committedOnly: true });
+	} catch (error) {
+		failure = error;
+	}
+	assert.ok(failure instanceof CandidateViewError);
+	assert.equal(failure.reason, "candidate-view-output-limit");
+	assert.deepEqual(failure.diagnostics, {
+		phase: "candidate-view",
+		category: "output-limit",
+		git_subcommand: "for-each-ref",
+		timeout_ms: 10_000,
+		max_buffer_bytes: 64 * 1024 * 1024,
+		message: "candidate-view Git command for-each-ref exceeded the 67108864-byte output limit; inspect the candidate state before any new START",
+	});
+	assert.doesNotMatch(failure.message, /sensitive base-reference output/);
+});
+
+test("every synchronous candidate-view Git command receives the explicit 64 MiB output limit", (t) => {
+	const calls: Array<{ arguments: readonly string[]; maxBuffer: number | undefined }> = [];
+	const executor: CandidateGitExecutor = (file, arguments_, options) => {
+		calls.push({ arguments: arguments_, maxBuffer: options.maxBuffer });
+		return execFileSync(file, arguments_, options);
+	};
+	const view = new CandidateViewRegistry(executor).create({ contributorRoot: repository(t) });
+	try {
+		assert.ok(calls.length > 1);
+		assert.ok(calls.every((call) => call.maxBuffer === 64 * 1024 * 1024), JSON.stringify(calls));
+	} finally {
+		view.cleanup();
+	}
+});
+
+test("candidate view classifies both Node synchronous-process output-limit errors ahead of killed state without exposing process output", (t) => {
+	const attemptedOutputBytes = 64 * 1024 * 1024 + 1;
+	for (const code of ["ENOBUFS", "ERR_CHILD_PROCESS_STDIO_MAXBUFFER"]) {
+		let failure: unknown;
+		try {
+			new CandidateViewRegistry((_file, _arguments, options) => {
+				assert.ok((options.maxBuffer ?? 0) < attemptedOutputBytes, code);
+				throw Object.assign(new Error("sensitive stderr and candidate bytes"), { code, killed: true, stderr: Buffer.from("sensitive stderr and candidate bytes") });
+			}).create({ contributorRoot: repository(t) });
+		} catch (error) {
+			failure = error;
+		}
+		assert.ok(failure instanceof CandidateViewError, code);
+		assert.equal(failure.reason, "candidate-view-output-limit", code);
+		assert.deepEqual((failure as CandidateViewError & { diagnostics?: unknown }).diagnostics, {
+			phase: "candidate-view",
+			category: "output-limit",
+			git_subcommand: "rev-parse",
+			timeout_ms: 10_000,
+			max_buffer_bytes: 64 * 1024 * 1024,
+			message: "candidate-view Git command rev-parse exceeded the 67108864-byte output limit; inspect the candidate state before any new START",
+		}, code);
+		assert.doesNotMatch(failure.message, /sensitive stderr|candidate bytes/, code);
+	}
+});
+
+test("candidate Git accepts deterministic output above 1 MiB up to its explicit bound", () => {
+	const row = `:100644 100644 ${"a".repeat(40)} ${"b".repeat(40)} M\0tracked.txt\0`;
+	const copies = Math.ceil((1024 * 1024 + 1) / Buffer.byteLength(row));
+	const output = Buffer.from(row.repeat(copies));
+	assert.ok(output.length > 1024 * 1024);
+	assert.ok(output.length < 64 * 1024 * 1024);
+	const calls: Array<{ maxBuffer: number | undefined }> = [];
+	const manifest = deriveChangedPathManifest("/candidate", "a".repeat(40), "b".repeat(40), (_file, arguments_, options) => {
+		assert.deepEqual(arguments_.slice(0, 2), ["diff", "--raw"]);
+		calls.push({ maxBuffer: options.maxBuffer });
+		return output;
+	});
+	assert.equal(manifest.length, copies);
+	assert.ok(manifest.every((entry) => entry.path === "tracked.txt" && entry.status === "M"));
+	assert.deepEqual(calls, [{ maxBuffer: 64 * 1024 * 1024 }]);
 });
 
 test("committed-only candidate views scope an explicit base to committed changes and exclude dirty worktree files", (t) => {

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { __testing, createGentleAiExtension } from "../extensions/gentle-ai.ts";
@@ -1510,6 +1510,35 @@ test("native START preserves a candidate-view diagnostic before native invocatio
 	assert.equal(starts, 0);
 });
 
+test("native START returns a structured pre-native candidate-view output-limit diagnostic without calling native START", async (t) => {
+	const cwd = repository(t);
+	let starts = 0;
+	const candidateViews = new CandidateViewRegistry(() => {
+		throw Object.assign(new Error("sensitive stderr and candidate bytes"), { code: "ENOBUFS", stderr: Buffer.from("sensitive stderr and candidate bytes") });
+	});
+	const { controller } = runtime(fakeNative({
+		start: async () => {
+			starts += 1;
+			return { lineageId: "must-not-start", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: true };
+		},
+	}), undefined, undefined, undefined, candidateViews);
+	const result = await controller.execute("candidate-view-output-limit", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+	const details = result.details as Record<string, unknown>;
+	assert.equal(details.outcome, "native-operation-failed");
+	assert.equal(details.lineage_created, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.deepEqual(details.diagnostics, {
+		phase: "candidate-view",
+		category: "output-limit",
+		git_subcommand: "rev-parse",
+		timeout_ms: 10_000,
+		max_buffer_bytes: 64 * 1024 * 1024,
+		message: "candidate-view Git command rev-parse exceeded the 67108864-byte output limit; inspect the candidate state before any new START",
+	});
+	assert.doesNotMatch(JSON.stringify(details), /sensitive stderr|candidate bytes/);
+	assert.equal(starts, 0);
+});
+
 test("ambiguous native START failure preserves rebuilt sanitized diagnostics across duplicated module instances", async (t) => {
 	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-controller-"));
 	t.after(() => rmSync(cwd, { recursive: true, force: true }));
@@ -1718,6 +1747,52 @@ test("native START re-verifies candidate-view integrity before granting workspac
 	assert.equal(starts, 0);
 });
 
+test("native START preserves an explicit base-resolution timeout diagnostic without native START", async (t) => {
+	const cwd = repository(t);
+	const bin = join(cwd, "test-bin");
+	mkdirSync(bin);
+	const fakeGit = join(bin, "git");
+	writeFileSync(fakeGit, "#!/bin/sh\nexec sleep 1\n");
+	chmodSync(fakeGit, 0o755);
+	const previousPath = process.env.PATH;
+	const previousTimeout = process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS;
+	t.after(() => {
+		if (previousPath === undefined) delete process.env.PATH;
+		else process.env.PATH = previousPath;
+		if (previousTimeout === undefined) delete process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS;
+		else process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS = previousTimeout;
+	});
+	process.env.PATH = `${bin}${delimiter}${previousPath ?? ""}`;
+	process.env.GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS = "1";
+	let starts = 0;
+	let statuses = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			statuses += 1;
+			throw new Error("target status must not run after base resolution fails");
+		},
+		start: async () => {
+			starts += 1;
+			return { lineageId: "must-not-start", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: true };
+		},
+	}), undefined, undefined, undefined, new CandidateViewRegistry());
+	const result = await controller.execute("base-resolution-timeout", { operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef: "refs/heads/main", committedOnly: true }) }, undefined, undefined, context(cwd));
+	const details = result.details as Record<string, unknown>;
+	assert.equal(details.outcome, "native-operation-failed");
+	assert.equal(details.lineage_created, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.deepEqual(details.diagnostics, {
+		phase: "candidate-view",
+		category: "timeout",
+		git_subcommand: "for-each-ref",
+		timeout_ms: 1,
+		max_buffer_bytes: 64 * 1024 * 1024,
+		message: "candidate-view Git command for-each-ref timed out after 1ms; inspect the candidate state before any new START",
+	});
+	assert.equal(statuses, 0);
+	assert.equal(starts, 0);
+});
+
 test("native START rejects an unresolvable explicit base before native mutation", async (t) => {
 	const cwd = repository(t);
 	let starts = 0;
@@ -1877,6 +1952,267 @@ test("ordinary START fails closed before legacy policy handling when target stat
 	const { controller } = runtime(null);
 	const result = await controller.execute("legacy-start", { operation: "start", input: JSON.stringify({ mode: "ordinary", policyHash: "a".repeat(64) }) }, undefined, undefined, context(cwd));
 	assert.equal((result.details as { outcome?: string }).outcome, "native-status-unsupported");
+});
+
+test("INSPECT reports a missing package-local native binary with fail-closed reinstall guidance", async (t) => {
+	const cwd = repository(t);
+	const rawPath = "/private/workspace/.gentle-ai/gentle-ai";
+	const rawSecret = "package-binary-secret";
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			throw new NativeReviewCliError(
+				NATIVE_REVIEW_ERROR_CODE.PACKAGE_BINARY_MISSING,
+				NATIVE_REVIEW_OPERATION.VERSION,
+				false,
+				false,
+				`missing ${rawPath} token=${rawSecret}`,
+			);
+		},
+	}));
+	const response = await controller.execute("inspect-package-binary-missing", { operation: "inspect" }, undefined, undefined, context(cwd));
+	const details = response.details as Record<string, unknown>;
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-status-package-binary-missing");
+	assert.deepEqual(details.diagnostics, {
+		operation: NATIVE_REVIEW_OPERATION.VERSION,
+		error_code: NATIVE_REVIEW_ERROR_CODE.PACKAGE_BINARY_MISSING,
+		timed_out: false,
+		output_limit_exceeded: false,
+	});
+	assert.equal(details.inventory_complete, false);
+	assert.equal(details.mutation_performed, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.equal(details.next_action, "reinstall-package-local-gentle-ai");
+	assert.doesNotMatch(JSON.stringify(details), new RegExp(`${rawPath}|${rawSecret}`));
+});
+
+test("START reports a missing package-local native binary before any native mutation", async (t) => {
+	const cwd = repository(t);
+	let starts = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			throw new NativeReviewCliError(
+				NATIVE_REVIEW_ERROR_CODE.PACKAGE_BINARY_MISSING,
+				NATIVE_REVIEW_OPERATION.VERSION,
+				false,
+				false,
+				"package-local binary missing",
+			);
+		},
+		start: async () => {
+			starts += 1;
+			return { lineageId: "must-not-start", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: true };
+		},
+	}));
+	const response = await controller.execute("start-package-binary-missing", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+	const details = response.details as Record<string, unknown>;
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-status-package-binary-missing");
+	assert.equal(details.inventory_complete, false);
+	assert.equal(details.lineage_created, false);
+	assert.equal(details.mutation_performed, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.equal(details.next_action, "reinstall-package-local-gentle-ai");
+	assert.equal(starts, 0);
+});
+
+test("REPAIR reports a missing package-local native binary without touching authority", async (t) => {
+	const cwd = repository(t);
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			throw new NativeReviewCliError(
+				NATIVE_REVIEW_ERROR_CODE.PACKAGE_BINARY_MISSING,
+				NATIVE_REVIEW_OPERATION.VERSION,
+				false,
+				false,
+				"package-local binary missing",
+			);
+		},
+	}));
+	const response = await controller.execute("repair-package-binary-missing", { operation: "repair" }, undefined, undefined, context(cwd));
+	const details = response.details as Record<string, unknown>;
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-status-package-binary-missing");
+	assert.equal(details.inventory_complete, false);
+	assert.equal(details.mutation_performed, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.equal(details.next_action, "reinstall-package-local-gentle-ai");
+});
+
+test("START preserves bounded sanitized version-process diagnostics before native mutation", async (t) => {
+	const cwd = repository(t);
+	const rawPath = "/private/workspace/gentle-ai";
+	const rawSecret = "version-process-secret";
+	const stderr = `version process failed token=${rawSecret}\n${"x".repeat(5_000)}`;
+	const foreignError = Object.assign(new Error(`version process failed at ${rawPath} token=${rawSecret}`), {
+		name: "NativeReviewCliError",
+		code: NATIVE_REVIEW_ERROR_CODE.NON_ZERO,
+		diagnostics: {
+			operation: NATIVE_REVIEW_OPERATION.VERSION,
+			error_code: NATIVE_REVIEW_ERROR_CODE.NON_ZERO,
+			exit_code: 17,
+			timed_out: false,
+			output_limit_exceeded: false,
+			stderr,
+		},
+	});
+	let starts = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => { throw foreignError; },
+		start: async () => {
+			starts += 1;
+			return { lineageId: "must-not-start", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: true };
+		},
+	}));
+	const response = await controller.execute("start-version-process-failure", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+	const details = response.details as Record<string, unknown>;
+	const diagnostics = details.diagnostics as { operation?: string; error_code?: string; stderr?: string };
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-operation-failed");
+	assert.equal(diagnostics.operation, NATIVE_REVIEW_OPERATION.VERSION);
+	assert.equal(diagnostics.error_code, NATIVE_REVIEW_ERROR_CODE.NON_ZERO);
+	assert.match(diagnostics.stderr ?? "", /token=\[REDACTED\]/);
+	assert.ok((diagnostics.stderr?.length ?? 0) <= 4_096);
+	assert.equal(details.lineage_created, false);
+	assert.equal(details.mutation_performed, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.equal(starts, 0);
+	assert.doesNotMatch(JSON.stringify(details), new RegExp(`${rawPath}|${rawSecret}`));
+
+	const inspect = await controller.execute("inspect-version-process-failure", { operation: "inspect" }, undefined, undefined, context(cwd));
+	const inspectDetails = inspect.details as Record<string, unknown>;
+	assert.equal(inspectDetails.status, "blocked");
+	assert.equal(inspectDetails.outcome, "native-status-unavailable");
+	assert.deepEqual(inspectDetails.diagnostics, details.diagnostics);
+	assert.equal(inspectDetails.inventory_complete, false);
+	assert.equal(inspectDetails.mutation_performed, false);
+	assert.equal(inspectDetails.mutation_outcome, "none");
+	assert.doesNotMatch(JSON.stringify(inspectDetails), new RegExp(`${rawPath}|${rawSecret}`));
+});
+
+test("INSPECT preserves bounded sanitized review/status process diagnostics and remains fail-closed", async (t) => {
+	const cwd = repository(t);
+	const rawPath = "/private/workspace/review-status";
+	const rawSecret = "review-status-secret";
+	const stderr = `review status failed token=${rawSecret}\n${"x".repeat(5_000)}`;
+	const foreignError = Object.assign(new Error(`review status failed at ${rawPath} token=${rawSecret}`), {
+		name: "NativeReviewCliError",
+		code: NATIVE_REVIEW_ERROR_CODE.NON_ZERO,
+		diagnostics: {
+			operation: NATIVE_REVIEW_OPERATION.STATUS,
+			error_code: NATIVE_REVIEW_ERROR_CODE.NON_ZERO,
+			exit_code: 18,
+			timed_out: false,
+			output_limit_exceeded: false,
+			stderr,
+		},
+	});
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => { throw foreignError; },
+	}));
+	const response = await controller.execute("inspect-review-status-process-failure", { operation: "inspect" }, undefined, undefined, context(cwd));
+	const details = response.details as Record<string, unknown>;
+	const diagnostics = details.diagnostics as { operation?: string; error_code?: string; stderr?: string };
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-status-unavailable");
+	assert.equal(diagnostics.operation, NATIVE_REVIEW_OPERATION.STATUS);
+	assert.equal(diagnostics.error_code, NATIVE_REVIEW_ERROR_CODE.NON_ZERO);
+	assert.match(diagnostics.stderr ?? "", /token=\[REDACTED\]/);
+	assert.ok((diagnostics.stderr?.length ?? 0) <= 4_096);
+	assert.equal(details.inventory_complete, false);
+	assert.equal(details.mutation_performed, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.doesNotMatch(JSON.stringify(details), new RegExp(`${rawPath}|${rawSecret}`));
+});
+
+test("INSPECT keeps version-incompatible target status failures mapped to native-status-unsupported", async (t) => {
+	const cwd = repository(t);
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			throw new NativeReviewCliError(
+				NATIVE_REVIEW_ERROR_CODE.VERSION_INCOMPATIBLE,
+				NATIVE_REVIEW_OPERATION.VERSION,
+				true,
+				false,
+				"native version is incompatible",
+			);
+		},
+	}));
+	const response = await controller.execute("inspect-version-incompatible", { operation: "inspect" }, undefined, undefined, context(cwd));
+	const details = response.details as Record<string, unknown>;
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-status-unsupported");
+	assert.equal(details.inventory_complete, false);
+	assert.equal(details.mutation_performed, false);
+	assert.equal(details.mutation_outcome, undefined);
+});
+
+test("INSPECT preserves output-limit diagnostics from native review status and remains fail-closed", async (t) => {
+	const cwd = repository(t);
+	const diagnostics = {
+		operation: NATIVE_REVIEW_OPERATION.STATUS,
+		error_code: NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT,
+		output_limit_exceeded: true,
+		timed_out: false,
+	};
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			throw new NativeReviewCliError(
+				NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT,
+				NATIVE_REVIEW_OPERATION.STATUS,
+				true,
+				false,
+				"native process output exceeded limit",
+				diagnostics,
+			);
+		},
+	}));
+	const response = await controller.execute("inspect-output-limit", { operation: "inspect" }, undefined, undefined, context(cwd));
+	const details = response.details as Record<string, unknown>;
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-status-unavailable");
+	assert.deepEqual(details.diagnostics, diagnostics);
+	assert.equal(details.inventory_complete, false);
+	assert.equal(details.next_action, "require-complete-native-authority-inventory");
+	assert.equal(details.mutation_performed, false);
+	assert.equal(details.mutation_outcome, "none");
+});
+
+test("START preserves actionable review/status output-limit diagnostics before native mutation", async (t) => {
+	const cwd = repository(t);
+	const diagnostics = {
+		operation: NATIVE_REVIEW_OPERATION.STATUS,
+		error_code: NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT,
+		output_limit_exceeded: true,
+		timed_out: false,
+		max_buffer_bytes: 16 * 1024 * 1024,
+		configuration_hint: "Inspect native review state before any new START; GENTLE_PI_REVIEW_MAX_BUFFER_BYTES accepts a positive decimal up to 67108864.",
+	};
+	let starts = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			throw new NativeReviewCliError(
+				NATIVE_REVIEW_ERROR_CODE.OUTPUT_LIMIT,
+				NATIVE_REVIEW_OPERATION.STATUS,
+				true,
+				false,
+				"native process output exceeded limit",
+				diagnostics,
+			);
+		},
+		start: async () => {
+			starts += 1;
+			return { lineageId: "must-not-start", state: "reviewing", riskLevel: "medium", selectedLenses: ["review-reliability"], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: true };
+		},
+	}));
+	const response = await controller.execute("start-status-output-limit", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
+	const details = response.details as Record<string, unknown>;
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-operation-failed");
+	assert.deepEqual(details.diagnostics, diagnostics);
+	assert.equal(details.lineage_created, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.equal(starts, 0);
 });
 
 test("general STATUS and INSPECT use negotiated target status without mutation or inventory reads", async (t) => {


### PR DESCRIPTION
Closes #254

## Summary

This PR hardens the review paths that were blocking real delivery workflows. It keeps all failure modes fail-closed while preserving safe diagnostics and provider identity bindings.

- Raises the native review output bound to 16 MiB with a capped `GENTLE_PI_REVIEW_MAX_BUFFER_BYTES` override.
- Fixes fresh consent relays that omit `--lineage` while preserving strict target and prebound-lineage checks.
- Adds bounded candidate Git buffering and timeout configuration, with sanitized diagnostics for output limits and timeouts.
- Preserves native `version` and `review/status` diagnostics and adds actionable package-local binary recovery guidance.

## Related issues

- Related: #255, #252, #196, #232.
- Gentle AI #1833 is resolved on `main` by merged PR #1965 (`39d62b61`), which fixed the fresh large-workspace status timeout.
- #213 is a separate mixed-authority/retained-lock recovery case. This PR deliberately does not invent authority recovery or lock-repair behavior.
- The snapshot identity portion of #254 was already resolved by #253 and is preserved here.

## Changes

| Area | Change |
|------|--------|
| Native review client | Bounded output buffer, safe override, output-limit precedence, actionable diagnostics, and source/runtime parity. |
| Consent relay | Optional canonical lineage parsing with exact matching when provider-bound. |
| Candidate view | Explicit 64 MiB Git buffer, bounded timeout override, output-limit/timeout classification, and base-resolution diagnostic preservation. |
| Controller | Preserves sanitized status/version and candidate-view diagnostics without attempting native mutation. |
| Tests | Regression coverage for fresh consent, large output, timeouts, diagnostics, and fail-closed routing. |

## Test plan

- [x] `node --experimental-strip-types --test tests/review-candidate-view.test.ts tests/native-review-cli.test.ts tests/native-review-consent.test.ts tests/review-controller-native-routing.test.ts` (287 passed)
- [x] `git diff --check`
- [ ] Full `pnpm test`: three parity-runtime tests require the external global RDD mode to be enabled; it was not changed automatically.
- [x] No shell scripts changed, so shellcheck was not applicable.

## Review workload

This PR is intentionally submitted as a `size:exception`: it contains 936 additions and 58 deletions across the implementation and its regression coverage. The changes were implemented and verified as sequential work units in one candidate, but remain one PR at the user's request.

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Tests included with the implementation
- [x] No `Co-Authored-By` trailers
- [x] No merge to `main` performed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer diagnostics and reinstall guidance when native review tools or package binaries are unavailable.
  * Added configurable output limits for native review processes and Git operations, with actionable configuration hints.
  * Added support for validating provider-issued consent lineage information.

* **Bug Fixes**
  * Improved handling of timeouts, output-limit failures, version issues, and status failures.
  * Preserved diagnostic details during review setup and repair operations while preventing unsafe follow-up actions.
  * Sanitized failure output to avoid exposing sensitive information.

* **Tests**
  * Expanded coverage for diagnostics, output limits, consent validation, binary failures, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->