### PR TITLE
fix(review): record consent latch after granted follow-up

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -126,6 +126,7 @@ import {
 } from "../lib/native-review-cli.ts";
 import type { ReviewConsentV2, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 import { assertDistinctCorrectionEvidence, resolveCorrectionStep, type CorrectionEvidence, type CorrectionOutcome, type CorrectionStep } from "../lib/review-correction-lifecycle.ts";
+import { recordReviewConsentLatch } from "../lib/review-consent-latch.ts";
 
 const GRAPH_V1_ORDINARY_READ_ONLY = "Graph-v1 ordinary review authority is read-only; use native compact-v2 review operations";
 import {
@@ -5199,7 +5200,9 @@ async function executeReviewControllerOperation(
 					...nativeStartPreAuthorityRejection(),
 				};
 			}
-			return completeNativeStart(parameters.operation, answered.start, pending.repositoryCwd, pending.candidateView, candidateViews);
+			const completed = completeNativeStart(parameters.operation, answered.start, pending.repositoryCwd, pending.candidateView, candidateViews);
+			if (input.answer === "granted") recordReviewConsentLatch(pending.repositoryCwd);
+			return completed;
 		} catch (error) {
 			const value = error as { mutationOutcome?: unknown };
 			if (value.mutationOutcome === "none") candidateViews?.cleanup(pending.candidateView.token);

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5004,6 +5004,7 @@ async function executeReviewControllerOperation(
 	context?: ExtensionContext,
 	correctionEvidenceByLineage: Map<string, CorrectionEvidence> = new Map(),
 	pendingReviewConsents: Map<string, PendingReviewConsent> = new Map(),
+	writeReviewConsentLatch: typeof recordReviewConsentLatch = recordReviewConsentLatch,
 ): Promise<Record<string, unknown>> {
 	const parameters = parseReviewControllerParameters(parametersValue);
 	const defaultCwd = resolveReviewControllerWorkspaceRoot(parameters.workspaceRoot, sessionCwd);
@@ -5183,6 +5184,7 @@ async function executeReviewControllerOperation(
 		// The one-shot binding is consumed before the provider mutation. Any
 		// ambiguous result reconciles through STATUS and can never be replayed.
 		consumePendingReviewConsent(pending, pendingReviewConsents);
+		let completed: Record<string, unknown>;
 		try {
 			const answered = await nativeReviewCli.answerConsent({
 				cwd: pending.authorityCwd,
@@ -5200,9 +5202,7 @@ async function executeReviewControllerOperation(
 					...nativeStartPreAuthorityRejection(),
 				};
 			}
-			const completed = completeNativeStart(parameters.operation, answered.start, pending.repositoryCwd, pending.candidateView, candidateViews);
-			if (input.answer === "granted") recordReviewConsentLatch(pending.repositoryCwd);
-			return completed;
+			completed = completeNativeStart(parameters.operation, answered.start, pending.repositoryCwd, pending.candidateView, candidateViews);
 		} catch (error) {
 			const value = error as { mutationOutcome?: unknown };
 			if (value.mutationOutcome === "none") candidateViews?.cleanup(pending.candidateView.token);
@@ -5212,6 +5212,16 @@ async function executeReviewControllerOperation(
 				projection: "workspace",
 			});
 		}
+		if (input.answer === "granted") {
+			try {
+				writeReviewConsentLatch(pending.repositoryCwd);
+			} catch (error) {
+				try {
+					context?.ui.notify(`Native review start completed, but Pi could not record the local consent latch: ${error instanceof Error ? error.message : String(error)}`, "warning");
+				} catch { /* Reporting is best effort; native completion remains authoritative. */ }
+			}
+		}
+		return completed;
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.START) {
 		const rawStart = parseControllerJson(
@@ -6046,6 +6056,7 @@ export const __testing = {
 	resolveStartupControllerSddStatus,
 	repositoryLocationIdentity,
 	runPublicationProbeGit,
+	createGentleAiExtension: createGentleAiExtensionForTesting,
 	publicationProbeErrorCode: PUBLICATION_PROBE_ERROR_CODE,
 };
 
@@ -6102,6 +6113,13 @@ export interface GentleAiRuntimeDependencies {
 }
 
 export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencies = {}): (pi: ExtensionAPI) => void {
+	return createGentleAiExtensionForTesting(dependencies);
+}
+
+function createGentleAiExtensionForTesting(
+	dependencies: GentleAiRuntimeDependencies = {},
+	writeReviewConsentLatch: typeof recordReviewConsentLatch = recordReviewConsentLatch,
+): (pi: ExtensionAPI) => void {
 	const nativeReviewCli = dependencies.nativeReviewCli === undefined ? createNativeReviewCli() : dependencies.nativeReviewCli;
 	const publicationProbe = dependencies.publicationProbe ?? nodePublicationProbe;
 	const publicationProbeTimeoutMs = dependencies.publicationProbeTimeoutMs ?? PUBLICATION_PROBE_TIMEOUT_MS;
@@ -6165,6 +6183,7 @@ export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencie
 				ctx,
 				correctionEvidenceByLineage,
 				pendingReviewConsents,
+				writeReviewConsentLatch,
 			);
 			return {
 				content: [{ type: "text", text: JSON.stringify(details) }],

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -21,7 +21,7 @@ import {
 	type NativeStartRequest,
 } from "../lib/native-review-cli.ts";
 import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
-import { recordReviewConsentLatch } from "../lib/review-consent-latch.ts";
+import { readReviewConsentLatch, recordReviewConsentLatch } from "../lib/review-consent-latch.ts";
 import type { AuthorityRepairAssessmentV1, ReviewConsentV2, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 
 // Queued-adapter clients never execute a real process; default to a fixed
@@ -610,8 +610,9 @@ test("consent relay returns the identical complete parent-visible envelope with 
 });
 
 test("explicit consent follow-up grants or declines exactly once", async (t) => {
-	const cwd = repository(t);
 	for (const answer of ["granted", "declined"] as const) {
+		const cwd = repository(t);
+		assert.equal(readReviewConsentLatch(cwd), false);
 		const { native, answers, startRequests, answerRequests } = relayedConsentNative(cwd);
 		const { controller } = runtime(native);
 		const blocked = await blockedConsent(controller, `consent-${answer}`, headlessContext(cwd));
@@ -626,12 +627,15 @@ test("explicit consent follow-up grants or declines exactly once", async (t) => 
 		assert.equal(answerRequests[0]?.consent.targetIdentity, startRequests[0]?.targetIdentity);
 		if (answer === "granted") {
 			const actorBinding = result.actor_binding as { workspace_root: string; candidate_root: string };
-			assert.equal(actorBinding.workspace_root, cwd);
+			assert.equal(actorBinding.workspace_root, realpathSync(cwd));
 			assert.notEqual(actorBinding.candidate_root, cwd);
+			assert.equal(readReviewConsentLatch(cwd), true);
 		} else {
 			assert.equal(result.outcome, "consent-declined-this-candidate");
 			assert.equal(result.lineage_created, false);
-			assert.equal(result.actor_binding, undefined);
+			assert.equal("actor_binding" in result, false);
+			assert.equal("result" in result, false);
+			assert.equal(readReviewConsentLatch(cwd), false);
 		}
 		await assert.rejects(() => answerConsent(controller, blocked.consent_binding, answer, headlessContext(cwd)), /unknown, expired, or already consumed/);
 	}
@@ -657,6 +661,7 @@ test("a consent binding mismatch surfaces as an actionable local failure, not an
 	assert.equal(result.mutation_outcome, "none");
 	assert.equal(result.next_action, "resolve-consent-binding");
 	assert.deepEqual(answers, []);
+	assert.equal(readReviewConsentLatch(cwd), false);
 });
 
 test("consent follow-up rejects invalid token, unknown id, changed cwd, and changed target binding", async (t) => {
@@ -682,6 +687,17 @@ test("consent follow-up rejects invalid token, unknown id, changed cwd, and chan
 	(consent.choices[0] as { invocation: string }).invocation = consent.choices[0].invocation.replace("native-lineage", "changed-lineage");
 	await assert.rejects(() => answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd)), /consent envelope binding changed/);
 	assert.deepEqual(answers, []);
+	assert.equal(readReviewConsentLatch(cwd), false);
+});
+
+test("unavailable consent follow-up leaves the clone latch unset", async (t) => {
+	const cwd = repository(t);
+	const { native } = relayedConsentNative(cwd);
+	delete native.answerConsent;
+	const { controller } = runtime(native);
+	const blocked = await blockedConsent(controller, "consent-unavailable", headlessContext(cwd));
+	await assert.rejects(() => answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd)), /consent follow-up is unavailable/);
+	assert.equal(readReviewConsentLatch(cwd), false);
 });
 
 test("ambiguous consent mutation consumes the one-shot binding and requires status instead of blind replay", async (t) => {
@@ -696,6 +712,7 @@ test("ambiguous consent mutation consumes the one-shot binding and requires stat
 	await answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd));
 	assert.equal(statusCalls, 2, "ambiguous consent must reconcile through target status");
 	await assert.rejects(() => answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd)), /unknown, expired, or already consumed/);
+	assert.equal(readReviewConsentLatch(cwd), false);
 });
 
 test("session shutdown clears pending candidate consent bindings and is idempotent", async (t) => {
@@ -738,7 +755,9 @@ test("candidate-scoped decline creates no authority and the next candidate asks 
 		const result = await answerConsent(controller, blocked.consent_binding, "declined", headlessContext(cwd));
 		assert.equal(result.outcome, "consent-declined-this-candidate");
 		assert.equal(result.lineage_created, false);
-		assert.equal(result.actor_binding, undefined);
+		assert.equal("actor_binding" in result, false);
+		assert.equal("result" in result, false);
+		assert.equal(readReviewConsentLatch(cwd), false);
 	}
 	assert.deepEqual(answers, ["declined", "declined"]);
 });

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -791,6 +791,27 @@ test("candidate-scoped decline creates no authority and the next candidate asks 
 	assert.deepEqual(answers, ["declined", "declined"]);
 });
 
+// Upstream gentle-ai.review-integration.consent/v3 consent is per-candidate:
+// the clone-local latch records only that the one-time question was already
+// put to the user, never that any later candidate is pre-approved. A fresh
+// START with the latch already recorded must still relay the complete
+// blocking envelope, and only an explicit ANSWER_CONSENT may resolve it.
+test("a pre-recorded consent latch never suppresses a later candidate's consent envelope or auto-answers it", async (t) => {
+	const cwd = repository(t);
+	recordReviewConsentLatch(cwd);
+	assert.equal(readReviewConsentLatch(cwd), true);
+	const { native, answers, startRequests } = relayedConsentNative(cwd);
+	const { controller } = runtime(native);
+	const blocked = await blockedConsent(controller, "consent-latched-fresh-start", headlessContext(cwd));
+	assert.deepEqual(blocked.consent, candidateConsent(cwd).raw, "the full consent envelope is relayed despite the pre-recorded latch");
+	assert.deepEqual(answers, [], "the latch must never auto-answer a later candidate's consent");
+	assert.equal(blocked.lineage_created, false);
+	assert.equal(startRequests.length, 1);
+	const result = await answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd));
+	assert.deepEqual(answers, ["granted"], "explicit ANSWER_CONSENT is still required to proceed");
+	assert.ok(result.result);
+});
+
 test("low-risk zero-lens START remains silent", async (t) => {
 	const cwd = repository(t);
 	const { native } = fakeOrganicNative({ riskEvidence: undefined, lensesRequired: false });

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -662,7 +662,7 @@ test("granted consent preserves the completed native start when local latch pers
 
 	assert.deepEqual(answers, ["granted"]);
 	assert.equal(latchWrites, 1);
-	assert.ok(result.result, "the completed native start result must remain authoritative");
+	assert.deepEqual(result.result, { lineage_id: "native-lineage", state: "reviewing", risk_tier: "high", selected_lenses: ["review-risk", "review-resilience", "review-readability", "review-reliability"], changed_files: 1, original_changed_lines: 1, correction_budget: 1, action: "created", lenses_required: true });
 	assert.equal((result.actor_binding as { workspace_root: string }).workspace_root, realpathSync(cwd));
 	assert.equal(readReviewConsentLatch(cwd), false);
 	assert.equal(notices.length, 1);

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -441,12 +441,15 @@ interface RegisteredEventFixture {
 	(event: unknown, ctx: ExtensionContext): Promise<unknown> | unknown;
 }
 
-function runtime(nativeReviewCli: NativeReviewCli | null): { controller: RegisteredTool; commands: Map<string, RegisteredCommandFixture>; events: Map<string, RegisteredEventFixture> } {
+function runtime(
+	nativeReviewCli: NativeReviewCli | null,
+	writeReviewConsentLatch: typeof recordReviewConsentLatch = recordReviewConsentLatch,
+): { controller: RegisteredTool; commands: Map<string, RegisteredCommandFixture>; events: Map<string, RegisteredEventFixture> } {
 	const tools = new Map<string, RegisteredTool>();
 	const commands = new Map<string, RegisteredCommandFixture>();
 	const events = new Map<string, RegisteredEventFixture>();
 	const dependencies = { nativeReviewCli, candidateViews: new CandidateViewRegistry() } as unknown as Parameters<typeof createGentleAiExtension>[0];
-	createGentleAiExtension(dependencies)({
+	__testing.createGentleAiExtension(dependencies, writeReviewConsentLatch)({
 		on(name: string, handler: RegisteredEventFixture) { events.set(name, handler); },
 		registerTool(definition: RegisteredTool & { name: string }) { tools.set(definition.name, definition); },
 		registerCommand(name: string, definition: RegisteredCommandFixture) { commands.set(name, definition); },
@@ -611,7 +614,11 @@ test("consent relay returns the identical complete parent-visible envelope with 
 
 test("explicit consent follow-up grants or declines exactly once", async (t) => {
 	for (const answer of ["granted", "declined"] as const) {
-		const cwd = repository(t);
+		const repositoryCwd = repository(t);
+		const cwd = `${repositoryCwd}-alias`;
+		symlinkSync(repositoryCwd, cwd, process.platform === "win32" ? "junction" : "dir");
+		t.after(() => rmSync(cwd, { force: true }));
+		const canonicalCwd = realpathSync(cwd);
 		assert.equal(readReviewConsentLatch(cwd), false);
 		const { native, answers, startRequests, answerRequests } = relayedConsentNative(cwd);
 		const { controller } = runtime(native);
@@ -627,8 +634,8 @@ test("explicit consent follow-up grants or declines exactly once", async (t) => 
 		assert.equal(answerRequests[0]?.consent.targetIdentity, startRequests[0]?.targetIdentity);
 		if (answer === "granted") {
 			const actorBinding = result.actor_binding as { workspace_root: string; candidate_root: string };
-			assert.equal(actorBinding.workspace_root, realpathSync(cwd));
-			assert.notEqual(actorBinding.candidate_root, cwd);
+			assert.equal(actorBinding.workspace_root, canonicalCwd);
+			assert.notEqual(actorBinding.candidate_root, canonicalCwd);
 			assert.equal(readReviewConsentLatch(cwd), true);
 		} else {
 			assert.equal(result.outcome, "consent-declined-this-candidate");
@@ -639,6 +646,28 @@ test("explicit consent follow-up grants or declines exactly once", async (t) => 
 		}
 		await assert.rejects(() => answerConsent(controller, blocked.consent_binding, answer, headlessContext(cwd)), /unknown, expired, or already consumed/);
 	}
+});
+
+test("granted consent preserves the completed native start when local latch persistence fails", async (t) => {
+	const cwd = repository(t);
+	const { native, answers } = relayedConsentNative(cwd);
+	const notices: Array<{ message: string; type?: string }> = [];
+	let latchWrites = 0;
+	const { controller } = runtime(native, () => {
+		latchWrites += 1;
+		throw new Error("injected consent latch failure");
+	});
+	const blocked = await blockedConsent(controller, "consent-latch-failure", headlessContext(cwd, notices));
+	const result = await answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd, notices));
+
+	assert.deepEqual(answers, ["granted"]);
+	assert.equal(latchWrites, 1);
+	assert.ok(result.result, "the completed native start result must remain authoritative");
+	assert.equal((result.actor_binding as { workspace_root: string }).workspace_root, realpathSync(cwd));
+	assert.equal(readReviewConsentLatch(cwd), false);
+	assert.equal(notices.length, 1);
+	assert.equal(notices[0]?.type, "warning");
+	assert.match(notices[0]?.message ?? "", /native review start completed, but Pi could not record the local consent latch/i);
 });
 
 // Issue #247: a local binding mismatch was indistinguishable from a provider


### PR DESCRIPTION
Closes nothing. Advances #256 (track 2 of 10).

This work unit does not close #256 or complete the remaining track 2 delivery acceptance.

## Summary

- Record Pi's clone-local consent latch only after the real `ANSWER_CONSENT granted` flow completes successfully.
- Keep declined, mismatched, unavailable, invalid, and ambiguous follow-ups pre-authority and latch-free.
- Add behavior-first coverage for granted and declined candidate-scoped consent.

## Why

Official RC6 override testing exposed that Pi's consent latch writer had no production caller. The previous dev-binary expectation also exercised a synthetic START confirmation instead of the real `ANSWER_CONSENT` path.

This change fixes the Pi-side flow without modifying the stable v2.2.3 pin or PR #291's dev-binary fixture.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Record the clone-local latch after successful granted consent completion |
| `tests/native-review-parity.test.ts` | Cover granted, declined, mismatched, unavailable, invalid, and ambiguous outcomes |

## Test Plan

- [x] Consent/controller tests: 10 passed
- [x] Consent and latch unit suites: 12 passed
- [x] `pnpm run check:transaction-runner`
- [x] `pnpm run test:harness`
- [x] `git diff --check`
- [x] Native four-lens review approved
- [x] Pre-commit receipt validation returned `allow`

## Known Baseline

`pnpm test` remains red locally with 10 failures and 52 cancellations. Every failure and the cancellation origin were reproduced at the exact base commit; no candidate-caused regression was found.

## Contributor Checklist

- [x] Linked approved issue #256 without closing the umbrella
- [x] Exactly one `type:*` label planned: `type:bug`
- [x] No shell scripts changed
- [x] Repository-local skills reviewed
- [x] Tests included with the behavior
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Review Request

Please focus on the `ANSWER_CONSENT` ordering and the negative controls that keep decline and failed follow-ups pre-authority.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Successful native review consent is now recorded consistently.
  * Declined, failed, invalid, unavailable, or ambiguous consent flows no longer incorrectly record consent.
  * Declined results no longer include unrelated review details.
  * Completed native reviews remain successful even if consent recording fails, with a warning displayed when applicable.
  * Consent records now use consistent repository identification across review flows.
  * Existing consent records no longer suppress consent requests for later review candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->