### PR TITLE
feat(coverage): warn on unbound provider phases, fail on unknown Pi bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,28 +35,36 @@ jobs:
         env:
           GENTLE_PI_REQUIRE_NATIVE_BINARY: "1"
 
-      # Offline mirror + capabilities/gentle-ai-release.lock.json reconciliation
-      # (contracts/, docs/gentle-ai/, capabilities/*.semantic.json) runs here,
-      # fully offline. Only scripts/sync-gentle-ai-release.mjs --write, invoked
-      # exclusively by the not-yet-landed pin-bump job, ever downloads or
-      # verifies a minisign signature; no job in this workflow does.
-      - name: Verify package contents
-        run: node scripts/verify-package-files.mjs
-
-      # Generated NATIVE_CLI_CONTRACTS row + REQUIRED_* floors (D7): offline,
-      # reads only the checked-in semantic snapshot, lock, and
-      # capabilities/native-cli-history.json. Only scripts/bump-gentle-ai-pin.mjs
-      # (P4) ever runs this with --write.
-      - name: Verify generated gentle-ai baselines
-        run: node scripts/build-gentle-ai-baselines.mjs --check
-
-      # Skill vendor + overlay reconciliation (D8): offline, reads only the
-      # checked-in vendored bodies (skills/_vendor/**), their recorded
-      # digests (skills/_vendor/manifest.json), and each overlay.md. Catches
-      # a hand-edited vendored file and a stale overlay anchor before either
-      # reaches skills/<name>/SKILL.md.
-      - name: Verify generated skill overlays
-        run: node scripts/build-skill-overlays.mjs --check
+      # The complete offline `--check` set (design.md "Data Flow" — "EVERY PR
+      # (offline)"), assembled as one integration gate. Every command here
+      # reads only checked-in state and never touches the network:
+      #
+      #   1. mirrors + lock — contracts/, docs/gentle-ai/,
+      #      capabilities/*.semantic.json reconciled against
+      #      capabilities/gentle-ai-release.lock.json, PLUS the phase-coverage
+      #      gate (D9): assets/agents/** and assets/chains/** reconciled
+      #      against assets/phase-coverage.json. A provider-declared phase
+      #      with no Pi binding WARNS (named, non-fatal — the provider's fast
+      #      release cadence adds phases regularly); a Pi agent binding
+      #      naming no declared phase and not listed Pi-only FAILS (a real
+      #      inconsistency in Pi's own configuration).
+      #   2. baselines (D7) — generated NATIVE_CLI_CONTRACTS row + REQUIRED_*
+      #      floors, reads only the checked-in semantic snapshot, lock, and
+      #      capabilities/native-cli-history.json.
+      #   3. skill overlays (D8) — checked-in vendored bodies
+      #      (skills/_vendor/**), their recorded digests
+      #      (skills/_vendor/manifest.json), and each overlay.md. Catches a
+      #      hand-edited vendored file and a stale overlay anchor before
+      #      either reaches skills/<name>/SKILL.md.
+      #
+      # Only scripts/sync-gentle-ai-release.mjs --write (the not-yet-landed
+      # pin-bump job, P4) ever downloads or verifies a minisign signature; no
+      # step in this workflow does.
+      - name: Verify offline checks (mirrors/lock, phase coverage, baselines, skill overlays)
+        run: |
+          node scripts/verify-package-files.mjs --check
+          node scripts/build-gentle-ai-baselines.mjs --check
+          node scripts/build-skill-overlays.mjs --check
 
       - name: Verify packed installation
         run: pnpm run test:packed-runner

--- a/assets/phase-coverage.json
+++ b/assets/phase-coverage.json
@@ -1,0 +1,34 @@
+{
+  "schema": "gentle-pi.phase-coverage/v1",
+  "declaredPhases": [
+    "jd-fix-agent",
+    "jd-judge-a",
+    "jd-judge-b",
+    "review-readability",
+    "review-refuter",
+    "review-reliability",
+    "review-resilience",
+    "review-risk",
+    "sdd-apply",
+    "sdd-archive",
+    "sdd-design",
+    "sdd-explore",
+    "sdd-init",
+    "sdd-onboard",
+    "sdd-propose",
+    "sdd-spec",
+    "sdd-tasks",
+    "sdd-verify"
+  ],
+  "alias": {
+    "sdd-proposal": "sdd-propose"
+  },
+  "piOnly": [
+    "gentle-ai-explore",
+    "gentle-ai-verify",
+    "gentle-ai-worker",
+    "review-validator",
+    "sdd-status",
+    "sdd-sync"
+  ]
+}

--- a/openspec/changes/consume-gentle-ai-release-artifacts/apply-progress.md
+++ b/openspec/changes/consume-gentle-ai-release-artifacts/apply-progress.md
@@ -1,7 +1,7 @@
 # Apply Progress: consume-gentle-ai-release-artifacts
 
-> Cumulative across batches: **PR 1 / P1a** through **PR 6 / P3b**, all complete
-> (tasks 1.1-6.8). PR 7 (P3c) and later are NOT started.
+> Cumulative across batches: **PR 1 / P1a** through **PR 7 / P3c**, all complete
+> (tasks 1.1-7.8). PR 8 (P4) is NOT started.
 
 ## Completed Tasks
 
@@ -864,3 +864,168 @@ None new. Same `node_modules`/`postinstall` HTTP 404 environment condition docum
 8/8 tasks in PR 6 (P3b) complete. 55/55 tasks total across P1a+P1b+P2a+P2b+P3a+P3b. Ready for `sdd-verify`,
 or for `sdd-apply` to continue with PR 7 (P3c) in a fresh batch, on a new branch based on this one
 (`feat/skill-vendor-overlay`).
+
+---
+
+# PR 7 / P3c — Phase-coverage gate + generic evidence harness
+
+**Worktree**: `gentle-pi-worktrees/p3c`, **branch**: `feat/phase-coverage-evidence`, based on P3b's
+`feat/skill-vendor-overlay`.
+
+## Maintainer decision superseding tasks.md 7.1 (recorded, not silently deviated)
+
+Task 7.1's wording says a provider-declared phase with no Pi binding "fails". **The maintainer decided it
+WARNS instead**, naming the missing phase, and does **not** fail CI. Reasoning, as given: under the
+provider's fast release cadence new phases appear regularly, and blocking the build for a phase nobody has
+decided to implement yet trains people to ignore the gate — a gate that cries wolf gets muted, and then it
+protects nothing.
+
+**The reverse direction is unchanged and still fails**: a Pi agent binding naming no declared phase, and not
+listed Pi-only, is a real inconsistency in Pi's own configuration (not a provider-cadence problem) and
+breaks the build.
+
+Implemented as `phaseCoverageGate()` in `scripts/verify-package-files.mjs`: `missingBindings` (forward
+direction) are reported with `console.warn` and never reach a `process.exit(1)` branch; `unknownBindings`
+(reverse direction) are reported with `console.error` and do reach `process.exit(1)`. The two arrays are
+computed and handled through entirely separate code paths — there is no shared branch that could
+accidentally promote a warning into a failure or vice versa.
+
+## Design interpretation note: reverse check scope is `assets/agents/**` only
+
+`design.md` D9 titles the gate "for `assets/agents/**` and `assets/chains/**`" and task 7.1 says "a Pi
+binding naming no declared phase … fails" without restricting that to agents. In practice, reconciling the
+**real** trees settles this: gentle-ai (`~/work/gentle-ai`, `internal/assets/claude/agents/`) declares
+exactly 18 phases (`jd-fix-agent`, `jd-judge-a`, `jd-judge-b`, `review-readability`, `review-refuter`,
+`review-reliability`, `review-resilience`, `review-risk`, `sdd-apply`, `sdd-archive`, `sdd-design`,
+`sdd-explore`, `sdd-init`, `sdd-onboard`, `sdd-propose`, `sdd-spec`, `sdd-tasks`, `sdd-verify`) and **has no
+`chains/` directory at all** (confirmed by direct filesystem check, matching design.md's "upstream has no
+chains/ directory at all"). Pi's `assets/agents/**` has 24 files: those 18 (with `sdd-proposal` ↔
+`sdd-propose` aliased) plus the 6 declared-Pi-only names from task 7.3 — an exact 18+6=24 reconciliation with
+**zero** extra Pi-only entries needed. Pi's `assets/chains/**` has 4 files (`4r-review`, `sdd-full`,
+`sdd-plan`, `sdd-verify`); 3 of those 4 names match no declared phase and aren't in task 7.3's fixed Pi-only
+list. Since task 7.3 gives an exact, closed Pi-only set (not "at least"), the only interpretation that
+reconciles the real tree without inventing unauthorized Pi-only entries is: the **reverse** check walks only
+`assets/agents/**` (chains compose multiple phases into Pi-only workflows and are not themselves
+single-phase bindings), while the **forward** check (does a declared phase have *some* binding) accepts
+either an agent or a chain name, per the task's literal "Pi agent/chain binding" wording. This is documented
+in `scripts/verify-package-files.mjs`'s gate comment, not just here.
+
+## `issue-creation` is never touched (task 7.2)
+
+`phaseCoverageBindings()` reads only `assets/agents/**` and `assets/chains/**` — it never lists or opens
+anything under `skills/`. Proven directly: a fixture test
+(`tests/verify-package-files.test.ts` "skills/issue-creation/SKILL.md is never read or flagged") builds a
+temp tree with `assets/agents/sdd-apply.md`, `assets/chains/sdd-plan.chain.md`, and
+`skills/issue-creation/SKILL.md` side by side, and asserts `issue-creation` appears in neither
+`agentNames`/`chainNames` nor any gate output.
+
+## Generic S/R evidence ledger harness (tasks 7.5/7.6)
+
+`tests/evidence/ledger.ts` — reuses the **exact** `evidence.class` discipline
+`lib/release-artifact.ts`'s `RELEASE_ARTIFACT_EVIDENCE_CLASS` already carries (`development/bootstrap` = S,
+`release` = R — the same values persisted into the checked-in `capabilities/gentle-ai-release.lock.json`'s
+`evidence.class` field), rather than inventing a parallel S/R vocabulary. It is deliberately generic — no
+gentle-ai-specific fields (no signature, no repository, no tag) — so Wave 1 changes can build their own S-vs-R
+evidence ledgers directly on `EvidenceLedger`/`createEvidenceRecord`/`assertNeverRelabeledFromBootstrap`
+without reimplementing the shape. The invariant (an S-class record can never be relabeled R) is enforced
+twice: once as a standalone assertion function, and once on `EvidenceLedger.record()`'s own mutation path (a
+rejected S→R attempt never mutates the ledger — proven by
+`tests/evidence.test.ts` "EvidenceLedger.record enforces the invariant on the mutation path itself").
+
+## TDD Cycle Evidence
+
+| Task | Test File | RED | GREEN | REFACTOR |
+|------|-----------|-----|-------|----------|
+| 7.1 | `tests/verify-package-files.test.ts` | ✅ Written referencing `phaseCoverageGate`/`phaseCoverageBindings` before they existed → whole-module `SyntaxError: ... does not provide an export named 'phaseCoverageBindings'` (`node --test tests/verify-package-files.test.ts` failed 1/1) | ✅ 8 new phase-coverage cases pass (21/21 in the file) | ✅ Clean — `bindingNamesFromDirectory` shared by both directory reads, `phaseCoverageGate` kept pure (no I/O), `phaseCoverageBindings` is the sole I/O boundary |
+| 7.2 | `tests/verify-package-files.test.ts` | ✅ Same RED (whole-module failure covers this case too — the fixture test importing the not-yet-existing exports) | ✅ "skills/issue-creation/SKILL.md is never read or flagged" passes | N/A |
+| 7.3 | `assets/phase-coverage.json` | N/A — data file | ✅ created; the "real assets/phase-coverage.json fully reconciles" test passes against the actual `assets/agents`/`assets/chains` trees | N/A |
+| 7.4 | `scripts/verify-package-files.mjs` | (covered by 7.1 RED) | ✅ `main()` wired: `console.warn` per missing binding, `process.exit(1)` only when `unknownBindings.length > 0` | ✅ Clean — reuses the file's existing "one gate, exact messages, never a silent boolean" pattern |
+| 7.5 | `tests/evidence.test.ts` | ✅ Written referencing `./evidence/ledger.ts` before it existed → `ERR_MODULE_NOT_FOUND` (`node --test tests/evidence.test.ts` failed 1/1) | ✅ 7/7 cases pass | ✅ Clean |
+| 7.6 | `tests/evidence/ledger.ts` | (covered by 7.5 RED) | ✅ `EVIDENCE_LEDGER_CLASS`, `createEvidenceRecord`, `assertNeverRelabeledFromBootstrap`, `EvidenceLedger` created | ✅ Clean — single-purpose module, no gentle-ai-specific coupling |
+| 7.7 | `.github/workflows/ci.yml` | N/A — CI config | ✅ 3 separate offline-check steps consolidated into one "Verify offline checks" step (`verify-package-files.mjs --check` now includes phase coverage; `build-gentle-ai-baselines.mjs --check`; `build-skill-overlays.mjs --check`) | N/A |
+| 7.8 | full suite | — | ✅ `node --experimental-strip-types --test tests/*.test.ts`: 1145/1145 collected, 1132 pass, 1 known pre-existing environmental fail, 12 skipped. `node scripts/verify-package-files.mjs --check` exits 0 against the real tree with zero warnings (full coverage already exists) | N/A |
+
+## Work Unit Evidence
+
+| Evidence | Value |
+|---|---|
+| Focused test command and exact result | `node --experimental-strip-types --test tests/verify-package-files.test.ts tests/evidence.test.ts` → 28/28 pass (21 pre-existing/updated `verify-package-files` cases including 8 new phase-coverage cases, 7 new `evidence.test.ts` cases) |
+| Runtime harness command/scenario and exact result | `node scripts/verify-package-files.mjs --check` against the real repository tree → exit 0, `gentle-pi package resource check passed (73 files; 66 lock-pinned mirror artifacts at release v2.2.3).`, zero phase-coverage warnings (full 18/18 declared-phase coverage already exists). Combined offline gate exactly as `ci.yml` runs it (`verify-package-files.mjs --check && build-gentle-ai-baselines.mjs --check && build-skill-overlays.mjs --check`) → exit 0. |
+| Rollback boundary | `git revert` of this unit's commits removes `assets/phase-coverage.json`, the phase-coverage gate block in `scripts/verify-package-files.mjs` (and its `requiredPaths` entry), `tests/evidence/**` + `tests/evidence.test.ts`, the phase-coverage test cases in `tests/verify-package-files.test.ts`, and reverts `.github/workflows/ci.yml`'s single combined step back to 3 separate steps — restoring exactly the P3b end state. No P1/P2/P3a/P3b file or behavior is touched by this unit. |
+
+## Proof: WARN path never fails CI, FAIL path does
+
+Direct inspection of `phaseCoverageGate()`'s two return arrays and `main()`'s two handling branches
+(`console.warn` only for `missingBindings`, `process.exit(1)` gated strictly on
+`unknownBindings.length > 0`), confirmed by calling the exported function directly:
+
+```
+WARN-only case:  {"missingBindings":["sdd-brand-new-phase"],"unknownBindings":[]}   -> would process.exit(1)? false
+FAIL case:       {"missingBindings":[],"unknownBindings":["gentle-ai-rogue"]}        -> would process.exit(1)? true
+```
+
+Also proven end-to-end against the real tree: `node scripts/verify-package-files.mjs --check` exits 0 with
+no output beyond the final success line, because the real tree currently has zero missing bindings and zero
+unknown bindings (18/18 declared phases bound, 24/24 Pi agent names accounted for).
+
+## Full-suite proof (`node --experimental-strip-types --test tests/*.test.ts`)
+
+`tests 1145 / pass 1132 / fail 1 / skipped 12` (1130 pre-existing + 15 new: 8 in
+`tests/verify-package-files.test.ts`, 7 in `tests/evidence.test.ts`). The 1 failure is the same
+pre-existing, sandbox-only, no-network `tests/native-review-cli.test.ts` "native output limits dominate
+killed timeout signals..." failure documented in every prior unit of this tracker. Not new, not related to
+this unit.
+
+`pnpm run test:harness` (`tests/runtime-harness.mjs`) also fails in this sandbox with an unrelated
+pre-existing environmental symptom of the same root cause (no native `.gentle-ai/v2.2.3/gentle-ai` binary
+installed, no network): "Gentle AI pre-pr gate could not reconsult review mode and failed closed." —
+confirmed via `git stash` to reproduce identically on the clean P3b tip before any P3c change, so it is not
+introduced by this unit. `pnpm test`/`pnpm install` still fail their own network step in this sandbox
+(`postinstall` HTTP 404 fetching the binary) exactly as documented in every prior unit; `pnpm install`
+still succeeds far enough to populate `node_modules` from the local pnpm store, so the direct
+`node --experimental-strip-types --test tests/*.test.ts` invocation was used, matching every prior unit's
+documented workaround.
+
+## Deviations from Design
+
+1. **Task 7.1's forward-direction "fails" wording is superseded by an explicit maintainer decision** (see
+   above) — the design's own D9 prose ("Failure names the missing binding") is ambiguous about severity for
+   the forward direction; the maintainer's instruction resolves it to WARN, non-fatal. The reverse direction
+   is unchanged (still fails).
+2. **The reverse ("Pi binding naming no declared phase") check is scoped to `assets/agents/**` only**, not
+   `assets/chains/**` — a design-interpretation choice forced by reconciling the real tree against task
+   7.3's exact, closed Pi-only list (see "Design interpretation note" above). The forward check still
+   accepts either an agent or a chain binding, per task 7.1's literal wording.
+
+## Issues Found
+
+None new. Same `node_modules`/`postinstall` HTTP 404 environment condition documented in every prior unit,
+plus the `tests/runtime-harness.mjs` pre-existing failure newly confirmed (via `git stash`) to also
+reproduce on the clean P3b tip — both are sandbox-only, no-network symptoms of the same missing native
+binary, neither introduced by this unit.
+
+## Remaining Tasks
+
+- [ ] PR 8 — P4 (`scripts/bump-gentle-ai-pin.mjs` + `gentle-ai-release-received.yml` receiver): not started.
+
+## Workload / PR Boundary (P3c)
+
+- Mode: feature-branch-chain, `size:exception` (tasks.md: `Delivery strategy: exception-ok`)
+- Current work unit: P3c (PR 7, base: P3b's branch `feat/skill-vendor-overlay`)
+- Boundary: `assets/phase-coverage.json` (new), the phase-coverage gate block in
+  `scripts/verify-package-files.mjs` (new exports + `main()` wiring + one new `requiredPaths` entry),
+  `tests/evidence/**` (new: `ledger.ts`), `tests/evidence.test.ts` (new), phase-coverage test cases appended
+  to `tests/verify-package-files.test.ts`, and `.github/workflows/ci.yml`'s three offline-check steps
+  consolidated into one. No P1/P2/P3a/P3b file touched.
+- Estimated review budget impact: tracked-file diff is 241 insertions / 30 deletions across 4 files
+  (`git diff --stat`), plus 168 lines across 3 new untracked files (`assets/phase-coverage.json` 34,
+  `tests/evidence.test.ts` 65, `tests/evidence/ledger.ts` 69) — 439 total changed lines, all authored (no
+  vendored/golden content in this unit, unlike P3b). Above the 400-line budget, already covered by the
+  tracker-wide `Delivery strategy: exception-ok` (tasks.md: `400-line budget risk: High`,
+  `Decision needed before apply: No`), same policy every prior unit operated under.
+
+## Status (P3c)
+
+8/8 tasks in PR 7 (P3c) complete. 63/68 tasks total across P1a+P1b+P2a+P2b+P3a+P3b+P3c. Ready for
+`sdd-verify`, or for `sdd-apply` to continue with PR 8 (P4) in a fresh batch, on a new branch based on this
+one (`feat/phase-coverage-evidence`).

--- a/openspec/changes/consume-gentle-ai-release-artifacts/tasks.md
+++ b/openspec/changes/consume-gentle-ai-release-artifacts/tasks.md
@@ -108,14 +108,14 @@ Chain strategy: feature-branch-chain
 
 ## PR 7 — P3c: Phase-coverage gate + generic evidence harness (depends: PR 6)
 
-- [ ] 7.1 RED: phase-coverage gate — a provider-declared phase with no Pi agent/chain binding fails naming it; a Pi binding naming no declared phase (and not listed Pi-only) fails.
-- [ ] 7.2 RED: `skills/issue-creation/SKILL.md` is never flagged by the phase-coverage gate (repo-identity, not drift).
-- [ ] 7.3 GREEN: create `assets/phase-coverage.json` — declared alias `sdd-proposal` ↔ `sdd-propose`; declared Pi-only bindings `gentle-ai-explore`, `gentle-ai-worker`, `gentle-ai-verify`, `sdd-status`, `sdd-sync`, `review-validator`.
-- [ ] 7.4 GREEN: `scripts/verify-package-files.mjs` — add the phase-coverage gate, driven by the snapshot mirror plus `assets/phase-coverage.json`.
-- [ ] 7.5 RED: generic evidence-harness test — an S-class (bootstrap) record can never be relabeled R; an R-class record requires live signed-release inputs.
-- [ ] 7.6 GREEN: create `tests/evidence/**` — generic immutable-evidence harness implementing the plan §12 ledger shape (S vs R classes), reusable by later changes.
-- [ ] 7.7 GREEN: `.github/workflows/ci.yml` — assemble the full offline `--check` set (mirrors/lock, baselines, skill overlays, phase-coverage) as one integration gate.
-- [ ] 7.8 Verify: `pnpm test`; `node scripts/verify-package-files.mjs --check` (phase-coverage included).
+- [x] 7.1 RED: phase-coverage gate — a provider-declared phase with no Pi agent/chain binding fails naming it; a Pi binding naming no declared phase (and not listed Pi-only) fails. **Superseded by maintainer decision** (see apply-progress.md P3c): the forward direction (declared phase with no binding) WARNS, naming the missing phase, and does NOT fail CI — under the provider's fast release cadence, failing the build for a phase nobody decided to implement yet trains people to ignore the gate. The reverse direction (Pi binding naming no declared phase, not Pi-only) still fails, unchanged.
+- [x] 7.2 RED: `skills/issue-creation/SKILL.md` is never flagged by the phase-coverage gate (repo-identity, not drift).
+- [x] 7.3 GREEN: create `assets/phase-coverage.json` — declared alias `sdd-proposal` ↔ `sdd-propose`; declared Pi-only bindings `gentle-ai-explore`, `gentle-ai-worker`, `gentle-ai-verify`, `sdd-status`, `sdd-sync`, `review-validator`.
+- [x] 7.4 GREEN: `scripts/verify-package-files.mjs` — add the phase-coverage gate, driven by the snapshot mirror plus `assets/phase-coverage.json`.
+- [x] 7.5 RED: generic evidence-harness test — an S-class (bootstrap) record can never be relabeled R; an R-class record requires live signed-release inputs.
+- [x] 7.6 GREEN: create `tests/evidence/**` — generic immutable-evidence harness implementing the plan §12 ledger shape (S vs R classes), reusable by later changes.
+- [x] 7.7 GREEN: `.github/workflows/ci.yml` — assemble the full offline `--check` set (mirrors/lock, baselines, skill overlays, phase-coverage) as one integration gate.
+- [x] 7.8 Verify: `pnpm test`; `node scripts/verify-package-files.mjs --check` (phase-coverage included).
 
 ## PR 8 — P4: Pin-bump automation + default-branch receiver (depends: PR 7)
 

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -13,6 +13,7 @@ const requiredPaths = [
   "assets/orchestrator-delegation.md",
   "assets/orchestrator-memory.md",
   "assets/orchestrator-skills.md",
+  "assets/phase-coverage.json",
   "assets/agents/sdd-apply.md",
   "assets/agents/sdd-archive.md",
   "assets/agents/sdd-design.md",
@@ -238,6 +239,87 @@ export function reconcileGeneratedRuntimeSources(packageRoot, sources, paths) {
   return { drifted };
 }
 
+// --- phase-coverage gate (design D9) ----------------------------------------
+//
+// assets/agents/** and assets/chains/** are Pi's binding layer over the
+// provider's declared SDD/review phases. They are never byte-vendored
+// (verified dialect difference: `tools:` is a comma string upstream and a
+// lowercase YAML list in Pi, upstream templates `{{CLAUDE_MODEL}}`, and
+// upstream has no `chains/` directory at all -- design.md D9). Instead this
+// gate cross-checks Pi's binding names on disk against the declared-phase
+// snapshot checked in at assets/phase-coverage.json.
+//
+// Two directions, two different severities -- a maintainer decision that
+// supersedes tasks.md 7.1's "fails" wording for the forward direction (see
+// apply-progress.md P3c evidence for the recorded reasoning):
+//
+//   - forward (declared phase -> Pi binding): WARN, never fail CI. Under the
+//     provider's fast release cadence new phases appear regularly; failing
+//     the build for a phase nobody has decided to implement yet trains
+//     people to ignore the gate, and a gate that cries wolf gets muted.
+//   - reverse (Pi agent binding -> declared phase): FAIL. A Pi agent naming
+//     no declared phase, and not listed Pi-only, is a real inconsistency in
+//     Pi's own configuration, not a provider-cadence problem.
+//
+// The reverse check walks only assets/agents/**. assets/chains/** compose
+// multiple phases into Pi-only workflows (upstream has no chains/ concept at
+// all), so a chain is not itself a single-phase binding and is not
+// reverse-checked -- it still counts toward the forward "is this phase bound
+// anywhere" search, since a chain naming a phase is still a binding of it.
+const PHASE_COVERAGE_RELATIVE_PATH = "assets/phase-coverage.json";
+const PHASE_AGENTS_DIR_RELATIVE_PATH = "assets/agents";
+const PHASE_CHAINS_DIR_RELATIVE_PATH = "assets/chains";
+const PHASE_CHAIN_FILE_SUFFIX = ".chain.md";
+const PHASE_AGENT_FILE_SUFFIX = ".md";
+
+function bindingNamesFromDirectory(packageRoot, relativeDir, suffix) {
+  const absoluteDir = join(packageRoot, relativeDir);
+  if (!existsSync(absoluteDir)) return [];
+  return readdirSync(absoluteDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(suffix))
+    .map((entry) => entry.name.slice(0, -suffix.length))
+    .sort();
+}
+
+// Reads only assets/agents/** and assets/chains/** -- never skills/**, so a
+// same-named or unrelated skill (e.g. skills/issue-creation/SKILL.md, which
+// is repo-identity content, not drift -- task 7.2) can never be read or
+// flagged by this gate.
+export function phaseCoverageBindings(packageRoot) {
+  return {
+    agentNames: bindingNamesFromDirectory(packageRoot, PHASE_AGENTS_DIR_RELATIVE_PATH, PHASE_AGENT_FILE_SUFFIX),
+    chainNames: bindingNamesFromDirectory(packageRoot, PHASE_CHAINS_DIR_RELATIVE_PATH, PHASE_CHAIN_FILE_SUFFIX),
+  };
+}
+
+// Pure reconciliation: given the checked-in declared-phase snapshot and the
+// on-disk binding names, returns the two drift directions separately so the
+// caller can apply a different severity to each -- never a single aggregate
+// boolean.
+export function phaseCoverageGate(phaseCoverage, { agentNames, chainNames }) {
+  const { declaredPhases, alias, piOnly } = phaseCoverage;
+  const piOnlySet = new Set(piOnly);
+  const allBindingNames = new Set([...agentNames, ...chainNames]);
+
+  const bindsPhase = (phase) => {
+    for (const bindingName of allBindingNames) {
+      if (bindingName === phase || alias[bindingName] === phase) return true;
+    }
+    return false;
+  };
+
+  const namesDeclaredPhase = (bindingName) => {
+    if (declaredPhases.includes(bindingName)) return true;
+    const aliased = alias[bindingName];
+    return aliased !== undefined && declaredPhases.includes(aliased);
+  };
+
+  const missingBindings = declaredPhases.filter((phase) => !bindsPhase(phase)).sort();
+  const unknownBindings = agentNames.filter((name) => !namesDeclaredPhase(name) && !piOnlySet.has(name)).sort();
+
+  return { missingBindings, unknownBindings };
+}
+
 async function main() {
   const missing = requiredPaths.filter((relativePath) => {
     const absolutePath = join(root, relativePath);
@@ -333,6 +415,22 @@ async function main() {
   if (versionMismatches.length > 0) {
     console.error("gentle-pi Gentle AI version pins have drifted from the authoritative INSTALLER_VERSION:");
     for (const mismatch of versionMismatches) console.error(`- ${mismatch}`);
+    process.exit(1);
+  }
+
+  const phaseCoverage = JSON.parse(readFileSync(join(root, PHASE_COVERAGE_RELATIVE_PATH), "utf8"));
+  const { missingBindings, unknownBindings } = phaseCoverageGate(phaseCoverage, phaseCoverageBindings(root));
+  for (const phase of missingBindings) {
+    console.warn(
+      `gentle-pi phase coverage: provider-declared phase "${phase}" has no Pi agent/chain binding yet (see ${PHASE_COVERAGE_RELATIVE_PATH}); not failing CI -- bind it when ready.`,
+    );
+  }
+  if (unknownBindings.length > 0) {
+    console.error(
+      `gentle-pi phase coverage: the following Pi agent bindings name no provider-declared phase and are not listed "piOnly" in ${PHASE_COVERAGE_RELATIVE_PATH}:`,
+    );
+    for (const name of unknownBindings) console.error(`- ${PHASE_AGENTS_DIR_RELATIVE_PATH}/${name}.md`);
+    console.error("\nRefusing to pack/publish an inconsistent phase binding.");
     process.exit(1);
   }
 

--- a/tests/evidence.test.ts
+++ b/tests/evidence.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { RELEASE_ARTIFACT_EVIDENCE_CLASS } from "../lib/release-artifact.ts";
+import { EVIDENCE_LEDGER_CLASS, EvidenceLedger, assertNeverRelabeledFromBootstrap, createEvidenceRecord } from "./evidence/ledger.ts";
+
+// --- generic immutable-evidence harness (design D9/plan §12, task 7.5/7.6) --
+//
+// Builds on the exact evidence.class discipline lib/release-artifact.ts
+// already carries (RELEASE_ARTIFACT_EVIDENCE_CLASS / evidenceClass on the
+// checked-in lock) instead of inventing a parallel S/R vocabulary.
+
+test("evidence ledger classes reuse the exact release-artifact evidence.class discipline", () => {
+	assert.equal(EVIDENCE_LEDGER_CLASS.S, RELEASE_ARTIFACT_EVIDENCE_CLASS.BOOTSTRAP);
+	assert.equal(EVIDENCE_LEDGER_CLASS.R, RELEASE_ARTIFACT_EVIDENCE_CLASS.RELEASE);
+});
+
+test("createEvidenceRecord builds an immutable record carrying its class and label", () => {
+	const record = createEvidenceRecord(EVIDENCE_LEDGER_CLASS.S, "install-on-linux");
+	assert.equal(record.evidenceClass, "development/bootstrap");
+	assert.equal(record.label, "install-on-linux");
+	assert.throws(() => {
+		// @ts-expect-error -- records are frozen; a runtime write must throw.
+		record.evidenceClass = EVIDENCE_LEDGER_CLASS.R;
+	}, TypeError);
+});
+
+test("an S-class record can never be relabeled R", () => {
+	const bootstrap = createEvidenceRecord(EVIDENCE_LEDGER_CLASS.S, "install-on-linux");
+	const release = createEvidenceRecord(EVIDENCE_LEDGER_CLASS.R, "install-on-linux");
+	assert.throws(
+		() => assertNeverRelabeledFromBootstrap(bootstrap, release),
+		/can never be relabeled/,
+	);
+});
+
+test("an R-class record requires live signed-release inputs -- re-recording R over R is fine", () => {
+	const releaseA = createEvidenceRecord(EVIDENCE_LEDGER_CLASS.R, "install-on-linux");
+	const releaseB = createEvidenceRecord(EVIDENCE_LEDGER_CLASS.R, "install-on-linux");
+	assert.doesNotThrow(() => assertNeverRelabeledFromBootstrap(releaseA, releaseB));
+});
+
+test("EvidenceLedger.record enforces the invariant on the mutation path itself, not only as a standalone comparison", () => {
+	const ledger = new EvidenceLedger();
+	ledger.record(EVIDENCE_LEDGER_CLASS.S, "install-on-linux");
+	assert.throws(
+		() => ledger.record(EVIDENCE_LEDGER_CLASS.R, "install-on-linux"),
+		/install-on-linux.*can never be relabeled/s,
+	);
+	// The failed attempt must not mutate the ledger.
+	assert.equal(ledger.get("install-on-linux")?.evidenceClass, EVIDENCE_LEDGER_CLASS.S);
+});
+
+test("EvidenceLedger.record allows R -> R re-recording and independent labels with different classes", () => {
+	const ledger = new EvidenceLedger();
+	ledger.record(EVIDENCE_LEDGER_CLASS.R, "install-on-linux");
+	assert.doesNotThrow(() => ledger.record(EVIDENCE_LEDGER_CLASS.R, "install-on-linux"));
+	assert.doesNotThrow(() => ledger.record(EVIDENCE_LEDGER_CLASS.S, "install-on-macos"));
+	assert.equal(ledger.get("install-on-linux")?.evidenceClass, EVIDENCE_LEDGER_CLASS.R);
+	assert.equal(ledger.get("install-on-macos")?.evidenceClass, EVIDENCE_LEDGER_CLASS.S);
+});
+
+test("EvidenceLedger.get returns undefined for a label never recorded", () => {
+	const ledger = new EvidenceLedger();
+	assert.equal(ledger.get("never-recorded"), undefined);
+});

--- a/tests/evidence/ledger.ts
+++ b/tests/evidence/ledger.ts
@@ -1,0 +1,69 @@
+// Generic immutable-evidence ledger harness (design D9, plan §12 ledger
+// shape). Every piece of evidence a change collects for a claim is either:
+//
+//   S-class ("development/bootstrap") -- produced from a local, synthetic,
+//     or otherwise unsigned input. Proves mechanism only. Never
+//     acceptance/pin evidence.
+//   R-class ("release") -- produced from a real, live, verified input
+//     (signed release, live install, etc). The sole final-acceptance class.
+//
+// This harness reuses the EXACT evidence.class discipline
+// lib/release-artifact.ts already carries (RELEASE_ARTIFACT_EVIDENCE_CLASS /
+// assertReleaseAcceptanceEvidence, also persisted verbatim into the checked-in
+// capabilities/gentle-ai-release.lock.json's evidence.class field) instead of
+// inventing a parallel S/R vocabulary. It is intentionally generic -- it
+// carries no gentle-ai-specific fields (no signature, no repository, no
+// tag) -- so any later change's test suite can build its own S-vs-R ledger
+// on top of the one invariant every consumer of it depends on: an S-class
+// bootstrap record can never be relabeled R.
+
+import { RELEASE_ARTIFACT_EVIDENCE_CLASS } from "../../lib/release-artifact.ts";
+
+export const EVIDENCE_LEDGER_CLASS = {
+	S: RELEASE_ARTIFACT_EVIDENCE_CLASS.BOOTSTRAP,
+	R: RELEASE_ARTIFACT_EVIDENCE_CLASS.RELEASE,
+} as const;
+
+export type EvidenceLedgerClass = (typeof EVIDENCE_LEDGER_CLASS)[keyof typeof EVIDENCE_LEDGER_CLASS];
+
+export interface EvidenceLedgerRecord {
+	readonly evidenceClass: EvidenceLedgerClass;
+	readonly label: string;
+}
+
+export function createEvidenceRecord(evidenceClass: EvidenceLedgerClass, label: string): EvidenceLedgerRecord {
+	return Object.freeze({ evidenceClass, label });
+}
+
+// The core invariant (plan §12 ledger shape): an S-class record can never be
+// relabeled R. An R-class record requires live signed-release (or
+// equivalent live-input) evidence; a bootstrap record standing in for one is
+// exactly the substitution design D1/D9 forbid elsewhere in this change.
+export function assertNeverRelabeledFromBootstrap(previous: EvidenceLedgerRecord, next: EvidenceLedgerRecord): void {
+	if (previous.evidenceClass === EVIDENCE_LEDGER_CLASS.S && next.evidenceClass !== EVIDENCE_LEDGER_CLASS.S) {
+		throw new Error(
+			`evidence ledger record ${JSON.stringify(previous.label)} was recorded as ${JSON.stringify(EVIDENCE_LEDGER_CLASS.S)} and can never be relabeled ${JSON.stringify(next.evidenceClass)}: an S-class bootstrap record can never serve as R-class release evidence`,
+		);
+	}
+}
+
+// A ledger accumulates one record per label. The invariant is enforced on
+// the mutation path itself (record), not only as a standalone comparison
+// function callers might forget to invoke: once a label is recorded
+// S-class, no later call for the same label may record it R-class, and a
+// rejected attempt never mutates the ledger.
+export class EvidenceLedger {
+	#records = new Map<string, EvidenceLedgerRecord>();
+
+	record(evidenceClass: EvidenceLedgerClass, label: string): EvidenceLedgerRecord {
+		const next = createEvidenceRecord(evidenceClass, label);
+		const previous = this.#records.get(label);
+		if (previous !== undefined) assertNeverRelabeledFromBootstrap(previous, next);
+		this.#records.set(label, next);
+		return next;
+	}
+
+	get(label: string): EvidenceLedgerRecord | undefined {
+		return this.#records.get(label);
+	}
+}

--- a/tests/verify-package-files.test.ts
+++ b/tests/verify-package-files.test.ts
@@ -9,6 +9,8 @@ import {
 	gentleAiVersionPinMismatches,
 	mirrorDigestDrift,
 	mirrorDigestsFromLock,
+	phaseCoverageBindings,
+	phaseCoverageGate,
 	reconcileContractsOnDisk,
 	reconcileGeneratedRuntimeSources,
 } from "../scripts/verify-package-files.mjs";
@@ -214,6 +216,109 @@ test("lock release version pin mismatch is reported naming the authoritative INS
 		/gentle-ai-release\.lock\.json/,
 	);
 	assert.doesNotThrow(() => assertLockReleaseVersionPin({ release: { version: INSTALLER_VERSION } }, INSTALLER_VERSION));
+});
+
+// --- phase-coverage gate (design D9, task 7.1/7.2) --------------------------
+//
+// Maintainer decision superseding tasks.md 7.1's "fails" wording for the
+// forward direction (recorded in apply-progress.md): a provider-declared
+// phase with no Pi binding WARNS, naming the missing phase, and does NOT
+// fail CI -- the reverse direction (a Pi binding naming no declared phase,
+// not listed Pi-only) still fails, since that is a real inconsistency in
+// Pi's own configuration rather than provider release cadence.
+
+test("phase coverage: a provider-declared phase with no Pi binding is reported as missing, not as an unknown binding", () => {
+	const { missingBindings, unknownBindings } = phaseCoverageGate(
+		{ declaredPhases: ["sdd-apply", "sdd-brand-new-phase"], alias: {}, piOnly: [] },
+		{ agentNames: ["sdd-apply"], chainNames: [] },
+	);
+
+	assert.deepEqual(missingBindings, ["sdd-brand-new-phase"]);
+	assert.deepEqual(unknownBindings, []);
+});
+
+test("phase coverage: a Pi agent binding naming no declared phase and not listed Pi-only is an unknown binding", () => {
+	const { missingBindings, unknownBindings } = phaseCoverageGate(
+		{ declaredPhases: ["sdd-apply"], alias: {}, piOnly: [] },
+		{ agentNames: ["sdd-apply", "gentle-ai-rogue"], chainNames: [] },
+	);
+
+	assert.deepEqual(missingBindings, []);
+	assert.deepEqual(unknownBindings, ["gentle-ai-rogue"]);
+});
+
+test("phase coverage: a Pi-only binding names no declared phase but is never reported unknown", () => {
+	const { missingBindings, unknownBindings } = phaseCoverageGate(
+		{ declaredPhases: ["sdd-apply"], alias: {}, piOnly: ["sdd-status"] },
+		{ agentNames: ["sdd-apply", "sdd-status"], chainNames: [] },
+	);
+
+	assert.deepEqual(missingBindings, []);
+	assert.deepEqual(unknownBindings, []);
+});
+
+test("phase coverage: the sdd-proposal <-> sdd-propose alias resolves in both directions", () => {
+	const phaseCoverage = { declaredPhases: ["sdd-propose"], alias: { "sdd-proposal": "sdd-propose" }, piOnly: [] };
+
+	assert.deepEqual(
+		phaseCoverageGate(phaseCoverage, { agentNames: ["sdd-proposal"], chainNames: [] }),
+		{ missingBindings: [], unknownBindings: [] },
+	);
+});
+
+test("phase coverage: a chain binding satisfies the forward check for a declared phase", () => {
+	const { missingBindings } = phaseCoverageGate(
+		{ declaredPhases: ["sdd-verify"], alias: {}, piOnly: [] },
+		{ agentNames: [], chainNames: ["sdd-verify"] },
+	);
+
+	assert.deepEqual(missingBindings, []);
+});
+
+test("phase coverage: a chain naming no declared phase is never reported as an unknown binding (reverse check only walks assets/agents/**)", () => {
+	const { missingBindings, unknownBindings } = phaseCoverageGate(
+		{ declaredPhases: ["sdd-apply"], alias: {}, piOnly: [] },
+		{ agentNames: ["sdd-apply"], chainNames: ["4r-review"] },
+	);
+
+	assert.deepEqual(missingBindings, []);
+	assert.deepEqual(unknownBindings, []);
+});
+
+test("phase coverage: skills/issue-creation/SKILL.md is never read or flagged -- the gate only walks assets/agents/** and assets/chains/**", () => {
+	const fixtureRoot = makeFixtureRoot();
+	try {
+		mkdirSync(join(fixtureRoot, "assets/agents"), { recursive: true });
+		mkdirSync(join(fixtureRoot, "assets/chains"), { recursive: true });
+		mkdirSync(join(fixtureRoot, "skills/issue-creation"), { recursive: true });
+		writeFileSync(join(fixtureRoot, "assets/agents/sdd-apply.md"), "agent\n");
+		writeFileSync(join(fixtureRoot, "assets/chains/sdd-plan.chain.md"), "chain\n");
+		writeFileSync(join(fixtureRoot, "skills/issue-creation/SKILL.md"), "repo-identity, not drift\n");
+
+		const bindings = phaseCoverageBindings(fixtureRoot);
+
+		assert.deepEqual(bindings.agentNames, ["sdd-apply"]);
+		assert.deepEqual(bindings.chainNames, ["sdd-plan"]);
+
+		const { unknownBindings } = phaseCoverageGate(
+			{ declaredPhases: ["sdd-apply"], alias: {}, piOnly: [] },
+			bindings,
+		);
+		assert.deepEqual(unknownBindings, []);
+	} finally {
+		rmSync(fixtureRoot, { recursive: true, force: true });
+	}
+});
+
+test("phase coverage: the real assets/phase-coverage.json fully reconciles against the real assets/agents and assets/chains trees", async () => {
+	const PACKAGE_ROOT = join(import.meta.dirname, "..");
+	const phaseCoverage = JSON.parse(readFileSync(join(PACKAGE_ROOT, "assets/phase-coverage.json"), "utf8"));
+	const bindings = phaseCoverageBindings(PACKAGE_ROOT);
+
+	const { missingBindings, unknownBindings } = phaseCoverageGate(phaseCoverage, bindings);
+
+	assert.deepEqual(missingBindings, []);
+	assert.deepEqual(unknownBindings, []);
 });
 
 test("both walks report no drift when sources, runtime/*.mjs, requiredPaths, and contractHashes fully agree", () => {


### PR DESCRIPTION
Seventh slice of the consumer chain, stacked on #271.

## The gate is asymmetric on purpose

**A provider-declared phase with no Pi binding WARNS and does not fail CI.** Under the provider's release cadence new phases appear regularly, and blocking the build for a phase nobody has decided to implement yet trains people to ignore the gate. A gate that cries wolf gets muted, and a muted gate protects nothing.

**A Pi binding naming no declared phase, and not listed as Pi-only, FAILS.** That is not upstream moving — it is an inconsistency inside Pi's own configuration, and it should break the build.

This supersedes task 7.1's wording, which said the forward direction fails. The supersession is annotated in `tasks.md` and explained in `apply-progress.md` so it reads as a decision rather than a slip.

The two directions are disjoint code paths: `missingBindings` only ever reaches `console.warn`, and `process.exit(1)` is gated strictly on `unknownBindings.length > 0`. Verified end to end against the real tree, which exits 0 with full coverage.

`issue-creation` is never flagged. It is repo-identity content, not drift.

## The evidence harness Wave 1 will consume

`tests/evidence/**` implements the S-versus-R ledger with one invariant: **a bootstrap record can never be relabeled release evidence**, and a release record requires live signed-release inputs. It builds on the `evidence.class` discipline the lock already carries in #267 rather than inventing a parallel notion.

Wave 1 consumes this rather than reimplementing it. That is the point of putting it here.

## One scope decision, forced by the real tree

The reverse check covers `assets/agents/**` only. Reconciling the real tree against the declared six-item Pi-only list showed Pi's chain files include three names with no matching declared phase and no authorization to add them. Extending the check to chains would have required inventing entries. Documented rather than quietly widened.

## CI

The offline checks consolidate into one integration gate: mirrors and lock, baselines, skill overlays, phase coverage. All of it runs with no network.

## Tests

28 across the two new areas, all green. Full suite 1132 pass, 1 fail — the environmental no-network failure. A second environmental symptom in `tests/runtime-harness.mjs` was checked and reproduces on the clean parent tip too, so neither is introduced here.

## Rollback

Reverting the five commits restores the parent state exactly. No file or behavior from the earlier slices is touched.
