### PR TITLE
fix(installer): derive every gentle-ai version literal from one authoritative pin

### DIFF
--- a/lib/gentle-ai-binary.ts
+++ b/lib/gentle-ai-binary.ts
@@ -7,6 +7,7 @@ import {
 	GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
 	GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH,
 	GENTLE_AI_WINDOWS_SOURCE_TAG,
+	INSTALLER_VERSION,
 	isGentleAiWindowsGoVersionSupported,
 	isWindowsGoSumdbSourceTarget,
 	resolveGentleAiReleaseAsset,
@@ -14,7 +15,10 @@ import {
 import { fileURLToPath } from "node:url";
 
 export const GENTLE_AI_BINARY_MISSING_CODE = "package-local-binary-missing";
-export const GENTLE_AI_VERSION = "2.2.3";
+// Derived from the one authoritative pinned version in
+// scripts/gentle-ai-installer.mjs rather than repeating the literal here, so
+// the two can never independently drift apart the way they once did.
+export const GENTLE_AI_VERSION = INSTALLER_VERSION;
 
 export class PackageLocalGentleAiBinaryMissingError extends Error {
 	readonly code = GENTLE_AI_BINARY_MISSING_CODE;

--- a/runtime/gentle-ai-binary.mjs
+++ b/runtime/gentle-ai-binary.mjs
@@ -8,6 +8,7 @@ import {
 	GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM,
 	GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH,
 	GENTLE_AI_WINDOWS_SOURCE_TAG,
+	INSTALLER_VERSION,
 	isGentleAiWindowsGoVersionSupported,
 	isWindowsGoSumdbSourceTarget,
 	resolveGentleAiReleaseAsset,
@@ -15,7 +16,10 @@ import {
 import { fileURLToPath } from "node:url";
 
 export const GENTLE_AI_BINARY_MISSING_CODE = "package-local-binary-missing";
-export const GENTLE_AI_VERSION = "2.2.3";
+// Derived from the one authoritative pinned version in
+// scripts/gentle-ai-installer.mjs rather than repeating the literal here, so
+// the two can never independently drift apart the way they once did.
+export const GENTLE_AI_VERSION = INSTALLER_VERSION;
 
 export class PackageLocalGentleAiBinaryMissingError extends Error {
 	         code = GENTLE_AI_BINARY_MISSING_CODE;

--- a/scripts/gentle-ai-installer.mjs
+++ b/scripts/gentle-ai-installer.mjs
@@ -19,21 +19,26 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
-const RELEASE_BASE_URL = "https://github.com/Gentleman-Programming/gentle-ai/releases/download/v2.2.3/";
 const MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
 const MAX_REDIRECTS = 3;
 const DOWNLOAD_TIMEOUTS = { headers: 10_000, body: 30_000, attempts: 2, retryDelay: 100 };
 const GO_COMMAND_TIMEOUT_MS = 120_000;
 const GO_COMMAND_MAX_BUFFER = 1024 * 1024;
 const WINDOWS_SYSTEM_ROOT = "C:\\Windows";
+// The one authoritative pinned Gentle AI version. Every other location in this
+// module (the release download URL, the Windows source tag, and the reported
+// version check below) derives from this constant instead of repeating the
+// literal, so a pin bump cannot leave a stale copy behind. See
+// scripts/install-gentle-ai.mjs for the incident that motivated this.
 export const INSTALLER_VERSION = "2.2.3";
+export const RELEASE_BASE_URL = `https://github.com/Gentleman-Programming/gentle-ai/releases/download/v${INSTALLER_VERSION}/`;
 export const GENTLE_AI_INSTALL_METHOD = Object.freeze({
 	SIGNED_RELEASE_ASSET: "signed-release-asset",
 	GO_SUMDB_SOURCE_BUILD: "go-sumdb-source-build",
 });
 export const GENTLE_AI_WINDOWS_SOURCE_PACKAGE_PATH = "github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai";
 export const GENTLE_AI_WINDOWS_SOURCE_MODULE = "github.com/gentleman-programming/gentle-ai/v2";
-export const GENTLE_AI_WINDOWS_SOURCE_TAG = "v2.2.3";
+export const GENTLE_AI_WINDOWS_SOURCE_TAG = `v${INSTALLER_VERSION}`;
 // `go mod download -json github.com/gentleman-programming/gentle-ai/v2@v2.2.3`
 // with GOSUMDB=sum.golang.org reports this exact module SumDB checksum.
 export const GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM = "h1:GWFPqNIgPDv82BiCceWQBV6p9VKbFm51W//sKTKNn5c=";
@@ -330,11 +335,13 @@ async function verifyGoBuildMetadata(execute, goPath, binaryPath, environment, c
 	catch (error) { if (error instanceof GentleAiInstallerError) throw error; throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, "Gentle AI source build metadata could not be verified.", error); }
 }
 
+function escapeRegExp(value) { return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); }
+
 async function assertExactGentleAiVersion(execute, binaryPath, environment, cwd) {
 	let result;
 	try { result = await runCommand(execute, binaryPath, ["version"], commandOptions(environment, cwd)); }
 	catch (error) { throw new GentleAiInstallerError(GENTLE_AI_VERSION_MISMATCH_CODE, `Gentle AI source build at ${binaryPath} could not report its version.`, error); }
-	if (!/^gentle-ai 2\.2\.3\r?\n?$/.test(commandOutput(result))) throw new GentleAiInstallerError(GENTLE_AI_VERSION_MISMATCH_CODE, `Gentle AI source build reported ${JSON.stringify(commandOutput(result).trim())}; expected gentle-ai ${INSTALLER_VERSION}.`);
+	if (!new RegExp(`^gentle-ai ${escapeRegExp(INSTALLER_VERSION)}\\r?\\n?$`).test(commandOutput(result))) throw new GentleAiInstallerError(GENTLE_AI_VERSION_MISMATCH_CODE, `Gentle AI source build reported ${JSON.stringify(commandOutput(result).trim())}; expected gentle-ai ${INSTALLER_VERSION}.`);
 }
 
 function sameFile(before, after) { return before.dev === after.dev && before.ino === after.ino && before.size === after.size && before.mtimeMs === after.mtimeMs; }

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -174,6 +174,31 @@ export function reconcileContractsOnDisk(packageRoot, hashes) {
   };
 }
 
+// Compares every location that pins the Gentle AI version against the one
+// authoritative constant (scripts/gentle-ai-installer.mjs INSTALLER_VERSION),
+// returning a mismatch message per drifted location instead of a boolean.
+// This replaces a textual `.includes(...)` grep that could not have caught
+// the documented incident (scripts/install-gentle-ai.mjs header comment):
+// two hardcoded version copies drifted apart, and the installer reported
+// installing one version while writing another to disk. A textual grep only
+// verifies a string appears in a file; it cannot verify that two values
+// agree, which is exactly what this function checks instead.
+export function gentleAiVersionPinMismatches({ installerVersion, releaseBaseUrl, windowsSourceTag, libGentleAiVersion }) {
+  const mismatches = [];
+  if (libGentleAiVersion !== installerVersion) {
+    mismatches.push(
+      `lib/gentle-ai-binary.ts GENTLE_AI_VERSION ("${libGentleAiVersion}") does not match the authoritative scripts/gentle-ai-installer.mjs INSTALLER_VERSION ("${installerVersion}")`,
+    );
+  }
+  if (!releaseBaseUrl.includes(`/v${installerVersion}/`)) {
+    mismatches.push(`RELEASE_BASE_URL ("${releaseBaseUrl}") does not pin the authoritative v${installerVersion}`);
+  }
+  if (windowsSourceTag !== `v${installerVersion}`) {
+    mismatches.push(`GENTLE_AI_WINDOWS_SOURCE_TAG ("${windowsSourceTag}") does not match the authoritative v${installerVersion}`);
+  }
+  return mismatches;
+}
+
 // Reads the generator's `sources` array by regex rather than importing it,
 // so this script never needs the generator to export anything it doesn't
 // already export for its own `--write`/`--check` CLI use.
@@ -272,7 +297,9 @@ async function main() {
 
   // Release guard: refuse to pack/publish while any installer digest is not a real
   // pinned SHA-256 (for example the pre-release pending sentinel).
-  const { GENTLE_AI_RELEASE_ASSETS } = await import(new URL("./gentle-ai-installer.mjs", import.meta.url));
+  const { GENTLE_AI_RELEASE_ASSETS, INSTALLER_VERSION, RELEASE_BASE_URL, GENTLE_AI_WINDOWS_SOURCE_TAG } = await import(
+    new URL("./gentle-ai-installer.mjs", import.meta.url)
+  );
   const unpinnedDigests = Object.entries(GENTLE_AI_RELEASE_ASSETS).flatMap(([target, asset]) =>
     [["sha256", asset.sha256], ["binarySha256", asset.binarySha256]]
       .filter(([, digest]) => !/^[0-9a-f]{64}$/.test(digest))
@@ -295,10 +322,16 @@ async function main() {
     process.exit(1);
   }
 
-  const installer = readFileSync(join(root, "scripts/gentle-ai-installer.mjs"), "utf8");
-  const binaryResolver = readFileSync(join(root, "lib/gentle-ai-binary.ts"), "utf8");
-  if (!installer.includes('INSTALLER_VERSION = "2.2.3"') || !binaryResolver.includes('GENTLE_AI_VERSION = "2.2.3"')) {
-    console.error("gentle-pi package-local Gentle AI version pins are not both v2.2.3.");
+  const { GENTLE_AI_VERSION } = await import(new URL("../lib/gentle-ai-binary.ts", import.meta.url));
+  const versionMismatches = gentleAiVersionPinMismatches({
+    installerVersion: INSTALLER_VERSION,
+    releaseBaseUrl: RELEASE_BASE_URL,
+    windowsSourceTag: GENTLE_AI_WINDOWS_SOURCE_TAG,
+    libGentleAiVersion: GENTLE_AI_VERSION,
+  });
+  if (versionMismatches.length > 0) {
+    console.error("gentle-pi Gentle AI version pins have drifted from the authoritative INSTALLER_VERSION:");
+    for (const mismatch of versionMismatches) console.error(`- ${mismatch}`);
     process.exit(1);
   }
 

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -280,7 +280,7 @@ test("package verification binds the published Gentle AI v2.2.3 runtime pin", ()
 	assert.match(installer, /GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM = "h1:GWFPqNIgPDv82BiCceWQBV6p9VKbFm51W\/\/sKTKNn5c="/);
 	assert.match(installer, /GOTOOLCHAIN: "local"/);
 	assert.match(installer, /GOSUMDB: "sum\.golang\.org"/);
-	assert.match(binary, /GENTLE_AI_VERSION = "2\.2\.3"/);
+	assert.match(binary, /GENTLE_AI_VERSION = INSTALLER_VERSION/);
 	assert.match(binary, /GO_SUMDB_SOURCE_BUILD/);
 	assert.match(binary, /GENTLE_AI_WINDOWS_SOURCE_MODULE_CHECKSUM/);
 	assert.match(verifier, /v2\.2\.3/);

--- a/tests/verify-package-files.test.ts
+++ b/tests/verify-package-files.test.ts
@@ -4,9 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+	gentleAiVersionPinMismatches,
 	reconcileContractsOnDisk,
 	reconcileGeneratedRuntimeSources,
 } from "../scripts/verify-package-files.mjs";
+import { INSTALLER_VERSION, RELEASE_BASE_URL, GENTLE_AI_WINDOWS_SOURCE_TAG } from "../scripts/gentle-ai-installer.mjs";
+import { GENTLE_AI_VERSION } from "../lib/gentle-ai-binary.ts";
 
 function makeFixtureRoot(): string {
 	return mkdtempSync(join(tmpdir(), "gentle-pi-verify-package-files-"));
@@ -89,6 +92,49 @@ test("sources <-> runtime/*.mjs walk fails when a sources entry is absent from r
 	} finally {
 		rmSync(fixtureRoot, { recursive: true, force: true });
 	}
+});
+
+// Regression test for the documented incident in scripts/install-gentle-ai.mjs:
+// the installer once reported installing v2.1.11 while writing v2.2.0 to disk
+// because two hardcoded version copies had drifted apart. The textual
+// `.includes(...)` grep this replaces could not have caught this, because it
+// only verifies a string appears in a file, not that two values agree.
+test("Gentle AI version pin mismatch is reported with a specific message when a derived location disagrees with the authoritative constant", () => {
+	const mismatches = gentleAiVersionPinMismatches({
+		installerVersion: "2.2.3",
+		releaseBaseUrl: "https://github.com/Gentleman-Programming/gentle-ai/releases/download/v2.2.3/",
+		windowsSourceTag: "v2.2.3",
+		libGentleAiVersion: "2.2.0",
+	});
+
+	assert.deepEqual(mismatches, [
+		'lib/gentle-ai-binary.ts GENTLE_AI_VERSION ("2.2.0") does not match the authoritative scripts/gentle-ai-installer.mjs INSTALLER_VERSION ("2.2.3")',
+	]);
+});
+
+test("Gentle AI version pin mismatch also flags a drifted release URL and a drifted Windows source tag", () => {
+	const mismatches = gentleAiVersionPinMismatches({
+		installerVersion: "2.2.3",
+		releaseBaseUrl: "https://github.com/Gentleman-Programming/gentle-ai/releases/download/v2.2.0/",
+		windowsSourceTag: "v2.1.11",
+		libGentleAiVersion: "2.2.3",
+	});
+
+	assert.deepEqual(mismatches, [
+		'RELEASE_BASE_URL ("https://github.com/Gentleman-Programming/gentle-ai/releases/download/v2.2.0/") does not pin the authoritative v2.2.3',
+		'GENTLE_AI_WINDOWS_SOURCE_TAG ("v2.1.11") does not match the authoritative v2.2.3',
+	]);
+});
+
+test("Gentle AI version pin agrees across the installer version, the release URL, the Windows source tag, and lib/gentle-ai-binary.ts", () => {
+	const mismatches = gentleAiVersionPinMismatches({
+		installerVersion: INSTALLER_VERSION,
+		releaseBaseUrl: RELEASE_BASE_URL,
+		windowsSourceTag: GENTLE_AI_WINDOWS_SOURCE_TAG,
+		libGentleAiVersion: GENTLE_AI_VERSION,
+	});
+
+	assert.deepEqual(mismatches, []);
 });
 
 test("both walks report no drift when sources, runtime/*.mjs, requiredPaths, and contractHashes fully agree", () => {


### PR DESCRIPTION
Quick win. Independent of the release-artifact initiative and of any tracker.

## Problem

The pinned gentle-ai version was hand-duplicated across six literals plus a textual grep. This already caused a production incident, documented verbatim in the header of `scripts/install-gentle-ai.mjs`: the installer reported installing v2.1.11 while writing v2.2.0 to disk, because two hardcoded copies survived a pin bump.

The check meant to catch that was `installer.includes(...)` on a literal string — it verifies a string appears in a file, not that the values agree. That is exactly why it did not catch the incident.

## Change

`INSTALLER_VERSION` becomes the sole authoritative literal. `RELEASE_BASE_URL`, `GENTLE_AI_WINDOWS_SOURCE_TAG`, `lib/gentle-ai-binary.ts`'s `GENTLE_AI_VERSION`, and the previously undocumented sixth copy (the hardcoded version regex in `assertExactGentleAiVersion`) all derive from it.

`scripts/verify-package-files.mjs` now imports the live constants and compares actual values through a new pure `gentleAiVersionPinMismatches(...)`, replacing the textual grep.

The pinned version value is unchanged (2.2.3). This is a refactor of how the value is expressed, not a bump.

## Out of scope, deliberately

Per-platform sha256 digests stay as data — they are inherently plural and cannot be single-sourced. Symlink rejection, path confinement and the TOCTOU re-check in `runtime/gentle-ai-binary.mjs` are untouched.

## Tests

RED first: importing `RELEASE_BASE_URL` failed before the export existed. Three new tests in `tests/verify-package-files.test.ts` cover a single-field mismatch, a multi-field mismatch, and agreement across the real values — the first is the regression test for the documented incident and could not have failed under the old grep.

`pnpm run check:transaction-runner` passes (`runtime/` regenerated, never hand-edited). `node scripts/verify-package-files.mjs` passes.

Three tests in `native-review-parity-runtime.test.ts` fail on this branch and fail identically on clean `main` — they require receipt-driven development to be enabled, which is globally off in this environment. Verified independently against the base commit.

## Rollback

Single commit. Reverting restores the prior six-literal-plus-grep state with no other side effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the Gentle AI version remains consistent across the installer, library, release URL, and Windows source.
  * Improved package verification to detect version mismatches clearly.

* **Tests**
  * Added coverage for mismatched version pins and confirmed successful validation when all versions agree.
  * Updated package checks to verify version references dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->