### PR TITLE
feat(release): prepare pin-bump PRs automatically, and never merge them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,13 @@ jobs:
       #      hand-edited vendored file and a stale overlay anchor before
       #      either reaches skills/<name>/SKILL.md.
       #
-      # Only scripts/sync-gentle-ai-release.mjs --write (the not-yet-landed
-      # pin-bump job, P4) ever downloads or verifies a minisign signature; no
-      # step in this workflow does.
+      # scripts/sync-gentle-ai-release.mjs --write only ever runs in the
+      # pin-bump job of .github/workflows/gentle-ai-release-received.yml
+      # (design D1/D6/P4) -- no step in THIS workflow downloads a gentle-ai
+      # release or verifies a minisign signature. (This job's own `pnpm
+      # install` above still reaches the npm registry for dependency
+      # installation; that is a separate, pre-existing surface unrelated to
+      # the gentle-ai release trust boundary this design adds.)
       - name: Verify offline checks (mirrors/lock, phase coverage, baselines, skill overlays)
         run: |
           node scripts/verify-package-files.mjs --check

--- a/.github/workflows/gentle-ai-release-received.yml
+++ b/.github/workflows/gentle-ai-release-received.yml
@@ -1,0 +1,91 @@
+name: gentle-ai release received
+
+# Pin-bump receiver (design.md "P4" / proposal.md P4). This workflow is the
+# sole `repository_dispatch` receiver for a published gentle-ai release and
+# hosts the ONLY job in this repository, in any workflow, that gentle-pi
+# lets download a gentle-ai release (design D1/D6: "every per-PR check is
+# offline; only the pin-bump job downloads").
+#
+# WHY THIS RECEIVER IS INERT UNTIL IT REACHES `main` (expected state, not a
+# defect -- do not "fix" it):
+#
+#   GitHub only triggers `repository_dispatch` for a workflow file that
+#   already exists on the repository's DEFAULT branch. A `repository_dispatch`
+#   event fired against gentle-pi cannot invoke this workflow at all until
+#   this exact file is merged to `main`. Before that point, this workflow
+#   simply never runs -- there is no bug to chase and nothing to debug.
+#
+#   This is also why future bump PRs must always target `main`, never a
+#   temporary feature/tracker branch: once this file lands on `main`, the
+#   live event source is the provider's `main`-branch-triggered publish, and
+#   a bump PR against a non-default branch would never be reachable by it.
+#
+# Maintainer decision: the dispatch payload is the TAG ONLY (see
+# scripts/bump-gentle-ai-pin.mjs for why -- a richer payload would be a
+# second source of truth). The tag is passed to the bump script through an
+# environment variable (`DISPATCHED_TAG` below), never interpolated directly
+# into a `run:` script body -- interpolating `${{ github.event.* }}` straight
+# into shell text is GitHub Actions' own well-known script-injection vector.
+# scripts/bump-gentle-ai-pin.mjs then validates it against ^v\d+\.\d+\.\d+$
+# before any use (see that file's threat-matrix comment).
+#
+# Maintainer decision: this job NEVER merges the PR it opens. A human always
+# reviews and merges a pin bump. Do not add a merge or auto-merge step here.
+
+on:
+  repository_dispatch:
+    types: [gentle-ai-release-published]
+
+permissions:
+  contents: read
+
+jobs:
+  pin-bump:
+    # The ONLY job, in the ONLY workflow, that gentle-pi lets download a
+    # gentle-ai release. Every job in .github/workflows/ci.yml stays fully
+    # offline against checked-in mirrors and the lock (design D6); this job's
+    # own `pnpm install` step still reaches the npm registry for dependency
+    # installation, which is a separate, pre-existing surface unrelated to
+    # the gentle-ai release trust boundary this design adds.
+    if: github.repository == 'Gentleman-Programming/gentle-pi'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      DISPATCHED_TAG: ${{ github.event.client_payload.tag }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity for the automated pin-bump commit
+        run: |
+          git config user.name "gentle-ai-release-bot"
+          git config user.email "gentle-ai-release-bot@users.noreply.github.com"
+
+      - name: Bump gentle-ai pin
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # DISPATCHED_TAG is read from the environment (set above from the
+        # dispatch payload), never interpolated into this script body.
+        # scripts/bump-gentle-ai-pin.mjs validates it before any use and
+        # always opens the PR against the explicit literal base "main" --
+        # never auto-merging it. See that script for the full threat-matrix
+        # rationale.
+        run: node scripts/bump-gentle-ai-pin.mjs --tag "$DISPATCHED_TAG"

--- a/openspec/changes/consume-gentle-ai-release-artifacts/apply-progress.md
+++ b/openspec/changes/consume-gentle-ai-release-artifacts/apply-progress.md
@@ -1,7 +1,8 @@
 # Apply Progress: consume-gentle-ai-release-artifacts
 
-> Cumulative across batches: **PR 1 / P1a** through **PR 7 / P3c**, all complete
-> (tasks 1.1-7.8). PR 8 (P4) is NOT started.
+> Cumulative across batches: **PR 1 / P1a** through **PR 8 / P4**, all complete
+> (tasks 1.1-8.5). This is the tracker's FINAL work unit — all 68 tasks across
+> P1a+P1b+P2a+P2b+P3a+P3b+P3c+P4 are now checked.
 
 ## Completed Tasks
 
@@ -1004,9 +1005,10 @@ plus the `tests/runtime-harness.mjs` pre-existing failure newly confirmed (via `
 reproduce on the clean P3b tip — both are sandbox-only, no-network symptoms of the same missing native
 binary, neither introduced by this unit.
 
-## Remaining Tasks
+## Remaining Tasks (as of P3c)
 
-- [ ] PR 8 — P4 (`scripts/bump-gentle-ai-pin.mjs` + `gentle-ai-release-received.yml` receiver): not started.
+- [x] PR 8 — P4 (`scripts/bump-gentle-ai-pin.mjs` + `gentle-ai-release-received.yml` receiver): complete — see
+  "PR 8 — P4" section below. Nothing remains; this was the tracker's last work unit.
 
 ## Workload / PR Boundary (P3c)
 
@@ -1029,3 +1031,302 @@ binary, neither introduced by this unit.
 8/8 tasks in PR 7 (P3c) complete. 63/68 tasks total across P1a+P1b+P2a+P2b+P3a+P3b+P3c. Ready for
 `sdd-verify`, or for `sdd-apply` to continue with PR 8 (P4) in a fresh batch, on a new branch based on this
 one (`feat/phase-coverage-evidence`).
+
+---
+
+# PR 8 — P4: Pin-bump automation + default-branch receiver
+
+> Worktree `gentle-pi-worktrees/p4`, branch `feat/pin-bump-automation`, based on P3c's
+> `feat/phase-coverage-evidence`. Tasks 8.1-8.5. **This completes the consumer tracker's 68 tasks —
+> all of P1a+P1b+P2a+P2b+P3a+P3b+P3c+P4 are now checked.**
+
+## Completed Tasks
+
+- [x] 8.1 RED: `tests/bump-gentle-ai-pin.test.ts` — threat-matrix "PR commands": a dispatched tag carrying
+  shell metacharacters is rejected (10 cases: `;`, `&&`, `|`, backtick, `$()`, embedded newline, quotes,
+  `>`, `&`); a `--head`/`--base` injection attempt is rejected (5 cases, including a bare `--head` and a
+  tag with an embedded space followed by `--head evil-branch`); an implicit (omitted) base is rejected, and
+  any alternate non-`main` base is rejected.
+- [x] 8.2 GREEN: created `scripts/bump-gentle-ai-pin.mjs` — `validateDispatchedTag` (anchored
+  `^v\d+\.\d+\.\d+$`, runs before any other code touches the value), `deriveBumpHeadBranch` (derives
+  `bump/gentle-ai-<tag>` only from an already-validated tag, and defensively re-validates even if called
+  directly), `buildPullRequestArguments` (flat `gh` argv array; base must be the exact literal `"main"`;
+  head must match the exact derived-prefix shape), `buildPullRequestBody`, and `runGentleAiPinBump`
+  orchestrating, in order: `git checkout -b <head>` → `sync-gentle-ai-release.mjs --write` →
+  `build-gentle-ai-baselines.mjs --write` → `build-skill-overlays.mjs --write` → `git add -A` → `git status
+  --porcelain` (short-circuits with no commit/push/PR if empty) → `git commit` → `git push --set-upstream`
+  → `gh pr create --base main --head <branch> ...`. Every subprocess call goes through `execFile` with a
+  fixed argv array (`shell: false`); nowhere does the script compose a shell string by interpolating the
+  tag, the branch name, or any other external payload.
+- [x] 8.3 GREEN: created `.github/workflows/gentle-ai-release-received.yml` — `on: repository_dispatch:
+  types: [gentle-ai-release-published]`; single `pin-bump` job with `contents: write` +
+  `pull-requests: write`; the dispatch payload's tag is read into `DISPATCHED_TAG` via `env:` (never
+  interpolated directly into a `run:` script body — GitHub Actions' own well-known script-injection
+  vector); the bump step runs `node scripts/bump-gentle-ai-pin.mjs --tag "$DISPATCHED_TAG"`. The workflow's
+  header comment explains, in detail, why this receiver is inert until it reaches `main` (see "Why the
+  receiver is inert for now" below) so nobody "fixes" it.
+- [x] 8.4 GREEN: `.github/workflows/ci.yml` — replaced the stale "not-yet-landed pin-bump job, P4" comment
+  with one naming the actual receiver workflow and job, and explicitly scoping the "only job with network
+  access" boundary to the gentle-ai release download (not `pnpm install`'s pre-existing, unrelated npm
+  registry access — see "Network access boundary, precisely scoped" below for why that distinction matters
+  and is not a loophole).
+- [x] 8.5 Verify: `pnpm test -- bump-gentle-ai-pin` (`node --experimental-strip-types --test
+  tests/bump-gentle-ai-pin.test.ts`) → `pass 33 fail 0`. Dry-run dispatch against a fixture tag proven two
+  ways (both below): (a) a real local git repo + a stub `gh` on `PATH`, exercising the REAL `execFile`
+  subprocess path end to end; (b) direct CLI invocation with a shell-metacharacter tag, proving rejection
+  happens before a single subprocess is spawned. `repository_dispatch` activation itself cannot be proven
+  in this sandbox (no network, no GitHub API, and by design this workflow cannot fire until merged to
+  `main` — see below); that is the one remaining real-world step, documented under "What remains before
+  this automation can actually run."
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 8.1/8.2 | `tests/bump-gentle-ai-pin.test.ts` | Unit | N/A (new file) | ✅ Written first — referenced `validateDispatchedTag`/`deriveBumpHeadBranch`/`buildPullRequestArguments`/`buildPullRequestBody`/`parseArguments`/`runGentleAiPinBump` before `scripts/bump-gentle-ai-pin.mjs` existed → confirmed `ERR_MODULE_NOT_FOUND` (ran the whole suite before writing any production code) | ✅ 33/33 pass on the first implementation pass | ✅ 10 shell-metacharacter tag variants, 5 `--head`/`--base` injection variants, implicit-base AND alternate-base rejection, head-branch-shape rejection, an argv-shape assertion (tokens are separate strings, never a composed string), an explicit "never `--auto`" assertion, plus 4 orchestration-level tests (reject-before-any-command, stop-after-sync-failure, full happy-path-in-order, no-changes-short-circuit) | ✅ Clean — one pure validation function is the single point every other function and the orchestration re-uses; no duplicated regex or ad hoc string checks anywhere else in the file |
+
+## Test Summary
+
+- **Total tests written**: 33 (in `tests/bump-gentle-ai-pin.test.ts`)
+- **Total tests passing**: 33/33
+- **Layers used**: Unit (29, pure functions), orchestration with an injected command fake (4)
+- **Pure functions created**: `validateDispatchedTag`, `deriveBumpHeadBranch`, `buildPullRequestArguments`,
+  `buildPullRequestBody`, `parseArguments` — `runGentleAiPinBump` is the only function with I/O, and that
+  I/O (`runCommand`) is fully injectable, exactly matching the seam pattern already used by
+  `syncGentleAiRelease`'s `fetchText`/`downloadArchive`/`extractor` options.
+
+## RED-then-GREEN evidence (exact commands)
+
+RED (before `scripts/bump-gentle-ai-pin.mjs` existed):
+
+```
+$ node --experimental-strip-types --test tests/bump-gentle-ai-pin.test.ts
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+'/home/gentleman/work/gentle-pi-worktrees/p4/scripts/bump-gentle-ai-pin.mjs' imported from
+tests/bump-gentle-ai-pin.test.ts
+✖ tests/bump-gentle-ai-pin.test.ts (71.2ms)
+ℹ tests 1 / pass 0 / fail 1
+```
+
+GREEN (after implementation):
+
+```
+$ node --experimental-strip-types --test tests/bump-gentle-ai-pin.test.ts
+ℹ tests 33
+ℹ pass 33
+ℹ fail 0
+```
+
+## How each injection vector is proven rejected
+
+1. **Shell metacharacters** — `validateDispatchedTag` is exercised with 10 payloads: `; rm -rf /`,
+   `&& rm -rf /`, `| cat /etc/passwd`, a backtick command substitution, a `$()` command substitution, an
+   embedded newline followed by `rm -rf /`, a single quote, a double quote, an output redirection (`>
+   /tmp/pwned`), and a background operator (`&`). Every one fails the anchored `^v\d+\.\d+\.\d+$` pattern
+   and throws before any other code runs. Proven twice: once as a `node:test` table-driven case, and once
+   live against the real CLI (`node scripts/bump-gentle-ai-pin.mjs --tag 'v1.2.3; touch
+   /tmp/pwned-marker'`) — exit code 1, the exact rejection message, and no `/tmp/pwned-marker` file created.
+2. **`--head` injection attempt** — 5 payloads: a tag with an embedded space followed by `--head
+   evil-branch`; a tag with an embedded tab followed by `--head=evil-branch`; a bare `--head`; a bare
+   `--head evil-branch`; and a tag with an embedded space followed by `--base evil-base` (the same vector
+   applied to `--base`, since the design's own threat row names both). All 5 fail the same anchored
+   pattern (it permits only digits and dots — no spaces, tabs, or dashes at all), so an attacker cannot
+   smuggle an extra CLI flag inside the tag value under any circumstance, structurally, not just by
+   coincidence of the test cases chosen.
+3. **Implicit base** — `buildPullRequestArguments({ base: undefined, ... })` throws
+   `gentle-ai pin-bump PR base must be the explicit literal "main"; refusing an implicit or alternate base
+   undefined`. A second test proves an explicitly-supplied alternate base (`"develop"`) is rejected with
+   the identical message — the function does not merely default a missing base to `main`, it requires the
+   caller to pass the literal `"main"` and refuses anything else, including `undefined`.
+
+None of these three checks live only in tests: `runGentleAiPinBump`'s only path to `buildPullRequestArguments`
+passes the hardcoded `GENTLE_AI_BUMP_BASE_BRANCH` constant, so the implicit-base guard is unreachable from
+production code by construction — it exists to keep the function safe for any future caller, not because
+today's one caller could trigger it.
+
+## Confirmation that no auto-merge path exists
+
+- `buildPullRequestArguments` returns exactly `["pr", "create", "--base", base, "--head", head, "--title",
+  title, "--body", body]` — 10 tokens, no more. A dedicated test
+  (`buildPullRequestArguments never includes an auto-merge flag`) asserts `--auto`, `--admin`, `--squash`,
+  and `merge` are all absent from that array.
+- The happy-path orchestration test additionally scans **every** recorded subprocess call across the whole
+  `runGentleAiPinBump` run (not just the `gh` call) and asserts none of them is `gh pr merge` and none of
+  them includes an `--auto` token anywhere.
+- `scripts/bump-gentle-ai-pin.mjs` contains exactly one `gh` invocation in its entire source: the
+  `pr create` call inside `runGentleAiPinBump`. Grepped and confirmed: `rg -n '"gh"' scripts/bump-gentle-ai-pin.mjs`
+  returns one match.
+- `.github/workflows/gentle-ai-release-received.yml` has exactly one job and one `gh`-invoking step (the
+  `Bump gentle-ai pin` step); there is no merge, auto-merge, or auto-approve step anywhere in the workflow.
+- The PR body itself (`buildPullRequestBody`) states, verbatim: "**This PR requires human review and is
+  never auto-merged**, even when every check is green" — so the intent is visible to the human reviewer
+  inside the PR, not only enforced in code.
+
+## Dry-run dispatch proof (task 8.5)
+
+Two independent proofs, neither touching the real repository, the network, or a real GitHub API:
+
+**(a) Real subprocess path against a throwaway local git repo.** Built a temp bare "origin" + a work clone,
+with stub `sync-gentle-ai-release.mjs`/`build-gentle-ai-baselines.mjs`/`build-skill-overlays.mjs` that each
+write a marker file, and a stub `gh` executable on `PATH` that logs its argv and exits 0. Called
+`runGentleAiPinBump({ rawTag: "v9.9.9", packageRoot: workDir })` with the REAL (non-injected)
+`defaultRunCommand` — i.e. real `execFile`, real `git`. Result:
+
+```
+result: { tag: 'v9.9.9', headBranch: 'bump/gentle-ai-v9.9.9', prOpened: true }
+gh invocation log: pr create --base main --head bump/gentle-ai-v9.9.9 --title chore(gentle-ai): bump pin to v9.9.9 --body ...
+branch on origin: bump/gentle-ai-v9.9.9
+last commit message on branch: chore(gentle-ai): bump pin to v9.9.9
+DRY RUN OK: real git subprocess path + stub gh argv handoff both verified.
+```
+
+This proves the real `git checkout -b` / `git commit` / `git push` / `gh` argv handoff all work together,
+end to end, exactly as the injected-fake unit tests assert in isolation — a real branch landed on the
+local "origin", with the right commit message, and `gh` received the exact expected `--base main --head
+bump/gentle-ai-v9.9.9` tokens.
+
+**(b) Direct CLI rejection proof.** `node scripts/bump-gentle-ai-pin.mjs --tag 'v1.2.3; touch
+/tmp/pwned-marker'` → exit code 1, the exact `does not match` rejection message, and (confirmed via `test
+-f /tmp/pwned-marker`) no injected command ever executed.
+
+Neither proof is checked into the repository as a permanent test (they require a real local git repo /
+`PATH` manipulation not appropriate for `tests/*.test.ts`); they are throwaway verification evidence,
+matching how `pnpm run test:harness`-style scenarios in prior units of this tracker were also documented
+as manual/scripted proof rather than promoted into `node:test`.
+
+## Why the receiver is inert for now
+
+`repository_dispatch` only invokes a workflow file that ALREADY EXISTS on the repository's default branch.
+`.github/workflows/gentle-ai-release-received.yml` cannot receive a single event until this exact file is
+merged to `main` — this branch (`feat/pin-bump-automation`), the tracker branch, and every other
+non-default branch will never see a `repository_dispatch` event fire this workflow, no matter how the
+provider dispatches it. This is documented at length in the workflow file's own header comment specifically
+so a future maintainer does not mistake "the workflow never runs here" for a bug and try to "fix" it by,
+for example, changing the trigger or adding a workaround. It also explains, in the same comment, why every
+future bump PR must target `main` and never a temporary tracker branch: once this file is on `main`, the
+live event source is the provider's own `main`-branch-triggered publish, and a PR against a non-default
+branch would never be reachable by a subsequent dispatch.
+
+## Network access boundary, precisely scoped
+
+The instruction "the pin-bump job must remain the only job with network access; every other check stays
+offline" is design D6's existing invariant ("every per-PR check is offline; only the pin-bump job
+downloads") applied to P4. Read literally against *every* kind of network access, it would also indict
+`ci.yml`'s pre-existing `pnpm install --frozen-lockfile` step (npm registry) and the new receiver's own
+`pnpm install` step — both of which predate this design entirely and are unrelated to the gentle-ai release
+trust boundary D1-D6 establish. The scoped, design-consistent reading — and the one implemented and
+documented in both workflow files' comments — is: **no job other than the pin-bump job in
+`gentle-ai-release-received.yml` ever downloads a gentle-ai release or invokes `scripts/sync-gentle-ai-release.mjs
+--write`.** Dependency installation via `pnpm install` remains a separate, pre-existing, package-manager-level
+concern present in every job of every workflow in this repository, before and after this change, and
+altering that would be out of this change's scope. This is stated explicitly, not silently narrowed, in
+both `ci.yml`'s comment (task 8.4) and the new receiver workflow's job-level comment.
+
+## Rollback boundary
+
+Delete `scripts/bump-gentle-ai-pin.mjs`, `tests/bump-gentle-ai-pin.test.ts`, and
+`.github/workflows/gentle-ai-release-received.yml`; revert the one comment edit in
+`.github/workflows/ci.yml`. No P1/P2/P3 file is touched by this unit. Manual, human-verified pin bumps
+(the process every prior release used) resume exactly as before — nothing in P1-P3's trust, generation, or
+gate code depends on this automation existing.
+
+## Work Unit Evidence (P4)
+
+| Evidence | Value |
+|---|---|
+| Focused test command and exact result | `node --experimental-strip-types --test tests/bump-gentle-ai-pin.test.ts` → `pass 33 fail 0` |
+| Runtime harness command/scenario and exact result | No `pnpm run test:harness`/`--check` runtime boundary applies to this unit's own new code (it has no generated-runtime or offline-gate surface of its own). Instead: manual `workflow_dispatch`-equivalent dry-run replay against a fixture tag (`v9.9.9`), against a real local git repo with a stub `gh`, proving the real subprocess path end to end — see "Dry-run dispatch proof" above. `pnpm run test:harness` was still re-run as part of the full-suite proof below to confirm this unit introduces no regression there. |
+| Rollback boundary | See "Rollback boundary" above. |
+
+## Full-suite proof (`node --experimental-strip-types --test tests/*.test.ts`)
+
+`tests 1178 / pass 1165 / fail 1 / skipped 12` (1145 pre-existing + 33 new, all in
+`tests/bump-gentle-ai-pin.test.ts`). The 1 failure is the same pre-existing, sandbox-only, no-network
+`tests/native-review-cli.test.ts` "native output limits dominate killed timeout signals..." failure
+documented in every prior unit of this tracker — word-for-word identical failure message and stack
+(`package-local-binary-missing: Gentle AI v2.2.3 is not installed`) to P3c's documented occurrence. Not
+new, not related to this unit.
+
+`node --experimental-strip-types tests/runtime-harness.mjs` also fails in this sandbox, with the exact same
+message P3c already documented and attributed to the identical root cause (no native
+`.gentle-ai/v2.2.3/gentle-ai` binary, no network): "Gentle AI pre-pr gate could not reconsult review mode
+and failed closed." Word-for-word identical to the P3c record — not introduced by this unit.
+
+`pnpm install` still fails its own `postinstall` network step in this sandbox (HTTP 404 fetching the
+binary), exactly as documented in every prior unit; it still succeeds far enough to populate `node_modules`
+from the local pnpm store, so the direct `node --experimental-strip-types --test tests/*.test.ts`
+invocation was used, matching every prior unit's documented workaround.
+
+Offline generator/gate checks, all passing against the real tree after this unit's changes:
+
+```
+$ node scripts/verify-package-files.mjs --check
+gentle-pi package resource check passed (73 files; 66 lock-pinned mirror artifacts at release v2.2.3).
+
+$ node scripts/build-gentle-ai-baselines.mjs --check
+gentle-ai baselines match their checked-in sources (lib/gentle-ai-required-floor.generated.ts)
+
+$ node scripts/build-skill-overlays.mjs --check
+skill overlays match their checked-in sources (7 skills: branch-pr, chained-pr, cognitive-doc-design,
+comment-writer, skill-improver, skill-registry, work-unit-commits)
+```
+
+## Deviations from Design
+
+None — implementation matches design.md D1/D6's network-boundary invariant and the threat-matrix "PR
+commands" row exactly. The one interpretive choice made explicit above ("Network access boundary, precisely
+scoped") is a scoping clarification of an instruction that, read maximally literally, would contradict this
+repository's own pre-existing, unrelated `pnpm install` steps — not a deviation from design.md, which never
+mentions dependency-installation network access at all.
+
+## Issues Found
+
+None new. Same `node_modules`/`postinstall` HTTP 404 sandbox environment condition documented in every
+prior unit of this tracker, plus the same `tests/runtime-harness.mjs` pre-existing failure P3c already
+confirmed reproduces on a clean tip — neither introduced by this unit.
+
+## What remains before this automation can actually run
+
+1. **This branch chain must merge to `main`.** `repository_dispatch` cannot invoke
+   `.github/workflows/gentle-ai-release-received.yml` until that exact file is present on the default
+   branch (see "Why the receiver is inert for now" above) — this is a GitHub platform restriction, not
+   something any code change here can work around.
+2. **The provider must publish a real signed gentle-ai release and dispatch it.** `GENTLE_AI_RELEASE_TRUSTED_PUBLIC_KEY`
+   in `scripts/sync-gentle-ai-release.mjs` is still the `PENDING-GENTLE-AI-RELEASE-MINISIGN-PUBLIC-KEY`
+   sentinel (documented since P1b); a live `--write` run fails closed while it remains pending, by design —
+   this is out of scope for the consumer tracker and tracked entirely on the provider side
+   (`publish-gentle-ai-release-artifacts`).
+3. **The provider must dispatch the `gentle-ai-release-published` event type** with `client_payload.tag`
+   set to the published tag. The exact event type name (`gentle-ai-release-published`) is this change's own
+   choice, not previously pinned anywhere in design.md/tasks.md/proposal.md; if the provider side settles on
+   a different name, only the one `types:` line in `gentle-ai-release-received.yml` needs to change.
+4. **A GitHub Actions bot identity and token permissions must be confirmed at merge time** — the workflow
+   requests `contents: write` + `pull-requests: write` and configures a bot git identity
+   (`gentle-ai-release-bot`) for the automated commit; this has not been exercised against real GitHub
+   Actions permissions in this sandbox (no network, no GitHub API access here).
+
+None of these are code-completeness gaps in this unit — they are the real-world activation steps that can
+only happen once this code lands on `main`, matching the design's own stated rollout: "Live
+`repository_dispatch` activates only after P4's receiver reaches `main`."
+
+## Workload / PR Boundary (P4)
+
+- Mode: feature-branch-chain, `size:exception` (tasks.md: `Delivery strategy: exception-ok`)
+- Current work unit: P4 (PR 8, base: P3c's branch `feat/phase-coverage-evidence`)
+- Boundary: `scripts/bump-gentle-ai-pin.mjs` (new), `tests/bump-gentle-ai-pin.test.ts` (new),
+  `.github/workflows/gentle-ai-release-received.yml` (new), one comment edit in
+  `.github/workflows/ci.yml`. No P1/P2/P3 file touched.
+- Estimated review budget impact: `git diff --stat` shows 1 tracked file changed
+  (`.github/workflows/ci.yml`: 7 insertions/3 deletions), plus 3 new untracked files —
+  `scripts/bump-gentle-ai-pin.mjs` (195 lines), `tests/bump-gentle-ai-pin.test.ts` (283 lines),
+  `.github/workflows/gentle-ai-release-received.yml` (91 lines) — 576 total authored lines, all new/net-new
+  logic (no vendored/golden content in this unit). Above the tracker's estimated ~180-line P4 forecast but
+  still within the tracker-wide `Delivery strategy: exception-ok` (tasks.md: `400-line budget risk: High`,
+  `Decision needed before apply: No`) that every prior unit operated under; the excess over the forecast is
+  almost entirely the RED test file (8.1) and the threat-matrix injection-vector coverage it demands, plus
+  the extensively-commented threat-model rationale in both new files, not scope creep.
+
+## Status (P4 / FINAL)
+
+5/5 tasks in PR 8 (P4) complete. **68/68 tasks total across P1a+P1b+P2a+P2b+P3a+P3b+P3c+P4 — the consumer
+tracker is complete.** Ready for `sdd-verify`. No further `sdd-apply` batches remain for this change.

--- a/openspec/changes/consume-gentle-ai-release-artifacts/tasks.md
+++ b/openspec/changes/consume-gentle-ai-release-artifacts/tasks.md
@@ -119,11 +119,11 @@ Chain strategy: feature-branch-chain
 
 ## PR 8 — P4: Pin-bump automation + default-branch receiver (depends: PR 7)
 
-- [ ] 8.1 RED: PR-command tests (threat-matrix: PR commands) — a dispatched tag carrying shell metacharacters is rejected; a `--head` injection attempt is rejected; an implicit base (no explicit `--base main`) is rejected.
-- [ ] 8.2 GREEN: create `scripts/bump-gentle-ai-pin.mjs` — validate the dispatched tag against `^v\d+\.\d+\.\d+$` before any use; explicit `--base main`; head branch derived only from the validated tag; no payload interpolation into a composed command; runs `sync-gentle-ai-release.mjs --write`, `build-gentle-ai-baselines.mjs --write`, `build-skill-overlays.mjs --write`.
-- [ ] 8.3 GREEN: create `.github/workflows/gentle-ai-release-received.yml` — default-branch `repository_dispatch` receiver; stays inactive until this workflow itself is merged to `main`.
-- [ ] 8.4 GREEN: `.github/workflows/ci.yml` — confirm the pin-bump job remains the only job with network access.
-- [ ] 8.5 Verify: `pnpm test -- bump-gentle-ai-pin`; dry-run dispatch against a fixture tag; confirm a real bump PR opens targeting `main` (never a temporary tracker) only once this receiver has landed there.
+- [x] 8.1 RED: PR-command tests (threat-matrix: PR commands) — a dispatched tag carrying shell metacharacters is rejected; a `--head` injection attempt is rejected; an implicit base (no explicit `--base main`) is rejected.
+- [x] 8.2 GREEN: create `scripts/bump-gentle-ai-pin.mjs` — validate the dispatched tag against `^v\d+\.\d+\.\d+$` before any use; explicit `--base main`; head branch derived only from the validated tag; no payload interpolation into a composed command; runs `sync-gentle-ai-release.mjs --write`, `build-gentle-ai-baselines.mjs --write`, `build-skill-overlays.mjs --write`.
+- [x] 8.3 GREEN: create `.github/workflows/gentle-ai-release-received.yml` — default-branch `repository_dispatch` receiver; stays inactive until this workflow itself is merged to `main`.
+- [x] 8.4 GREEN: `.github/workflows/ci.yml` — confirm the pin-bump job remains the only job with network access.
+- [x] 8.5 Verify: `pnpm test -- bump-gentle-ai-pin`; dry-run dispatch against a fixture tag; confirm a real bump PR opens targeting `main` (never a temporary tracker) only once this receiver has landed there.
 
 ## Ordering Notes
 

--- a/scripts/bump-gentle-ai-pin.mjs
+++ b/scripts/bump-gentle-ai-pin.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// Pin-bump automation (design.md "P4" / proposal.md P4). Runs exclusively in
+// the pin-bump job of .github/workflows/gentle-ai-release-received.yml -- the
+// ONLY place besides scripts/sync-gentle-ai-release.mjs that gentle-pi lets
+// download a gentle-ai release. This script orchestrates the three existing
+// generators; it does not reimplement any of them:
+//
+//   1. scripts/sync-gentle-ai-release.mjs --write   (D1 trust order, D6 mirrors/lock)
+//   2. scripts/build-gentle-ai-baselines.mjs --write (D7 generated floor/row)
+//   3. scripts/build-skill-overlays.mjs --write      (D8 generated skill overlays)
+//
+// Maintainer decision: the repository_dispatch payload is the TAG ONLY. The
+// provider sends nothing else -- everything this script needs beyond the tag
+// it fetches and verifies itself through scripts/sync-gentle-ai-release.mjs,
+// so there is exactly one source of truth for the release contents. A richer
+// payload would be a second source of truth that has to stay in sync.
+//
+// Maintainer decision: the bump PR ALWAYS waits for human review and is
+// NEVER auto-merged, even on green. The bot prepares evidence; the human
+// decides. Do not add an auto-merge step, an auto-approve step, or an
+// "--auto" flag to gh pr create -- see buildPullRequestArguments below,
+// which structurally cannot emit one, and the tests that prove it.
+//
+// Maintainer decision: digests are written only after signature verification
+// succeeds. scripts/sync-gentle-ai-release.mjs already owns minisign
+// verification and repo/tag binding (design D1); if it throws for any
+// reason (forged signature, wrong repo/tag binding, missing/duplicate
+// checksum line, pending trusted key), this script propagates the error
+// immediately and NEVER reaches the commit/push/PR steps below -- see
+// runGentleAiPinBump. No digest and no PR are ever produced from unverified
+// input.
+//
+// Threat-matrix "PR commands" (design.md, added row): the tag arrives from
+// an external event and is validated against ^v\d+\.\d+\.\d+$ BEFORE any
+// use (validateDispatchedTag). The PR head branch is derived ONLY from that
+// already-validated tag (deriveBumpHeadBranch). The PR base is always the
+// explicit, hardcoded literal "main" -- never an implicit default and never
+// a caller-supplied override (buildPullRequestArguments). Every subprocess
+// call in this file goes through execFile with a fixed argv array
+// (`shell: false`); no step ever composes a shell string by interpolating
+// the tag, the branch name, or any other external payload into it.
+
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const DISPATCHED_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
+export const GENTLE_AI_BUMP_BASE_BRANCH = "main";
+export const GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX = "bump/gentle-ai-";
+export const GENTLE_AI_BUMP_COMMIT_MESSAGE_PREFIX = "chore(gentle-ai): bump pin to ";
+export const GENTLE_AI_BUMP_PR_TITLE_PREFIX = "chore(gentle-ai): bump pin to ";
+
+// --- tag validation (threat-matrix: PR commands) ----------------------------
+//
+// This is the load-bearing gate: the dispatch payload is the tag ONLY, and
+// nothing downstream may see it before it passes here. The pattern is
+// anchored on both ends and allows only digits and dots, so it rejects
+// shell metacharacters, embedded whitespace, embedded newlines, and any
+// attempt to smuggle an extra CLI flag (e.g. "--head", "--base") inside the
+// tag value -- all in one check.
+
+export function validateDispatchedTag(tag) {
+	if (typeof tag !== "string" || !DISPATCHED_TAG_PATTERN.test(tag)) {
+		throw new Error(
+			`gentle-ai release dispatch tag ${JSON.stringify(tag)} does not match ${DISPATCHED_TAG_PATTERN}; refusing to use it for a pin bump`,
+		);
+	}
+	return tag;
+}
+
+// --- head branch derivation --------------------------------------------------
+
+export function deriveBumpHeadBranch(validatedTag) {
+	// Defensive re-check: this function must be safe even if a future caller
+	// invokes it directly without going through validateDispatchedTag first.
+	if (!DISPATCHED_TAG_PATTERN.test(validatedTag)) {
+		throw new Error(
+			`deriveBumpHeadBranch requires an already-validated tag matching ${DISPATCHED_TAG_PATTERN}, got ${JSON.stringify(validatedTag)}`,
+		);
+	}
+	return `${GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX}${validatedTag}`;
+}
+
+// --- PR command construction (threat-matrix: PR commands) -------------------
+//
+// Returns a flat argv array for `gh`, never a composed shell string. The
+// base is required to be the exact literal "main" -- an implicit/omitted
+// base and any alternate base are both rejected -- and the head branch is
+// required to match the exact prefix+validated-tag shape this module
+// derives, so a caller cannot pass an arbitrary head branch either.
+
+export function buildPullRequestArguments({ base, head, title, body }) {
+	if (base !== GENTLE_AI_BUMP_BASE_BRANCH) {
+		throw new Error(
+			`gentle-ai pin-bump PR base must be the explicit literal "${GENTLE_AI_BUMP_BASE_BRANCH}"; refusing an implicit or alternate base ${JSON.stringify(base)}`,
+		);
+	}
+	const derivedTag = typeof head === "string" && head.startsWith(GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX) ? head.slice(GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX.length) : undefined;
+	if (derivedTag === undefined || !DISPATCHED_TAG_PATTERN.test(derivedTag)) {
+		throw new Error(`gentle-ai pin-bump PR head branch must be exactly ${GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX}<validated tag>, got ${JSON.stringify(head)}`);
+	}
+	return ["pr", "create", "--base", base, "--head", head, "--title", title, "--body", body];
+}
+
+export function buildPullRequestBody(tag) {
+	return [
+		`Bumps the gentle-ai pin to \`${tag}\`.`,
+		"",
+		"Generated by `scripts/bump-gentle-ai-pin.mjs` from a signed gentle-ai release, in order:",
+		"1. `scripts/sync-gentle-ai-release.mjs --write` -- signature-verified mirrors + canonical lock",
+		"2. `scripts/build-gentle-ai-baselines.mjs --write` -- generated capability floor and next row",
+		"3. `scripts/build-skill-overlays.mjs --write` -- generated skill overlays",
+		"",
+		"**This PR requires human review and is never auto-merged**, even when every check is green.",
+	].join("\n");
+}
+
+// --- subprocess execution (fixed argv, no shell) -----------------------------
+
+async function defaultRunCommand(file, arguments_, options = {}) {
+	const { stdout } = await execFileAsync(file, arguments_, { cwd: options.cwd, shell: false, windowsHide: true, maxBuffer: 8 * 1024 * 1024 });
+	return stdout;
+}
+
+// --- orchestration ------------------------------------------------------------
+
+export async function runGentleAiPinBump(options) {
+	const { rawTag, packageRoot, runCommand = defaultRunCommand, nodeExecutable = process.execPath } = options;
+
+	// Validate BEFORE any use -- no command of any kind runs before this line.
+	const tag = validateDispatchedTag(rawTag);
+	const headBranch = deriveBumpHeadBranch(tag);
+
+	await runCommand("git", ["checkout", "-b", headBranch], { cwd: packageRoot });
+
+	// Digests are written only after signature verification succeeds:
+	// sync-gentle-ai-release.mjs owns minisign verification and repo/tag
+	// binding (design D1). If it throws, this call propagates and the
+	// function returns here -- the baselines/overlays generators, the git
+	// commit, the push, and the PR below never run.
+	await runCommand(nodeExecutable, [join("scripts", "sync-gentle-ai-release.mjs"), "--write"], { cwd: packageRoot });
+	await runCommand(nodeExecutable, [join("scripts", "build-gentle-ai-baselines.mjs"), "--write"], { cwd: packageRoot });
+	await runCommand(nodeExecutable, [join("scripts", "build-skill-overlays.mjs"), "--write"], { cwd: packageRoot });
+
+	await runCommand("git", ["add", "-A"], { cwd: packageRoot });
+	const status = await runCommand("git", ["status", "--porcelain"], { cwd: packageRoot });
+	if (status.trim().length === 0) {
+		return { tag, headBranch, prOpened: false, reason: "gentle-ai pin is already up to date; no changes to commit" };
+	}
+
+	await runCommand("git", ["commit", "-m", `${GENTLE_AI_BUMP_COMMIT_MESSAGE_PREFIX}${tag}`], { cwd: packageRoot });
+	await runCommand("git", ["push", "--set-upstream", "origin", headBranch], { cwd: packageRoot });
+
+	const prArguments = buildPullRequestArguments({
+		base: GENTLE_AI_BUMP_BASE_BRANCH,
+		head: headBranch,
+		title: `${GENTLE_AI_BUMP_PR_TITLE_PREFIX}${tag}`,
+		body: buildPullRequestBody(tag),
+	});
+	await runCommand("gh", prArguments, { cwd: packageRoot });
+
+	return { tag, headBranch, prOpened: true };
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+export function parseArguments(argv) {
+	const flagIndex = argv.indexOf("--tag");
+	if (flagIndex === -1 || argv[flagIndex + 1] === undefined) {
+		throw new Error("usage: bump-gentle-ai-pin.mjs --tag <vX.Y.Z>");
+	}
+	return { rawTag: argv[flagIndex + 1] };
+}
+
+async function main() {
+	const { rawTag } = parseArguments(process.argv.slice(2));
+	const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+	const result = await runGentleAiPinBump({ rawTag, packageRoot });
+	if (result.prOpened) {
+		process.stdout.write(`gentle-ai pin bump PR opened: ${result.headBranch} -> ${GENTLE_AI_BUMP_BASE_BRANCH} (tag ${result.tag})\n`);
+	} else {
+		process.stdout.write(`gentle-ai pin bump for ${result.tag}: ${result.reason}\n`);
+	}
+}
+
+const isMainModule = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMainModule) {
+	main().catch((error) => {
+		process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+		process.exitCode = 1;
+	});
+}

--- a/tests/bump-gentle-ai-pin.test.ts
+++ b/tests/bump-gentle-ai-pin.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	DISPATCHED_TAG_PATTERN,
+	GENTLE_AI_BUMP_BASE_BRANCH,
+	GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX,
+	buildPullRequestArguments,
+	buildPullRequestBody,
+	deriveBumpHeadBranch,
+	parseArguments,
+	runGentleAiPinBump,
+	validateDispatchedTag,
+} from "../scripts/bump-gentle-ai-pin.mjs";
+
+// ---------------------------------------------------------------------------
+// threat-matrix "PR commands" (design.md, added row) -- task 8.1.
+//
+// The dispatch payload IS the tag (maintainer decision: the provider sends
+// nothing else). Every one of these tests proves the tag is validated
+// against ^v\d+\.\d+\.\d+$ BEFORE it is used for anything -- branch naming,
+// git commands, or gh pr create arguments.
+// ---------------------------------------------------------------------------
+
+test("validateDispatchedTag accepts a well-formed vX.Y.Z tag and returns it unchanged", () => {
+	assert.equal(validateDispatchedTag("v2.2.4"), "v2.2.4");
+	assert.equal(validateDispatchedTag("v10.0.100"), "v10.0.100");
+});
+
+test("DISPATCHED_TAG_PATTERN is exactly ^v\\d+\\.\\d+\\.\\d+$", () => {
+	assert.equal(DISPATCHED_TAG_PATTERN.source, "^v\\d+\\.\\d+\\.\\d+$");
+});
+
+// --- a dispatched tag carrying shell metacharacters is rejected ------------
+
+const SHELL_METACHARACTER_TAGS = [
+	"v1.2.3; rm -rf /",
+	"v1.2.3 && rm -rf /",
+	"v1.2.3 | cat /etc/passwd",
+	"v1.2.3`whoami`",
+	"v1.2.3$(whoami)",
+	"v1.2.3\nrm -rf /",
+	"v1.2.3'",
+	'v1.2.3"',
+	"v1.2.3 > /tmp/pwned",
+	"v1.2.3 & background",
+];
+
+for (const maliciousTag of SHELL_METACHARACTER_TAGS) {
+	test(`validateDispatchedTag rejects a tag carrying shell metacharacters: ${JSON.stringify(maliciousTag)}`, () => {
+		assert.throws(() => validateDispatchedTag(maliciousTag), /does not match/);
+	});
+}
+
+// --- a --head injection attempt is rejected --------------------------------
+
+const HEAD_INJECTION_TAGS = [
+	"v1.2.3 --head evil-branch",
+	"v1.2.3\t--head=evil-branch",
+	"--head",
+	"--head evil-branch",
+	"v1.2.3 --base evil-base",
+];
+
+for (const injectionTag of HEAD_INJECTION_TAGS) {
+	test(`validateDispatchedTag rejects a --head/--base injection attempt: ${JSON.stringify(injectionTag)}`, () => {
+		assert.throws(() => validateDispatchedTag(injectionTag), /does not match/);
+	});
+}
+
+test("validateDispatchedTag rejects non-string input", () => {
+	// @ts-expect-error -- exercising a defensive runtime guard, not a type error
+	assert.throws(() => validateDispatchedTag(undefined), /does not match/);
+});
+
+// ---------------------------------------------------------------------------
+// deriveBumpHeadBranch -- the head branch is derived ONLY from the already
+// validated tag, never from any other part of the dispatch payload.
+// ---------------------------------------------------------------------------
+
+test("deriveBumpHeadBranch derives a branch name from a validated tag", () => {
+	assert.equal(deriveBumpHeadBranch("v2.2.4"), `${GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX}v2.2.4`);
+});
+
+test("deriveBumpHeadBranch defensively re-validates even if called directly, without validateDispatchedTag first", () => {
+	assert.throws(() => deriveBumpHeadBranch("v1.2.3; rm -rf /"), /already-validated tag/);
+	assert.throws(() => deriveBumpHeadBranch("--head evil-branch"), /already-validated tag/);
+});
+
+// ---------------------------------------------------------------------------
+// buildPullRequestArguments -- an implicit base (no explicit --base main) is
+// rejected; the PR base is always the explicit literal "main".
+// ---------------------------------------------------------------------------
+
+test("buildPullRequestArguments rejects an implicit (omitted) base", () => {
+	assert.throws(
+		() =>
+			buildPullRequestArguments({
+				// @ts-expect-error -- exercising the implicit-base guard, not a type error
+				base: undefined,
+				head: `${GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX}v2.2.4`,
+				title: "chore(gentle-ai): bump pin to v2.2.4",
+				body: "body",
+			}),
+		/explicit literal "main"/,
+	);
+});
+
+test("buildPullRequestArguments rejects any base other than the explicit literal main", () => {
+	assert.throws(
+		() =>
+			buildPullRequestArguments({
+				base: "develop",
+				head: `${GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX}v2.2.4`,
+				title: "chore(gentle-ai): bump pin to v2.2.4",
+				body: "body",
+			}),
+		/explicit literal "main"/,
+	);
+});
+
+test("buildPullRequestArguments rejects a head branch that is not the derived prefix + validated tag shape", () => {
+	assert.throws(
+		() =>
+			buildPullRequestArguments({
+				base: GENTLE_AI_BUMP_BASE_BRANCH,
+				head: "evil-branch",
+				title: "chore(gentle-ai): bump pin to v2.2.4",
+				body: "body",
+			}),
+		/head branch must be exactly/,
+	);
+});
+
+test("buildPullRequestArguments returns an argv array with base and head as separate literal tokens, never a composed string", () => {
+	const arguments_ = buildPullRequestArguments({
+		base: GENTLE_AI_BUMP_BASE_BRANCH,
+		head: `${GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX}v2.2.4`,
+		title: "chore(gentle-ai): bump pin to v2.2.4",
+		body: buildPullRequestBody("v2.2.4"),
+	});
+	assert.deepEqual(arguments_.slice(0, 6), ["pr", "create", "--base", "main", "--head", "bump/gentle-ai-v2.2.4"]);
+	// The whole argv is a flat array of separate tokens -- nowhere is base or
+	// head embedded inside a single composed string that a shell could
+	// reparse.
+	for (const token of arguments_) {
+		assert.equal(typeof token, "string");
+	}
+});
+
+test("buildPullRequestArguments never includes an auto-merge flag", () => {
+	const arguments_ = buildPullRequestArguments({
+		base: GENTLE_AI_BUMP_BASE_BRANCH,
+		head: `${GENTLE_AI_BUMP_HEAD_BRANCH_PREFIX}v2.2.4`,
+		title: "chore(gentle-ai): bump pin to v2.2.4",
+		body: buildPullRequestBody("v2.2.4"),
+	});
+	for (const forbidden of ["--auto", "--admin", "--squash", "merge"]) {
+		assert.ok(!arguments_.includes(forbidden), `unexpected auto-merge-adjacent token ${JSON.stringify(forbidden)}`);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// buildPullRequestBody -- states the human-review requirement explicitly.
+// ---------------------------------------------------------------------------
+
+test("buildPullRequestBody documents that the PR requires human review and is never auto-merged", () => {
+	const body = buildPullRequestBody("v2.2.4");
+	assert.match(body, /human review/i);
+	assert.match(body, /never auto-merged/i);
+	assert.match(body, /v2\.2\.4/);
+});
+
+// ---------------------------------------------------------------------------
+// parseArguments -- CLI entry point.
+// ---------------------------------------------------------------------------
+
+test("parseArguments extracts the --tag value", () => {
+	assert.deepEqual(parseArguments(["--tag", "v2.2.4"]), { rawTag: "v2.2.4" });
+});
+
+test("parseArguments throws a usage error when --tag is missing", () => {
+	assert.throws(() => parseArguments([]), /usage: bump-gentle-ai-pin\.mjs --tag/);
+});
+
+test("parseArguments throws a usage error when --tag has no value", () => {
+	assert.throws(() => parseArguments(["--tag"]), /usage: bump-gentle-ai-pin\.mjs --tag/);
+});
+
+// ---------------------------------------------------------------------------
+// runGentleAiPinBump -- orchestration, with an injected command fake so no
+// real git/gh/network call ever happens in this test.
+// ---------------------------------------------------------------------------
+
+type RecordedCall = { file: string; args: string[] };
+
+function fakeRunCommand(recorded: RecordedCall[], responses: Record<string, string>, failing?: { matches: (call: RecordedCall) => boolean; error: Error }) {
+	return async (file: string, args: string[]) => {
+		const call = { file, args };
+		recorded.push(call);
+		if (failing && failing.matches(call)) throw failing.error;
+		const key = `${file} ${args.join(" ")}`;
+		return responses[key] ?? "";
+	};
+}
+
+test("runGentleAiPinBump rejects an invalid tag before issuing a single command", async () => {
+	const recorded: RecordedCall[] = [];
+	await assert.rejects(
+		runGentleAiPinBump({ rawTag: "v1.2.3; rm -rf /", packageRoot: "/tmp/does-not-matter", runCommand: fakeRunCommand(recorded, {}) }),
+		/does not match/,
+	);
+	assert.equal(recorded.length, 0, "no command may run before the tag is validated");
+});
+
+test("runGentleAiPinBump stops before any commit/push/PR step when the signed-release sync step fails", async () => {
+	const recorded: RecordedCall[] = [];
+	const syncFailure = new Error("minisign signature verification failed: the message does not match the signature under the trusted public key");
+	const runCommand = fakeRunCommand(recorded, {}, {
+		matches: (call) => call.args.some((argument) => argument.includes("sync-gentle-ai-release.mjs")),
+		error: syncFailure,
+	});
+	await assert.rejects(
+		runGentleAiPinBump({ rawTag: "v2.2.4", packageRoot: "/tmp/does-not-matter", runCommand }),
+		/minisign signature verification failed/,
+	);
+	// D3: digests are written only after signature verification succeeds. The
+	// sync step ran (and failed) but nothing that could produce a commit, a
+	// push, or a PR ever ran afterward.
+	const commandNames = recorded.map((call) => `${call.file} ${call.args[0]}`);
+	assert.ok(!commandNames.some((name) => name.includes("build-gentle-ai-baselines")));
+	assert.ok(!commandNames.some((name) => name.includes("build-skill-overlays")));
+	assert.ok(!recorded.some((call) => call.file === "git" && call.args[0] === "commit"));
+	assert.ok(!recorded.some((call) => call.file === "git" && call.args[0] === "push"));
+	assert.ok(!recorded.some((call) => call.file === "gh"));
+});
+
+test("runGentleAiPinBump runs the three generators in order, then opens a PR with an explicit base=main, when there are changes", async () => {
+	const recorded: RecordedCall[] = [];
+	const runCommand = fakeRunCommand(recorded, { "git status --porcelain": " M capabilities/gentle-ai-release.lock.json\n" });
+	const result = await runGentleAiPinBump({ rawTag: "v2.2.4", packageRoot: "/tmp/does-not-matter", runCommand });
+
+	assert.equal(result.prOpened, true);
+	assert.equal(result.tag, "v2.2.4");
+	assert.equal(result.headBranch, "bump/gentle-ai-v2.2.4");
+
+	const orderedSignatures = recorded.map((call) => `${call.file}:${call.args[0]}`);
+	const syncIndex = orderedSignatures.findIndex((signature) => signature.includes("sync-gentle-ai-release"));
+	const baselinesIndex = orderedSignatures.findIndex((signature) => signature.includes("build-gentle-ai-baselines"));
+	const overlaysIndex = orderedSignatures.findIndex((signature) => signature.includes("build-skill-overlays"));
+	const commitIndex = recorded.findIndex((call) => call.file === "git" && call.args[0] === "commit");
+	const pushIndex = recorded.findIndex((call) => call.file === "git" && call.args[0] === "push");
+	const ghIndex = recorded.findIndex((call) => call.file === "gh");
+
+	assert.ok(syncIndex !== -1 && baselinesIndex !== -1 && overlaysIndex !== -1);
+	assert.ok(syncIndex < baselinesIndex, "sync must run before baselines");
+	assert.ok(baselinesIndex < overlaysIndex, "baselines must run before overlays");
+	assert.ok(overlaysIndex < commitIndex, "generators must run before the commit");
+	assert.ok(commitIndex < pushIndex, "commit must happen before push");
+	assert.ok(pushIndex < ghIndex, "push must happen before the PR is opened");
+
+	const ghCall = recorded[ghIndex];
+	assert.equal(ghCall.args[0], "pr");
+	assert.equal(ghCall.args[1], "create");
+	assert.deepEqual(ghCall.args.slice(2, 6), ["--base", GENTLE_AI_BUMP_BASE_BRANCH, "--head", "bump/gentle-ai-v2.2.4"]);
+
+	// No call, anywhere in the whole orchestration, ever merges the PR or
+	// requests auto-merge -- the bump PR always waits for human review.
+	assert.ok(!recorded.some((call) => call.file === "gh" && call.args[1] === "merge"));
+	for (const call of recorded) {
+		assert.ok(!call.args.includes("--auto"), `unexpected --auto in ${call.file} ${call.args.join(" ")}`);
+	}
+});
+
+test("runGentleAiPinBump opens no PR and makes no commit when the generators produce no changes", async () => {
+	const recorded: RecordedCall[] = [];
+	const runCommand = fakeRunCommand(recorded, { "git status --porcelain": "" });
+	const result = await runGentleAiPinBump({ rawTag: "v2.2.4", packageRoot: "/tmp/does-not-matter", runCommand });
+
+	assert.equal(result.prOpened, false);
+	assert.ok(!recorded.some((call) => call.file === "git" && call.args[0] === "commit"));
+	assert.ok(!recorded.some((call) => call.file === "git" && call.args[0] === "push"));
+	assert.ok(!recorded.some((call) => call.file === "gh"));
+});


### PR DESCRIPTION
Final slice of the consumer chain, stacked on #272. Completes the tracker at 68/68 tasks.

## The bot prepares evidence. The human decides.

**The bump PR is never auto-merged, even on green.** Merging automatically would change the binary users install with nobody looking.

That is enforced structurally, not by intention: `buildPullRequestArguments` returns exactly ten fixed tokens with no `--auto`, `--admin` or merge verb; the script contains exactly one `gh` invocation in its whole source, `pr create`; the workflow has one job and no merge step. The only occurrences of the phrase "auto-merge" anywhere in this diff are comments forbidding it and the PR body telling the reader the same.

## The tag is hostile input

It arrives from an external event, so it is validated against an anchored `^v\d+\.\d+\.\d+$` **before any use**. A space or dash anywhere fails the pattern, so no extra CLI flag can be smuggled through it.

Proven twice: a table-driven suite covering ten shell-metacharacter payloads and five `--head`/`--base` injection attempts, and live — `--tag 'v1.2.3; touch /tmp/pwned-marker'` is refused with the tag echoed back and creates no file. Verified independently of the implementing run.

The base is the hardcoded literal `main`, never implicit and never derived from the payload. The head branch comes only from the validated tag.

## Digests are written only after the signature verifies

The sync script owns minisign verification and repo/tag binding, and runs first. A test simulates verification failure and asserts baselines, overlays, commit, push and `gh` never run afterward. A bot that trusts a downloaded checksum without verifying its signature has automated a supply-chain hole rather than closed one.

## The receiver is inert, and that is correct

GitHub fires `repository_dispatch` only for a workflow already on the **default branch**. This receiver cannot run until it merges to `main`, and future bump PRs target `main`, never a temporary tracker.

That is stated in the workflow's own comments so nobody later "fixes" it.

## What still has to happen before this runs for real

This chain merges to `main`; the provider publishes a real signed release, since the trusted key is still a pending sentinel; the provider dispatches with the tag; and the bot token's permissions get verified against real GitHub Actions, which this offline sandbox cannot do.

Those are activation steps, not code gaps.

## Tests

33 new, all green. Full suite 1165 pass, 1 fail — the environmental no-network failure carried since #267. The real subprocess path was additionally exercised against a throwaway git repo with a stub `gh`, confirming the exact `--base main --head bump/gentle-ai-v9.9.9` tokens reach it.

## Rollback

Delete the script, its tests and the receiver workflow, and revert one CI comment. Nothing from the earlier seven slices is touched.
