### PR TITLE
feat(skill-registry): index pi.skills project-declared skill dirs

### DIFF
--- a/extensions/skill-registry.ts
+++ b/extensions/skill-registry.ts
@@ -74,6 +74,32 @@ function userSkillDirs(): string[] {
 	];
 }
 
+async function piSkillsDirs(cwd: string): Promise<string[]> {
+	// Read the pi.skills multi-path array from the project package.json so projects
+	// that declare skills via package.json (e.g. "./penpot-design/skills") are indexed,
+	// not only fixed convention dirs like cwd/skills or cwd/.pi/skills.
+	const pkgPath = join(cwd, "package.json");
+	if (!(await pathExists(pkgPath))) return [];
+	let pkg: { pi?: { skills?: unknown } };
+	try {
+		pkg = JSON.parse(await readFile(pkgPath, "utf8"));
+	} catch {
+		return [];
+	}
+	const skills = pkg?.pi?.skills;
+	if (!Array.isArray(skills)) return [];
+	const out: string[] = [];
+	for (const entry of skills) {
+		if (typeof entry !== "string" || entry === "") continue;
+		const candidate = join(cwd, entry);
+		// Confine to the project so a malformed entry cannot traverse outside cwd.
+		const rel = relative(cwd, candidate);
+		if (rel === "" || rel.startsWith("..")) continue;
+		out.push(candidate);
+	}
+	return out;
+}
+
 function projectSkillDirs(cwd: string): string[] {
 	return [
 		join(cwd, "skills"),
@@ -371,6 +397,7 @@ async function regenerateRegistry(
 	const existingDirs = await uniqueExistingDirs([
 		...projectSkillDirs(cwd),
 		...userSkillDirs(),
+		...(await piSkillsDirs(cwd)),
 	]);
 	const files: string[] = [];
 	for (const dir of existingDirs) {
@@ -489,6 +516,7 @@ async function startSkillRegistryWatcher(
 	const dirs = await uniqueExistingDirs([
 		...projectSkillDirs(cwd),
 		...userSkillDirs(),
+		...(await piSkillsDirs(cwd)),
 	]);
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	const refresh = () => {

--- a/extensions/skill-registry.ts
+++ b/extensions/skill-registry.ts
@@ -10,7 +10,7 @@ import {
 	writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, join, normalize, relative, sep } from "node:path";
+import { basename, isAbsolute, join, normalize, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
@@ -93,8 +93,10 @@ async function piSkillsDirs(cwd: string): Promise<string[]> {
 		if (typeof entry !== "string" || entry === "") continue;
 		const candidate = join(cwd, entry);
 		// Confine to the project so a malformed entry cannot traverse outside cwd.
+		// Component-level: reject exact parent, parent traversal, and absolute entries,
+		// but allow legitimate names that merely start with ".." (e.g. "..design").
 		const rel = relative(cwd, candidate);
-		if (rel === "" || rel.startsWith("..")) continue;
+		if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(entry)) continue;
 		out.push(candidate);
 	}
 	return out;


### PR DESCRIPTION
## Problem

`projectSkillDirs(cwd)` scans a fixed list of convention directories (`cwd/skills`, `cwd/.pi/skills`, `cwd/.claude/skills`, …). It does **not** read `package.json`, so projects that declare their skills via the `pi.skills` multi-path array (e.g. `"./penpot-design/skills"`) are **never indexed** — those skills are absent from `.atl/skill-registry.md` and therefore invisible to delegated subagents.

## Fix

Add `piSkillsDirs(cwd)`:
- reads `<cwd>/package.json` → `pi.skills` (string array)
- resolves each entry relative to `cwd`
- confines results to the project (rejects entries that traverse outside `cwd`)
- wired into both `regenerateRegistry` and `startSkillRegistryWatcher`

`findSkillFiles` already descends one level (`root/*/SKILL.md`), which matches the `pi.skills` layout (each entry points to a directory of skill subdirs), so no recursion change is needed. Paths under `cwd` are already classified `"project"` by `scopeForPath`, so scope is correct without changes.

## Verification

- `node --experimental-strip-types --check` passes.
- On a project with `pi.skills: ["./penpot-design/skills", "./penpot-utilities/skills", "./penpot-build/skills"]`, all 16 declared skills (5+6+5) are discovered after the patch (0 before).

## Scope / relation to #281

Independent of #281 (npm-package scan). Both PRs touch the same two scan-list lines, so merging both produces a trivial 1-line-per-list conflict that resolves to `...discoverNpmPackageSkillDirs(), ...piSkillsDirs(cwd),`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering skills from paths declared in a project’s package configuration.
  * Valid skill directories are included when refreshing the skill registry and monitoring for changes.
  * Invalid, empty, malformed, or unsafe paths are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->