### PR TITLE
fix(models): support max thinking effort

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -556,7 +556,16 @@ const CORE_MODEL_AGENT_NAMES = [
 ] as const;
 const CORE_MODEL_AGENT_NAME_SET = new Set<string>(CORE_MODEL_AGENT_NAMES);
 
-type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+const THINKING_LEVELS = [
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
+type ThinkingLevel = (typeof THINKING_LEVELS)[number];
 interface AgentRoutingEntry {
 	model?: string;
 	thinking?: ThinkingLevel;
@@ -580,12 +589,7 @@ const CUSTOM_MODEL = "Custom model id";
 const INHERIT_THINKING = "Inherit effort";
 const THINKING_OPTIONS: (ThinkingLevel | typeof INHERIT_THINKING)[] = [
 	INHERIT_THINKING,
-	"off",
-	"minimal",
-	"low",
-	"medium",
-	"high",
-	"xhigh",
+	...THINKING_LEVELS,
 ];
 
 const MODEL_CONTROL_OPTIONS = [
@@ -805,12 +809,8 @@ function writePersonaMode(cwd: string, mode: PersonaMode): string[] {
 
 function isThinkingLevel(value: unknown): value is ThinkingLevel {
 	return (
-		value === "off" ||
-		value === "minimal" ||
-		value === "low" ||
-		value === "medium" ||
-		value === "high" ||
-		value === "xhigh"
+		typeof value === "string" &&
+		(THINKING_LEVELS as readonly string[]).includes(value)
 	);
 }
 

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -1700,6 +1700,44 @@ async function run() {
 		const restoredAgent = await readFile(join(modelsCwd, ".pi", "agents", "sdd-apply.md"), "utf8");
 		assert.match(restoredAgent, /model: restore\/provider/);
 		assert.match(restoredAgent, /thinking: high/);
+
+		// issue #286: `thinking: "max"` must survive save normalization and
+		// reach both subagents.json (effort) and agent frontmatter (thinking).
+		ctx.ui.custom = () =>
+			Promise.resolve({
+				type: "save",
+				config: { "sdd-apply": { model: "openai/gpt-5", thinking: "max" } },
+			});
+		await commands.get("gentle:models").handler("", ctx);
+		const maxSavedConfig = JSON.parse(await readFile(globalModelsPath, "utf8"));
+		assert.equal(maxSavedConfig["sdd-apply"].thinking, "max");
+		const maxSubagents = JSON.parse(
+			await readFile(join(modelsCwd, ".pi", "subagents.json"), "utf8"),
+		);
+		assert.equal(maxSubagents.model_profiles["sdd-apply"].effort, "max");
+		const maxApplyAgent = await readFile(
+			join(modelsCwd, ".pi", "agents", "sdd-apply.md"),
+			"utf8",
+		);
+		assert.match(maxApplyAgent, /thinking: max/);
+
+		// issue #286: effort picker must offer `max` after `xhigh` and save it.
+		let maxPickerCalls = 0;
+		ctx.ui.custom = (factory) =>
+			new Promise((resolve) => {
+				maxPickerCalls += 1;
+				const panel = factory(null, null, null, resolve);
+				if (maxPickerCalls === 1) {
+					panel.handleInput(kittyE); // open effort picker (set-all row)
+					for (let i = 0; i < 7; i++) panel.handleInput("j"); // max
+					panel.handleInput("\r");
+					panel.handleInput("\u0013"); // ctrl+s saves the draft
+					return;
+				}
+			});
+		await commands.get("gentle:models").handler("", ctx);
+		const pickerMaxConfig = JSON.parse(await readFile(globalModelsPath, "utf8"));
+		assert.equal(pickerMaxConfig["sdd-apply"].thinking, "max");
 	} finally {
 		await rm(modelsCwd, { recursive: true, force: true });
 		await rm(globalModelsPath, { force: true });


### PR DESCRIPTION
Closes #286

## Summary

- Add `max` to the ordered thinking-effort vocabulary used by `/gentle:models`.
- Derive the TypeScript type, picker options, and runtime validator from one source of truth.
- Preserve `thinking: "max"` through normalization and emit it as `effort: "max"` in generated subagent profiles.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Centralize thinking levels and add `max` after `xhigh`. |
| `tests/runtime-harness.mjs` | Cover picker selection and config-to-subagents/frontmatter propagation. |

## Test plan

- [x] `pnpm run test:harness`
- [x] `node --experimental-strip-types --test tests/gentle-ai.test.ts`
- [x] Independent verification passed.
- [x] Native four-lens review completed without findings.
- [x] Pre-commit, pre-push, and pre-PR gates validated the reviewed candidate.

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Contributor checklist

- [x] Linked an approved issue.
- [x] Uses one `type:*` label.
- [x] Tests are included with the behavior change.
- [x] Documentation is unchanged because the README does not enumerate effort levels.
- [x] Commit follows Conventional Commits.
- [x] No AI attribution or co-author trailer.

## Out of scope

Provider-specific effort filtering remains the runtime responsibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Max** as a thinking-level option.
  * Model-routing configurations can now save and apply the Max effort level.
  * The effort picker includes Max after the Extra High option.

* **Bug Fixes**
  * Fixed persistence of the Max thinking level across model-routing settings and agent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->