### PR TITLE
fix(review): tolerate added gates and projections, keep mandatory features exact

### DIFF
--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -712,12 +712,17 @@ export function decodeReviewCapabilitiesV2(value: unknown, verifiedExecutableDig
 	if (selfReportedDigest !== normalizedVerifiedDigest) throw new TypeError("review provider executable digest mismatch");
 
 	const advertisedOperations = stringArray(body.operations, "capabilities.operations", { minimum: REQUIRED_OPERATIONS.length, unique: true });
-	const gates = enumArray(body.gates, REQUIRED_GATES, "capabilities.gates", { minimum: 5, maximum: 5, unique: true });
-	const projections = enumArray(body.projections, REQUIRED_PROJECTIONS, "capabilities.projections", { minimum: 2, maximum: 2, unique: true });
+	// Gates and projections are, like operations and schemas, a superset promise
+	// rather than an exact manifest: a compatible provider release may advertise
+	// an additional gate or projection name beyond the required floor. Decode as
+	// a plain string array (not `enumArray` against the known enum) so an
+	// unknown addition is not rejected before assertSupersetOf can even run.
+	const advertisedGates = stringArray(body.gates, "capabilities.gates", { minimum: REQUIRED_GATES.length, unique: true });
+	const advertisedProjections = stringArray(body.projections, "capabilities.projections", { minimum: REQUIRED_PROJECTIONS.length, unique: true });
 	const advertisedSchemas = stringArray(body.schemas, "capabilities.schemas", { minimum: REQUIRED_SCHEMAS.length, unique: true });
 	assertSupersetOf(advertisedOperations, REQUIRED_OPERATIONS, "capabilities operations");
-	assertExactSet(gates, REQUIRED_GATES, "capabilities gates");
-	assertExactSet(projections, REQUIRED_PROJECTIONS, "capabilities projections");
+	assertSupersetOf(advertisedGates, REQUIRED_GATES, "capabilities gates");
+	assertSupersetOf(advertisedProjections, REQUIRED_PROJECTIONS, "capabilities projections");
 	assertSupersetOf(advertisedSchemas, REQUIRED_SCHEMAS, "capabilities schemas");
 
 	const features = exactRecord(body.features, "capabilities.features", ["mandatory", "optional"]);
@@ -764,8 +769,8 @@ export function decodeReviewCapabilitiesV2(value: unknown, verifiedExecutableDig
 		buildId,
 		executableDigest: selfReportedDigest,
 		operations: new Set(REQUIRED_OPERATIONS),
-		gates: new Set(gates),
-		projections: new Set(projections),
+		gates: new Set(REQUIRED_GATES),
+		projections: new Set(REQUIRED_PROJECTIONS),
 		schemas: new Set(REQUIRED_SCHEMAS),
 		mandatoryFeatures: new Set(mandatoryNames),
 		optionalFeatures: new Set(optional.filter((feature) => feature.supported && (FEATURE_NAMES as readonly string[]).includes(feature.name)).map((feature) => feature.name)),

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -713,12 +713,17 @@ export function decodeReviewCapabilitiesV2(value         , verifiedExecutableDig
 	if (selfReportedDigest !== normalizedVerifiedDigest) throw new TypeError("review provider executable digest mismatch");
 
 	const advertisedOperations = stringArray(body.operations, "capabilities.operations", { minimum: REQUIRED_OPERATIONS.length, unique: true });
-	const gates = enumArray(body.gates, REQUIRED_GATES, "capabilities.gates", { minimum: 5, maximum: 5, unique: true });
-	const projections = enumArray(body.projections, REQUIRED_PROJECTIONS, "capabilities.projections", { minimum: 2, maximum: 2, unique: true });
+	// Gates and projections are, like operations and schemas, a superset promise
+	// rather than an exact manifest: a compatible provider release may advertise
+	// an additional gate or projection name beyond the required floor. Decode as
+	// a plain string array (not `enumArray` against the known enum) so an
+	// unknown addition is not rejected before assertSupersetOf can even run.
+	const advertisedGates = stringArray(body.gates, "capabilities.gates", { minimum: REQUIRED_GATES.length, unique: true });
+	const advertisedProjections = stringArray(body.projections, "capabilities.projections", { minimum: REQUIRED_PROJECTIONS.length, unique: true });
 	const advertisedSchemas = stringArray(body.schemas, "capabilities.schemas", { minimum: REQUIRED_SCHEMAS.length, unique: true });
 	assertSupersetOf(advertisedOperations, REQUIRED_OPERATIONS, "capabilities operations");
-	assertExactSet(gates, REQUIRED_GATES, "capabilities gates");
-	assertExactSet(projections, REQUIRED_PROJECTIONS, "capabilities projections");
+	assertSupersetOf(advertisedGates, REQUIRED_GATES, "capabilities gates");
+	assertSupersetOf(advertisedProjections, REQUIRED_PROJECTIONS, "capabilities projections");
 	assertSupersetOf(advertisedSchemas, REQUIRED_SCHEMAS, "capabilities schemas");
 
 	const features = exactRecord(body.features, "capabilities.features", ["mandatory", "optional"]);
@@ -765,8 +770,8 @@ export function decodeReviewCapabilitiesV2(value         , verifiedExecutableDig
 		buildId,
 		executableDigest: selfReportedDigest,
 		operations: new Set(REQUIRED_OPERATIONS),
-		gates: new Set(gates),
-		projections: new Set(projections),
+		gates: new Set(REQUIRED_GATES),
+		projections: new Set(REQUIRED_PROJECTIONS),
 		schemas: new Set(REQUIRED_SCHEMAS),
 		mandatoryFeatures: new Set(mandatoryNames),
 		optionalFeatures: new Set(optional.filter((feature) => feature.supported && (FEATURE_NAMES                     ).includes(feature.name)).map((feature) => feature.name)),

--- a/tests/review-integration-v2.test.ts
+++ b/tests/review-integration-v2.test.ts
@@ -245,6 +245,50 @@ test("capabilities enforce the exact mandatory feature set while accepting a sup
 	const extraOperation = clone(source);
 	(extraOperation.operations as string[]).push("review.future_operation");
 	assert.doesNotThrow(() => decode(extraOperation));
+
+	// mandatory features must stay an exact match: a known-but-optional feature
+	// name added to the mandatory list must still be rejected. This is the
+	// contract boundary (unknown_mandatory: "reject") and must not regress when
+	// gates/projections become additive-tolerant below.
+	const extraMandatoryUnknownAddition = clone(source);
+	((extraMandatoryUnknownAddition.features as JsonObject).mandatory as JsonObject[]).push({ name: "bounded_process_waits", supported: true, requires: [] });
+	assert.throws(() => decode(extraMandatoryUnknownAddition), /mandatory/);
+});
+
+test("capabilities gates and projections accept an additive superset beyond the required floor", () => {
+	const source = fixture<JsonObject>("capabilities.fixture.json");
+	const decode = (value: unknown) => decodeReviewCapabilitiesV2(value, executableDigest);
+
+	const extraGate = clone(source);
+	(extraGate.gates as string[]).push("future-gate");
+	const decodedExtraGate = decode(extraGate) as { gates: ReadonlySet<string> };
+	assert.equal(decodedExtraGate.gates.has("future-gate"), false, "an unknown advertised gate must not leak into internal use");
+	for (const gate of ["post-apply", "pre-commit", "pre-push", "pre-pr", "release"]) {
+		assert.equal(decodedExtraGate.gates.has(gate), true, gate);
+	}
+	assert.equal(decodedExtraGate.gates.size, 5);
+
+	const extraProjection = clone(source);
+	(extraProjection.projections as string[]).push("future-projection");
+	const decodedExtraProjection = decode(extraProjection) as { projections: ReadonlySet<string> };
+	assert.equal(decodedExtraProjection.projections.has("future-projection"), false, "an unknown advertised projection must not leak into internal use");
+	for (const projection of ["staged", "workspace"]) {
+		assert.equal(decodedExtraProjection.projections.has(projection), true, projection);
+	}
+	assert.equal(decodedExtraProjection.projections.size, 2);
+});
+
+test("capabilities gates and projections still enforce the required floor", () => {
+	const source = fixture<JsonObject>("capabilities.fixture.json");
+	const decode = (value: unknown) => decodeReviewCapabilitiesV2(value, executableDigest);
+
+	const missingGate = clone(source);
+	missingGate.gates = (missingGate.gates as string[]).filter((gate) => gate !== "release");
+	assert.throws(() => decode(missingGate), /gates/);
+
+	const missingProjection = clone(source);
+	missingProjection.projections = (missingProjection.projections as string[]).filter((projection) => projection !== "workspace");
+	assert.throws(() => decode(missingProjection), /projections/);
 });
 
 test("START independently binds base/candidate tree and the target-mode overlay pair", () => {


### PR DESCRIPTION
Quick win. Independent of the release-artifact initiative and of any tracker.

## Problem

`lib/review-integration-v2.ts` validated the provider's advertised capability surface inconsistently: operations and schemas used `assertSupersetOf` (additive-tolerant, correct), while gates, projections and mandatory features used `assertExactSet`.

The file's own comment already recorded the lesson from v2.2.0 — *"demanding an exact match rejects a compatible provider release"* — but it was applied to only half the surface. Under the current provider release cadence, that rejects compatible releases repeatedly and predictably.

## Change

Gates and projections become required floors that tolerate additions. Unknown added names decode safely, the required floor is verified, and internal use narrows to the supported required members so additions never leak into behavior.

**Mandatory features intentionally stay exact and keep rejecting unknown additions.** The provider's own contract advertises `compatibility.unknown_mandatory: "reject"` (`contracts/review-integration/v2/fixtures/capabilities.fixture.json`, constrained by `"unknown_mandatory": {"const": "reject"}` in the schema). Relaxing them would violate the contract the provider publishes.

## Not a one-line swap

`enumArray` rejected unknown members *before* any assertion ran, and the gates/projections calls passed fixed `minimum`/`maximum` bounds of 5 and 2. Swapping only the assertion would have left `enumArray` rejecting first and the fix would silently have done nothing. The decode path itself changed.

## Tests

Six behaviors, RED first:

1. gate floor + 1 unknown gate — was `TypeError: capabilities.gates has an invalid length`, now passes
2. projection floor + 1 unknown projection — same pattern
3. gate set missing a required member — still rejected
4. projection set missing a required member — still rejected
5. mandatory features + 1 unknown addition — **still rejected**, proving the contract boundary did not regress
6. unknown additions are absent from the decoded sets — additions never drive behavior

`pnpm run check:transaction-runner` passes (`runtime/` regenerated, never hand-edited).

Three tests in `native-review-parity-runtime.test.ts` fail on this branch and fail identically on clean `main` — they require receipt-driven development to be enabled, which is globally off in this environment. Verified independently against the base commit.

## Rollback

Single commit. No consumer code outside `decodeReviewCapabilitiesV2` reads the raw gates/projections locals, so reverting restores exact-match validation with no other side effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with providers that advertise additional capabilities.
  * Capability detection now accepts additive gates and projections while retaining the required supported set.
  * Added validation to ensure all mandatory capabilities remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->