### PR TITLE
test(devbinary): derive the start fixture's projection from the real repository

### DIFF
--- a/tests/devbinary/native-review-parity.devtest.ts
+++ b/tests/devbinary/native-review-parity.devtest.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createGentleAiExtension } from "../../extensions/gentle-ai.ts";
+import { deriveChangedPathManifest } from "../../lib/review-candidate-view.ts";
 import {
 	NativeReviewCliV214,
 	createNodeExecFileAdapter,
@@ -77,7 +78,7 @@ function journeyNative(binary: string): NativeReviewCli {
 		reviewMode: (request) => bridge.reviewMode(request),
 		async targetStatus(request) {
 			return request.lineageId === undefined
-				? unrelatedStartTargetStatus()
+				? unrelatedStartTargetStatus(request.cwd)
 				: currentTargetStatusFixture(request.lineageId, request.cwd);
 		},
 	} as unknown as NativeReviewCli;
@@ -117,12 +118,34 @@ const RAW_UNSUPPORTED_REPAIR_ASSESSMENT = {
 	authorization_schema: UNSUPPORTED_REPAIR_ASSESSMENT.authorizationSchema,
 };
 
-function unrelatedStartTargetStatus(): ReviewStatusV3 {
+// The candidate-view guard (assertNativeStartCandidateBinding) compares this
+// fixture's projection against the trees and paths gentle-pi derives from the
+// real workspace, so the fixture cannot invent them. It mirrors exactly what
+// lib/review-candidate-view.ts does: read HEAD into a scratch index, stage
+// everything, and write that tree. Hardcoded placeholders can never match, and
+// a mismatch surfaces as candidate-target-projection-drift long before the
+// binary under test is ever asked anything.
+function realProjectionFacts(cwd: string): { baseTree: string; candidateTree: string; paths: readonly string[] } {
+	const baseTree = git(cwd, "rev-parse", "HEAD^{tree}");
+	const index = mkdtempSync(join(tmpdir(), "gentle-pi-devtest-index-"));
+	try {
+		const environment = { ...process.env, GIT_INDEX_FILE: join(index, "index") };
+		execFileSync("git", ["read-tree", "HEAD"], { cwd, env: environment });
+		execFileSync("git", ["add", "-A"], { cwd, env: environment });
+		const candidateTree = execFileSync("git", ["write-tree"], { cwd, env: environment, encoding: "utf8" }).trim();
+		const paths = deriveChangedPathManifest(cwd, baseTree, candidateTree).map((entry) => entry.path);
+		return { baseTree, candidateTree, paths };
+	} finally {
+		rmSync(index, { recursive: true, force: true });
+	}
+}
+
+function unrelatedStartTargetStatus(cwd: string): ReviewStatusV3 {
 	const sha = `sha256:${"a".repeat(64)}`;
-	const tree = "b".repeat(40);
+	const { baseTree, candidateTree, paths } = realProjectionFacts(cwd);
 	const projection = {
 		schema: "gentle-ai.review-integration.projection/v1" as const, kind: "current-changes" as const, projection: "workspace" as const,
-		baseTree: tree, initialReviewTree: tree, currentCandidateTree: tree, pathsDigest: sha, paths: [], intendedUntracked: [],
+		baseTree, initialReviewTree: candidateTree, currentCandidateTree: candidateTree, pathsDigest: sha, paths, intendedUntracked: [],
 		intendedUntrackedProof: sha, initialSnapshotIdentity: sha, currentSnapshotIdentity: sha,
 	};
 	return {
@@ -132,7 +155,7 @@ function unrelatedStartTargetStatus(): ReviewStatusV3 {
 			schema: "gentle-ai.review-integration.status/v3", contract: "gentle-ai.review-integration/v2", operation: "review.status",
 			applicability: "unrelated", receipt: { status: "not_applicable" }, action: "start", replayability: "not_replayable", target_identity: sha,
 			repair: RAW_UNSUPPORTED_REPAIR_ASSESSMENT,
-			projection: { schema: projection.schema, kind: projection.kind, projection: projection.projection, base_tree: tree, initial_review_tree: tree, current_candidate_tree: tree, paths_digest: sha, paths: [], intended_untracked: [], intended_untracked_proof: sha, initial_snapshot_identity: sha, current_snapshot_identity: sha },
+			projection: { schema: projection.schema, kind: projection.kind, projection: projection.projection, base_tree: baseTree, initial_review_tree: candidateTree, current_candidate_tree: candidateTree, paths_digest: sha, paths, intended_untracked: [], intended_untracked_proof: sha, initial_snapshot_identity: sha, current_snapshot_identity: sha },
 			candidates: [],
 		},
 	};


### PR DESCRIPTION
Part of #256, track 8. This does **not** close it, and it does not make the devbinary axis green. Draft on purpose: what is left red after this is the real parity work.

## What this changes

`unrelatedStartTargetStatus()` hardcoded `"b".repeat(40)` as every tree and an empty path list. `assertNativeStartCandidateBinding` compares exactly `baseTree`, `initialReviewTree`, `currentCandidateTree` and sorted `paths` against the candidate view gentle-pi derives from the real workspace, so those placeholders could never match. Every start-driven journey died on `candidate-target-projection-drift` before the binary under test was asked anything.

The fixture now mirrors `lib/review-candidate-view.ts` exactly: read HEAD into a scratch `GIT_INDEX_FILE`, stage everything, write that tree, and take paths from `deriveChangedPathManifest`. Not a placeholder loose enough to slip past the guard, the same values the guard computes.

## Before and after

Against `v2.4.0-rc.1`, `main`, and one more build, all three: 2 pass / 3 fail, all three failures `candidate-target-projection-drift`.

After: the drift is gone and the real binary runs. The three remaining failures are behavioral, and they are #256's content, not this file's. The clearest one is tier 0: it expects a structured start result carrying `lenses_required: false` and a `hint`, while gentle-ai answers with a non-zero exit and the hint on stderr:

```
"stderr": "Error: the candidate has no pending changes; already-committed work can be reviewed by
rerunning review start with --base-ref <commit> naming the base to compare against"
```

Worth noting alongside that: no released capability row (2.2.0 through 2.2.3) sets `hint: true` or `riskEvidence: true`. The devtest spoofs both on in `test.before`, so those two journeys have always been describing a provider generation that no pinned release actually is.

---

## For whoever picks this up

This branch exists because of a report on Discord: running the devbinary tests against the 2.4.0-rc.1 binary shows placeholder OIDs in the projection (`baseTree "bbbb..."`, `pathsDigest "sha256:aaaa..."`) and the tests fail at binding before START. That report is accurate about what it saw and worth reading carefully, so here is the whole picture in one place.

**The placeholders were never the binary's.** `journeyNative()` overrides `targetStatus` with the fixture this PR fixes, and `bridgeAdapter()` intercepts the `version` argv to return a fake `BRIDGE_VERSION = "9.8.7"`. On that path gentle-ai's status is never called and the version handshake never happens. Both are deliberate: the header comment scopes this file to the plain-CLI decode path, not the negotiated status contract.

**It was never RC-specific.** Identical 2 pass / 3 fail against `v2.4.0-rc.1`, against gentle-ai `main`, and against a third build. Three different binaries, one result, because the guard rejected the fixture before any of them mattered.

**Real installs are not affected.** `lib/native-review-cli.ts` refuses a provider whose `packageVersion` differs from the pin and names both versions in the error. Only the `GENTLE_AI_DEV_BINARY` harness gets past that, precisely because it spoofs the version reply.

**Running these tests against an RC is a declared non-goal.** #256 lists "Pinning an RC or mutable provider main" under Non-goals. The post-2.2.2 uplift is that issue, and it is gated on a stable upstream release. So a finding like this belongs as a comment on #256 under track 8 rather than as a new issue, which is exactly the call the reporter made when they asked first.

**What is actually left.** After this PR the harness stops lying about the projection, which is the precondition for using it to measure parity at all. The remaining three failures are the gap between what gentle-pi expects of a post-2.2.2 provider and what gentle-ai currently does. Closing them is track 8 work: repin the stable release, vendor its published schemas and fixtures, and consume the contracts gentle-ai ships instead of maintaining a parallel transport layer here.