### PR TITLE
feat(release-artifact): verify at pin time, mirror offline, and lock what was verified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
         env:
           GENTLE_PI_REQUIRE_NATIVE_BINARY: "1"
 
+      # Offline mirror + capabilities/gentle-ai-release.lock.json reconciliation
+      # (contracts/, docs/gentle-ai/, capabilities/*.semantic.json) runs here,
+      # fully offline. Only scripts/sync-gentle-ai-release.mjs --write, invoked
+      # exclusively by the not-yet-landed pin-bump job, ever downloads or
+      # verifies a minisign signature; no job in this workflow does.
       - name: Verify package contents
         run: node scripts/verify-package-files.mjs
 

--- a/capabilities/gentle-ai-release.lock.json
+++ b/capabilities/gentle-ai-release.lock.json
@@ -1,0 +1,756 @@
+{
+  "release": {
+    "repository": "Gentleman-Programming/gentle-ai",
+    "tag": "v2.2.3",
+    "version": "2.2.3",
+    "commit": "0000000000000000000000000000000000000000"
+  },
+  "contract": {
+    "id": "gentle-ai.release-artifact",
+    "major": 1,
+    "minor": 0,
+    "schemaId": "https://gentle-ai.dev/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+    "schemaPath": "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+    "layoutVersion": 1
+  },
+  "archive": {
+    "asset": "gentle-ai_2.2.3_assets.tar.gz",
+    "sha256": "sha256:f7c263dc6c459cbf8a7bdfe32924733ac121fbeac7dacbd3ae8643c6ef7d93be",
+    "digestSource": "signed-checksums.txt"
+  },
+  "tree": {
+    "algorithm": "sha256",
+    "canonicalization": "gentle-ai.release-artifact-tree/v1",
+    "digest": "sha256:4c4c5c6ef640e86dc26fc94a115f9c7f1878294d7103d1cc9b613492d3481399"
+  },
+  "entries": [
+    {
+      "path": "capabilities/review-integration-v2.semantic.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 4054,
+      "digest": "sha256:d626daf0bca02326373bfddf62e858f7392edac26f6927abd217ff9a3e8a187a"
+    },
+    {
+      "path": "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 4309,
+      "digest": "sha256:9fe23ab8dea0fb0a0d687d119e88c08ee9b9bc4ed3b3c9fd1d122399e7e577de"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/binding-revision-conflict.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 792,
+      "digest": "sha256:c2e294843cee5185324cb7a41702574ef94852517239d99e7493a1414a60b363"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.1.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5839,
+      "digest": "sha256:1b3dc40dce7bfb5d3ecc7e92af68d66e71b733ba0b0f71ba94d3c633adc48bcf"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.2.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 6443,
+      "digest": "sha256:2970d21cd95a7fcaea6547c47a591a5151046e7ede658b3e8c5b9a9c5d106b65"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.3.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 7490,
+      "digest": "sha256:0ec783ea13b4c82c0b002c5caa758f33e2b488537297cc2d0694ec92176ac0cb"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.4.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 7816,
+      "digest": "sha256:84e0db457b76b97b35c2be772dfc647f9eab66810ea98f64fed85645c3c266ba"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.5.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 8065,
+      "digest": "sha256:0cc952af3767c393bde9e4785e4071615a529fd672bc94da4fcc204780524a27"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 4535,
+      "digest": "sha256:b3ca822189a236f2d891628c665ca23e308bf5185a1701e1f07231bd970461bb"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/consent.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1869,
+      "digest": "sha256:b2ff4809b9eb75a54206800dca13f96396976aca7387e45f765ac6ec98029cd1"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/failure.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1671,
+      "digest": "sha256:e72b6ab5e3c529abac47bd324444f84ca90f67ef0a67189f5fd8d24d199a2759"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/final-verification-incident.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 626,
+      "digest": "sha256:f8bc06549e62b0bee5cf2ecde625e18da178dd18c9d3023b7d7e8fd0ebbba646"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/operation.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 2064,
+      "digest": "sha256:3547748a4df57382178064abbdb1cf12f1d58a75c0e9d6452fdd9beb3aaeac3a"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/repair-preflight.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1915,
+      "digest": "sha256:7168cb53ad470066d0b3edc3b7911d1aebff91abd41ecc3d822f8ffa5cea6cb1"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/start-v2.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 4541,
+      "digest": "sha256:388c7c21374b89afe2d42d64bd1987d17ec0e2c7151cab1c56a08969ffb2ea0e"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/start.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1744,
+      "digest": "sha256:f369160ac26eb3427b57de2dd01c9d8c81e51c8a2bd546446780129d31b1945b"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-ambiguous.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 2627,
+      "digest": "sha256:ee695fd58ba72adfb3b51dfd16432a177498173a45bfcb594d6bdc53bfa32e6e"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-corrupted.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 2602,
+      "digest": "sha256:4cfc0048c28a39cec8a32fecfaad66e56e5c1248263ceb4ce66b6717981880b2"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-recover.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 3508,
+      "digest": "sha256:714f762f72380ce93d567626cafbaa536ab3aae02af73d3d40ca123f1f30d8b0"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-unrelated.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 2443,
+      "digest": "sha256:deab36c877ced3c9b480ca33724c10d88f75c761d6426fa14be850345122891d"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-ambiguous.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 3361,
+      "digest": "sha256:80a459a7a18d8d933dd42acb6a94a75ac19278e9a6c3b125e3017946768eaa47"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-corrupted.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 3336,
+      "digest": "sha256:466f1e28b101e95178630f26a90fff96ad3516e2aa6a17f5f357bab9bda2ab52"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-final-verification-retry.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 7082,
+      "digest": "sha256:889ede9a84bdbe561df2d2401adda95634582c44db9d1075ba839f33d65c7886"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-recover.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 4262,
+      "digest": "sha256:178331fc7177d2316fd4f56610ac295f7da2780be96b233b72935d5f476610f2"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-repair.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5169,
+      "digest": "sha256:89083cad752fca38da09e919825d0b80641a8a029364ba1869e5b58ef2e59a1d"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-unrelated.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 3171,
+      "digest": "sha256:c178b338dcd5d30888acef37a9d752bd0932d6dedfffb61b0596a9cceabeb692"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 7055,
+      "digest": "sha256:5410d8bbae1b7152a43b3a5c4c880e9e98a5e47b76d910456f5ef13f19836f3a"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 4656,
+      "digest": "sha256:555054d8046a896162995dcb117752f9cd1ef903fb9ebaad29af1b7e7f319bb3"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/verification-evidence.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 724,
+      "digest": "sha256:b30e3863548845b90e256d92193435d02da458bf8f15a4c33d023cd1f6894a5f"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/admitted-result.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1430,
+      "digest": "sha256:7796e8dbba331434594108c902dfab7ec46f691fa447a9259a78f2448111b0de"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/artifact-subject.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1272,
+      "digest": "sha256:f7dcd934e27e8f3735a37f3d0ec8048dd8ccc1811b9df61124a1dcbf8a03f40e"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/authority-repair-assessment.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5396,
+      "digest": "sha256:232591670009f99c53a68e91d1e7e60465c294f1721f493ab1e7ae182842cfb5"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.1.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 7923,
+      "digest": "sha256:2b14162284f375f8563e49d3a28caaa0aabb572094d8d290eb61844b1353af78"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.2.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 8126,
+      "digest": "sha256:df1722adcd9c999edbef090bfd5d9a9713f6852a9bc9cb79684ef7c9c91c0d62"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.3.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 10332,
+      "digest": "sha256:3401a062fa8a034ef7743f84adbfdd2ceadaf81bee8a7e62115fd4e18afacfcd"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.4.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 10487,
+      "digest": "sha256:926b61c8ac0f870f09214f6bd8af1b035c5b72f14f0b83c0d4a7bdbb277f5447"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.5.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 4915,
+      "digest": "sha256:abc783821524dcc33339495284805a85f79b3352efb7358c95016ed164bd7f24"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 6717,
+      "digest": "sha256:ad333177494a251beac153f74bd751fa77126a9968aad69e64fc2abf15cff0f7"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/consent.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 3123,
+      "digest": "sha256:f8f2edec17568124488482c2aee399909111fe0cce2cba426fb29efd2c7c1cd0"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/failure.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5647,
+      "digest": "sha256:0ce29f61408fc21d72640fffdb215a608a820c29f3e5ff62d9cc295ed0451937"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/final-verification-incident.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1226,
+      "digest": "sha256:39b1ec178b1d3bc8da9a3d92dadd8092385000f2a6930b5bfcb4a84dbc6493ca"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/operation.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5593,
+      "digest": "sha256:6cf15b54977fea7301b9a5c766e709f8a912fda33560365de6dfcab4d2ecbce0"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/projection.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1678,
+      "digest": "sha256:7168a3eba929dde2b8f0b7723ee51d5a5421102bdeefe892578c263debd08db2"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/repair.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5383,
+      "digest": "sha256:febb747dc68f8ded5974b6dd94051ec3cfdb5a886ccb853b1ce53aaf2e41efc0"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/result-artifact-v2.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1413,
+      "digest": "sha256:38895aae2f6ca4980b1a8e157fee8503920820d5f6be3c757c0fa04e8430cd6b"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/result-artifact.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 878,
+      "digest": "sha256:91296bd2c261fd2fe03bffd63efe58badd4927e0d0d8480cd4213f651ecacdf6"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/start-v2.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 7476,
+      "digest": "sha256:ec8550cd93bbe84af1ce87dfd7abfa9e24692f42b20f8f0bf9cac1d4b88ea46c"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/start.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5945,
+      "digest": "sha256:4296aebbd4128ce51945a2f6d3228aa77ac7215c802978d559bff5279ec56229"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/status-v2.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 16215,
+      "digest": "sha256:63e8988ce276d948ea8305008a3d27c4e26dff664cf54fffed9e188f465d92d1"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/status.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 13366,
+      "digest": "sha256:67f3bddf5f5feeb3213bce489de8548546163b2e1d49a0e3965c0091dabc8c39"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/targeted-validation-request.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1575,
+      "digest": "sha256:52b91154693b4dd66983fc91ecf7197503555f2c9e85cac626cffd3035c53d65"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/verification-evidence.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1751,
+      "digest": "sha256:fd15890bf2ef1db95d771ee7f468e9e64014351d7940f65604eb24f41e68a22f"
+    },
+    {
+      "path": "contracts/review-integration/v2/fixtures/capabilities.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 6545,
+      "digest": "sha256:17c150d851c15b3f0c20d18c2e2741eb2232ffa24f35aa71d6d30e90a85e42b7"
+    },
+    {
+      "path": "contracts/review-integration/v2/fixtures/consent.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1947,
+      "digest": "sha256:203cc96d5c29ba0f27b5c4db04c2e88566e0a923d3a0cdb317f78d9065349075"
+    },
+    {
+      "path": "contracts/review-integration/v2/fixtures/start.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 4257,
+      "digest": "sha256:34b21328fa910e03af2fac8e816c5b510ba146201da0cd4ef1693d39a6344ba0"
+    },
+    {
+      "path": "contracts/review-integration/v2/fixtures/status.fixture.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5098,
+      "digest": "sha256:d5438578f2969f17635fecea94c7ef46d14c78fa668e50df48c4254254d5e935"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/admitted-result.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 620,
+      "digest": "sha256:c6a9c880191d65c46d9cfc8a0812af16b636573a8f6e57ea34aa16d6f6bb9735"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/artifact-subject.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1415,
+      "digest": "sha256:3e71a81340ea6149b03afa71530d10ce654c415fa21d4e07f0c9c25b3d2d70a3"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/capabilities.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5909,
+      "digest": "sha256:7ab061ed27bd3b929d6033cc20f56097e851f4454ca14a815255748b50191248"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/consent.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 2771,
+      "digest": "sha256:b2b4465338497f11927de91cb2e5da12b6cb4a1039afe05aebe1abbf53b21858"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/failure.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 2206,
+      "digest": "sha256:1c53da8c543cc5e03fbbfc700d4fc80cadb3b0e5e72c6d77a7790008671d0962"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/operation.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1963,
+      "digest": "sha256:beee02046ec1d5b8c89e3d7de35f897c275830e43c67ecd162886bfd0138ace6"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/repair.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 1197,
+      "digest": "sha256:9e842d1ded797a91ede16b2054a38708b2d1fc7a0d6217541f84c0f2f5a2e73e"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/start.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5053,
+      "digest": "sha256:86ddfcfe1912489abef7461613d692ea53a4d7d73d444d5f6dbbd7f9866a2c37"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/status.schema.json",
+      "type": "file",
+      "mode": "0644",
+      "size": 5980,
+      "digest": "sha256:132b15dd7a0514aa451373bd4b3c02a1491b7b11cf5b9ce43bc300b549397ac9"
+    },
+    {
+      "path": "docs/gentle-ai/review-integration.md",
+      "type": "file",
+      "mode": "0644",
+      "size": 1484,
+      "digest": "sha256:c8d3189e66aa0cfb9a2ed3856f816e14cb88a474e4242e37306fab603eabe2ba"
+    }
+  ],
+  "generated": [
+    {
+      "path": "capabilities/review-integration-v2.semantic.json",
+      "sha256": "sha256:d626daf0bca02326373bfddf62e858f7392edac26f6927abd217ff9a3e8a187a"
+    },
+    {
+      "path": "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+      "sha256": "sha256:9fe23ab8dea0fb0a0d687d119e88c08ee9b9bc4ed3b3c9fd1d122399e7e577de"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/binding-revision-conflict.fixture.json",
+      "sha256": "sha256:c2e294843cee5185324cb7a41702574ef94852517239d99e7493a1414a60b363"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.1.fixture.json",
+      "sha256": "sha256:1b3dc40dce7bfb5d3ecc7e92af68d66e71b733ba0b0f71ba94d3c633adc48bcf"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.2.fixture.json",
+      "sha256": "sha256:2970d21cd95a7fcaea6547c47a591a5151046e7ede658b3e8c5b9a9c5d106b65"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.3.fixture.json",
+      "sha256": "sha256:0ec783ea13b4c82c0b002c5caa758f33e2b488537297cc2d0694ec92176ac0cb"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.4.fixture.json",
+      "sha256": "sha256:84e0db457b76b97b35c2be772dfc647f9eab66810ea98f64fed85645c3c266ba"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities-v1.5.fixture.json",
+      "sha256": "sha256:0cc952af3767c393bde9e4785e4071615a529fd672bc94da4fcc204780524a27"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/capabilities.fixture.json",
+      "sha256": "sha256:b3ca822189a236f2d891628c665ca23e308bf5185a1701e1f07231bd970461bb"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/consent.fixture.json",
+      "sha256": "sha256:b2ff4809b9eb75a54206800dca13f96396976aca7387e45f765ac6ec98029cd1"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/failure.fixture.json",
+      "sha256": "sha256:e72b6ab5e3c529abac47bd324444f84ca90f67ef0a67189f5fd8d24d199a2759"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/final-verification-incident.fixture.json",
+      "sha256": "sha256:f8bc06549e62b0bee5cf2ecde625e18da178dd18c9d3023b7d7e8fd0ebbba646"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/operation.fixture.json",
+      "sha256": "sha256:3547748a4df57382178064abbdb1cf12f1d58a75c0e9d6452fdd9beb3aaeac3a"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/repair-preflight.fixture.json",
+      "sha256": "sha256:7168cb53ad470066d0b3edc3b7911d1aebff91abd41ecc3d822f8ffa5cea6cb1"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/start-v2.fixture.json",
+      "sha256": "sha256:388c7c21374b89afe2d42d64bd1987d17ec0e2c7151cab1c56a08969ffb2ea0e"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/start.fixture.json",
+      "sha256": "sha256:f369160ac26eb3427b57de2dd01c9d8c81e51c8a2bd546446780129d31b1945b"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-ambiguous.fixture.json",
+      "sha256": "sha256:ee695fd58ba72adfb3b51dfd16432a177498173a45bfcb594d6bdc53bfa32e6e"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-corrupted.fixture.json",
+      "sha256": "sha256:4cfc0048c28a39cec8a32fecfaad66e56e5c1248263ceb4ce66b6717981880b2"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-recover.fixture.json",
+      "sha256": "sha256:714f762f72380ce93d567626cafbaa536ab3aae02af73d3d40ca123f1f30d8b0"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-unrelated.fixture.json",
+      "sha256": "sha256:deab36c877ced3c9b480ca33724c10d88f75c761d6426fa14be850345122891d"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-ambiguous.fixture.json",
+      "sha256": "sha256:80a459a7a18d8d933dd42acb6a94a75ac19278e9a6c3b125e3017946768eaa47"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-corrupted.fixture.json",
+      "sha256": "sha256:466f1e28b101e95178630f26a90fff96ad3516e2aa6a17f5f357bab9bda2ab52"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-final-verification-retry.fixture.json",
+      "sha256": "sha256:889ede9a84bdbe561df2d2401adda95634582c44db9d1075ba839f33d65c7886"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-recover.fixture.json",
+      "sha256": "sha256:178331fc7177d2316fd4f56610ac295f7da2780be96b233b72935d5f476610f2"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-repair.fixture.json",
+      "sha256": "sha256:89083cad752fca38da09e919825d0b80641a8a029364ba1869e5b58ef2e59a1d"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2-unrelated.fixture.json",
+      "sha256": "sha256:c178b338dcd5d30888acef37a9d752bd0932d6dedfffb61b0596a9cceabeb692"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status-v2.fixture.json",
+      "sha256": "sha256:5410d8bbae1b7152a43b3a5c4c880e9e98a5e47b76d910456f5ef13f19836f3a"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/status.fixture.json",
+      "sha256": "sha256:555054d8046a896162995dcb117752f9cd1ef903fb9ebaad29af1b7e7f319bb3"
+    },
+    {
+      "path": "contracts/review-integration/v1/fixtures/verification-evidence.fixture.json",
+      "sha256": "sha256:b30e3863548845b90e256d92193435d02da458bf8f15a4c33d023cd1f6894a5f"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/admitted-result.schema.json",
+      "sha256": "sha256:7796e8dbba331434594108c902dfab7ec46f691fa447a9259a78f2448111b0de"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/artifact-subject.schema.json",
+      "sha256": "sha256:f7dcd934e27e8f3735a37f3d0ec8048dd8ccc1811b9df61124a1dcbf8a03f40e"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/authority-repair-assessment.schema.json",
+      "sha256": "sha256:232591670009f99c53a68e91d1e7e60465c294f1721f493ab1e7ae182842cfb5"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.1.schema.json",
+      "sha256": "sha256:2b14162284f375f8563e49d3a28caaa0aabb572094d8d290eb61844b1353af78"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.2.schema.json",
+      "sha256": "sha256:df1722adcd9c999edbef090bfd5d9a9713f6852a9bc9cb79684ef7c9c91c0d62"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.3.schema.json",
+      "sha256": "sha256:3401a062fa8a034ef7743f84adbfdd2ceadaf81bee8a7e62115fd4e18afacfcd"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.4.schema.json",
+      "sha256": "sha256:926b61c8ac0f870f09214f6bd8af1b035c5b72f14f0b83c0d4a7bdbb277f5447"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities-v1.5.schema.json",
+      "sha256": "sha256:abc783821524dcc33339495284805a85f79b3352efb7358c95016ed164bd7f24"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/capabilities.schema.json",
+      "sha256": "sha256:ad333177494a251beac153f74bd751fa77126a9968aad69e64fc2abf15cff0f7"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/consent.schema.json",
+      "sha256": "sha256:f8f2edec17568124488482c2aee399909111fe0cce2cba426fb29efd2c7c1cd0"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/failure.schema.json",
+      "sha256": "sha256:0ce29f61408fc21d72640fffdb215a608a820c29f3e5ff62d9cc295ed0451937"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/final-verification-incident.schema.json",
+      "sha256": "sha256:39b1ec178b1d3bc8da9a3d92dadd8092385000f2a6930b5bfcb4a84dbc6493ca"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/operation.schema.json",
+      "sha256": "sha256:6cf15b54977fea7301b9a5c766e709f8a912fda33560365de6dfcab4d2ecbce0"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/projection.schema.json",
+      "sha256": "sha256:7168a3eba929dde2b8f0b7723ee51d5a5421102bdeefe892578c263debd08db2"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/repair.schema.json",
+      "sha256": "sha256:febb747dc68f8ded5974b6dd94051ec3cfdb5a886ccb853b1ce53aaf2e41efc0"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/result-artifact-v2.schema.json",
+      "sha256": "sha256:38895aae2f6ca4980b1a8e157fee8503920820d5f6be3c757c0fa04e8430cd6b"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/result-artifact.schema.json",
+      "sha256": "sha256:91296bd2c261fd2fe03bffd63efe58badd4927e0d0d8480cd4213f651ecacdf6"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/start-v2.schema.json",
+      "sha256": "sha256:ec8550cd93bbe84af1ce87dfd7abfa9e24692f42b20f8f0bf9cac1d4b88ea46c"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/start.schema.json",
+      "sha256": "sha256:4296aebbd4128ce51945a2f6d3228aa77ac7215c802978d559bff5279ec56229"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/status-v2.schema.json",
+      "sha256": "sha256:63e8988ce276d948ea8305008a3d27c4e26dff664cf54fffed9e188f465d92d1"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/status.schema.json",
+      "sha256": "sha256:67f3bddf5f5feeb3213bce489de8548546163b2e1d49a0e3965c0091dabc8c39"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/targeted-validation-request.schema.json",
+      "sha256": "sha256:52b91154693b4dd66983fc91ecf7197503555f2c9e85cac626cffd3035c53d65"
+    },
+    {
+      "path": "contracts/review-integration/v1/schemas/verification-evidence.schema.json",
+      "sha256": "sha256:fd15890bf2ef1db95d771ee7f468e9e64014351d7940f65604eb24f41e68a22f"
+    },
+    {
+      "path": "contracts/review-integration/v2/fixtures/capabilities.fixture.json",
+      "sha256": "sha256:17c150d851c15b3f0c20d18c2e2741eb2232ffa24f35aa71d6d30e90a85e42b7"
+    },
+    {
+      "path": "contracts/review-integration/v2/fixtures/consent.fixture.json",
+      "sha256": "sha256:203cc96d5c29ba0f27b5c4db04c2e88566e0a923d3a0cdb317f78d9065349075"
+    },
+    {
+      "path": "contracts/review-integration/v2/fixtures/start.fixture.json",
+      "sha256": "sha256:34b21328fa910e03af2fac8e816c5b510ba146201da0cd4ef1693d39a6344ba0"
+    },
+    {
+      "path": "contracts/review-integration/v2/fixtures/status.fixture.json",
+      "sha256": "sha256:d5438578f2969f17635fecea94c7ef46d14c78fa668e50df48c4254254d5e935"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/admitted-result.schema.json",
+      "sha256": "sha256:c6a9c880191d65c46d9cfc8a0812af16b636573a8f6e57ea34aa16d6f6bb9735"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/artifact-subject.schema.json",
+      "sha256": "sha256:3e71a81340ea6149b03afa71530d10ce654c415fa21d4e07f0c9c25b3d2d70a3"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/capabilities.schema.json",
+      "sha256": "sha256:7ab061ed27bd3b929d6033cc20f56097e851f4454ca14a815255748b50191248"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/consent.schema.json",
+      "sha256": "sha256:b2b4465338497f11927de91cb2e5da12b6cb4a1039afe05aebe1abbf53b21858"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/failure.schema.json",
+      "sha256": "sha256:1c53da8c543cc5e03fbbfc700d4fc80cadb3b0e5e72c6d77a7790008671d0962"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/operation.schema.json",
+      "sha256": "sha256:beee02046ec1d5b8c89e3d7de35f897c275830e43c67ecd162886bfd0138ace6"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/repair.schema.json",
+      "sha256": "sha256:9e842d1ded797a91ede16b2054a38708b2d1fc7a0d6217541f84c0f2f5a2e73e"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/start.schema.json",
+      "sha256": "sha256:86ddfcfe1912489abef7461613d692ea53a4d7d73d444d5f6dbbd7f9866a2c37"
+    },
+    {
+      "path": "contracts/review-integration/v2/schemas/status.schema.json",
+      "sha256": "sha256:132b15dd7a0514aa451373bd4b3c02a1491b7b11cf5b9ce43bc300b549397ac9"
+    },
+    {
+      "path": "docs/gentle-ai/review-integration.md",
+      "sha256": "sha256:c8d3189e66aa0cfb9a2ed3856f816e14cb88a474e4242e37306fab603eabe2ba"
+    }
+  ]
+}

--- a/capabilities/gentle-ai-release.lock.json
+++ b/capabilities/gentle-ai-release.lock.json
@@ -1,4 +1,8 @@
 {
+  "evidence": {
+    "class": "development/bootstrap",
+    "signatureStatus": "not-applicable/local-unsigned"
+  },
   "release": {
     "repository": "Gentleman-Programming/gentle-ai",
     "tag": "v2.2.3",

--- a/capabilities/review-integration-v2.semantic.json
+++ b/capabilities/review-integration-v2.semantic.json
@@ -1,0 +1,58 @@
+{
+  "schema": "gentle-ai.release-semantic-capabilities/v1",
+  "contract": "gentle-ai.review-integration/v2",
+  "protocol": { "major": 2, "minor": 0 },
+  "package": { "name": "gentle-ai", "version": "2.2.3", "release_channel": "stable" },
+  "operations": [
+    "review.bind_sdd",
+    "review.capabilities",
+    "review.finalize",
+    "review.repair",
+    "review.retry_final_verification",
+    "review.start",
+    "review.status",
+    "review.validate"
+  ],
+  "gates": ["post-apply", "pre-commit", "pre-push", "pre-pr", "release"],
+  "projections": ["staged", "workspace"],
+  "features": {
+    "mandatory": [
+      { "name": "compact_v2_authority", "supported": true, "requires": [] },
+      { "name": "exact_receipt_replay", "supported": true, "requires": ["compact_v2_authority"] },
+      { "name": "five_delivery_gates", "supported": true, "requires": ["compact_v2_authority"] },
+      { "name": "immutable_snapshot", "supported": true, "requires": [] },
+      { "name": "legacy_v1_target_scoped_read_only", "supported": true, "requires": ["target_scoped_status"] },
+      { "name": "repository_independent_capabilities", "supported": true, "requires": [] },
+      { "name": "restart_safe_projection", "supported": true, "requires": ["target_scoped_status"] },
+      { "name": "sdd_receipt_binding", "supported": true, "requires": ["compact_v2_authority"] },
+      { "name": "target_scoped_status", "supported": true, "requires": ["repository_independent_capabilities"] },
+      { "name": "uniform_failure_envelope", "supported": true, "requires": ["repository_independent_capabilities"] }
+    ],
+    "optional": [
+      { "name": "base_ref_workspace_overlay", "supported": true, "requires": ["immutable_snapshot", "restart_safe_projection"] },
+      { "name": "bounded_process_waits", "supported": true, "requires": ["uniform_failure_envelope"] },
+      { "name": "classified_authority_repair", "supported": true, "requires": ["native_next_transition", "uniform_failure_envelope"] },
+      { "name": "exact_gate_receipt_discovery", "supported": true, "requires": ["five_delivery_gates"] },
+      { "name": "native_frozen_candidate_context", "supported": true, "requires": ["immutable_snapshot"] },
+      { "name": "native_low_risk_verification", "supported": true, "requires": ["compact_v2_authority"] },
+      { "name": "native_next_transition", "supported": true, "requires": ["target_scoped_status"] },
+      { "name": "one_shot_final_verification_retry", "supported": true, "requires": ["compact_v2_authority", "exact_receipt_replay", "native_next_transition"] },
+      { "name": "opaque_repository_context", "supported": true, "requires": ["compact_v2_authority", "native_next_transition"] },
+      { "name": "outcome_bound_verification_evidence", "supported": true, "requires": ["compact_v2_authority", "native_next_transition"] },
+      { "name": "provider_artifact_admission", "supported": true, "requires": ["compact_v2_authority", "native_frozen_candidate_context", "opaque_repository_context"] },
+      { "name": "provider_targeted_validation_request", "supported": true, "requires": ["compact_v2_authority", "native_next_transition"] },
+      { "name": "recovered_correction_evidence", "supported": true, "requires": ["compact_v2_authority", "provider_targeted_validation_request"] },
+      { "name": "risk_reasons", "supported": true, "requires": ["repository_independent_capabilities"] },
+      { "name": "scope_change_diagnostics", "supported": true, "requires": ["uniform_failure_envelope"] },
+      { "name": "validating_result_reopen", "supported": true, "requires": ["compact_v2_authority", "provider_artifact_admission"] },
+      { "name": "provider_bound_native_git_context", "supported": true, "requires": ["native_frozen_candidate_context", "opaque_repository_context", "provider_artifact_admission"] }
+    ]
+  },
+  "compatibility": {
+    "minimum_protocol_major": 2,
+    "maximum_protocol_major": 2,
+    "additive_minor_policy": "optional-fields-only",
+    "unknown_mandatory": "reject",
+    "unknown_optional": "ignore"
+  }
+}

--- a/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json
+++ b/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gentle-ai.dev/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+  "title": "Gentle AI release artifact manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "contract", "release", "layout", "archive", "references", "tree", "compatibility", "entries"
+  ],
+  "properties": {
+    "schema": {"const": "gentle-ai.release-artifact-manifest/v1"},
+    "contract": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "major", "minor", "schema_id", "schema_path"],
+      "properties": {
+        "id": {"const": "gentle-ai.release-artifact"},
+        "major": {"type": "integer", "minimum": 1},
+        "minor": {"type": "integer", "minimum": 0},
+        "schema_id": {"type": "string", "minLength": 1},
+        "schema_path": {"type": "string", "minLength": 1}
+      }
+    },
+    "release": {
+      "type": "object", "additionalProperties": false,
+      "required": ["repository", "tag", "version", "commit"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "tag": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+      }
+    },
+    "layout": {
+      "type": "object", "additionalProperties": false,
+      "required": ["version"],
+      "properties": {"version": {"type": "integer", "minimum": 1}}
+    },
+    "archive": {
+      "type": "object", "additionalProperties": false,
+      "required": ["asset", "digest_source"],
+      "properties": {
+        "asset": {"type": "string", "minLength": 1},
+        "digest_source": {"const": "signed-checksums.txt"}
+      }
+    },
+    "references": {
+      "type": "object", "additionalProperties": false,
+      "required": ["semantic_snapshots", "contracts"],
+      "properties": {
+        "semantic_snapshots": {
+          "type": "array", "minItems": 1,
+          "items": {
+            "type": "object", "additionalProperties": false,
+            "required": ["contract", "path", "schema"],
+            "properties": {
+              "contract": {"type": "string", "minLength": 1},
+              "path": {"type": "string", "minLength": 1},
+              "schema": {"const": "gentle-ai.release-semantic-capabilities/v1"}
+            }
+          }
+        },
+        "contracts": {
+          "type": "array", "minItems": 1,
+          "items": {
+            "type": "object", "additionalProperties": false,
+            "required": ["id", "root"],
+            "properties": {
+              "id": {"type": "string", "minLength": 1},
+              "root": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      }
+    },
+    "tree": {
+      "type": "object", "additionalProperties": false,
+      "required": ["algorithm", "canonicalization", "manifest_included", "digest"],
+      "properties": {
+        "algorithm": {"const": "sha256"},
+        "canonicalization": {"const": "gentle-ai.release-artifact-tree/v1"},
+        "manifest_included": {"const": false},
+        "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+      }
+    },
+    "compatibility": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "minimum_contract_major", "maximum_contract_major", "additive_minor_policy", "unknown_mandatory",
+        "unknown_optional"
+      ],
+      "properties": {
+        "minimum_contract_major": {"type": "integer", "minimum": 1},
+        "maximum_contract_major": {"type": "integer", "minimum": 1},
+        "additive_minor_policy": {"const": "optional-fields-only"},
+        "unknown_mandatory": {"const": "reject"},
+        "unknown_optional": {"const": "ignore"}
+      }
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": ["path", "type", "mode", "size", "digest"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1, "maxLength": 1024},
+          "type": {"const": "file"},
+          "mode": {"const": "0644"},
+          "size": {"type": "integer", "minimum": 0},
+          "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+        }
+      }
+    }
+  }
+}

--- a/docs/gentle-ai/review-integration.md
+++ b/docs/gentle-ai/review-integration.md
@@ -1,0 +1,28 @@
+<!--
+This file mirrors gentle-ai's own review-integration documentation. It is
+written only by scripts/sync-gentle-ai-release.mjs and MUST NOT be hand-edited
+(see openspec/changes/consume-gentle-ai-release-artifacts/design.md D6).
+
+Bootstrap-evidence notice: this copy was materialized from a local, unsigned
+`--bootstrap-archive` sync run (development/bootstrap evidence class) because
+gentle-ai has not yet published a signed release under the
+`gentle-ai.release-artifact` contract this mirror is sourced from. It proves
+the mirror-writing and lock-reconciliation mechanism only and carries no
+release, pin, or final-acceptance evidence. Re-run
+`node scripts/sync-gentle-ai-release.mjs --write` against a live signed
+release to replace it with real `release`-class content once one is
+published.
+-->
+
+# Review Integration Contract (provider mirror)
+
+This is a provider-mirrored copy of gentle-ai's review-integration contract
+documentation, checked in for offline reference alongside the byte-identical
+`contracts/review-integration/{v1,v2}/**` schemas and fixtures. gentle-pi's
+own consumer-facing guide lives at [`../review-integration.md`](../review-integration.md)
+and is authored separately; the two are not the same document and are not
+kept byte-identical to each other.
+
+Once gentle-ai publishes the first signed `gentle-ai.release-artifact`
+release, this file is replaced verbatim by the sync script with the
+provider's real published documentation for the pinned version.

--- a/openspec/changes/consume-gentle-ai-release-artifacts/apply-progress.md
+++ b/openspec/changes/consume-gentle-ai-release-artifacts/apply-progress.md
@@ -1,6 +1,7 @@
 # Apply Progress: consume-gentle-ai-release-artifacts
 
-> Scope of this batch: **PR 1 / P1a only** — tasks 1.1 through 1.8. P1b and later are NOT started.
+> Cumulative across batches: **PR 1 / P1a** (tasks 1.1-1.8, complete) and **PR 2 / P1b**
+> (tasks 2.1-2.10, complete). PR 3 (P2a) and later are NOT started.
 
 ## Completed Tasks
 
@@ -62,18 +63,141 @@ None material. Two implementation choices fill gaps the design left open (design
 
 None. One environment note, not a code issue: this worktree had no `.gentle-ai/` runtime binary installed at session start (fresh worktree, `pnpm install` never ran), which cascaded into ~16 unrelated pre-existing test-file failures across the full `pnpm test` suite. Running `pnpm install` (triggered incidentally by `pnpm run check:transaction-runner`) installed the pinned binary via `postinstall` and resolved all of them except the three failures already called out as expected (RDD globally disabled) in `tests/native-review-parity-runtime.test.ts`. Verified via `git stash` that this file is bit-for-bit unmodified by this PR and the same three-failure result reproduces on the clean tree.
 
-## Remaining Tasks (P1b and later — not started)
+## Remaining Tasks (P1a and P1b are both complete)
 
-- [ ] 2.1-2.10 (PR 2 / P1b): signed sync path, mirrors, canonical lock, `verify-package-files.mjs` reconciliation, evidence-S/R labeling, CI wiring.
+- [x] 2.1-2.10 (PR 2 / P1b): signed sync path, mirrors, canonical lock, `verify-package-files.mjs` reconciliation, evidence-S/R labeling, CI wiring.
 - [ ] 3.1-8.5 (PR 3-8 / P2a through P4): out of scope for this batch.
 
-## Workload / PR Boundary
+## Workload / PR Boundary (P1a)
 
 - Mode: feature-branch-chain, `size:exception` per tasks.md's Review Workload Forecast (`Delivery strategy: exception-ok`)
 - Current work unit: P1a (PR 1, base: tracker branch `feat/consume-gentle-ai-release-artifacts`)
 - Boundary: starts and ends entirely within `lib/release-artifact.ts` + its generated runtime + its tests/fixtures; touches exactly one existing line in `scripts/build-git-commit-transaction-runner.mjs` (`sources` list). No mirrors, lock, installer, or CI file touched.
 - Estimated review budget impact: forecast ~250 changed lines for P1a; actual added/modified lines stay in that neighborhood (one new ~520-line lib file is generator-mirrored, not duplicated authored content — the `runtime/*.mjs` counterpart is machine-generated).
 
-## Status
+## Status (P1a)
 
-8/8 tasks in PR 1 (P1a) complete. Ready for `sdd-verify`, or for `sdd-apply` to continue with PR 2 (P1b) in a fresh batch.
+8/8 tasks in PR 1 (P1a) complete.
+
+---
+
+# PR 2 / P1b: Signed sync path + mirrors + canonical lock
+
+> Base: PR 1's branch (`feat/release-artifact-decoder`). Builds on `lib/release-artifact.ts` (owns D1
+> steps 6-11) — this unit owns D1 steps 1-5, the network/pin-time trust boundary.
+
+## Completed Tasks
+
+- [x] 2.1 RED: `scripts/sync-gentle-ai-release.mjs` tests (`tests/sync-gentle-ai-release.test.ts`) — forged minisign signature (wrong signing key, tampered message, tampered trusted comment, each independently rejected); wrong trusted-comment repo/tag binding rejected (repo mismatch and tag mismatch as distinct cases); missing checksum line rejected; duplicate checksum line rejected.
+- [x] 2.2 GREEN: `scripts/sync-gentle-ai-release.mjs` created — a from-scratch minisign verifier (Ed25519 wire-format parser + `node:crypto` verify, no third-party dependency), checksums.txt line matcher, trusted-comment repo/tag binder, and `syncGentleAiRelease()` orchestration implementing D1 steps 1-5 (resolve pinned identity, download or accept `--bootstrap-archive`, verify signature + binding, match the one checksum line, verify archive digest) before delegating to `lib/release-artifact.ts` for D1 steps 6-11 and D2 extraction.
+- [x] 2.3 GREEN: mirrors written by running `sync-gentle-ai-release.mjs --write --bootstrap-archive <archive>` for real against a locally-built archive (see "Materializing the initial mirror + lock" below) — `contracts/review-integration/{v1,v2}/**` (64 files, byte-identical to the content that previously lived in the hand-maintained `contractHashes` map — verified via `git status`: zero diff on any existing tracked file), plus three new files this unit introduces: `contracts/release-artifact/v1/schemas/artifact-manifest.schema.json`, `capabilities/review-integration-v2.semantic.json`, `docs/gentle-ai/review-integration.md`.
+- [x] 2.4 GREEN: `capabilities/gentle-ai-release.lock.json` created by the same sync run — canonical LF-only, 2-space indent, `entries`/`generated` sorted by raw path bytes (`buildGentleAiReleaseLock`), exactly one trailing LF (`canonicalLockJson`). `assertLockVersionPin`/`assertLockReleaseVersionPin` assert `lock.release.version === INSTALLER_VERSION` both at write time (sync script) and at every offline check (`verify-package-files.mjs`).
+- [x] 2.5 RED: `scripts/verify-package-files.mjs` reconciliation tests added to `tests/verify-package-files.test.ts` — a file on disk under `docs/gentle-ai/` unlisted in the lock fails naming it; a lock entry with no file on disk under `capabilities/` fails naming it (while correctly excluding the lock file itself and the future hand-authored `capabilities/native-cli-history.json`); a digest drift fails naming the exact file and both digests.
+- [x] 2.6 GREEN: `scripts/verify-package-files.mjs` — the ~60-entry hand-maintained `contractHashes` map deleted entirely; `reconcileContractsOnDisk` extended (same function name/pattern, not reinvented) to walk `MIRROR_WALK_ROOTS = ["contracts", "docs/gentle-ai", "capabilities"]` with an explicit exclusion set for non-mirror files; digests now come from `mirrorDigestsFromLock(lock)`, reading `capabilities/gentle-ai-release.lock.json` instead of a hardcoded table.
+- [x] 2.7 RED: evidence-S/R labeling tests in `tests/sync-gentle-ai-release.test.ts` — a `syncGentleAiRelease` run against `--bootstrap-archive` returns `evidenceClass: "development/bootstrap"`, and `assertReleaseAcceptanceEvidence` (imported from `lib/release-artifact.ts`, P1a) throws on that result naming it barred from pin/final-acceptance evidence; proven both with `write: true` (mirrors+lock written) and `write: false`.
+- [x] 2.8 GREEN: evidence labeling wired directly into `syncGentleAiRelease` — the bootstrap branch calls `resolveBootstrapArtifactSource` (P1a) and propagates its `evidenceClass`/`signatureStatus` verbatim into the result; the network branch stamps `evidenceClass: "release"`, `signatureStatus: "verified"` only after minisign + trusted-comment + checksum-line + archive-digest all pass. This matches explore.md §11's S-vs-R ledger table exactly (the section originally numbered §12 in the pre-rewrite plan).
+- [x] 2.9 GREEN: `.github/workflows/ci.yml` — added a clarifying comment above the existing "Verify package contents" step: it now performs offline mirror/lock reconciliation as part of `verify-package-files.mjs`, and no job in this workflow downloads or verifies a minisign signature (that stays confined to the not-yet-landed pin-bump job, P4).
+- [x] 2.10 Verify: `pnpm test` → 1065/1069 passing (3 known RDD-disabled failures in `tests/native-review-parity-runtime.test.ts`, file bit-for-bit unmodified by this PR; 1 pre-existing unrelated skip); `node scripts/verify-package-files.mjs --check` → `gentle-pi package resource check passed (69 files; 66 lock-pinned mirror artifacts at release v2.2.3).`, run with no network access available to the process.
+
+## Materializing the initial mirror + lock (task 2.3/2.4 — how, and why it is safe)
+
+No real signed gentle-ai release exists yet under the `gentle-ai.release-artifact` contract (that is
+entirely the provider-side `publish-gentle-ai-release-artifacts` change, out of scope here), so tasks
+2.3/2.4's "write mirrors" / "create the lock" could not be satisfied by a real `--write` network run in
+this session. Instead, an uncommitted, one-off local script built a `development/bootstrap` archive
+from:
+
+1. **The existing real `contracts/review-integration/{v1,v2}/**` files, byte-for-byte unchanged** — read
+   directly off disk and re-packed into the archive, so running the sync script against them is a
+   verified no-op. Confirmed via `git status --short` after the sync run: zero modified lines on any
+   previously-tracked file, only new files/directories appear.
+2. **Three genuinely new mirror files** this unit introduces: the schema mirror (reusing P1a's
+   already-established fixture bytes for this exact contract, `tests/fixtures/release-artifact/artifact-manifest.schema.json`), a semantic capability snapshot (`capabilities/review-integration-v2.semantic.json`, built from the real, already-checked-in v2 capability surface — same operations/gates/projections/features already present in `contracts/review-integration/v2/fixtures/capabilities.fixture.json`, re-labeled under the release-semantic-capabilities schema and the real pinned `2.2.3` version), and a placeholder provider-doc mirror (`docs/gentle-ai/review-integration.md`) carrying an explicit HTML-comment bootstrap-evidence notice.
+3. `node scripts/sync-gentle-ai-release.mjs --write --bootstrap-archive <archive>` then ran for real
+   against that archive, exercising the actual production write path (not a test double) to produce the
+   checked-in mirror tree and `capabilities/gentle-ai-release.lock.json`.
+
+This checked-in lock is **development/bootstrap evidence**, not release evidence — `syncGentleAiRelease`'s
+returned `evidenceClass` for this exact run was `"development/bootstrap"`, and
+`assertReleaseAcceptanceEvidence` throws on it. It proves the mirror-writing and lock-reconciliation
+mechanism end-to-end and pins today's already-correct mirror bytes; it must be **regenerated** by a real
+`--write` network run once gentle-ai publishes a signed release under this contract (P4's pin-bump job).
+No test, doc, or commit in this unit claims otherwise.
+
+## Design decision: the minisign trusted public key is a pending sentinel, not a placeholder key
+
+`GENTLE_AI_RELEASE_TRUSTED_PUBLIC_KEY = GENTLE_AI_RELEASE_TRUSTED_PUBLIC_KEY_PENDING` (a sentinel string,
+mirroring the existing `GENTLE_AI_PENDING_DIGEST` pattern in `scripts/gentle-ai-installer.mjs`). The
+network branch of `syncGentleAiRelease` throws immediately — before any fetch — while this sentinel is in
+place: `scripts/sync-gentle-ai-release.mjs cannot verify a live release: the trusted minisign public key
+is still the pending sentinel; pin the real gentle-ai release signing key before running a network sync`.
+Verified manually: calling `syncGentleAiRelease({ packageRoot, write: false })` with no `bootstrapArchivePath` throws exactly this message with zero network activity. Filling in the real key is P4/pin-bump-job
+work (tracked, not fabricated here) — no invented key is shipped that could later be confused for the
+real one.
+
+## Deviations from Design
+
+None material to D1/D6. Two scope clarifications, not deviations:
+
+1. **Minisign implementation is hand-written, not a library.** Design's rejected-alternatives table only
+   discusses avoiding a JSON-Schema validator inside the *install* trust path (`ajv`); it does not name a
+   minisign dependency choice for the *sync* script. A from-scratch Ed25519/minisign wire-format
+   verifier (`node:crypto` only, no new dependency) was chosen for the same reasoning the design applies
+   elsewhere: the sync script is a small, auditable, pin-bump-only surface, and a general-purpose
+   minisign npm package would be a larger, less-audited dependency for a ~60-line wire format.
+2. **`reconcileContractsOnDisk` gained a third parameter shape internally (`MIRROR_WALK_ROOTS`,
+   `MIRROR_WALK_EXCLUSIONS`), not a new function.** Task 2.6 explicitly says "via `reconcileContractsOnDisk`" — the exported name, call sites, and 2-argument public signature are unchanged; only its internal walk now covers `docs/gentle-ai/` and `capabilities/` (with exclusions for the lock file itself and the future hand-authored `capabilities/native-cli-history.json`) in addition to the original `contracts/` root.
+
+## Issues Found (and fixed as part of this unit)
+
+1. **P1a gap surfaced by actually running `verify-package-files.mjs` end-to-end for the first time**:
+   `runtime/release-artifact.mjs` and `lib/release-artifact.ts` were never added to
+   `requiredPaths`/the three-way generated-runtime reconciliation, so the script failed immediately with
+   `release-artifact: missing from requiredPaths`. Fixed by adding both entries (one-line each) — this is
+   a correctness fix to existing P1a output, not new P1b scope creep; noted here for traceability.
+2. **`capabilities/` was missing from `package.json`'s `files` allowlist.** Added, since the lock and
+   semantic snapshot must ship in the published npm package like every other mirror directory.
+3. No other issues. The three RDD-disabled `tests/native-review-parity-runtime.test.ts` failures are
+   expected environment state (receipt-driven development is globally disabled here) — confirmed
+   unmodified by `git diff --stat -- tests/native-review-parity-runtime.test.ts runtime/` (zero output).
+
+## TDD Cycle Evidence (P1b)
+
+| Task | Test File | Layer | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|-----|-------|-------------|----------|
+| 2.1 | `tests/sync-gentle-ai-release.test.ts` | Unit | ✅ Written (`ERR_MODULE_NOT_FOUND` against `scripts/sync-gentle-ai-release.mjs` before it existed) | ✅ 18/18 pure-function tests pass | ✅ forged-signature covered 3 ways (wrong key, tampered message, tampered trusted comment); trusted-comment binding covered 2 ways (wrong repo, wrong tag); checksum line covered 3 ways (missing, duplicate, exact match) | ✅ Clean — parser/verifier/binder are small pure functions, no duplication |
+| 2.2 | `tests/sync-gentle-ai-release.test.ts` | Unit + orchestration | ✅ Written before `syncGentleAiRelease` existed | ✅ bootstrap-path orchestration test passes against a real system-`tar` archive | ✅ `write: true` and `write: false` both covered | ✅ Clean — network branch and bootstrap branch share the same post-extraction write/lock path |
+| 2.3/2.4 | manual production run (`node scripts/sync-gentle-ai-release.mjs --write --bootstrap-archive`) + `tests/sync-gentle-ai-release.test.ts` lock-shape tests | Integration (real tar, real filesystem) | N/A — generation task | ✅ mirrors + lock written; `git status` shows zero diff on pre-existing tracked files | ➖ single real run, no branching to triangulate | N/A |
+| 2.5 | `tests/verify-package-files.test.ts` | Unit | ✅ Written (`reconcileContractsOnDisk`/`mirrorDigestDrift`/`mirrorDigestsFromLock`/`assertLockReleaseVersionPin` referenced before they existed with the new mirror-root behavior) | ✅ 13/13 tests pass | ✅ unlisted-on-disk, listed-but-missing, and digest-drift each independently proven, plus the lock-derivation and version-pin functions in isolation | ✅ Clean — reconciliation, drift, lock-derivation, and version-pin are four separate small functions |
+| 2.6 | `tests/verify-package-files.test.ts` (existing 7 tests) | Regression | N/A (existing tests) | ✅ all 7 pre-existing tests still pass unmodified against the rewritten implementation | N/A | ✅ ~60-line hand-maintained map deleted; behavior fully covered by lock-derived tests instead |
+| 2.7/2.8 | `tests/sync-gentle-ai-release.test.ts` | Unit + orchestration | ✅ Written referencing `RELEASE_ARTIFACT_EVIDENCE_CLASS.BOOTSTRAP` / `assertReleaseAcceptanceEvidence` before the orchestration wired them | ✅ both tests pass | ✅ proven with `write: true` (mirrors+lock side effects) and `write: false` (no side effects) | ✅ Clean — evidence labeling is a straight pass-through from `resolveBootstrapArtifactSource`, no duplicated logic |
+| 2.9 | N/A — documentation/comment only | N/A | N/A | ✅ comment added, `pnpm test` and `verify-package-files.mjs --check` both still pass | N/A | N/A |
+| 2.10 | Full suite | Integration | N/A | ✅ `pnpm test` 1065/1069 (3 expected RDD-disabled + 1 pre-existing unrelated skip); `verify-package-files.mjs --check` passes offline | N/A | N/A |
+
+## Test Summary (P1b)
+
+- **New test files**: `tests/sync-gentle-ai-release.test.ts` (18 tests)
+- **Extended test files**: `tests/verify-package-files.test.ts` (+6 tests: 13 total, up from 7)
+- **Total P1b tests**: 24 new, all passing
+- **Full repo suite**: 1065/1069 passing (3 known RDD-disabled, 1 pre-existing unrelated skip) — unchanged failure set from the P1a baseline
+
+## Work Unit Evidence (P1b)
+
+| Evidence | Value |
+|---|---|
+| Focused test command and exact result | `node --experimental-strip-types --test tests/verify-package-files.test.ts tests/sync-gentle-ai-release.test.ts` → `pass 31 fail 0` |
+| Runtime harness command/scenario and exact result | N/A — offline gate, no live binary invocation (per tasks.md's own Suggested Work Units table for P1b). Confirmed instead via `node scripts/verify-package-files.mjs --check` → `gentle-pi package resource check passed (69 files; 66 lock-pinned mirror artifacts at release v2.2.3).`, and via a direct manual call proving the network path fails closed with zero network activity while the trusted-key sentinel is in place. |
+| Rollback boundary | Delete `scripts/sync-gentle-ai-release.mjs`, `tests/sync-gentle-ai-release.test.ts`, `capabilities/`, `contracts/release-artifact/`, `docs/gentle-ai/`; revert `scripts/verify-package-files.mjs`, `tests/verify-package-files.test.ts`, `package.json` (`capabilities/` files entry), `.github/workflows/ci.yml` (comment only) to restore the hand-maintained `contractHashes` map. No file outside this list is touched by this PR. |
+
+## Workload / PR Boundary (P1b)
+
+- Mode: feature-branch-chain, `size:exception` (tasks.md: `Delivery strategy: exception-ok`)
+- Current work unit: P1b (PR 2, base: PR 1's branch `feat/release-artifact-decoder`)
+- Boundary: `scripts/sync-gentle-ai-release.mjs` (new), `scripts/verify-package-files.mjs` (rewritten reconciliation only — `requiredPaths`/`files` additions are the sole P1a-gap fix folded in), their tests, the new mirror tree (`capabilities/`, `contracts/release-artifact/`, `docs/gentle-ai/`), `package.json` (`files` entry), and a comment-only `.github/workflows/ci.yml` change. No installer, binary-resolution, or generator file touched — those are P2a/P2b/P3a scope.
+- Estimated review budget impact: tasks.md forecast ~320 changed lines for P1b. Authored diff across `.github/workflows/ci.yml`, `package.json`, `scripts/verify-package-files.mjs`, `tests/verify-package-files.test.ts` is ~174 lines changed (`git diff --stat`); `scripts/sync-gentle-ai-release.mjs` (356 lines) and `tests/sync-gentle-ai-release.test.ts` (320 lines) are new files. The generated mirror tree (`capabilities/`, `contracts/release-artifact/`, `docs/gentle-ai/`) is excluded from authored risk count per the review workload guard's "generated goldens are excluded from authored risk count" rule — these are sync-script-written mirror/lock artifacts, not hand-authored logic.
+
+## Status (P1b)
+
+10/10 tasks in PR 2 (P1b) complete. 18/18 tasks total across P1a+P1b. Ready for `sdd-verify`, or for
+`sdd-apply` to continue with PR 3 (P2a) in a fresh batch. Task 3.1's guard is already satisfied:
+`consolidate-review-parity-runtime` is archived (`openspec/changes/archive/2026-08-01-consolidate-review-parity-runtime/`) and `openspec/specs/package-runtime/spec.md` exists — confirmed present in this worktree, so PR 3/PR 4 (P2a/P2b) may open without the stall escape hatch.

--- a/openspec/changes/consume-gentle-ai-release-artifacts/tasks.md
+++ b/openspec/changes/consume-gentle-ai-release-artifacts/tasks.md
@@ -46,16 +46,16 @@ Chain strategy: feature-branch-chain
 
 ## PR 2 — P1b: Signed sync path + mirrors + canonical lock (Req: "Offline mirrors and a canonical lock bind provider identity"; "Bootstrap snapshot evidence never substitutes for release evidence")
 
-- [ ] 2.1 RED: `scripts/sync-gentle-ai-release.mjs` tests (threat-matrix: network trust boundary) — forged minisign signature rejected; wrong trusted-comment repo/tag binding rejected; missing checksum line rejected; duplicate checksum line rejected.
-- [ ] 2.2 GREEN: create `scripts/sync-gentle-ai-release.mjs` (`--write`, pin-bump job only, network) — downloads `checksums.txt`/`.minisig`/archive, runs D1 trust order via `lib/release-artifact.ts`, writes mirrors + lock.
-- [ ] 2.3 GREEN: write mirrors — `contracts/review-integration/{v1,v2}/**`, `contracts/release-artifact/v1/schemas/artifact-manifest.schema.json`, `capabilities/review-integration-v2.semantic.json`, `docs/gentle-ai/review-integration.md`.
-- [ ] 2.4 GREEN: create `capabilities/gentle-ai-release.lock.json` (canonical LF, 2-space, path-sorted, one trailing LF); assert `lock.release.version === INSTALLER_VERSION`.
-- [ ] 2.5 RED: `scripts/verify-package-files.mjs` reconciliation tests — unlisted-on-disk mirror file, listed-but-missing file, and digest drift each fail naming the exact file.
-- [ ] 2.6 GREEN: `scripts/verify-package-files.mjs` — delete the ~60-entry `contractHashes` map; reconcile on-disk mirrors against `lock.entries` via `reconcileContractsOnDisk`.
-- [ ] 2.7 RED: evidence-S/R labeling test — a sync result run against `--bootstrap-archive` is labeled `development/bootstrap` and never relabeled as release evidence.
-- [ ] 2.8 GREEN: wire evidence labeling into `sync-gentle-ai-release.mjs` (plan §12 ledger shape).
-- [ ] 2.9 GREEN: `.github/workflows/ci.yml` — add offline mirror/lock reconciliation to the per-PR gate; only the pin-bump job invokes `sync-gentle-ai-release.mjs --write` with network.
-- [ ] 2.10 Verify: `pnpm test`; `node scripts/verify-package-files.mjs --check` offline, no network access.
+- [x] 2.1 RED: `scripts/sync-gentle-ai-release.mjs` tests (threat-matrix: network trust boundary) — forged minisign signature rejected; wrong trusted-comment repo/tag binding rejected; missing checksum line rejected; duplicate checksum line rejected.
+- [x] 2.2 GREEN: create `scripts/sync-gentle-ai-release.mjs` (`--write`, pin-bump job only, network) — downloads `checksums.txt`/`.minisig`/archive, runs D1 trust order via `lib/release-artifact.ts`, writes mirrors + lock.
+- [x] 2.3 GREEN: write mirrors — `contracts/review-integration/{v1,v2}/**`, `contracts/release-artifact/v1/schemas/artifact-manifest.schema.json`, `capabilities/review-integration-v2.semantic.json`, `docs/gentle-ai/review-integration.md`.
+- [x] 2.4 GREEN: create `capabilities/gentle-ai-release.lock.json` (canonical LF, 2-space, path-sorted, one trailing LF); assert `lock.release.version === INSTALLER_VERSION`.
+- [x] 2.5 RED: `scripts/verify-package-files.mjs` reconciliation tests — unlisted-on-disk mirror file, listed-but-missing file, and digest drift each fail naming the exact file.
+- [x] 2.6 GREEN: `scripts/verify-package-files.mjs` — delete the ~60-entry `contractHashes` map; reconcile on-disk mirrors against `lock.entries` via `reconcileContractsOnDisk`.
+- [x] 2.7 RED: evidence-S/R labeling test — a sync result run against `--bootstrap-archive` is labeled `development/bootstrap` and never relabeled as release evidence.
+- [x] 2.8 GREEN: wire evidence labeling into `sync-gentle-ai-release.mjs` (plan §12 ledger shape).
+- [x] 2.9 GREEN: `.github/workflows/ci.yml` — add offline mirror/lock reconciliation to the per-PR gate; only the pin-bump job invokes `sync-gentle-ai-release.mjs --write` with network.
+- [x] 2.10 Verify: `pnpm test`; `node scripts/verify-package-files.mjs --check` offline, no network access.
 
 ## PR 3 — P2a: POSIX assets install + integrity manifest + resolver (depends: sibling `consolidate-review-parity-runtime` archived)
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "files": [
     "assets/",
+    "capabilities/",
     "contracts/",
     "docs/",
     "extensions/",

--- a/scripts/sync-gentle-ai-release.mjs
+++ b/scripts/sync-gentle-ai-release.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+// Pin-time trust boundary (design D1 steps 1-5) and offline mirror/lock
+// writer (design D6). This is the ONLY place in gentle-pi that downloads a
+// gentle-ai release or verifies a minisign signature. It runs exclusively in
+// the pin-bump job (P4, not yet landed) or manually by a maintainer; every
+// other CI job — including this repository's own per-PR gate — stays fully
+// offline against the mirrors and capabilities/gentle-ai-release.lock.json
+// this script writes.
+//
+// A local, explicitly-passed `--bootstrap-archive <path>` (never
+// auto-discovered — see lib/release-artifact.ts resolveBootstrapArtifactSource)
+// skips the network and signature verification entirely and stamps the
+// result `development/bootstrap`: it proves decoder, layout, extraction, and
+// mirror-writing behavior only. It can never serve as release, pin, or
+// final-acceptance evidence — assertReleaseAcceptanceEvidence throws on it,
+// and this script never relabels it. Only a live `--write` run against a
+// real signed release produces `release` evidence.
+
+import { createHash, createPublicKey, verify as cryptoVerify } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import https from "node:https";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+	RELEASE_ARTIFACT_EVIDENCE_CLASS,
+	createSystemReleaseArtifactExtractor,
+	extractReleaseArtifact,
+	resolveBootstrapArtifactSource,
+} from "../lib/release-artifact.ts";
+import { INSTALLER_VERSION } from "./gentle-ai-installer.mjs";
+
+export const GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH = "capabilities/gentle-ai-release.lock.json";
+export const GENTLE_AI_RELEASE_BASE_URL = `https://github.com/Gentleman-Programming/gentle-ai/releases/download/v${INSTALLER_VERSION}/`;
+export const GENTLE_AI_RELEASE_REPOSITORY = "Gentleman-Programming/gentle-ai";
+export const GENTLE_AI_RELEASE_ASSET_NAME = `gentle-ai_${INSTALLER_VERSION}_assets.tar.gz`;
+
+// Sentinel for the not-yet-pinned minisign trusted public key. gentle-ai has
+// not yet published a signed release under the `gentle-ai.release-artifact`
+// contract this module consumes (that work is tracked entirely in the
+// provider-side `publish-gentle-ai-release-artifacts` change, out of scope
+// here). A network `--write` run fails closed while this sentinel is in
+// place, mirroring the GENTLE_AI_PENDING_DIGEST pattern in
+// scripts/gentle-ai-installer.mjs, rather than trusting a placeholder key
+// that could later be mistaken for the real one.
+export const GENTLE_AI_RELEASE_TRUSTED_PUBLIC_KEY_PENDING = "PENDING-GENTLE-AI-RELEASE-MINISIGN-PUBLIC-KEY";
+export const GENTLE_AI_RELEASE_TRUSTED_PUBLIC_KEY = GENTLE_AI_RELEASE_TRUSTED_PUBLIC_KEY_PENDING;
+
+const MAX_TEXT_ASSET_BYTES = 1 * 1024 * 1024;
+const MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
+
+// --- minisign wire format ---------------------------------------------------
+//
+// minisign's on-disk formats (github.com/jedisct1/minisign, SIGNATURE.md):
+//   public key file: "untrusted comment: ...\n<base64: 2B algorithm + 8B key id + 32B key>\n"
+//   signature file:  "untrusted comment: ...\n<base64: 2B algorithm + 8B key id + 64B sig>\n"
+//                     "trusted comment: <comment>\n<base64: 64B global signature>\n"
+// The global signature covers (the 74-byte decoded signature line || the raw
+// UTF-8 bytes of the trusted comment, without the "trusted comment: " prefix
+// or trailing newline).
+
+const MINISIGN_ALGORITHM = "Ed";
+// Fixed 12-byte DER prefix for an Ed25519 SubjectPublicKeyInfo (OID
+// 1.3.101.112), so a raw 32-byte minisign public key can be handed to
+// node:crypto's createPublicKey without a general-purpose ASN.1 encoder.
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function nonEmptyLines(text) {
+	return text.trim().split(/\r?\n/).filter((line) => line.length > 0);
+}
+
+export function parseMinisignPublicKey(publicKeyText) {
+	const lines = nonEmptyLines(publicKeyText);
+	if (lines.length < 2) throw new Error("minisign public key must have an untrusted comment line and a key line");
+	const raw = Buffer.from(lines[1], "base64");
+	if (raw.length !== 42) throw new Error("minisign public key must decode to 42 bytes (2 algorithm + 8 key id + 32 key)");
+	const algorithm = raw.subarray(0, 2).toString("latin1");
+	if (algorithm !== MINISIGN_ALGORITHM) throw new Error(`unsupported minisign public key algorithm: ${JSON.stringify(algorithm)}`);
+	return { keyId: raw.subarray(2, 10), publicKeyBytes: raw.subarray(10, 42) };
+}
+
+export function parseMinisignSignature(signatureText) {
+	const lines = nonEmptyLines(signatureText);
+	if (lines.length !== 4) throw new Error("minisign signature file must have exactly 4 non-empty lines");
+	const [, signatureLine, trustedCommentLine, globalSignatureLine] = lines;
+	if (!trustedCommentLine.startsWith("trusted comment: ")) throw new Error("minisign signature file is missing the trusted comment line");
+	const signedBytes = Buffer.from(signatureLine, "base64");
+	if (signedBytes.length !== 74) throw new Error("minisign signature line must decode to 74 bytes (2 algorithm + 8 key id + 64 signature)");
+	const algorithm = signedBytes.subarray(0, 2).toString("latin1");
+	if (algorithm !== MINISIGN_ALGORITHM) throw new Error(`unsupported minisign signature algorithm: ${JSON.stringify(algorithm)}`);
+	const globalSignature = Buffer.from(globalSignatureLine, "base64");
+	if (globalSignature.length !== 64) throw new Error("minisign global signature must decode to 64 bytes");
+	return {
+		keyId: signedBytes.subarray(2, 10),
+		signature: signedBytes.subarray(10, 74),
+		signedBytes,
+		trustedComment: trustedCommentLine.slice("trusted comment: ".length),
+		globalSignature,
+	};
+}
+
+function importEd25519PublicKey(rawPublicKeyBytes) {
+	return createPublicKey({ key: Buffer.concat([ED25519_SPKI_PREFIX, rawPublicKeyBytes]), format: "der", type: "spki" });
+}
+
+// Verifies BOTH the message signature and the global signature (which binds
+// the trusted comment to the same key), and returns the trusted comment on
+// success. Any structural defect, key mismatch, or forged/tampered signature
+// throws — this is the D1 step-3 gate that runs before any extracted byte is
+// trusted.
+export function verifyMinisignSignature(messageBytes, signatureText, publicKeyText) {
+	const { publicKeyBytes } = parseMinisignPublicKey(publicKeyText);
+	const parsed = parseMinisignSignature(signatureText);
+	const publicKey = importEd25519PublicKey(publicKeyBytes);
+	if (!cryptoVerify(null, messageBytes, publicKey, parsed.signature)) {
+		throw new Error("minisign signature verification failed: the message does not match the signature under the trusted public key");
+	}
+	const globalMessage = Buffer.concat([parsed.signedBytes, Buffer.from(parsed.trustedComment, "utf8")]);
+	if (!cryptoVerify(null, globalMessage, publicKey, parsed.globalSignature)) {
+		throw new Error("minisign global signature verification failed: the trusted comment does not match its signature under the trusted public key");
+	}
+	return { trustedComment: parsed.trustedComment };
+}
+
+// --- trusted-comment repo/tag binding ---------------------------------------
+
+export function parseTrustedCommentFields(trustedComment) {
+	const fields = new Map();
+	for (const token of trustedComment.split("\t")) {
+		const separatorIndex = token.indexOf(":");
+		if (separatorIndex === -1) continue;
+		fields.set(token.slice(0, separatorIndex), token.slice(separatorIndex + 1));
+	}
+	return fields;
+}
+
+export function assertTrustedCommentBinding(trustedComment, expected) {
+	const fields = parseTrustedCommentFields(trustedComment);
+	const repo = fields.get("repo");
+	if (repo !== expected.repository) {
+		throw new Error(`minisign trusted comment repo ${JSON.stringify(repo)} does not match the expected repository ${JSON.stringify(expected.repository)}`);
+	}
+	const tag = fields.get("tag");
+	if (tag !== expected.tag) {
+		throw new Error(`minisign trusted comment tag ${JSON.stringify(tag)} does not match the expected tag ${JSON.stringify(expected.tag)}`);
+	}
+}
+
+// --- checksums.txt line matching (D1 step 4) --------------------------------
+
+const CHECKSUM_LINE = /^([0-9a-f]{64})\s+(\S+)$/;
+
+export function findChecksumLine(checksumsText, assetName) {
+	const matches = [];
+	for (const line of nonEmptyLines(checksumsText)) {
+		const match = CHECKSUM_LINE.exec(line.trim());
+		if (match && match[2] === assetName) matches.push(match[1]);
+	}
+	if (matches.length === 0) throw new Error(`no checksum line found for ${JSON.stringify(assetName)} in checksums.txt`);
+	if (matches.length > 1) throw new Error(`duplicate checksum lines found for ${JSON.stringify(assetName)} in checksums.txt`);
+	return matches[0];
+}
+
+// --- canonical lock (design D6) ---------------------------------------------
+
+function byRawPath(a, b) {
+	return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+}
+
+export function buildGentleAiReleaseLock(manifest, generatedEntries, { archiveSha256 }) {
+	return {
+		release: { ...manifest.release },
+		contract: {
+			id: manifest.contract.id,
+			major: manifest.contract.major,
+			minor: manifest.contract.minor,
+			schemaId: manifest.contract.schemaId,
+			schemaPath: manifest.contract.schemaPath,
+			layoutVersion: manifest.layout.version,
+		},
+		archive: { asset: manifest.archive.asset, sha256: archiveSha256, digestSource: manifest.archive.digestSource },
+		tree: { algorithm: manifest.tree.algorithm, canonicalization: manifest.tree.canonicalization, digest: manifest.tree.digest },
+		entries: [...manifest.entries].sort(byRawPath).map((entry) => ({ path: entry.path, type: entry.type, mode: entry.mode, size: entry.size, digest: entry.digest })),
+		generated: [...generatedEntries].sort(byRawPath).map((entry) => ({ path: entry.path, sha256: entry.sha256 })),
+	};
+}
+
+export function canonicalLockJson(lock) {
+	return `${JSON.stringify(lock, null, 2)}\n`;
+}
+
+export function assertLockVersionPin(lock, installerVersion) {
+	if (lock.release.version !== installerVersion) {
+		throw new Error(`capabilities/gentle-ai-release.lock.json release.version ${JSON.stringify(lock.release.version)} does not match the authoritative scripts/gentle-ai-installer.mjs INSTALLER_VERSION ${JSON.stringify(installerVersion)}`);
+	}
+}
+
+// --- network fetch ports (D1 steps 1-2, injectable for tests) --------------
+
+function fetchOverHttps(url, maxBytes) {
+	return new Promise((resolve, reject) => {
+		https.get(url, { headers: { "user-agent": "gentle-pi-sync-gentle-ai-release" } }, (response) => {
+			const status = response.statusCode ?? 0;
+			if (status !== 200) {
+				response.resume();
+				reject(new Error(`gentle-ai release sync download failed with HTTP ${status} for ${url}`));
+				return;
+			}
+			const chunks = [];
+			let received = 0;
+			response.on("data", (chunk) => {
+				received += chunk.length;
+				if (received > maxBytes) {
+					response.destroy(new Error(`gentle-ai release sync download exceeds the maximum allowed size for ${url}`));
+					return;
+				}
+				chunks.push(chunk);
+			});
+			response.on("error", reject);
+			response.on("end", () => resolve(Buffer.concat(chunks)));
+		}).on("error", reject);
+	});
+}
+
+async function defaultFetchText(url) {
+	return (await fetchOverHttps(url, MAX_TEXT_ASSET_BYTES)).toString("utf8");
+}
+
+async function defaultDownloadArchive(url, destination) {
+	const bytes = await fetchOverHttps(url, MAX_DOWNLOAD_BYTES);
+	await new Promise((resolve, reject) => {
+		const output = createWriteStream(destination, { flags: "wx", mode: 0o600 });
+		output.on("error", reject);
+		output.on("finish", resolve);
+		output.end(bytes);
+	});
+}
+
+// --- orchestration (D1 steps 1-5 network trust order + D6 mirror/lock write) ---
+
+async function sha256OfFile(path) {
+	return `sha256:${createHash("sha256").update(await readFile(path)).digest("hex")}`;
+}
+
+export async function syncGentleAiRelease(options) {
+	const {
+		packageRoot,
+		bootstrapArchivePath,
+		write = false,
+		trustedPublicKey = GENTLE_AI_RELEASE_TRUSTED_PUBLIC_KEY,
+		expectedRepository = GENTLE_AI_RELEASE_REPOSITORY,
+		expectedTag = `v${INSTALLER_VERSION}`,
+		assetName = GENTLE_AI_RELEASE_ASSET_NAME,
+		releaseBaseUrl = GENTLE_AI_RELEASE_BASE_URL,
+		installerVersion = INSTALLER_VERSION,
+		fetchText = defaultFetchText,
+		downloadArchive = defaultDownloadArchive,
+		extractor = createSystemReleaseArtifactExtractor(),
+	} = options;
+
+	let archivePath;
+	let evidenceClass;
+	let signatureStatus;
+	let networkTempDir;
+
+	if (bootstrapArchivePath !== undefined) {
+		const source = resolveBootstrapArtifactSource(bootstrapArchivePath);
+		archivePath = source.archivePath;
+		evidenceClass = source.evidenceClass;
+		signatureStatus = source.signatureStatus;
+	} else {
+		if (trustedPublicKey === GENTLE_AI_RELEASE_TRUSTED_PUBLIC_KEY_PENDING) {
+			throw new Error("scripts/sync-gentle-ai-release.mjs cannot verify a live release: the trusted minisign public key is still the pending sentinel; pin the real gentle-ai release signing key before running a network sync");
+		}
+		networkTempDir = await mkdtemp(join(tmpdir(), "gentle-pi-sync-gentle-ai-release-network-"));
+		const checksumsText = await fetchText(`${releaseBaseUrl}checksums.txt`);
+		const minisigText = await fetchText(`${releaseBaseUrl}checksums.txt.minisig`);
+		const verified = verifyMinisignSignature(Buffer.from(checksumsText, "utf8"), minisigText, trustedPublicKey);
+		assertTrustedCommentBinding(verified.trustedComment, { repository: expectedRepository, tag: expectedTag });
+		const expectedDigest = findChecksumLine(checksumsText, assetName);
+		archivePath = join(networkTempDir, assetName);
+		await downloadArchive(`${releaseBaseUrl}${assetName}`, archivePath);
+		const actualDigest = (await sha256OfFile(archivePath)).slice("sha256:".length);
+		if (actualDigest !== expectedDigest) {
+			throw new Error(`gentle-ai release assets archive digest mismatch for ${assetName}: signed checksums.txt declares ${expectedDigest}, downloaded archive is ${actualDigest}`);
+		}
+		evidenceClass = RELEASE_ARTIFACT_EVIDENCE_CLASS.RELEASE;
+		signatureStatus = "verified";
+	}
+
+	const stagingTempDir = await mkdtemp(join(tmpdir(), "gentle-pi-sync-gentle-ai-release-staging-"));
+	try {
+		const { manifest } = await extractReleaseArtifact(archivePath, stagingTempDir, { extractor });
+		const archiveSha256 = await sha256OfFile(archivePath);
+
+		let lockPath;
+		const writtenPaths = [];
+		if (write) {
+			if (packageRoot === undefined) throw new Error("syncGentleAiRelease requires packageRoot when write is true");
+			const generated = [];
+			for (const entry of manifest.entries) {
+				const bytes = await readFile(join(stagingTempDir, entry.path));
+				const destination = join(packageRoot, entry.path);
+				await mkdir(dirname(destination), { recursive: true });
+				await writeFile(destination, bytes, { mode: 0o644 });
+				generated.push({ path: entry.path, sha256: `sha256:${createHash("sha256").update(bytes).digest("hex")}` });
+				writtenPaths.push(entry.path);
+			}
+
+			const lock = buildGentleAiReleaseLock(manifest, generated, { archiveSha256 });
+			assertLockVersionPin(lock, installerVersion);
+			lockPath = join(packageRoot, GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH);
+			await mkdir(dirname(lockPath), { recursive: true });
+			await writeFile(lockPath, canonicalLockJson(lock), { mode: 0o644 });
+			writtenPaths.push(GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH);
+		}
+
+		return { manifest, evidenceClass, signatureStatus, lockPath, writtenPaths };
+	} finally {
+		await rm(stagingTempDir, { recursive: true, force: true });
+		if (networkTempDir) await rm(networkTempDir, { recursive: true, force: true });
+	}
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+function parseArguments(argv) {
+	const write = argv.includes("--write");
+	const flagIndex = argv.indexOf("--bootstrap-archive");
+	const bootstrapArchivePath = flagIndex === -1 ? undefined : argv[flagIndex + 1];
+	if (flagIndex !== -1 && (bootstrapArchivePath === undefined || bootstrapArchivePath.startsWith("--"))) {
+		throw new Error("usage: sync-gentle-ai-release.mjs --write [--bootstrap-archive <path>]");
+	}
+	if (!write) {
+		throw new Error("usage: sync-gentle-ai-release.mjs --write [--bootstrap-archive <path>]");
+	}
+	return { write, bootstrapArchivePath };
+}
+
+async function main() {
+	const { write, bootstrapArchivePath } = parseArguments(process.argv.slice(2));
+	const packageRoot = join(dirname(new URL(import.meta.url).pathname), "..");
+	const result = await syncGentleAiRelease({ packageRoot, write, bootstrapArchivePath });
+	process.stdout.write(
+		`gentle-ai release sync complete: evidence class ${result.evidenceClass}, ${result.writtenPaths.length} paths written\n`,
+	);
+}
+
+const isMainModule = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMainModule) {
+	main().catch((error) => {
+		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/sync-gentle-ai-release.mjs
+++ b/scripts/sync-gentle-ai-release.mjs
@@ -168,8 +168,14 @@ function byRawPath(a, b) {
 	return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
 }
 
-export function buildGentleAiReleaseLock(manifest, generatedEntries, { archiveSha256 }) {
+// The evidence class is persisted into the lock rather than only carried on the
+// in-memory sync result. A reader that only has the file on disk must still be
+// able to refuse it as pin or final-acceptance evidence: a bootstrap lock whose
+// `release.commit` is a placeholder and whose `archive.digestSource` reads
+// "signed-checksums.txt" is otherwise indistinguishable from a real one.
+export function buildGentleAiReleaseLock(manifest, generatedEntries, { archiveSha256, evidenceClass, signatureStatus }) {
 	return {
+		evidence: { class: evidenceClass, signatureStatus },
 		release: { ...manifest.release },
 		contract: {
 			id: manifest.contract.id,
@@ -308,7 +314,7 @@ export async function syncGentleAiRelease(options) {
 				writtenPaths.push(entry.path);
 			}
 
-			const lock = buildGentleAiReleaseLock(manifest, generated, { archiveSha256 });
+			const lock = buildGentleAiReleaseLock(manifest, generated, { archiveSha256, evidenceClass, signatureStatus });
 			assertLockVersionPin(lock, installerVersion);
 			lockPath = join(packageRoot, GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH);
 			await mkdir(dirname(lockPath), { recursive: true });

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH } from "./sync-gentle-ai-release.mjs";
 
 const root = join(fileURLToPath(new URL("..", import.meta.url)));
 
@@ -43,15 +44,18 @@ const requiredPaths = [
   "lib/gentle-ai-binary.ts",
   "lib/git-commit-transaction.ts",
   "lib/native-review-cli.ts",
+  "lib/release-artifact.ts",
   "lib/review-integration-v2.ts",
   "lib/sdd-preflight.ts",
 	"runtime/gentle-ai-binary.mjs",
 	"runtime/git-commit-transaction.mjs",
 	"runtime/native-review-cli.mjs",
+	"runtime/release-artifact.mjs",
 	"runtime/review-integration-v2.mjs",
 	"scripts/build-git-commit-transaction-runner.mjs",
   "scripts/gentle-ai-installer.mjs",
   "scripts/install-gentle-ai.mjs",
+  "scripts/sync-gentle-ai-release.mjs",
   "scripts/run-git-commit-transaction.mjs",
 	"scripts/test-packed-runner.mjs",
   "tests/fixtures/native-review-cli/v2.1.3/start.json",
@@ -75,74 +79,25 @@ const requiredPaths = [
   "skills/work-unit-commits/SKILL.md",
 ];
 
-const contractHashes = {
-  "contracts/review-integration/v1/fixtures/binding-revision-conflict.fixture.json": "c2e294843cee5185324cb7a41702574ef94852517239d99e7493a1414a60b363",
-  "contracts/review-integration/v1/fixtures/capabilities-v1.1.fixture.json": "1b3dc40dce7bfb5d3ecc7e92af68d66e71b733ba0b0f71ba94d3c633adc48bcf",
-  "contracts/review-integration/v1/fixtures/capabilities-v1.2.fixture.json": "2970d21cd95a7fcaea6547c47a591a5151046e7ede658b3e8c5b9a9c5d106b65",
-  "contracts/review-integration/v1/fixtures/capabilities-v1.3.fixture.json": "0ec783ea13b4c82c0b002c5caa758f33e2b488537297cc2d0694ec92176ac0cb",
-  "contracts/review-integration/v1/fixtures/capabilities-v1.4.fixture.json": "84e0db457b76b97b35c2be772dfc647f9eab66810ea98f64fed85645c3c266ba",
-  "contracts/review-integration/v1/fixtures/capabilities-v1.5.fixture.json": "0cc952af3767c393bde9e4785e4071615a529fd672bc94da4fcc204780524a27",
-  "contracts/review-integration/v1/fixtures/capabilities.fixture.json": "b3ca822189a236f2d891628c665ca23e308bf5185a1701e1f07231bd970461bb",
-  "contracts/review-integration/v1/fixtures/consent.fixture.json": "b2ff4809b9eb75a54206800dca13f96396976aca7387e45f765ac6ec98029cd1",
-  "contracts/review-integration/v1/fixtures/failure.fixture.json": "e72b6ab5e3c529abac47bd324444f84ca90f67ef0a67189f5fd8d24d199a2759",
-  "contracts/review-integration/v1/fixtures/final-verification-incident.fixture.json": "f8bc06549e62b0bee5cf2ecde625e18da178dd18c9d3023b7d7e8fd0ebbba646",
-  "contracts/review-integration/v1/fixtures/operation.fixture.json": "3547748a4df57382178064abbdb1cf12f1d58a75c0e9d6452fdd9beb3aaeac3a",
-  "contracts/review-integration/v1/fixtures/repair-preflight.fixture.json": "7168cb53ad470066d0b3edc3b7911d1aebff91abd41ecc3d822f8ffa5cea6cb1",
-  "contracts/review-integration/v1/fixtures/start-v2.fixture.json": "388c7c21374b89afe2d42d64bd1987d17ec0e2c7151cab1c56a08969ffb2ea0e",
-  "contracts/review-integration/v1/fixtures/start.fixture.json": "f369160ac26eb3427b57de2dd01c9d8c81e51c8a2bd546446780129d31b1945b",
-  "contracts/review-integration/v1/fixtures/status-ambiguous.fixture.json": "ee695fd58ba72adfb3b51dfd16432a177498173a45bfcb594d6bdc53bfa32e6e",
-  "contracts/review-integration/v1/fixtures/status-corrupted.fixture.json": "4cfc0048c28a39cec8a32fecfaad66e56e5c1248263ceb4ce66b6717981880b2",
-  "contracts/review-integration/v1/fixtures/status-recover.fixture.json": "714f762f72380ce93d567626cafbaa536ab3aae02af73d3d40ca123f1f30d8b0",
-  "contracts/review-integration/v1/fixtures/status-unrelated.fixture.json": "deab36c877ced3c9b480ca33724c10d88f75c761d6426fa14be850345122891d",
-  "contracts/review-integration/v1/fixtures/status-v2-ambiguous.fixture.json": "80a459a7a18d8d933dd42acb6a94a75ac19278e9a6c3b125e3017946768eaa47",
-  "contracts/review-integration/v1/fixtures/status-v2-corrupted.fixture.json": "466f1e28b101e95178630f26a90fff96ad3516e2aa6a17f5f357bab9bda2ab52",
-  "contracts/review-integration/v1/fixtures/status-v2-final-verification-retry.fixture.json": "889ede9a84bdbe561df2d2401adda95634582c44db9d1075ba839f33d65c7886",
-  "contracts/review-integration/v1/fixtures/status-v2-recover.fixture.json": "178331fc7177d2316fd4f56610ac295f7da2780be96b233b72935d5f476610f2",
-  "contracts/review-integration/v1/fixtures/status-v2-repair.fixture.json": "89083cad752fca38da09e919825d0b80641a8a029364ba1869e5b58ef2e59a1d",
-  "contracts/review-integration/v1/fixtures/status-v2-unrelated.fixture.json": "c178b338dcd5d30888acef37a9d752bd0932d6dedfffb61b0596a9cceabeb692",
-  "contracts/review-integration/v1/fixtures/status-v2.fixture.json": "5410d8bbae1b7152a43b3a5c4c880e9e98a5e47b76d910456f5ef13f19836f3a",
-  "contracts/review-integration/v1/fixtures/status.fixture.json": "555054d8046a896162995dcb117752f9cd1ef903fb9ebaad29af1b7e7f319bb3",
-  "contracts/review-integration/v1/fixtures/verification-evidence.fixture.json": "b30e3863548845b90e256d92193435d02da458bf8f15a4c33d023cd1f6894a5f",
-  "contracts/review-integration/v1/schemas/admitted-result.schema.json": "7796e8dbba331434594108c902dfab7ec46f691fa447a9259a78f2448111b0de",
-  "contracts/review-integration/v1/schemas/artifact-subject.schema.json": "f7dcd934e27e8f3735a37f3d0ec8048dd8ccc1811b9df61124a1dcbf8a03f40e",
-  "contracts/review-integration/v1/schemas/authority-repair-assessment.schema.json": "232591670009f99c53a68e91d1e7e60465c294f1721f493ab1e7ae182842cfb5",
-  "contracts/review-integration/v1/schemas/capabilities-v1.1.schema.json": "2b14162284f375f8563e49d3a28caaa0aabb572094d8d290eb61844b1353af78",
-  "contracts/review-integration/v1/schemas/capabilities-v1.2.schema.json": "df1722adcd9c999edbef090bfd5d9a9713f6852a9bc9cb79684ef7c9c91c0d62",
-  "contracts/review-integration/v1/schemas/capabilities-v1.3.schema.json": "3401a062fa8a034ef7743f84adbfdd2ceadaf81bee8a7e62115fd4e18afacfcd",
-  "contracts/review-integration/v1/schemas/capabilities-v1.4.schema.json": "926b61c8ac0f870f09214f6bd8af1b035c5b72f14f0b83c0d4a7bdbb277f5447",
-  "contracts/review-integration/v1/schemas/capabilities-v1.5.schema.json": "abc783821524dcc33339495284805a85f79b3352efb7358c95016ed164bd7f24",
-  "contracts/review-integration/v1/schemas/capabilities.schema.json": "ad333177494a251beac153f74bd751fa77126a9968aad69e64fc2abf15cff0f7",
-  "contracts/review-integration/v1/schemas/consent.schema.json": "f8f2edec17568124488482c2aee399909111fe0cce2cba426fb29efd2c7c1cd0",
-  "contracts/review-integration/v1/schemas/failure.schema.json": "0ce29f61408fc21d72640fffdb215a608a820c29f3e5ff62d9cc295ed0451937",
-  "contracts/review-integration/v1/schemas/final-verification-incident.schema.json": "39b1ec178b1d3bc8da9a3d92dadd8092385000f2a6930b5bfcb4a84dbc6493ca",
-  "contracts/review-integration/v1/schemas/operation.schema.json": "6cf15b54977fea7301b9a5c766e709f8a912fda33560365de6dfcab4d2ecbce0",
-  "contracts/review-integration/v1/schemas/projection.schema.json": "7168a3eba929dde2b8f0b7723ee51d5a5421102bdeefe892578c263debd08db2",
-  "contracts/review-integration/v1/schemas/repair.schema.json": "febb747dc68f8ded5974b6dd94051ec3cfdb5a886ccb853b1ce53aaf2e41efc0",
-  "contracts/review-integration/v1/schemas/result-artifact-v2.schema.json": "38895aae2f6ca4980b1a8e157fee8503920820d5f6be3c757c0fa04e8430cd6b",
-  "contracts/review-integration/v1/schemas/result-artifact.schema.json": "91296bd2c261fd2fe03bffd63efe58badd4927e0d0d8480cd4213f651ecacdf6",
-  "contracts/review-integration/v1/schemas/start-v2.schema.json": "ec8550cd93bbe84af1ce87dfd7abfa9e24692f42b20f8f0bf9cac1d4b88ea46c",
-  "contracts/review-integration/v1/schemas/start.schema.json": "4296aebbd4128ce51945a2f6d3228aa77ac7215c802978d559bff5279ec56229",
-  "contracts/review-integration/v1/schemas/status-v2.schema.json": "63e8988ce276d948ea8305008a3d27c4e26dff664cf54fffed9e188f465d92d1",
-  "contracts/review-integration/v1/schemas/status.schema.json": "67f3bddf5f5feeb3213bce489de8548546163b2e1d49a0e3965c0091dabc8c39",
-  "contracts/review-integration/v1/schemas/targeted-validation-request.schema.json": "52b91154693b4dd66983fc91ecf7197503555f2c9e85cac626cffd3035c53d65",
-  "contracts/review-integration/v1/schemas/verification-evidence.schema.json": "fd15890bf2ef1db95d771ee7f468e9e64014351d7940f65604eb24f41e68a22f",
-  "contracts/review-integration/v2/fixtures/capabilities.fixture.json": "17c150d851c15b3f0c20d18c2e2741eb2232ffa24f35aa71d6d30e90a85e42b7",
-  "contracts/review-integration/v2/fixtures/consent.fixture.json": "203cc96d5c29ba0f27b5c4db04c2e88566e0a923d3a0cdb317f78d9065349075",
-  "contracts/review-integration/v2/fixtures/start.fixture.json": "34b21328fa910e03af2fac8e816c5b510ba146201da0cd4ef1693d39a6344ba0",
-  "contracts/review-integration/v2/fixtures/status.fixture.json": "d5438578f2969f17635fecea94c7ef46d14c78fa668e50df48c4254254d5e935",
-  "contracts/review-integration/v2/schemas/admitted-result.schema.json": "c6a9c880191d65c46d9cfc8a0812af16b636573a8f6e57ea34aa16d6f6bb9735",
-  "contracts/review-integration/v2/schemas/artifact-subject.schema.json": "3e71a81340ea6149b03afa71530d10ce654c415fa21d4e07f0c9c25b3d2d70a3",
-  "contracts/review-integration/v2/schemas/capabilities.schema.json": "7ab061ed27bd3b929d6033cc20f56097e851f4454ca14a815255748b50191248",
-  "contracts/review-integration/v2/schemas/consent.schema.json": "b2b4465338497f11927de91cb2e5da12b6cb4a1039afe05aebe1abbf53b21858",
-  "contracts/review-integration/v2/schemas/failure.schema.json": "1c53da8c543cc5e03fbbfc700d4fc80cadb3b0e5e72c6d77a7790008671d0962",
-  "contracts/review-integration/v2/schemas/operation.schema.json": "beee02046ec1d5b8c89e3d7de35f897c275830e43c67ecd162886bfd0138ace6",
-  "contracts/review-integration/v2/schemas/repair.schema.json": "9e842d1ded797a91ede16b2054a38708b2d1fc7a0d6217541f84c0f2f5a2e73e",
-  "contracts/review-integration/v2/schemas/start.schema.json": "86ddfcfe1912489abef7461613d692ea53a4d7d73d444d5f6dbbd7f9866a2c37",
-  "contracts/review-integration/v2/schemas/status.schema.json": "132b15dd7a0514aa451373bd4b3c02a1491b7b11cf5b9ce43bc300b549397ac9",
-  "docs/review-integration.md": "189f9b128cafaf225d2b6be53111f893ca46eb687fb9e5e051a84727b6a34bbc",
-};
+// The lock's canonical relative path (capabilities/gentle-ai-release.lock.json).
+// The lock, written only by scripts/sync-gentle-ai-release.mjs, replaces the
+// hand-maintained ~60-entry contractHashes map this script used to carry:
+// every mirror digest below is now read from the lock instead. The lock's
+// checked-in release.version is asserted equal to the authoritative
+// INSTALLER_VERSION pin below (currently v2.2.3, #262) rather than repeating
+// the literal a second time.
+requiredPaths.push(GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH);
 
-requiredPaths.push(...Object.keys(contractHashes));
+// Full-mirror directories: every file under these roots is written only by
+// scripts/sync-gentle-ai-release.mjs and MUST appear in the lock's entries.
+// Any other on-disk file here is unlisted drift.
+const MIRROR_WALK_ROOTS = ["contracts", "docs/gentle-ai", "capabilities"];
+
+// Files that legitimately live inside a MIRROR_WALK_ROOTS directory but are
+// NOT provider mirror content, so the walk must not flag them as unlisted:
+// the lock itself, and capabilities/native-cli-history.json (design D6:
+// "hand-authored, append-only" — the 4 non-derivable envelope flags).
+const MIRROR_WALK_EXCLUSIONS = new Set([GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH, "capabilities/native-cli-history.json"]);
 
 function listFilesRecursively(directory) {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -152,19 +107,25 @@ function listFilesRecursively(directory) {
   });
 }
 
-// Walks `contracts/` on disk and reconciles it against `contractHashes`
-// (restricted to `contracts/**` keys — `docs/review-integration.md` is a
-// byte-pinned contract artifact but lives outside this walk root). Reports
-// the two drift directions separately so a new unlisted file and a stale
-// hash-map entry are both visible.
+// Walks every full-mirror directory (MIRROR_WALK_ROOTS) on disk and
+// reconciles it against the lock's digest map, extended with entries
+// declared under those roots but not walked (e.g. capabilities/*.semantic.json
+// alongside hand-authored capabilities/native-cli-history.json). Reports the
+// two drift directions separately so a new unlisted file and a lock entry
+// with no file on disk are both visible, each naming the exact file.
 export function reconcileContractsOnDisk(packageRoot, hashes) {
-  const contractsRoot = join(packageRoot, "contracts");
-  const walked = existsSync(contractsRoot)
-    ? listFilesRecursively(contractsRoot).map((absolutePath) =>
-        relative(packageRoot, absolutePath).split(sep).join("/"),
-      )
-    : [];
-  const listed = Object.keys(hashes).filter((relativePath) => relativePath.startsWith("contracts/"));
+  const underAnyMirrorRoot = (relativePath) => MIRROR_WALK_ROOTS.some((root) => relativePath === root || relativePath.startsWith(`${root}/`));
+
+  const walked = [];
+  for (const mirrorRoot of MIRROR_WALK_ROOTS) {
+    const absoluteRoot = join(packageRoot, mirrorRoot);
+    if (!existsSync(absoluteRoot)) continue;
+    for (const absolutePath of listFilesRecursively(absoluteRoot)) {
+      const relativePath = relative(packageRoot, absolutePath).split(sep).join("/");
+      if (!MIRROR_WALK_EXCLUSIONS.has(relativePath)) walked.push(relativePath);
+    }
+  }
+  const listed = Object.keys(hashes).filter(underAnyMirrorRoot);
   const walkedSet = new Set(walked);
   const listedSet = new Set(listed);
 
@@ -172,6 +133,35 @@ export function reconcileContractsOnDisk(packageRoot, hashes) {
     unlistedOnDisk: walked.filter((relativePath) => !listedSet.has(relativePath)).sort(),
     listedButMissing: listed.filter((relativePath) => !walkedSet.has(relativePath)).sort(),
   };
+}
+
+// Recomputes each listed mirror file's digest from disk and compares it
+// against the lock's recorded digest, returning one entry per drifted file
+// so the offline gate can name it exactly (never a silent pass on a single
+// aggregate boolean).
+export function mirrorDigestDrift(packageRoot, digests) {
+  return Object.entries(digests).flatMap(([relativePath, expected]) => {
+    const actual = `sha256:${createHash("sha256").update(readFileSync(join(packageRoot, relativePath))).digest("hex")}`;
+    return actual === expected ? [] : [{ relativePath, expected, actual }];
+  });
+}
+
+// Builds the `{ relativePath: "sha256:<hex>" }` digest map the reconciliation
+// and drift functions above consume, straight from the lock's canonical
+// entries — the lock IS the source of truth; nothing here is hand-maintained.
+export function mirrorDigestsFromLock(lock) {
+  return Object.fromEntries(lock.entries.map((entry) => [entry.path, entry.digest]));
+}
+
+// A gate asserts the checked-in lock's release version equals the one
+// authoritative INSTALLER_VERSION pin (#262), so the lock can never silently
+// drift from the version the rest of the installer trusts.
+export function assertLockReleaseVersionPin(lock, installerVersion) {
+  if (lock.release.version !== installerVersion) {
+    throw new Error(
+      `capabilities/gentle-ai-release.lock.json release.version ("${lock.release.version}") does not match the authoritative scripts/gentle-ai-installer.mjs INSTALLER_VERSION ("${installerVersion}")`,
+    );
+  }
 }
 
 // Compares every location that pins the Gentle AI version against the one
@@ -260,12 +250,16 @@ async function main() {
     process.exit(1);
   }
 
-  const { unlistedOnDisk, listedButMissing } = reconcileContractsOnDisk(root, contractHashes);
+  const lockPath = join(root, GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH);
+  const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+  const mirrorDigests = mirrorDigestsFromLock(lock);
+
+  const { unlistedOnDisk, listedButMissing } = reconcileContractsOnDisk(root, mirrorDigests);
   if (unlistedOnDisk.length > 0 || listedButMissing.length > 0) {
-    console.error("gentle-pi packaged contracts/ tree has drifted from contractHashes:");
+    console.error(`gentle-pi packaged mirror tree has drifted from ${GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH}:`);
     for (const relativePath of unlistedOnDisk) console.error(`- unlisted-on-disk: ${relativePath}`);
     for (const relativePath of listedButMissing) console.error(`- listed-but-missing: ${relativePath}`);
-    console.error("\nRefusing to pack/publish an unreconciled contracts/ tree.");
+    console.error("\nRefusing to pack/publish an unreconciled mirror tree.");
     process.exit(1);
   }
 
@@ -284,14 +278,11 @@ async function main() {
     process.exit(1);
   }
 
-  const driftedContracts = Object.entries(contractHashes).flatMap(([relativePath, expected]) => {
-    const actual = createHash("sha256").update(readFileSync(join(root, relativePath))).digest("hex");
-    return actual === expected ? [] : [{ relativePath, expected, actual }];
-  });
+  const driftedMirrors = mirrorDigestDrift(root, mirrorDigests);
 
-  if (driftedContracts.length > 0) {
-    console.error("gentle-pi packaged review-integration/v1 and review-integration/v2 contract bytes drifted from the byte-identical Gentle AI v2.2.3 contract:");
-    for (const drift of driftedContracts) console.error(`- ${drift.relativePath}: expected ${drift.expected}, got ${drift.actual}`);
+  if (driftedMirrors.length > 0) {
+    console.error(`gentle-pi packaged mirror bytes drifted from ${GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH}:`);
+    for (const drift of driftedMirrors) console.error(`- ${drift.relativePath}: expected ${drift.expected}, got ${drift.actual}`);
     process.exit(1);
   }
 
@@ -308,6 +299,13 @@ async function main() {
     console.error("gentle-pi Gentle AI release digests are not pinned SHA-256 values:");
     for (const entry of unpinnedDigests) console.error(`- ${entry}`);
     console.error("Refusing to pack/publish until scripts/gentle-ai-installer.mjs pins the published checksums.txt archive digests and extracted binary digests.");
+    process.exit(1);
+  }
+
+  try {
+    assertLockReleaseVersionPin(lock, INSTALLER_VERSION);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 
@@ -335,7 +333,7 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`gentle-pi package resource check passed (${requiredPaths.length} files; ${Object.keys(contractHashes).length} exact byte-identical v2.2.3 contract artifacts).`);
+  console.log(`gentle-pi package resource check passed (${requiredPaths.length} files; ${lock.entries.length} lock-pinned mirror artifacts at release v${lock.release.version}).`);
 }
 
 const isMainModule = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/tests/sync-gentle-ai-release.test.ts
+++ b/tests/sync-gentle-ai-release.test.ts
@@ -1,0 +1,320 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash, generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import {
+	RELEASE_ARTIFACT_MANIFEST_FILE_NAME,
+	RELEASE_ARTIFACT_TREE_CANONICALIZATION,
+	assertReleaseAcceptanceEvidence,
+	RELEASE_ARTIFACT_EVIDENCE_CLASS,
+	treeDigest,
+	type ArtifactEntry,
+} from "../lib/release-artifact.ts";
+import {
+	GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH,
+	assertLockVersionPin,
+	assertTrustedCommentBinding,
+	buildGentleAiReleaseLock,
+	canonicalLockJson,
+	findChecksumLine,
+	parseMinisignPublicKey,
+	parseMinisignSignature,
+	parseTrustedCommentFields,
+	syncGentleAiRelease,
+	verifyMinisignSignature,
+} from "../scripts/sync-gentle-ai-release.mjs";
+
+const execFileAsync = promisify(execFile);
+
+async function tempWorkspace(): Promise<string> {
+	return mkdtemp(join(tmpdir(), "gentle-pi-sync-gentle-ai-release-"));
+}
+
+// --- minisign wire-format test helpers ------------------------------------
+// These build byte-identical minisign public key / signature files from a
+// locally generated Ed25519 keypair, so the parser and verifier can be
+// proven correct without depending on gentle-ai's real (not-yet-existing)
+// signing key. The wire format itself is minisign's documented format:
+// 2-byte algorithm "Ed" + 8-byte key id + payload, base64-encoded on one
+// line, preceded by an "untrusted comment:" line and followed (for
+// signatures) by a "trusted comment:" line and a base64 global signature
+// line covering (signature bytes || trusted comment bytes).
+
+const MINISIGN_ALGORITHM = Buffer.from("Ed", "latin1");
+
+function minisignKeyId(seed: number): Buffer {
+	const id = Buffer.alloc(8);
+	id.writeUInt32LE(seed, 0);
+	return id;
+}
+
+function buildMinisignPublicKeyText(publicKeyBytes: Buffer, keyId: Buffer): string {
+	const line = Buffer.concat([MINISIGN_ALGORITHM, keyId, publicKeyBytes]).toString("base64");
+	return `untrusted comment: minisign public key ${keyId.toString("hex")}\n${line}\n`;
+}
+
+function buildMinisignSignatureText(message: Buffer, trustedComment: string, privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"], keyId: Buffer): string {
+	const signature = cryptoSign(null, message, privateKey);
+	const signatureLineBytes = Buffer.concat([MINISIGN_ALGORITHM, keyId, signature]);
+	const trustedCommentBytes = Buffer.from(trustedComment, "utf8");
+	const globalSignature = cryptoSign(null, Buffer.concat([signatureLineBytes, trustedCommentBytes]), privateKey);
+	return [
+		"untrusted comment: minisign signature",
+		signatureLineBytes.toString("base64"),
+		`trusted comment: ${trustedComment}`,
+		globalSignature.toString("base64"),
+		"",
+	].join("\n");
+}
+
+function generateTestKeypair(seed: number) {
+	const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+	const rawPublicKey = publicKey.export({ type: "spki", format: "der" }).subarray(12);
+	const keyId = minisignKeyId(seed);
+	return {
+		privateKey,
+		keyId,
+		publicKeyText: buildMinisignPublicKeyText(rawPublicKey, keyId),
+	};
+}
+
+// --- minisign parsing (task 2.1) ------------------------------------------
+
+test("parseMinisignPublicKey decodes algorithm, key id, and raw 32-byte key", () => {
+	const { keyId, publicKeyText } = generateTestKeypair(1);
+	const parsed = parseMinisignPublicKey(publicKeyText);
+	assert.equal(parsed.keyId.toString("hex"), keyId.toString("hex"));
+	assert.equal(parsed.publicKeyBytes.length, 32);
+});
+
+test("parseMinisignSignature decodes the trusted comment and signature fields", () => {
+	const { privateKey, keyId } = generateTestKeypair(1);
+	const message = Buffer.from("checksums content\n");
+	const text = buildMinisignSignatureText(message, "repo:Gentleman-Programming/gentle-ai\ttag:v2.2.3", privateKey, keyId);
+	const parsed = parseMinisignSignature(text);
+	assert.equal(parsed.trustedComment, "repo:Gentleman-Programming/gentle-ai\ttag:v2.2.3");
+	assert.equal(parsed.keyId.toString("hex"), keyId.toString("hex"));
+	assert.equal(parsed.signature.length, 64);
+	assert.equal(parsed.globalSignature.length, 64);
+});
+
+// --- forged minisign signature rejected (threat-matrix: network trust boundary) ---
+
+test("verifyMinisignSignature rejects a signature produced by a different (untrusted) key", () => {
+	const trusted = generateTestKeypair(1);
+	const attacker = generateTestKeypair(2);
+	const message = Buffer.from("checksums content\n");
+	const forgedText = buildMinisignSignatureText(message, "repo:Gentleman-Programming/gentle-ai\ttag:v2.2.3", attacker.privateKey, trusted.keyId);
+	assert.throws(() => verifyMinisignSignature(message, forgedText, trusted.publicKeyText), /signature/i);
+});
+
+test("verifyMinisignSignature rejects a tampered message that no longer matches the signature", () => {
+	const trusted = generateTestKeypair(1);
+	const message = Buffer.from("checksums content\n");
+	const validText = buildMinisignSignatureText(message, "repo:Gentleman-Programming/gentle-ai\ttag:v2.2.3", trusted.privateKey, trusted.keyId);
+	const tamperedMessage = Buffer.from("checksums CONTENT\n");
+	assert.throws(() => verifyMinisignSignature(tamperedMessage, validText, trusted.publicKeyText), /signature/i);
+});
+
+test("verifyMinisignSignature rejects a tampered trusted comment even when the message signature is valid", () => {
+	const trusted = generateTestKeypair(1);
+	const message = Buffer.from("checksums content\n");
+	const validText = buildMinisignSignatureText(message, "repo:Gentleman-Programming/gentle-ai\ttag:v2.2.3", trusted.privateKey, trusted.keyId);
+	const tampered = validText.replace("tag:v2.2.3", "tag:v9.9.9");
+	assert.throws(() => verifyMinisignSignature(message, tampered, trusted.publicKeyText), /signature/i);
+});
+
+test("verifyMinisignSignature accepts a genuine signature and returns its trusted comment", () => {
+	const trusted = generateTestKeypair(1);
+	const message = Buffer.from("checksums content\n");
+	const text = buildMinisignSignatureText(message, "repo:Gentleman-Programming/gentle-ai\ttag:v2.2.3", trusted.privateKey, trusted.keyId);
+	const result = verifyMinisignSignature(message, text, trusted.publicKeyText);
+	assert.equal(result.trustedComment, "repo:Gentleman-Programming/gentle-ai\ttag:v2.2.3");
+});
+
+// --- wrong trusted-comment repo/tag binding rejected -----------------------
+
+test("parseTrustedCommentFields extracts tab-separated key:value tokens", () => {
+	const fields = parseTrustedCommentFields("timestamp:123\tfile:checksums.txt\trepo:Gentleman-Programming/gentle-ai\ttag:v2.2.3");
+	assert.equal(fields.get("repo"), "Gentleman-Programming/gentle-ai");
+	assert.equal(fields.get("tag"), "v2.2.3");
+});
+
+test("assertTrustedCommentBinding rejects a trusted comment naming the wrong repository", () => {
+	assert.throws(
+		() => assertTrustedCommentBinding("repo:someone-else/gentle-ai\ttag:v2.2.3", { repository: "Gentleman-Programming/gentle-ai", tag: "v2.2.3" }),
+		/repo/i,
+	);
+});
+
+test("assertTrustedCommentBinding rejects a trusted comment naming the wrong tag", () => {
+	assert.throws(
+		() => assertTrustedCommentBinding("repo:Gentleman-Programming/gentle-ai\ttag:v9.9.9", { repository: "Gentleman-Programming/gentle-ai", tag: "v2.2.3" }),
+		/tag/i,
+	);
+});
+
+test("assertTrustedCommentBinding accepts a trusted comment naming the expected repository and tag", () => {
+	assert.doesNotThrow(() =>
+		assertTrustedCommentBinding("repo:Gentleman-Programming/gentle-ai\ttag:v2.2.3", { repository: "Gentleman-Programming/gentle-ai", tag: "v2.2.3" }),
+	);
+});
+
+// --- missing / duplicate checksum line rejected -----------------------------
+
+test("findChecksumLine rejects a checksums.txt with no line for the expected asset", () => {
+	assert.throws(
+		() => findChecksumLine(`${"a".repeat(64)}  gentle-ai_other_assets.tar.gz\n`, "gentle-ai_2.2.3_assets.tar.gz"),
+		/no checksum line/i,
+	);
+});
+
+test("findChecksumLine rejects a checksums.txt with two lines for the expected asset", () => {
+	const text = `${"a".repeat(64)}  gentle-ai_2.2.3_assets.tar.gz\n${"b".repeat(64)}  gentle-ai_2.2.3_assets.tar.gz\n`;
+	assert.throws(() => findChecksumLine(text, "gentle-ai_2.2.3_assets.tar.gz"), /duplicate checksum/i);
+});
+
+test("findChecksumLine returns the exact one matching digest", () => {
+	const text = `${"a".repeat(64)}  gentle-ai_other_assets.tar.gz\n${"b".repeat(64)}  gentle-ai_2.2.3_assets.tar.gz\n`;
+	assert.equal(findChecksumLine(text, "gentle-ai_2.2.3_assets.tar.gz"), "b".repeat(64));
+});
+
+// --- canonical lock (task 2.4) ---------------------------------------------
+
+function buildTestManifest(entries: ArtifactEntry[]) {
+	return {
+		schema: "gentle-ai.release-artifact-manifest/v1",
+		contract: { id: "gentle-ai.release-artifact", major: 1, minor: 0, schemaId: "https://gentle-ai.dev/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json", schemaPath: "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json" },
+		release: { repository: "Gentleman-Programming/gentle-ai", tag: "v2.2.3", version: "2.2.3", commit: "0".repeat(40) },
+		layout: { version: 1 },
+		archive: { asset: "gentle-ai_2.2.3_assets.tar.gz", digestSource: "signed-checksums.txt" },
+		references: { semanticSnapshots: [], contracts: [] },
+		tree: { algorithm: "sha256", canonicalization: RELEASE_ARTIFACT_TREE_CANONICALIZATION, manifestIncluded: false, digest: treeDigest(entries) },
+		compatibility: { minimumContractMajor: 1, maximumContractMajor: 1, additiveMinorPolicy: "optional-fields-only", unknownMandatory: "reject", unknownOptional: "ignore" },
+		entries,
+	};
+}
+
+test("buildGentleAiReleaseLock sorts entries and generated by raw path bytes", () => {
+	const entries: ArtifactEntry[] = [
+		{ path: "z/last.json", type: "file", mode: "0644", size: 1, digest: `sha256:${"a".repeat(64)}` },
+		{ path: "a/first.json", type: "file", mode: "0644", size: 1, digest: `sha256:${"b".repeat(64)}` },
+	];
+	const manifest = buildTestManifest(entries);
+	const lock = buildGentleAiReleaseLock(manifest, [
+		{ path: "z/last.json", sha256: `sha256:${"a".repeat(64)}` },
+		{ path: "a/first.json", sha256: `sha256:${"b".repeat(64)}` },
+	], { archiveSha256: `sha256:${"c".repeat(64)}` });
+	assert.deepEqual(lock.entries.map((entry: { path: string }) => entry.path), ["a/first.json", "z/last.json"]);
+	assert.deepEqual(lock.generated.map((entry: { path: string }) => entry.path), ["a/first.json", "z/last.json"]);
+	assert.equal(lock.archive.sha256, `sha256:${"c".repeat(64)}`);
+	assert.equal(lock.contract.layoutVersion, 1);
+});
+
+test("canonicalLockJson serializes with 2-space indent, LF newlines, and exactly one trailing LF", () => {
+	const lock = buildGentleAiReleaseLock(buildTestManifest([{ path: "a.json", type: "file", mode: "0644", size: 1, digest: `sha256:${"a".repeat(64)}` }]), [
+		{ path: "a.json", sha256: `sha256:${"a".repeat(64)}` },
+	], { archiveSha256: `sha256:${"c".repeat(64)}` });
+	const text = canonicalLockJson(lock);
+	assert.ok(!text.includes("\r"));
+	assert.ok(text.endsWith("\n") && !text.endsWith("\n\n"));
+	assert.ok(text.includes('  "release"'));
+});
+
+test("assertLockVersionPin passes when lock.release.version matches the authoritative INSTALLER_VERSION", () => {
+	const lock = buildGentleAiReleaseLock(buildTestManifest([{ path: "a.json", type: "file", mode: "0644", size: 1, digest: `sha256:${"a".repeat(64)}` }]), [
+		{ path: "a.json", sha256: `sha256:${"a".repeat(64)}` },
+	], { archiveSha256: `sha256:${"c".repeat(64)}` });
+	assert.doesNotThrow(() => assertLockVersionPin(lock, "2.2.3"));
+	assert.throws(() => assertLockVersionPin(lock, "9.9.9"), /INSTALLER_VERSION/);
+});
+
+// --- evidence-S/R labeling (task 2.7) and mirror/lock writing (task 2.3/2.4) ---
+
+async function buildBootstrapArchive(sourceDir: string, archivePath: string): Promise<{ manifest: Record<string, unknown> }> {
+	const schemaBytes = await readFile(join(import.meta.dirname, "fixtures", "release-artifact", "artifact-manifest.schema.json"));
+	const semanticBytes = Buffer.from(`${JSON.stringify({ schema: "gentle-ai.release-semantic-capabilities/v1", operations: ["review.status"] }, null, 2)}\n`);
+	const entries = [
+		{ path: "capabilities/review-integration-v2.semantic.json", type: "file", mode: "0644", size: semanticBytes.length, digest: `sha256:${createHash("sha256").update(semanticBytes).digest("hex")}` },
+		{ path: "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json", type: "file", mode: "0644", size: schemaBytes.length, digest: `sha256:${createHash("sha256").update(schemaBytes).digest("hex")}` },
+	];
+	const manifest = {
+		schema: "gentle-ai.release-artifact-manifest/v1",
+		contract: { id: "gentle-ai.release-artifact", major: 1, minor: 0, schema_id: "https://gentle-ai.dev/contracts/release-artifact/v1/schemas/artifact-manifest.schema.json", schema_path: "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json" },
+		release: { repository: "Gentleman-Programming/gentle-ai", tag: "v2.2.3", version: "2.2.3", commit: "0".repeat(40) },
+		layout: { version: 1 },
+		archive: { asset: "gentle-ai_2.2.3_assets.tar.gz", digest_source: "signed-checksums.txt" },
+		references: {
+			semantic_snapshots: [{ contract: "gentle-ai.review-integration/v2", path: "capabilities/review-integration-v2.semantic.json", schema: "gentle-ai.release-semantic-capabilities/v1" }],
+			contracts: [{ id: "gentle-ai.review-integration/v2", root: "contracts/review-integration/v2" }],
+		},
+		tree: { algorithm: "sha256", canonicalization: RELEASE_ARTIFACT_TREE_CANONICALIZATION, manifest_included: false, digest: treeDigest(entries as ArtifactEntry[]) },
+		compatibility: { minimum_contract_major: 1, maximum_contract_major: 1, additive_minor_policy: "optional-fields-only", unknown_mandatory: "reject", unknown_optional: "ignore" },
+		entries,
+	};
+
+	await mkdir(join(sourceDir, "contracts", "release-artifact", "v1", "schemas"), { recursive: true });
+	await mkdir(join(sourceDir, "capabilities"), { recursive: true });
+	await writeFile(join(sourceDir, RELEASE_ARTIFACT_MANIFEST_FILE_NAME), JSON.stringify(manifest));
+	await writeFile(join(sourceDir, "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json"), schemaBytes);
+	await writeFile(join(sourceDir, "capabilities/review-integration-v2.semantic.json"), semanticBytes);
+	await execFileAsync("tar", [
+		"-czf",
+		archivePath,
+		"-C",
+		sourceDir,
+		RELEASE_ARTIFACT_MANIFEST_FILE_NAME,
+		"contracts/release-artifact/v1/schemas/artifact-manifest.schema.json",
+		"capabilities/review-integration-v2.semantic.json",
+	]);
+	return { manifest };
+}
+
+test("syncGentleAiRelease against --bootstrap-archive is labeled development/bootstrap and writes mirrors + lock", async () => {
+	const sourceDir = await tempWorkspace();
+	const packageRoot = await tempWorkspace();
+	const archivePath = join(sourceDir, "..", "sync-bootstrap.tar.gz");
+	try {
+		await buildBootstrapArchive(sourceDir, archivePath);
+
+		const result = await syncGentleAiRelease({ packageRoot, bootstrapArchivePath: archivePath, write: true });
+
+		assert.equal(result.evidenceClass, RELEASE_ARTIFACT_EVIDENCE_CLASS.BOOTSTRAP);
+		assert.throws(() => assertReleaseAcceptanceEvidence(result), /cannot serve as pin or final-acceptance evidence/);
+
+		const writtenSchema = await readFile(join(packageRoot, "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json"));
+		const expectedSchema = await readFile(join(import.meta.dirname, "fixtures", "release-artifact", "artifact-manifest.schema.json"));
+		assert.deepEqual(writtenSchema, expectedSchema);
+
+		const lockText = await readFile(join(packageRoot, GENTLE_AI_RELEASE_LOCK_RELATIVE_PATH), "utf8");
+		const lock = JSON.parse(lockText);
+		assert.equal(lock.release.version, "2.2.3");
+		assert.equal(lock.entries.length, 2);
+		assert.equal(lock.generated.length, 2);
+		assert.ok(lockText.endsWith("\n") && !lockText.endsWith("\n\n"));
+	} finally {
+		await rm(sourceDir, { recursive: true, force: true });
+		await rm(packageRoot, { recursive: true, force: true });
+		await rm(archivePath, { force: true });
+	}
+});
+
+test("syncGentleAiRelease against --bootstrap-archive never labels its result release evidence even when write is false", async () => {
+	const sourceDir = await tempWorkspace();
+	const packageRoot = await tempWorkspace();
+	const archivePath = join(sourceDir, "..", "sync-bootstrap-noop.tar.gz");
+	try {
+		await buildBootstrapArchive(sourceDir, archivePath);
+		const result = await syncGentleAiRelease({ packageRoot, bootstrapArchivePath: archivePath, write: false });
+		assert.equal(result.evidenceClass, RELEASE_ARTIFACT_EVIDENCE_CLASS.BOOTSTRAP);
+		assert.equal(result.signatureStatus, "not-applicable/local-unsigned");
+	} finally {
+		await rm(sourceDir, { recursive: true, force: true });
+		await rm(packageRoot, { recursive: true, force: true });
+		await rm(archivePath, { force: true });
+	}
+});

--- a/tests/sync-gentle-ai-release.test.ts
+++ b/tests/sync-gentle-ai-release.test.ts
@@ -318,3 +318,38 @@ test("syncGentleAiRelease against --bootstrap-archive never labels its result re
 		await rm(archivePath, { force: true });
 	}
 });
+
+test("the persisted lock records its evidence class, so a bootstrap-derived lock cannot be mistaken for release evidence", () => {
+	const manifest = buildTestManifest([{ path: "a.json", type: "file", mode: "0644", size: 1, digest: `sha256:${"a".repeat(64)}` }]);
+	const generated = [{ path: "a.json", sha256: `sha256:${"a".repeat(64)}` }];
+
+	const bootstrapLock = buildGentleAiReleaseLock(manifest, generated, {
+		archiveSha256: `sha256:${"c".repeat(64)}`,
+		evidenceClass: "development/bootstrap",
+		signatureStatus: "not-applicable/local-unsigned",
+	});
+	assert.equal(bootstrapLock.evidence.class, "development/bootstrap");
+	assert.equal(bootstrapLock.evidence.signatureStatus, "not-applicable/local-unsigned");
+
+	// The whole point: a reader that only has the file on disk must still be able
+	// to refuse it as pin or final-acceptance evidence. In-memory labelling that
+	// never reaches the artifact would leave a bootstrap lock indistinguishable
+	// from a real one, which is exactly what the spec forbids.
+	assert.throws(
+		() => assertReleaseAcceptanceEvidence({ evidenceClass: bootstrapLock.evidence.class }),
+		/cannot serve as pin or final-acceptance evidence/,
+	);
+
+	const releaseLock = buildGentleAiReleaseLock(manifest, generated, {
+		archiveSha256: `sha256:${"c".repeat(64)}`,
+		evidenceClass: "release",
+		signatureStatus: "verified",
+	});
+	assert.doesNotThrow(() => assertReleaseAcceptanceEvidence({ evidenceClass: releaseLock.evidence.class }));
+});
+
+test("the checked-in lock on disk is labelled bootstrap and is refused as acceptance evidence", async () => {
+	const onDisk = JSON.parse(await readFile(new URL("../capabilities/gentle-ai-release.lock.json", import.meta.url), "utf8"));
+	assert.equal(onDisk.evidence.class, "development/bootstrap");
+	assert.throws(() => assertReleaseAcceptanceEvidence({ evidenceClass: onDisk.evidence.class }));
+});

--- a/tests/verify-package-files.test.ts
+++ b/tests/verify-package-files.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+	assertLockReleaseVersionPin,
 	gentleAiVersionPinMismatches,
+	mirrorDigestDrift,
+	mirrorDigestsFromLock,
 	reconcileContractsOnDisk,
 	reconcileGeneratedRuntimeSources,
 } from "../scripts/verify-package-files.mjs";
@@ -135,6 +139,81 @@ test("Gentle AI version pin agrees across the installer version, the release URL
 	});
 
 	assert.deepEqual(mismatches, []);
+});
+
+// --- lock-based mirror reconciliation (task 2.5, replaces contractHashes) --
+
+test("mirror walk fails on a file that exists on disk under docs/gentle-ai but is unlisted in the lock", () => {
+	const fixtureRoot = makeFixtureRoot();
+	try {
+		mkdirSync(join(fixtureRoot, "docs/gentle-ai"), { recursive: true });
+		writeFileSync(join(fixtureRoot, "docs/gentle-ai/review-integration.md"), "known\n");
+		writeFileSync(join(fixtureRoot, "docs/gentle-ai/unlisted.md"), "unlisted\n");
+
+		const { unlistedOnDisk, listedButMissing } = reconcileContractsOnDisk(fixtureRoot, {
+			"docs/gentle-ai/review-integration.md": "irrelevant-for-this-walk",
+		});
+
+		assert.deepEqual(unlistedOnDisk, ["docs/gentle-ai/unlisted.md"]);
+		assert.deepEqual(listedButMissing, []);
+	} finally {
+		rmSync(fixtureRoot, { recursive: true, force: true });
+	}
+});
+
+test("mirror walk fails on a lock entry with no file on disk under capabilities/, excluding the lock itself and hand-authored files", () => {
+	const fixtureRoot = makeFixtureRoot();
+	try {
+		mkdirSync(join(fixtureRoot, "capabilities"), { recursive: true });
+		writeFileSync(join(fixtureRoot, "capabilities/gentle-ai-release.lock.json"), "{}\n");
+		writeFileSync(join(fixtureRoot, "capabilities/native-cli-history.json"), "[]\n");
+
+		const { unlistedOnDisk, listedButMissing } = reconcileContractsOnDisk(fixtureRoot, {
+			"capabilities/review-integration-v2.semantic.json": "irrelevant-for-this-walk",
+		});
+
+		assert.deepEqual(unlistedOnDisk, []);
+		assert.deepEqual(listedButMissing, ["capabilities/review-integration-v2.semantic.json"]);
+	} finally {
+		rmSync(fixtureRoot, { recursive: true, force: true });
+	}
+});
+
+test("mirror digest drift names the exact drifted file", () => {
+	const fixtureRoot = makeFixtureRoot();
+	try {
+		mkdirSync(join(fixtureRoot, "contracts/release-artifact/v1/schemas"), { recursive: true });
+		const path = "contracts/release-artifact/v1/schemas/artifact-manifest.schema.json";
+		writeFileSync(join(fixtureRoot, path), "{}\n");
+		const actualDigest = `sha256:${createHash("sha256").update(readFileSync(join(fixtureRoot, path))).digest("hex")}`;
+		const staleDigest = `sha256:${"0".repeat(64)}`;
+
+		const drift = mirrorDigestDrift(fixtureRoot, { [path]: staleDigest });
+
+		assert.deepEqual(drift, [{ relativePath: path, expected: staleDigest, actual: actualDigest }]);
+		assert.deepEqual(mirrorDigestDrift(fixtureRoot, { [path]: actualDigest }), []);
+	} finally {
+		rmSync(fixtureRoot, { recursive: true, force: true });
+	}
+});
+
+test("mirror digests are derived from capabilities/gentle-ai-release.lock.json entries, not a hand-maintained map", () => {
+	const lockEntries = [
+		{ path: "docs/gentle-ai/review-integration.md", digest: `sha256:${"a".repeat(64)}` },
+		{ path: "contracts/x.schema.json", digest: `sha256:${"b".repeat(64)}` },
+	];
+	assert.deepEqual(mirrorDigestsFromLock({ entries: lockEntries }), {
+		"docs/gentle-ai/review-integration.md": `sha256:${"a".repeat(64)}`,
+		"contracts/x.schema.json": `sha256:${"b".repeat(64)}`,
+	});
+});
+
+test("lock release version pin mismatch is reported naming the authoritative INSTALLER_VERSION", () => {
+	assert.throws(
+		() => assertLockReleaseVersionPin({ release: { version: "9.9.9" } }, INSTALLER_VERSION),
+		/gentle-ai-release\.lock\.json/,
+	);
+	assert.doesNotThrow(() => assertLockReleaseVersionPin({ release: { version: INSTALLER_VERSION } }, INSTALLER_VERSION));
 });
 
 test("both walks report no drift when sources, runtime/*.mjs, requiredPaths, and contractHashes fully agree", () => {


### PR DESCRIPTION
Second slice of the consumer chain, stacked on #266. Owns trust-order steps 1 through 5, the network boundary; #266 owns steps 6 through 11.

## Where the signature check actually belongs

`scripts/gentle-ai-installer.mjs` documents that the pinned sha256 literals were derived by a human from the signed `checksums.txt`, and install compares against that pin. So minisign verification and repo/tag binding belong to the **pin-time sync job**; install time inherits that trust through the lock.

Shipping a verifier and a trusted key to every end user would be a larger new trust surface for no gain, and it was rejected in design rather than skipped by accident.

## The lock is what makes every PR check offline

It binds release identity, contract major, archive digest, tree digest, canonical entries and generated-output digests. Only an explicit pin-bump job downloads anything.

`scripts/verify-package-files.mjs` loses its hand-maintained ~60-entry `contractHashes` map and reconciles against the lock instead. Three failure modes each fail naming the exact file: a mirror on disk the lock does not list, a lock entry with no file, and a drifted digest.

The offline claim is proven, not asserted: the trusted key is a pending sentinel that throws before any network call, and `verify-package-files.mjs --check` passes reading only the lock and local files.

## A defect this slice found and fixed in the previous one

Running the script end to end surfaced that `lib/release-artifact.ts` and its generated runtime were missing from `requiredPaths` in the package check. Fixed here rather than left for someone to trip over.

## And a defect in this slice, caught in review

The evidence class was carried only on the in-memory sync result. The lock that actually gets checked in, reviewed and later trusted carried **no indication of where it came from**.

That is precisely the failure mode the spec exists to prevent. A bootstrap-derived lock has a placeholder `release.commit` and an `archive.digestSource` reading `signed-checksums.txt` — any reader would take it for a real signed release, and nothing in the file said otherwise.

The lock now persists `evidence.class` and `evidence.signatureStatus`, so a reader holding only the file can still refuse it as pin or final-acceptance evidence. Two tests cover it, including one asserting the checked-in lock itself is labelled bootstrap. That fix is its own commit.

## Status of the checked-in lock

It is `development/bootstrap` evidence and says so. No gentle-ai release exists under this contract yet, so it must be regenerated by a real network `--write` run once the provider release lands and the real minisign key is provisioned.

## Tests

1067 pass, 3 fail. Those three are the known receipt-driven-development-disabled failures in `tests/native-review-parity-runtime.test.ts`, verified identical on clean `main` before this chain started. No regressions.

## One interpretation flagged

The minisign trusted-comment repo and tag convention was defined here because design did not specify an exact wire format for this boundary. It is tested, but it is an interpretation and should be confirmed against the provider's actual signing output before the first real sync.
