### PR TITLE
fix(review): prune expired consent bindings before reuse

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4637,6 +4637,20 @@ function cleanupAllPendingReviewConsents(pendingReviewConsents: Map<string, Pend
 	for (const pending of [...pendingReviewConsents.values()]) cleanupPendingReviewConsent(pending, pendingReviewConsents, candidateViews);
 }
 
+// An unused consent binding and the candidate view retained exclusively for
+// that binding expire as one lifecycle unit. TTL expiry is observable the
+// moment synchronous time says `expiresAt <= now`, so cleanup must be
+// synchronous with respect to that observation — the queued cleanup
+// macrotask is a safety net, not the authority. Pruning here (before any
+// later START may reuse the retained view) keeps timer order from deciding
+// correctness: a fresh candidate retry never reuses a view whose binding
+// already expired, so it cannot trip `candidate-target-projection-drift`.
+function pruneExpiredReviewConsents(pendingReviewConsents: Map<string, PendingReviewConsent>, candidateViews: CandidateViewRegistry | null, now: () => number): void {
+	for (const pending of [...pendingReviewConsents.values()]) {
+		if (pending.expiresAt <= now()) cleanupPendingReviewConsent(pending, pendingReviewConsents, candidateViews);
+	}
+}
+
 function reviewConsentDigest(consent: ReviewConsentV2): string {
 	return createHash("sha256").update(JSON.stringify(consent)).digest("hex");
 }
@@ -5105,6 +5119,8 @@ async function executeReviewControllerOperation(
 	correctionEvidenceByLineage: Map<string, CorrectionEvidence> = new Map(),
 	pendingReviewConsents: Map<string, PendingReviewConsent> = new Map(),
 	writeReviewConsentLatch: typeof recordReviewConsentLatch = recordReviewConsentLatch,
+	reviewConsentNow: () => number = Date.now,
+	reviewConsentScheduleTimer: (callback: () => void, delayMs: number) => { unref: () => void } = setTimeout,
 ): Promise<Record<string, unknown>> {
 	const parameters = parseReviewControllerParameters(parametersValue);
 	const defaultCwd = resolveReviewControllerWorkspaceRoot(parameters.workspaceRoot, sessionCwd);
@@ -5264,7 +5280,7 @@ async function executeReviewControllerOperation(
 		if (typeof input.consentBinding !== "string" || input.consentBinding.length === 0) throw new Error("Review controller answer-consent requires an opaque consentBinding");
 		if (input.answer !== "granted" && input.answer !== "declined") throw new Error("Review controller answer-consent answer must be granted or declined");
 		const pending = pendingReviewConsents.get(input.consentBinding);
-		if (pending === undefined || pending.expiresAt <= Date.now()) {
+		if (pending === undefined || pending.expiresAt <= reviewConsentNow()) {
 			if (pending !== undefined) cleanupPendingReviewConsent(pending, pendingReviewConsents, candidateViews);
 			throw new Error("Review controller consent binding is unknown, expired, or already consumed");
 		}
@@ -5372,6 +5388,12 @@ async function executeReviewControllerOperation(
 				return nativeOperationFailure(parameters.operation, error);
 			}
 			const replayKey = JSON.stringify({ cwd: defaultCwd, lineageId: parameters.lineageId ?? null, input: parameters.input ?? null, inputPath: parameters.inputPath ?? null });
+			// Synchronously drop any binding whose TTL has already elapsed
+			// before reusing its retained candidate view, so a fresh-candidate
+			// retry cannot reuse a view tied to an expired binding and trip
+			// candidate-target-projection-drift. Timer order must not decide
+			// correctness: the queued cleanup macrotask may not have fired yet.
+			pruneExpiredReviewConsents(pendingReviewConsents, candidateViews, reviewConsentNow);
 			let candidateView: ReturnType<CandidateViewRegistry["create"]> | undefined;
 			let nativeStartAttempted = false;
 			try {
@@ -5398,13 +5420,13 @@ async function executeReviewControllerOperation(
 					const consentCandidateView = candidateView;
 					const repositoryCwd = realpathSync(defaultCwd);
 					const consentDigest = reviewConsentDigest(error.consent);
-					const existing = [...pendingReviewConsents.values()].find((pending) => pending.repositoryCwd === repositoryCwd && pending.candidateView.token === consentCandidateView.token && pending.consentDigest === consentDigest && pending.expiresAt > Date.now());
+					const existing = [...pendingReviewConsents.values()].find((pending) => pending.repositoryCwd === repositoryCwd && pending.candidateView.token === consentCandidateView.token && pending.consentDigest === consentDigest && pending.expiresAt > reviewConsentNow());
 					if (existing === undefined) for (const pending of [...pendingReviewConsents.values()]) if (pending.candidateView.token === consentCandidateView.token) consumePendingReviewConsent(pending, pendingReviewConsents);
 					const id = existing?.id ?? randomUUID();
 					if (existing === undefined) {
-						const pending: PendingReviewConsent = { id, repositoryCwd, authorityCwd: defaultCwd, candidateView: consentCandidateView, consent: error.consent, consentDigest, expiresAt: Date.now() + PENDING_REVIEW_CONSENT_TTL_MS };
+						const pending: PendingReviewConsent = { id, repositoryCwd, authorityCwd: defaultCwd, candidateView: consentCandidateView, consent: error.consent, consentDigest, expiresAt: reviewConsentNow() + PENDING_REVIEW_CONSENT_TTL_MS };
 						pendingReviewConsents.set(id, pending);
-						pending.expiry = setTimeout(() => cleanupPendingReviewConsent(pending, pendingReviewConsents, candidateViews), PENDING_REVIEW_CONSENT_TTL_MS);
+						pending.expiry = reviewConsentScheduleTimer(() => cleanupPendingReviewConsent(pending, pendingReviewConsents, candidateViews), PENDING_REVIEW_CONSENT_TTL_MS);
 						pending.expiry.unref();
 					}
 					return {
@@ -6231,6 +6253,12 @@ export interface GentleAiRuntimeDependencies {
 	publicationProbe?: PublicationProbe;
 	publicationProbeTimeoutMs?: number;
 	bashTimeRevalidationTimeoutMs?: number;
+	// Deterministic test seam for the consent-binding TTL clock. Production
+	// leaves both undefined so the consent path observes real wall-clock time;
+	// tests inject a fake clock so expiry is observable without a 10-minute
+	// sleep and without relying on the queued cleanup macrotask firing.
+	now?: () => number;
+	scheduleTimer?: (callback: () => void, delayMs: number) => { unref: () => void };
 }
 
 export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencies = {}): (pi: ExtensionAPI) => void {
@@ -6245,6 +6273,8 @@ function createGentleAiExtensionForTesting(
 	const publicationProbe = dependencies.publicationProbe ?? nodePublicationProbe;
 	const publicationProbeTimeoutMs = dependencies.publicationProbeTimeoutMs ?? PUBLICATION_PROBE_TIMEOUT_MS;
 	const bashTimeRevalidationTimeoutMs = dependencies.bashTimeRevalidationTimeoutMs ?? BASH_TIME_REVALIDATION_TIMEOUT_MS;
+	const reviewConsentNow = dependencies.now ?? (() => Date.now());
+	const reviewConsentScheduleTimer = dependencies.scheduleTimer ?? ((callback, delayMs) => setTimeout(callback, delayMs));
 	if (!Number.isSafeInteger(publicationProbeTimeoutMs) || publicationProbeTimeoutMs <= 0) throw new TypeError("Publication probe timeout must be a positive safe integer");
 	if (!Number.isSafeInteger(bashTimeRevalidationTimeoutMs) || bashTimeRevalidationTimeoutMs <= 0) throw new TypeError("Bash-time revalidation timeout must be a positive safe integer");
 	return function gentleAi(pi: ExtensionAPI): void {
@@ -6305,6 +6335,8 @@ function createGentleAiExtensionForTesting(
 				correctionEvidenceByLineage,
 				pendingReviewConsents,
 				writeReviewConsentLatch,
+				reviewConsentNow,
+				reviewConsentScheduleTimer,
 			);
 			return {
 				content: [{ type: "text", text: JSON.stringify(details) }],

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -444,11 +444,12 @@ interface RegisteredEventFixture {
 function runtime(
 	nativeReviewCli: NativeReviewCli | null,
 	writeReviewConsentLatch: typeof recordReviewConsentLatch = recordReviewConsentLatch,
+	clock?: { now?: () => number; scheduleTimer?: (callback: () => void, delayMs: number) => { unref: () => void } },
 ): { controller: RegisteredTool; commands: Map<string, RegisteredCommandFixture>; events: Map<string, RegisteredEventFixture> } {
 	const tools = new Map<string, RegisteredTool>();
 	const commands = new Map<string, RegisteredCommandFixture>();
 	const events = new Map<string, RegisteredEventFixture>();
-	const dependencies = { nativeReviewCli, candidateViews: new CandidateViewRegistry() } as unknown as Parameters<typeof createGentleAiExtension>[0];
+	const dependencies = { nativeReviewCli, candidateViews: new CandidateViewRegistry(), ...clock } as unknown as Parameters<typeof createGentleAiExtension>[0];
 	__testing.createGentleAiExtension(dependencies, writeReviewConsentLatch)({
 		on(name: string, handler: RegisteredEventFixture) { events.set(name, handler); },
 		registerTool(definition: RegisteredTool & { name: string }) { tools.set(definition.name, definition); },
@@ -773,6 +774,77 @@ test("successful explicit disable clears pending candidate consent binding even 
 	await command.handler("enable", headlessContext(cwd));
 	await assert.rejects(() => answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd)), /unknown, expired, or already consumed/);
 	assert.deepEqual(answers, []);
+});
+
+// Issue #264: an unused consent binding and the candidate view retained
+// exclusively for that binding must expire as one lifecycle unit before any
+// later START may reuse the view. Cleanup is synchronous with respect to the
+// observable TTL; the queued cleanup macrotask is a safety net, not the
+// authority, so a fresh-candidate retry after expiry must get a new binding
+// rather than tripping candidate-target-projection-drift on a stale view.
+const REVIEW_CONSENT_TTL_MS = 10 * 60 * 1000;
+
+function fakeConsentClock(): { now: () => number; scheduleTimer: (callback: () => void, delayMs: number) => { unref: () => void }; advance: (ms: number) => void; scheduled: Array<() => void> } {
+	const start = Date.now();
+	let nowMs = start;
+	const scheduled: Array<() => void> = [];
+	return {
+		now: () => nowMs,
+		// Never fires the callback: simulates a queued cleanup macrotask that
+		// has not yet gotten a turn on the event loop.
+		scheduleTimer: (callback) => { scheduled.push(callback); return { unref: () => {} }; },
+		advance: (ms) => { nowMs = start + ms; },
+		scheduled,
+	};
+}
+
+test("an expired unused binding prunes synchronously so a fresh-candidate retry gets a new binding, not candidate-target-projection-drift", async (t) => {
+	const cwd = repository(t);
+	const { native, startRequests } = relayedConsentNative(cwd);
+	const clock = fakeConsentClock();
+	const { controller } = runtime(native, recordReviewConsentLatch, { now: clock.now, scheduleTimer: clock.scheduleTimer });
+	// First START: consent-required, binding T1 retained with a queued cleanup timer.
+	const first = await blockedConsent(controller, "expired-fresh-1", headlessContext(cwd));
+	const firstBinding = first.consent_binding;
+	assert.equal(clock.scheduled.length, 1, "the TTL cleanup macrotask is queued for T1");
+	// The candidate changes: a later START on a FRESH candidate must not reuse T1.
+	writeFileSync(join(cwd, "app.ts"), "export const value = 3;\n");
+	// Advance time past the TTL without letting the queued cleanup macrotask fire.
+	clock.advance(REVIEW_CONSENT_TTL_MS + 1);
+	assert.equal(clock.scheduled.length, 1, "the queued cleanup macrotask has not fired");
+	const second = await execStart(controller, "expired-fresh-2", headlessContext(cwd));
+	// The fix: a fresh consent-required binding, not candidate-target-projection-drift.
+	assert.equal(second.status, "blocked");
+	assert.equal(second.outcome, "native-review-consent-required", "the stale view must not trip candidate-target-projection-drift");
+	assert.equal(typeof second.consent_binding, "string");
+	assert.notEqual(second.consent_binding, firstBinding, "a fresh candidate gets a fresh binding, not the stale one");
+	assert.equal(startRequests.length, 2, "native start was attempted for both candidates");
+	assert.equal(clock.scheduled.length, 2, "the fresh binding queued its own cleanup macrotask");
+});
+
+test("a non-expired same-candidate consent request reuses the same binding instead of creating a new one", async (t) => {
+	const cwd = repository(t);
+	const { native } = relayedConsentNative(cwd);
+	const clock = fakeConsentClock();
+	const { controller } = runtime(native, recordReviewConsentLatch, { now: clock.now, scheduleTimer: clock.scheduleTimer });
+	const first = await blockedConsent(controller, "dedup-1", headlessContext(cwd));
+	// Same candidate, same consent, still within TTL: the existing binding is reused.
+	const second = await blockedConsent(controller, "dedup-2", headlessContext(cwd));
+	assert.equal(second.consent_binding, first.consent_binding, "a non-expired same-candidate request deduplicates the binding");
+	assert.equal(clock.scheduled.length, 1, "no new cleanup macrotask is queued when the binding is reused");
+});
+
+test("an expired consent binding is rejected on answer-consent even before the queued cleanup macrotask fires", async (t) => {
+	const cwd = repository(t);
+	const { native } = relayedConsentNative(cwd);
+	const clock = fakeConsentClock();
+	const { controller } = runtime(native, recordReviewConsentLatch, { now: clock.now, scheduleTimer: clock.scheduleTimer });
+	const blocked = await blockedConsent(controller, "expired-answer-1", headlessContext(cwd));
+	// Advance past TTL without firing the queued cleanup macrotask.
+	clock.advance(REVIEW_CONSENT_TTL_MS + 1);
+	assert.equal(clock.scheduled.length, 1, "the queued cleanup macrotask has not fired");
+	await assert.rejects(() => answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd)), /unknown, expired, or already consumed/);
+	assert.equal(clock.scheduled.length, 1, "rejection was synchronous from the TTL observation, not from a fired macrotask");
 });
 
 test("candidate-scoped decline creates no authority and the next candidate asks again", async (t) => {

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -747,7 +747,7 @@ test("ambiguous consent mutation consumes the one-shot binding and requires stat
 
 test("session shutdown clears pending candidate consent bindings and is idempotent", async (t) => {
 	const cwd = repository(t);
-	const { native, answers } = relayedConsentNative(cwd);
+	const { native, answers, startRequests } = relayedConsentNative(cwd);
 	const { controller, events } = runtime(native);
 	const blocked = await blockedConsent(controller, "consent-before-shutdown", headlessContext(cwd));
 	const shutdown = events.get("session_shutdown");
@@ -756,6 +756,18 @@ test("session shutdown clears pending candidate consent bindings and is idempote
 	await shutdown({}, headlessContext(cwd));
 	await assert.rejects(() => answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd)), /unknown, expired, or already consumed/);
 	assert.deepEqual(answers, []);
+	const afterShutdown = await blockedConsent(controller, "consent-after-shutdown", headlessContext(cwd));
+	assert.notEqual(afterShutdown.consent_binding, blocked.consent_binding, "the same candidate gets a fresh binding after shutdown cleanup");
+	assert.equal(startRequests.length, 2, "shutdown loss requires a fresh native START instead of local replay");
+});
+
+test("extension reload gives the same candidate a fresh consent binding instead of replaying lost local state", async (t) => {
+	const cwd = repository(t);
+	const { native, startRequests } = relayedConsentNative(cwd);
+	const beforeReload = await blockedConsent(runtime(native).controller, "consent-before-reload", headlessContext(cwd));
+	const afterReload = await blockedConsent(runtime(native).controller, "consent-after-reload", headlessContext(cwd));
+	assert.notEqual(afterReload.consent_binding, beforeReload.consent_binding);
+	assert.equal(startRequests.length, 2, "reload loss requires a fresh native START instead of local replay");
 });
 
 test("successful explicit disable clears pending candidate consent binding even after re-enable", async (t) => {
@@ -820,6 +832,19 @@ test("an expired unused binding prunes synchronously so a fresh-candidate retry 
 	assert.notEqual(second.consent_binding, firstBinding, "a fresh candidate gets a fresh binding, not the stale one");
 	assert.equal(startRequests.length, 2, "native start was attempted for both candidates");
 	assert.equal(clock.scheduled.length, 2, "the fresh binding queued its own cleanup macrotask");
+});
+
+test("an expired same-candidate consent request creates a fresh binding instead of replaying local state", async (t) => {
+	const cwd = repository(t);
+	const { native, startRequests } = relayedConsentNative(cwd);
+	const clock = fakeConsentClock();
+	const { controller } = runtime(native, recordReviewConsentLatch, { now: clock.now, scheduleTimer: clock.scheduleTimer });
+	const first = await blockedConsent(controller, "same-candidate-expired-1", headlessContext(cwd));
+	clock.advance(REVIEW_CONSENT_TTL_MS);
+	const second = await blockedConsent(controller, "same-candidate-expired-2", headlessContext(cwd));
+	assert.notEqual(second.consent_binding, first.consent_binding);
+	assert.equal(startRequests.length, 2, "expiry requires a fresh native START instead of local replay");
+	assert.equal(clock.scheduled.length, 2, "the fresh binding queues its own cleanup macrotask");
 });
 
 test("a non-expired same-candidate consent request reuses the same binding instead of creating a new one", async (t) => {

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -809,8 +809,8 @@ test("an expired unused binding prunes synchronously so a fresh-candidate retry 
 	assert.equal(clock.scheduled.length, 1, "the TTL cleanup macrotask is queued for T1");
 	// The candidate changes: a later START on a FRESH candidate must not reuse T1.
 	writeFileSync(join(cwd, "app.ts"), "export const value = 3;\n");
-	// Advance time past the TTL without letting the queued cleanup macrotask fire.
-	clock.advance(REVIEW_CONSENT_TTL_MS + 1);
+	// Advance time to the exact TTL boundary without letting the queued cleanup macrotask fire.
+	clock.advance(REVIEW_CONSENT_TTL_MS);
 	assert.equal(clock.scheduled.length, 1, "the queued cleanup macrotask has not fired");
 	const second = await execStart(controller, "expired-fresh-2", headlessContext(cwd));
 	// The fix: a fresh consent-required binding, not candidate-target-projection-drift.
@@ -840,8 +840,8 @@ test("an expired consent binding is rejected on answer-consent even before the q
 	const clock = fakeConsentClock();
 	const { controller } = runtime(native, recordReviewConsentLatch, { now: clock.now, scheduleTimer: clock.scheduleTimer });
 	const blocked = await blockedConsent(controller, "expired-answer-1", headlessContext(cwd));
-	// Advance past TTL without firing the queued cleanup macrotask.
-	clock.advance(REVIEW_CONSENT_TTL_MS + 1);
+	// Advance to the exact TTL boundary without firing the queued cleanup macrotask.
+	clock.advance(REVIEW_CONSENT_TTL_MS);
 	assert.equal(clock.scheduled.length, 1, "the queued cleanup macrotask has not fired");
 	await assert.rejects(() => answerConsent(controller, blocked.consent_binding, "granted", headlessContext(cwd)), /unknown, expired, or already consumed/);
 	assert.equal(clock.scheduled.length, 1, "rejection was synchronous from the TTL observation, not from a fired macrotask");


### PR DESCRIPTION
Closes #264

## Summary

- Prune expired unused consent bindings synchronously before candidate-view reuse.
- Remove the retained candidate view through the existing cleanup path, preventing fresh candidates from failing with `candidate-target-projection-drift`.
- Add deterministic acceptance coverage for exact TTL expiry, same-target retry, extension reload, shutdown cleanup, live deduplication, and expired-answer rejection.

## Why

The cleanup timer could remain queued after the consent TTL had elapsed. A new candidate could then reuse the stale candidate view before cleanup ran, leaving the operator without a fresh consent path.

The follow-up coverage commits add evidence only. They do not change the production architecture, authority model, replay rules, state, protocol, or configuration.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Prune expired consent bindings and their retained candidate views before START reuses a view. |
| `tests/native-review-parity.test.ts` | Prove fresh consent after exact TTL expiry, same-target expiry, extension reload, and shutdown while preserving live-binding dedup and expired-answer rejection. |

## Test plan

- [x] Issue #264 acceptance scenarios: 6 passed, 0 failed.
- [x] Modified native review parity test file: 44 passed, 0 failed.
- [x] `pnpm test`: 1109 passed, 1 skipped, 0 failed; provider contract and runtime harness passed.
- [x] `node scripts/verify-package-files.mjs`: passed.
- [x] CI package-content and packed-install verification: passed on `d02c39b3`.
- [x] Source candidate: Gentle AI four-lens native review approved.
- [x] Final test-only acceptance diff: Gentle AI reliability review and pre-commit/pre-push gates approved.

## Contributor checklist

- [x] Linked approved issue #264.
- [x] Added exactly one `type:*` label: `type:bug`.
- [x] Shellcheck is not applicable because no shell scripts changed.
- [x] Tests stay in the same PR as the behavior they prove.
- [x] No user-facing contract or documentation changed.
- [x] Conventional commits with no attribution trailers.