### PR TITLE
feat(orchestrator): close prompt-parity gaps and add the background-subagents policy

### DIFF
--- a/assets/agents/jd-judge-a.md
+++ b/assets/agents/jd-judge-a.md
@@ -34,6 +34,8 @@ Initial discovery and scoped re-judgment are separate modes.
 
 During initial discovery, run exactly once against the supplied `initial_review_tree` and return candidate rows only.
 
+Sweep budget: run one exhaustive read-only sweep, then stop — at most two sweeps for a full-4R-scale target (hot auth/update/security/payments paths, or more than 400 changed lines). There is no loop-until-dry mechanism; the sweep budget is the entire discovery pass.
+
 During initial discovery, do not persist state, mutate claims, launch actors, request fixes, validate fixes, or deliver anything.
 
 On controller-requested scoped re-judgment, receive only requested frozen IDs, their exact hash-bound rows, and the fix diff.

--- a/assets/agents/jd-judge-b.md
+++ b/assets/agents/jd-judge-b.md
@@ -34,6 +34,8 @@ Initial discovery and scoped re-judgment are separate modes.
 
 During initial discovery, run exactly once against the supplied `initial_review_tree` and return candidate rows only.
 
+Sweep budget: run one exhaustive read-only sweep, then stop — at most two sweeps for a full-4R-scale target (hot auth/update/security/payments paths, or more than 400 changed lines). There is no loop-until-dry mechanism; the sweep budget is the entire discovery pass.
+
 During initial discovery, do not persist state, mutate claims, launch actors, request fixes, validate fixes, or deliver anything.
 
 On controller-requested scoped re-judgment, receive only requested frozen IDs, their exact hash-bound rows, and the fix diff.

--- a/assets/agents/review-readability.md
+++ b/assets/agents/review-readability.md
@@ -9,6 +9,8 @@ tools:
   - gentle_review_scope
 ---
 
+> Manual/compat-lane only: the provider host-relay capture path never loads this agent definition; native lens capture materializes the Go-issued opaque prompt through the gentle-pi host relay.
+
 You are **R2 Readability**, a read-only reviewer. Find clarity problems; do not fix them.
 
 Rule sources: ai-course-2 slides `05-code-smells.md`, `06-safe-refactoring.md`, `07-advanced-refactoring.md`, `08-tech-debt.md`, `22-docs-as-code.md`, `25-executive-summary.md`.

--- a/assets/agents/review-reliability.md
+++ b/assets/agents/review-reliability.md
@@ -9,6 +9,8 @@ tools:
   - gentle_review_scope
 ---
 
+> Manual/compat-lane only: the provider host-relay capture path never loads this agent definition; native lens capture materializes the Go-issued opaque prompt through the gentle-pi host relay.
+
 You are **R3 Reliability**, a read-only reviewer. Find test and behavior risks; do not fix them.
 
 Rule sources: ai-course-2 slides `01-testing-setup.md`, `02-tdd-implementation.md`, `03-integration-testing.md`, `04-e2e-testing.md`, `10-strategic-coverage.md`, `11-playwright-visibility.md`, `12-quality-gates-husky.md`, `23-apis-components.md`.

--- a/assets/agents/review-resilience.md
+++ b/assets/agents/review-resilience.md
@@ -9,6 +9,8 @@ tools:
   - gentle_review_scope
 ---
 
+> Manual/compat-lane only: the provider host-relay capture path never loads this agent definition; native lens capture materializes the Go-issued opaque prompt through the gentle-pi host relay.
+
 You are **R4 Resilience**, a read-only reviewer. Find operational failure risks; do not fix them.
 
 Rule sources: ai-course-2 slides `09-essential-metrics.md`, `13-observability-strategy.md`, `14-sentry-implementation.md`, `15-sentry-errors.md`, `16-sentry-performance.md`, `17-sentry-alertas.md`, `29-performance-percibida.md`.

--- a/assets/agents/review-risk.md
+++ b/assets/agents/review-risk.md
@@ -9,6 +9,8 @@ tools:
   - gentle_review_scope
 ---
 
+> Manual/compat-lane only: the provider host-relay capture path never loads this agent definition; native lens capture materializes the Go-issued opaque prompt through the gentle-pi host relay.
+
 You are **R1 Risk**, a read-only reviewer. Find security risks; do not fix them.
 
 Rule sources: ai-course-2 slides `18-env-secrets.md`, `19-web-security.md`, `20-auth-tokens.md`, `21-owasp-top10.md`.

--- a/assets/chains/4r-review.chain.md
+++ b/assets/chains/4r-review.chain.md
@@ -3,6 +3,8 @@ name: 4r-review
 description: One-shot lens-only 4R discovery against a supplied initial review tree; the controller owns all authority.
 ---
 
+> Manual/compat-lane only: the provider host-relay capture path never loads this chain; it exists solely for explicit manual 4R invocation.
+
 ## review-risk
 
 output: review-risk-report.md

--- a/assets/orchestrator-delegation.md
+++ b/assets/orchestrator-delegation.md
@@ -86,9 +86,9 @@ These are parent-orchestrator routing boundaries. Use the smallest useful topolo
 5. **Per-action rule**: tests, builds, installs, and native review actors may use fresh workers without changing the implementation route or creating SDD state.
 6. **Optional SDD rule**: propose SDD only when durable proposal/spec/design/tasks materially reduce substantial ambiguity. Select SDD only after an explicit request or accepted proposal; risk alone never forces SDD.
 
-##### Pi Trigger Runtime Bindings
-
 <!-- pi-binding:start — Pi runtime routing for the triggers above -->
+
+##### Pi Trigger Runtime Bindings
 
 These are parent-orchestrator stop rules. Once any trigger fires, the parent MUST delegate through the best available subagent runtime. Prefer `subagent_run` when present; otherwise use Pi's native `Agent` or another available delegation mechanism. Do not replace a required delegation with inline execution. Do not inject these as child-agent permission to spawn subagents; children receive concrete role work and must not orchestrate.
 
@@ -252,10 +252,20 @@ Use the configured subagent runtime when available. Prefer the `subagent_*` tool
 
 The generic role precedence below is the explicit exception to this general runtime preference.
 
-Choose subagent mode by orchestration dependency, not by task length:
+<!-- gentle-pi:background-subagents -->
+#### Background Subagent Policy
 
-- Use `mode: "task"` when the parent must consume the result and continue the workflow, including SDD phases, implementation batches, verification, controller-selected review actors, and any delegated work whose output determines the next action. Lifecycle gates themselves launch zero actors.
-- Use `mode: "background"` only for independent work where automatic parent continuation is not required. Background completion may notify the user and preserve history, but it is not a guarantee that the parent model will resume orchestration.
+Background execution is policy-gated: the always-on orchestrator prompt renders one status line, `Background subagent policy: on|off (capability: ready|absent)`. If the policy is off OR the `subagent_run` tool is unavailable, run every delegation in the foreground — `mode: "task"` when `subagent_*` tools exist, otherwise the native `Agent` fallback — always.
+
+When the policy is on and `subagent_run` is available:
+
+- Use `subagent_run` `mode: "background"` ONLY for independent, read-only exploration, audit, or review work where the parent can continue non-overlapping work.
+- At the parent level, allow no more than 2 concurrent background tasks.
+- Completion notifications only: do not poll, sleep, run status checks, or proactively read for completion.
+- Use foreground `mode: "task"` when the result is needed before the next action, and always for user decisions, SDD apply or other writers, dependent verify evidence, archive, formal RDD/4R lenses, refuters, fix validators, Judgment Day actors, dependent phases, and any delegated work whose output determines the next action. Lifecycle gates themselves launch zero actors.
+- Do not duplicate launches or work, and do not overlap files or topics. Never run parallel writers in one worktree.
+- Background jobs are process-local and non-durable. A restart loses them; make no recovery claim.
+<!-- /gentle-pi:background-subagents -->
 
 For generic non-SDD exploration and mapping, first attempt the installed package-owned `gentle-ai-explore`. If that individual role is missing or unusable, fall back to Pi's native `Agent` with the same read-only mapping constraints and report the fallback.
 
@@ -327,7 +337,7 @@ stop writes → parent captures git status → diagnose affected repos/worktrees
 
 ### Review Actor Materialization
 
-Native RAR owns lens selection (canon Native Checking Contract above): the orchestrator never chooses which lenses run. This binding is materialization only. When a native transition or bound route names review actors, the parent launches exactly the named subagent definitions — `review-risk`, `review-resilience`, `review-readability`, `review-reliability` — with the provided scope and nothing more. `reviewer` remains an intent, never an installed subagent name; never launch a generic `reviewer` and never substitute, add, or drop a lens.
+Native RAR owns lens selection (canon Native Checking Contract above): the orchestrator never chooses which lenses run. On the provider host-relay path, lens capture never loads a Pi subagent definition at all: the host relay materializes the Go-issued opaque prompt into a fresh locked-down print-mode `pi` subprocess and submits the raw output bytes, and the adversarial roles execute through provider-rendered self-contained vectors. The packaged lens definitions — `review-risk`, `review-resilience`, `review-readability`, `review-reliability` — remain only for the manual/compat lane; when that lane's bound route names review actors, the parent launches exactly those named definitions with the provided scope and nothing more. `reviewer` remains an intent, never an installed subagent name; never launch a generic `reviewer` and never substitute, add, or drop a lens.
 
 ## Bounded Review Transaction Contract
 

--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -57,6 +57,8 @@ Mandatory Delegation Triggers — stop rules; once fired, delegate through the b
 6. **Long-session rule** — ~20 tool calls, 5 exploratory reads, or 2 non-mechanical edits without delegation → pause and delegate.
 7. **Review actor rule** — review lenses run only when selected by ordinary transaction start; explicit Judgment Day uses its two named judges. Lifecycle and SDD boundaries launch zero review actors.
 
+{{GENTLE_PI_BACKGROUND_POLICY}}; rules: the background-subagents block in the delegation contract.
+
 Full table, Work Routing Ladder examples/model-routing detail, Cost and Context Balance, Canonical Workflows, Review Actor Materialization, and the mirrored gentle-ai canon (blocking-prompt relays + defect handoff, language, delegation, native checking, review execution + stop table): `{{GENTLE_PI_DELEGATION_PATH}}`.
 
 ## SDD Workflow (lazy-loaded)

--- a/assets/sdd-orchestrator-workflow.md
+++ b/assets/sdd-orchestrator-workflow.md
@@ -68,8 +68,10 @@ The preflight captures:
 
 - execution mode: `interactive` or `auto`;
 - artifact store: `openspec`, `engram`, or `both` when callable memory tools are available;
-- chained PR strategy: `auto-forecast`, `ask-always`, `single-pr-default`, or `force-chained`;
+- chained PR strategy: the canonical `delivery_strategy` — `ask-on-risk`, `auto-chain`, `single-pr`, or `exception-ok`. The preflight menu offers the first three; `exception-ok` is reachable only when the user explicitly accepts `size:exception`, either up front or when `ask-on-risk` stops to ask;
 - review budget in changed lines.
+
+Those four PR values are exactly the `delivery_strategy` domain `sdd-tasks` and `sdd-apply` accept; never emit a value outside it. The preflight offers no separate chained option because `delivery_strategy` is only consulted once the tasks forecast flags review-budget risk: below that line there is nothing to chain, and above it `auto-chain` already resolves without asking again.
 
 The package should ensure SDD assets are present as global Pi runtime assets without the user needing to remember per-project setup commands. If assets are missing, install them non-destructively into:
 
@@ -104,8 +106,10 @@ This package does not provide persistent memory by itself.
 
 Use the session's SDD preflight choice:
 
-- `interactive`: default, pause between major phases and ask whether to continue.
-- `auto`: run phases back-to-back when the user explicitly wants speed and trusts the flow.
+- `auto`: phases run back-to-back without pausing, but the orchestrator gatekeeper validates after each phase before launching the next.
+- `interactive`: after each phase, show a concise summary and ask whether to adjust or continue.
+
+If the user doesn't specify, default to `auto`. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
 
 In interactive mode, between phases:
 
@@ -116,6 +120,28 @@ In interactive mode, between phases:
 Interactive approval is phase-scoped. A user response such as "continue", "dale", or "go on" approves only the immediate next phase, not the rest of the SDD pipeline. Do not treat a generated artifact as approved until the user has had a chance to review or explicitly delegate that review.
 
 Before `sdd-proposal` in interactive mode, offer the user a proposal question round instead of silently deciding whether the proposal is clear enough. Explain that the questions are meant to improve the PRD/proposal by uncovering business understanding, business rules, implications, impact, edge cases, and product tradeoffs. Prefer 3–5 concrete product questions per round, then summarize the resulting assumptions and ask whether the user wants to correct anything or run a second question round. Cover business/product/PRD decisions: business problem, target users and situations, business rules, product outcome, current-state gap, implications and impact, edge cases, decision gaps, first-slice scope boundaries, non-goals, product constraints, and business tradeoffs. Do not ask about test commands, PR shape, changed-line budget, or other harness mechanics at proposal time unless the user explicitly asks to discuss delivery.
+
+## Delivery Strategy
+
+On the first SDD chain request in a session, resolve the delivery strategy from preflight (or ask once) and cache it:
+
+- `ask-on-risk` — default; ask only when the tasks forecast detects review-budget risk.
+- `auto-chain` — automatically split into chained/stacked PR slices when needed.
+- `single-pr` — proceed as one PR only if the size is within budget.
+- `exception-ok` — user accepts `size:exception` when over budget. The preflight menu cannot select this; it is reached only when the user explicitly accepts `size:exception`, either up front or when `ask-on-risk` stops to ask.
+
+These four are the whole domain. Pass `delivery_strategy` to `sdd-tasks` and `sdd-apply`.
+
+## Chain Strategy
+
+When delivery planning yields chained PRs, ask once for chain strategy and cache it:
+
+- `stacked-to-main` — each PR targets the previous PR branch or main in sequence.
+- `feature-branch-chain` — PR #1 targets the tracker branch; child PRs target the immediate previous PR branch; only the tracker merges to main.
+
+When chained PRs are selected, treat the registry skill `gentle-ai-chained-pr` as a required skill match. Resolve and forward it by registry path to `sdd-tasks` and `sdd-apply`; do not hardcode its path.
+
+Pass it as `chain_strategy` to `sdd-tasks` and `sdd-apply` prompts alongside `delivery_strategy`.
 
 ## Result Contract
 
@@ -190,7 +216,46 @@ The Automatic Mode Gatekeeper one-rerun rule above is a quality gate, not a laun
 
 ## SDD Phase Delegation Mode
 
-Launch SDD phase subagents with `subagent_run` `mode: "task"` when the parent needs the phase result to route the next step. Do not use `mode: "background"` for SDD phases that must feed continuation; background completion is a notification/history mechanism, not an orchestration resume guarantee.
+Launch SDD phase subagents with `subagent_run` `mode: "task"` when the parent needs the phase result to route the next step. SDD phases, writers, dependent verify evidence, and archive are foreground-mandatory under the background subagent policy block in the delegation contract; background completion is a notification/history mechanism, not an orchestration resume guarantee.
+
+## Model Assignments
+
+Read this table before the first SDD/Judgment-Day phase delegation in a session, cache it, and use it only for SDD/Judgment-Day phase agents. If a phase is missing, use the `default` row. If the assigned tier is unavailable, use the runtime's default model and continue.
+
+On Pi, phase model routing is user-owned and persisted, not prompt-passed: `/gentle:models` writes `.pi/gentle-ai/models.json`, and the package applies each saved assignment to the installed phase agent definitions (frontmatter `model:`/`thinking:`) or `.pi/settings.json` overrides. The table below is the default capability tier per phase when the user has saved no assignment.
+
+**Mandatory phase model gate:** before launching an SDD/Judgment-Day phase agent, confirm the phase resolves through the saved model config or these defaults. Never pass an ad-hoc `model` parameter for SDD/Judgment-Day phases, and never apply this table to generic Pi delegation — generic subagents resolve model/thinking through `pi-subagents` config, and `model` is passed there only on an explicit user override.
+
+| Phase        | Default tier   | Reason                                     |
+| ------------ | -------------- | ------------------------------------------ |
+| sdd-explore  | balanced       | Reads code, structural - not architectural |
+| sdd-proposal | deep-reasoning | Architectural decisions                    |
+| sdd-spec     | balanced       | Structured writing                         |
+| sdd-design   | deep-reasoning | Architecture decisions                     |
+| sdd-tasks    | balanced       | Mechanical breakdown                       |
+| sdd-apply    | balanced       | Implementation                             |
+| sdd-verify   | balanced       | Validation against spec                    |
+| sdd-sync     | fast           | Reflect verified state                     |
+| sdd-archive  | fast           | Copy and close                             |
+| jd-judge-a   | deep-reasoning | Adversarial review                         |
+| jd-judge-b   | deep-reasoning | Adversarial review                         |
+| jd-fix-agent | balanced       | Surgical confirmed fixes                   |
+| default      | balanced       | SDD/JD phase fallback                      |
+
+## Sub-Agent Launch Deduplication
+
+Maintain a session-scoped launch log of `(phase, task-fingerprint)` pairs. If the same pair already exists, do NOT launch again. Emit exactly one launch per distinct task and append the pair after launch.
+
+## Sub-Agent Launch Protocol
+
+Pre-flight before every SDD/Judgment-Day phase launch:
+
+1. Identify the phase key (`sdd-apply`, `sdd-verify`, `jd-judge-a`, etc.).
+2. Confirm its model routing per the Model Assignments gate above.
+3. Resolve matching skill paths once per session from the registry and pass exact `SKILL.md` paths under `## Skills to load before work`.
+4. If a delegated result reports `skill_resolution` as `fallback-registry`, `fallback-path`, or `none`, re-read the registry before subsequent delegations.
+
+**Key Learnings closing (generic delegations):** when delegating to generic agents (`gentle-ai-explore`, `gentle-ai-worker`, `gentle-ai-verify`, scout/worker roles, or the native `Agent` fallback), instruct the sub-agent to close its final message with a `## Key Learnings` section containing 1–5 numbered items, each a standalone factual sentence of ≥4 words and ≥20 characters. This enables passive memory capture of learnings across delegation boundaries when a callable memory package is active. Include the same closing instruction in SDD phase launch prompts; Pi has no separate phase-common surface that injects it automatically.
 
 ## Strict TDD Forwarding
 
@@ -204,12 +269,31 @@ STRICT TDD MODE IS ACTIVE. Test runner: <command>. Follow RED, GREEN, TRIANGULAT
 
 Do not rely on the child agent to discover this independently.
 
+## Archive Final-State Handoff
+
+When launching `sdd-archive`, forward explicit final-state facts for any work completed after `apply-progress`, `verify-report`, or `sync-report` were persisted — verify warnings fixed in later commits, blockers resolved, tasks finished, updated test or issue counts — with commit or evidence references where available. Those artifacts are intermediate snapshots, valid at the time they were written; the archive report records the state at close, and explicit final-state facts in the `sdd-archive` launch prompt outrank stale snapshot claims.
+
 ## Review Workload Guard
 
-After `sdd-tasks` and before `sdd-apply`, inspect the task output for review workload risk.
+After `sdd-tasks` completes and before launching `sdd-apply`, inspect the task output's `Review Workload Forecast`.
 
-If estimated changed lines exceed 400, chained PRs are recommended, or a decision is needed, pause and ask unless the user already approved a delivery strategy.
+If it says `Chained PRs recommended: Yes`, `400-line budget risk: High`, estimated changed lines exceed 400, or `Decision needed before apply: Yes`, apply the cached `delivery_strategy`:
+
+- `ask-on-risk`: stop and ask whether to split or proceed with `size:exception`.
+- `auto-chain`: split automatically; ask for `chain_strategy` only if missing.
+- `single-pr`: stop and require/record `size:exception` before apply.
+- `exception-ok`: continue and tell `sdd-apply` this run uses `size:exception`.
+
+Any other `delivery_strategy` value is invalid. Do NOT pick the nearest branch and do NOT proceed: STOP, report the unrecognised value, and re-collect the delivery strategy before launching `sdd-apply`.
+
+Always pass the resolved `delivery_strategy`, `chain_strategy`, and any chosen PR boundary/exception to `sdd-apply` in the launch prompt.
 
 Any review transaction explicitly started outside SDD persists through its own artifact-store branch and budget. SDD completion itself launches no review actors and mints no review authority.
 
 Automatic mode does not override reviewer burnout protection.
+
+## Recovery
+
+- `engram` → resolve state with the injected memory search/get tools on the change topic keys (`sdd/{change-name}/...`).
+- `openspec` → read `openspec/changes/<change>/` artifacts and re-derive readiness through the native status engine.
+- `none` → state is not persisted; explain the limitation.

--- a/assets/support/sdd-status-contract.md
+++ b/assets/support/sdd-status-contract.md
@@ -13,6 +13,16 @@ Any phase that selects, continues, applies, verifies, syncs, or archives an SDD 
 - If multiple active changes match or the active change is unclear, ask the user to choose. Do not guess.
 - If no active changes exist, report that no SDD change is active and suggest starting one.
 
+## Native Engine
+
+- When the session artifact store is `openspec` or `both` (with an `openspec/` directory) and the `gentle-ai` binary is available, prefer `gentle-ai sdd-status [change] --cwd <repo> --json --instructions` for read-only status and `gentle-ai sdd-continue [change] --cwd <repo>` for dispatcher output, and treat their native status JSON as authoritative over prompt inference or manually reconstructed state.
+- For non-authoritative stores (`engram`, `none`, and `both` without an `openspec/` directory), do not treat dispatcher output as authoritative; follow Engine Authority by Store below.
+- Runtime-attempt authority is different from artifact dispatch: normal runtime-bearing OpenSpec and Engram continuations MUST bracket external execution with `gentle-ai sdd-attempt acquire|settle --cwd <repo> --change <change>`. Their bounded result contains only `proceed`, `blocked`, or `complete` plus an opaque continuation token when required, and MAY carry `settle_obligation` on a `proceed`. The Git-common-dir immutable chain remains the sole authority for ordinals, cumulative attempt/line budgets, runtime evidence, and atomic bound remediation.
+- A phase actor launched BY a parent that already holds a `proceed`-state acquire for that exact work unit is a distinct call/process, not a fresh continuation: it MUST NOT `acquire` again blind. Colliding with its own parent's active attempt is not a genuine `blocked: active_attempt` (#2291). It authenticates as that SAME attempt by passing the parent's returned token on its own `acquire --token <token>` call: a token matching the ledger's live active attempt returns `proceed` with that same token and zero mutation, while a non-matching token gets the ordinary `blocked: active_attempt` naming the real active token.
+- When `blockedReasons` is non-empty, do not proceed to terminal, archive, or apply work. Return or report `blockedReasons` and stop unless `nextRecommended` is `verify`, in which case verification may run only to remediate or refresh evidence for the blockers. When `nextRecommended` is `resolve-blockers`, always report `blockedReasons` and stop. When `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase — missing planning artifacts are the expected output of those phases, not genuine blockers.
+- `nextRecommended` is a bounded machine token for routing, not human prose. Route only by `nextRecommended` and dependency states. Human-readable explanation belongs in `blockedReasons`, not `nextRecommended`.
+- If the binary is unavailable, fall back to this prompt contract and the manual status schema below. Manual fallback status MUST stay shape-compatible with the native status JSON even when values are reconstructed manually.
+
 ## Status Schema
 
 Return status as markdown with these fields, or equivalent JSON when the host supports it:
@@ -71,7 +81,7 @@ actionContext:
   workspaceRoot: <absolute path>
   allowedEditRoots: [<absolute paths>]
   warnings: []
-nextRecommended: <command-or-action>
+nextRecommended: <bounded-machine-token>
 isNonAuthoritative: false  # boolean; true when the native engine is not authoritative for the store
 ```
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -226,15 +226,133 @@ function sddLocalAgentOverrideCount(cwd: string): number {
 	return count;
 }
 
-let orchestratorPromptCache: string | null = null;
-function getOrchestratorPrompt(): string {
-	if (orchestratorPromptCache === null) {
-		orchestratorPromptCache = renderOrchestratorPrompt(ASSETS_DIR);
-	}
-	return orchestratorPromptCache;
+// ---------------------------------------------------------------------------
+// Background subagents policy — project > global > env > default off
+// ---------------------------------------------------------------------------
+
+type BackgroundSubagentsPolicy = "on" | "off";
+type BackgroundSubagentsCapability = "ready" | "absent";
+
+interface BackgroundSubagentsRendering {
+	policy: BackgroundSubagentsPolicy;
+	capability: BackgroundSubagentsCapability;
 }
 
-function renderOrchestratorPrompt(assetsDir: string): string {
+interface LoadBackgroundSubagentsOptions {
+	/** Override the config home directory (used in tests to avoid touching ~/.pi). */
+	gentlePiConfigHome?: string;
+	/** Override the environment lookup (used in tests). */
+	env?: Record<string, string | undefined>;
+}
+
+const BACKGROUND_SUBAGENTS_SCHEMA = "gentle-pi.background-subagents/v1";
+const BACKGROUND_SUBAGENTS_FILE = "background-subagents.json";
+
+const DEFAULT_BACKGROUND_SUBAGENTS_RENDERING: BackgroundSubagentsRendering = {
+	policy: "off",
+	capability: "absent",
+};
+
+/**
+ * Strict decode of {"schema":"gentle-pi.background-subagents/v1","policy":"on"|"off"}.
+ * Any malformed shape (bad JSON, wrong schema, unknown keys, invalid policy)
+ * returns undefined so the caller fails closed to "off".
+ */
+function parseBackgroundSubagentsPolicyFile(
+	raw: string,
+): BackgroundSubagentsPolicy | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (!isRecord(parsed)) return undefined;
+	if (parsed.schema !== BACKGROUND_SUBAGENTS_SCHEMA) return undefined;
+	if (parsed.policy !== "on" && parsed.policy !== "off") return undefined;
+	if (Object.keys(parsed).length !== 2) return undefined;
+	return parsed.policy;
+}
+
+/**
+ * Load the background-subagents policy.
+ *
+ * Resolution order (first hit wins, mirroring loadRuntimeGuardrailsConfig):
+ *   1. Project file `${cwd}/.pi/gentle-ai/background-subagents.json`
+ *   2. Global file `${configHome}/background-subagents.json`
+ *      (configHome honors GENTLE_PI_CONFIG_HOME, default ~/.pi/gentle-ai)
+ *   3. Env var GENTLE_PI_BACKGROUND_SUBAGENTS ("on" | "off")
+ *   4. Default "off"
+ *
+ * A present-but-malformed file fails closed to "off" instead of falling
+ * through to a lower-priority source.
+ */
+function loadBackgroundSubagentsPolicy(
+	cwd: string,
+	options: LoadBackgroundSubagentsOptions = {},
+): BackgroundSubagentsPolicy {
+	try {
+		const env = options.env ?? process.env;
+		const configHome = options.gentlePiConfigHome ?? gentleAiConfigHome();
+		for (const path of [
+			join(cwd, ".pi", "gentle-ai", BACKGROUND_SUBAGENTS_FILE),
+			join(configHome, BACKGROUND_SUBAGENTS_FILE),
+		]) {
+			if (!existsSync(path)) continue;
+			return parseBackgroundSubagentsPolicyFile(readFileSync(path, "utf8")) ?? "off";
+		}
+		const fromEnv = env.GENTLE_PI_BACKGROUND_SUBAGENTS;
+		if (fromEnv === "on" || fromEnv === "off") return fromEnv;
+		return "off";
+	} catch {
+		return "off";
+	}
+}
+
+/**
+ * `subagent_run` availability probe. The extension has no synchronous runtime
+ * tool registry at prompt-render time, so capability is derived from the
+ * pi-subagents package presence via the builtinAgentDirs() probe.
+ */
+function resolveBackgroundSubagentsCapability(
+	cwd: string,
+): BackgroundSubagentsCapability {
+	try {
+		return builtinAgentDirs(cwd).some((dir) => existsSync(dir))
+			? "ready"
+			: "absent";
+	} catch {
+		return "absent";
+	}
+}
+
+function renderBackgroundSubagentsStatusLine(
+	background: BackgroundSubagentsRendering,
+): string {
+	return `Background subagent policy: ${background.policy} (capability: ${background.capability})`;
+}
+
+// Rendered prompts are memoized per background policy/capability key for the
+// process lifetime; the assets bytes themselves are read once per key.
+const orchestratorPromptCache = new Map<string, string>();
+function getOrchestratorPrompt(cwd: string = process.cwd()): string {
+	const background: BackgroundSubagentsRendering = {
+		policy: loadBackgroundSubagentsPolicy(cwd),
+		capability: resolveBackgroundSubagentsCapability(cwd),
+	};
+	const cacheKey = `${background.policy}:${background.capability}`;
+	let prompt = orchestratorPromptCache.get(cacheKey);
+	if (prompt === undefined) {
+		prompt = renderOrchestratorPrompt(ASSETS_DIR, background);
+		orchestratorPromptCache.set(cacheKey, prompt);
+	}
+	return prompt;
+}
+
+function renderOrchestratorPrompt(
+	assetsDir: string,
+	background: BackgroundSubagentsRendering = DEFAULT_BACKGROUND_SUBAGENTS_RENDERING,
+): string {
 	return readFileSync(join(assetsDir, "orchestrator.md"), "utf8")
 		.replaceAll(
 			"{{GENTLE_PI_SDD_WORKFLOW_PATH}}",
@@ -251,6 +369,10 @@ function renderOrchestratorPrompt(assetsDir: string): string {
 		.replaceAll(
 			"{{GENTLE_PI_SKILLS_PATH}}",
 			join(assetsDir, "orchestrator-skills.md"),
+		)
+		.replaceAll(
+			"{{GENTLE_PI_BACKGROUND_POLICY}}",
+			renderBackgroundSubagentsStatusLine(background),
 		)
 		.trim();
 }
@@ -287,7 +409,7 @@ const NEUTRAL_PERSONA_PROMPT = `Persona:
 - Push back when the user asks for code without enough context or understanding.
 - Correct errors directly, explain why, and show the better path.`;
 
-function buildGentlePrompt(persona: PersonaMode): string {
+function buildGentlePrompt(persona: PersonaMode, cwd: string = process.cwd()): string {
 	const personaPrompt =
 		persona === "neutral" ? NEUTRAL_PERSONA_PROMPT : GENTLEMAN_PERSONA_PROMPT;
 	const languageBoundary =
@@ -321,7 +443,7 @@ Harness principles:
 - Protect the human reviewer: avoid oversized changes, surface review workload risk, and ask before turning one task into a large multi-area change.
 - Never claim persistent memory is available because of this package. Memory is provided by separate packages or MCP tools when installed and callable.
 
-${getOrchestratorPrompt()}`;
+${getOrchestratorPrompt(cwd)}`;
 }
 
 // Matches `git [global-flags] push` — tolerates flags like -C /repo or --work-tree=/tmp
@@ -6206,6 +6328,10 @@ export const __testing = {
 	renderSddModelPanel: renderSddModelPanelForTesting,
 	getOrchestratorPrompt,
 	renderOrchestratorPrompt,
+	loadBackgroundSubagentsPolicy,
+	parseBackgroundSubagentsPolicyFile,
+	resolveBackgroundSubagentsCapability,
+	renderBackgroundSubagentsStatusLine,
 	resolveControllerSddStatus,
 	resolveStartupControllerSddStatus,
 	repositoryLocationIdentity,
@@ -6433,7 +6559,7 @@ function createGentleAiExtensionForTesting(
 			: "";
 		const gentlePrompt = isNamedAgent || isSddAgent
 			? ""
-			: `\n\n${buildGentlePrompt(readPersonaMode(ctx.cwd))}`;
+			: `\n\n${buildGentlePrompt(readPersonaMode(ctx.cwd), ctx.cwd)}`;
 		return {
 			systemPrompt: `${event.systemPrompt}${gentlePrompt}${sddPrompt}${nativeStatusPrompt}`,
 		};

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -103,6 +103,7 @@ const requiredPaths = [
   "skills/gentle-ai/SKILL.md",
   "skills/issue-creation/SKILL.md",
   "skills/judgment-day/SKILL.md",
+  "skills/rdd-defect-workflow/SKILL.md",
   "skills/release/SKILL.md",
   "skills/skill-creator/SKILL.md",
   "skills/skill-improver/SKILL.md",

--- a/skills/_shared/review-ledger-contract.md
+++ b/skills/_shared/review-ledger-contract.md
@@ -22,7 +22,7 @@ Generated files matching `testdata/golden/**` remain in snapshot identity but do
 
 Before status/START, consult effective review mode. `off` creates no authority or authorization and yields organic `disabled/unmanaged`, never approval. Ordinary START declares `--consent relay`; low risk stays silent. A medium/high `consent/v2` result always returns the complete raw provider envelope plus an opaque in-memory candidate binding to the parent, then stops without UI or provider follow-up. The parent localizes and presents it losslessly while preserving tokens, commands, target IDs, and invocations. One explicit `answer-consent` call accepts only that binding and `granted|declined`, consumes it before provider mutation, and rechecks repository/target/projection/lineage/answer binding. Ambiguity reconciles through STATUS, never replay. Grant is exact-candidate-only. Decline creates no lineage, authority, actor/candidate binding, latch, or pending authorization; the next candidate asks again. Old Pi clone latch files are inert.
 
-`finalize` canonicalizes selected-lens results, assigns missing lens/finding IDs, and performs only the legal transition from the current compact state. The five states are `reviewing`, `correction_required`, `validating`, `approved`, and `escalated`.
+Reviewer, refuter, and validator verdicts are admitted natively, never Pi-authored. `finalize` follows the provider's negotiated `next_transition` and supplies only the negotiated collection answers: a lens `review.capture-result` collect input rendered with `--agent=pi --materialize=true` is satisfied by the gentle-pi host relay, which prints the exact Go-materialized opaque prompt, launches a fresh locked-down print-mode `pi` subprocess in an empty scratch directory with every discovery surface disabled, and submits the untouched raw output bytes through the provider-owned submission form. The adversarial roles do not go through that relay: `review.capture-refuter` and `review.capture-validation` collect inputs render as self-contained authority-advancing vectors (binding tokens plus `--agent=pi --execute=true`, no submission descriptor); executing the exact rendered invocation makes Go materialize the role prompt, spawn its own locked-down `pi` process, and admit the raw verdict. Native Go owns validation, canonicalization, missing lens/finding ID assignment, persistence, and hashing, and performs only the legal transition from the current compact state. The five states are `reviewing`, `correction_required`, `validating`, `approved`, and `escalated`.
 
 `validate` loads the terminal receipt and authority, derives the named live Git gate, and runs with zero actors. It never mutates compact authority.
 
@@ -37,9 +37,7 @@ Every finding supplies `evidence_class`, `causal_disposition`, and concrete proo
 | `causal_disposition` | `introduced` \| `behavior-activated` \| `worsened` \| `pre-existing` \| `base-only` \| `unknown` |
 | `proof_refs` | Prefixed concrete proof references |
 
-Only severe `introduced`, `behavior-activated`, or `worsened` findings with valid proof can enter `correction_ids`. Deterministic candidate-caused blockers need no refuter. All inferential candidate-caused blockers use exactly one complete read-only refuter batch.
-
-If native IDs are assigned to inferential findings, FINALIZE first returns canonical rows plus a content-derived request hash without mutation; completion requires identical lens input, that hash, and one complete refuter batch.
+Only severe `introduced`, `behavior-activated`, or `worsened` findings with valid proof can enter `correction_ids`. Deterministic candidate-caused blockers need no refuter. All inferential candidate-caused blockers share exactly one complete read-only refuter batch, executed through the provider-rendered self-contained `review.capture-refuter` vector: Go materializes the refuter prompt, runs its own locked-down `pi` process, and admits the raw verdict. Pi never authors, edits, batches, or re-scores a refuter row.
 
 Refuter rows may cite independent concrete proof and do not need to repeat reviewer `proof_refs`. `pre-existing` and `base-only` findings become non-blocking follow-ups. `unknown`, insufficient evidence, malformed severe claims, empty/malformed proof, missing/duplicate/extra refuter rows, and inconclusive severe outcomes escalate. `WARNING` and `SUGGESTION` remain informational.
 
@@ -53,7 +51,7 @@ Before editing, `finalize` requires a positive correction-line forecast. A forec
 
 Initial lenses never rerun. The correction preserves frozen findings and genesis scope: the original candidate tree, paths, untracked set, and correction IDs. It cannot add scope.
 
-The targeted validator checks only the original criteria and one correction regression for the exact correction IDs. It cannot add findings, request another correction, launch actors, persist authority, or request another attempt. Failure escalates. Later observations are inert follow-ups.
+The targeted validator runs through the provider-rendered self-contained `review.capture-validation` vector — Go materializes its prompt, runs its own locked-down `pi` process, and admits the raw verdict — and checks only the original criteria and one correction regression for the exact correction IDs. It cannot add findings, request another correction, launch actors, persist authority, or request another attempt. Failure escalates. Later observations are inert follow-ups.
 
 Final verification evidence is supplied and hashed only during finalization. Failure escalates and never reopens review.
 

--- a/skills/issue-creation/SKILL.md
+++ b/skills/issue-creation/SKILL.md
@@ -1,223 +1,149 @@
 ---
 name: gentle-ai-issue-creation
-description: "Create Gentle AI issues with issue-first checks. Trigger: creating GitHub issues, bug reports, or feature requests."
+description: "Create and triage GitHub issues from repository evidence. Trigger: issue creation, bug reports, feature requests, or issue approval."
 license: Apache-2.0
 metadata:
   author: gentleman-programming
-  version: "1.0"
+  version: "1.2"
 ---
 
-## When to Use
+# Issue Creation
 
-Use this skill when:
-- Creating a GitHub issue (bug report or feature request)
-- Helping a contributor file an issue
-- Triaging or approving issues as a maintainer
+## When To Use
 
----
+Use this skill when creating, drafting, triaging, or approving an issue in the current GitHub repository.
 
-## Critical Rules
+## Core Rule
 
-1. **Blank issues are disabled** — MUST use a template (bug report or feature request)
-2. **Every issue gets `status:needs-review` automatically** on creation
-3. **A maintainer MUST add `status:approved`** before any PR can be opened
-4. **Questions go to [Discussions](https://github.com/Gentleman-Programming/agent-teams-lite/discussions)**, not issues
+Discover the repository's actual contribution workflow before proposing or publishing an issue. Templates, labels, approval gates, and Discussions support are repository policy, not universal GitHub behavior.
 
----
+## Safe Discovery
+
+Run read-only checks first:
+
+```bash
+gh auth status
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+REPO_URL="$(gh repo view --json url -q .url)"
+HOST="${REPO_URL#*://}"
+HOST="${HOST%%/*}"
+gh repo view --json nameWithOwner,url,hasDiscussionsEnabled,hasIssuesEnabled,isBlankIssuesEnabled
+git ls-files CONTRIBUTING.md CONTRIBUTING.* .github/CONTRIBUTING.md .github/ISSUE_TEMPLATE
+gh api --hostname "$HOST" --paginate "repos/$REPO/labels?per_page=100" --jq '.[].name'
+```
+
+Also inspect:
+
+- repository instructions such as `CONTRIBUTING.md` and `README.md`;
+- files under `.github/ISSUE_TEMPLATE`;
+- `.github/ISSUE_TEMPLATE/config.yml` when present;
+- issue forms, required fields, and labels declared by each template;
+- existing open and closed issues for duplicates and established wording.
+
+Stop and ask for repository context if authentication, repository resolution, verification that REPO and HOST are non-empty, required metadata is unavailable, hasIssuesEnabled is false, or policy discovery fails. Never continue from failed discovery into issue publication.
+
+A no-template fallback is allowed only when isBlankIssuesEnabled is explicitly true. Otherwise follow discovered contact links or stop and ask; never publish.
+
+After discovery and review, build optional label arguments using only labels that exist and repository policy permits the actor to apply:
+
+```bash
+LABEL_ARGS=()
+# Repeat for each reviewed, permitted discovered label.
+LABEL_ARGS+=(--label "$LABEL")
+```
+
+An empty array applies no label; do not invent labels.
 
 ## Workflow
 
-```
-1. Search existing issues for duplicates
-2. Choose the correct template (Bug Report or Feature Request)
-3. Fill in ALL required fields
-4. Check pre-flight checkboxes
-5. Submit → issue gets status:needs-review automatically
-6. Wait for maintainer to add status:approved
-7. Only then open a PR linking this issue
-```
+1. Describe the problem or request in one sentence and derive a short search query.
+2. Search open and closed issues:
 
----
+   ```bash
+   gh issue list --repo "$HOST/$REPO" --state all --search "$QUERY" --limit 1000
+   ```
 
-## Issue Templates
+   If 1000 results are returned or completeness remains uncertain, narrow the search, use read-only API discovery, or stop and ask before publishing.
 
-### Bug Report
+3. If an issue already covers the same behavior, comment there instead of creating a duplicate.
+4. Choose a repository-provided template only when its purpose matches the report.
+5. Fill every required template field from known evidence. Ask for missing facts rather than inventing them.
+6. Apply labels only when they exist and repository guidance establishes who should apply them.
+7. Publish only after the title, body, target repository, and selected template or fallback have been reviewed, and the pre-submission privacy review below has passed.
 
-Template: `.github/ISSUE_TEMPLATE/bug_report.yml`
-Auto-labels: `bug`, `status:needs-review`
+## Pre-submission Privacy Review
 
-#### Required Fields
+Pre-submission privacy review is mandatory. Scan every issue body immediately before `gh issue create`. The scan replaces — never deletes — environment-specific data with explicit placeholders so the reproduction still teaches:
 
-| Field | Description |
-|-------|-------------|
-| **Pre-flight Checks** | Checkboxes: no duplicate + understands approval workflow |
-| **Bug Description** | Clear description of the bug |
-| **Steps to Reproduce** | Numbered steps to reproduce |
-| **Expected Behavior** | What should have happened |
-| **Actual Behavior** | What happened instead (include errors/logs) |
-| **Operating System** | Dropdown: macOS, Linux variants, Windows, WSL |
-| **Agent / Client** | Dropdown: Claude Code, OpenCode, Gemini CLI, Cursor, Windsurf, Codex, Other |
-| **Shell** | Dropdown: bash, zsh, fish, Other |
+| Category | Replace with | Example (before → after) |
+|----------|---------------|---------------------------|
+| Private project names | `<project-name>` | `my-private-project-b` → `<project-name>` |
+| Usernames | `<user>` | `C:\Users\my-real-username\go\bin` → `C:\Users\<user>\go\bin` |
+| Hostnames | `<hostname>` | `devbox-macbook.local` → `<hostname>` |
+| Home paths | `/home/<user>` or `C:\Users\<user>` | (covered above) |
+| API keys, tokens, passwords | `<token>` / `<password>` | `ghp_abc123...` → `<token>` |
+| Internal ports / hostnames | `<host>:<port>` | `10.0.0.42:5432` → `<host>:<port>` |
 
-#### Optional Fields
+Do NOT redact intentionally public identifiers: tool names (`gentle-ai`, `engram`, `go`, `node`, `python`), package names, public documentation URLs, generic example domains (`example.com`, `localhost`). Keep reproduction structure with placeholders — never redact an example into nothingness.
 
-| Field | Description |
-|-------|-------------|
-| **Relevant Logs** | Log output (auto-formatted as code block) |
-| **Additional Context** | Screenshots, workarounds, extra info |
+**Rule of thumb:** if the reader can run the reproduction step after you replace every identifier with its placeholder, the sanitization is correct. If a step becomes impossible (because the placeholder consumed a needed value), that step needs the value — and you should mark it `<value-required>` and explain in the body what the user should fill in.
 
-#### Example — Bug Report via CLI
+## Template Paths
 
-```bash
-gh issue create --template "bug_report.yml" \
-  --title "fix(scripts): setup.sh fails on zsh with glob error" \
-  --body "
-### Pre-flight Checks
-- [x] I have searched existing issues and this is not a duplicate
-- [x] I understand this issue needs status:approved before a PR can be opened
+Do not guess a template filename. If multiple templates could apply and repository guidance does not distinguish them, stop and ask which one to use.
 
-### Bug Description
-Running setup.sh on zsh throws a glob error when no matching files exist.
+- .yml and .yaml files are GitHub Issue Forms. Do not parse or render their schema. Open the web issue chooser and stop for human completion:
 
-### Steps to Reproduce
-1. Clone the repo
-2. Run \`./scripts/setup.sh\` in zsh
-3. See error: \`zsh: no matches found: skills/*\`
+  ```bash
+  gh issue create --repo "$HOST/$REPO" --web "${LABEL_ARGS[@]}"
+  ```
 
-### Expected Behavior
-The script should handle missing glob matches gracefully.
+- .md files are Markdown templates. Read the matching template, complete it from known evidence into a reviewed BODY_FILE, then publish it:
 
-### Actual Behavior
-Script crashes with glob error.
+  ```bash
+  gh issue create --repo "$HOST/$REPO" --title "$TITLE" --body-file "$BODY_FILE" "${LABEL_ARGS[@]}"
+  ```
 
-### Operating System
-macOS
+## No-Template Fallback
 
-### Agent / Client
-Claude Code
+When the repository permits issue creation, provides no matching template, and isBlankIssuesEnabled is explicitly true, prepare a structured body with these sections:
 
-### Shell
-zsh
+- problem or requested outcome;
+- reproduction or motivating example;
+- expected behavior;
+- actual behavior or current limitation;
+- environment and relevant evidence;
+- alternatives or workarounds, when applicable.
 
-### Relevant Logs
-\`\`\`
-zsh: no matches found: skills/*
-\`\`\`
-"
-```
-
----
-
-### Feature Request
-
-Template: `.github/ISSUE_TEMPLATE/feature_request.yml`
-Auto-labels: `enhancement`, `status:needs-review`
-
-#### Required Fields
-
-| Field | Description |
-|-------|-------------|
-| **Pre-flight Checks** | Checkboxes: no duplicate + understands approval workflow |
-| **Problem Description** | The pain point this feature solves |
-| **Proposed Solution** | How it should work from the user's perspective |
-| **Affected Area** | Dropdown: Scripts, Skills, Examples, Documentation, CI/Workflows, Other |
-
-#### Optional Fields
-
-| Field | Description |
-|-------|-------------|
-| **Alternatives Considered** | Other approaches or workarounds |
-| **Additional Context** | Mockups, examples, references |
-
-#### Example — Feature Request via CLI
+Publish the reviewed fallback explicitly:
 
 ```bash
-gh issue create --template "feature_request.yml" \
-  --title "feat(scripts): add Codex support to setup.sh" \
-  --body "
-### Pre-flight Checks
-- [x] I have searched existing issues and this is not a duplicate
-- [x] I understand this issue needs status:approved before a PR can be opened
-
-### Problem Description
-The setup script only configures Claude Code, Gemini CLI, and OpenCode. Codex users have to manually copy skills.
-
-### Proposed Solution
-Add a Codex option to setup.sh that links skills to the .codex/ directory.
-
-Example:
-\`\`\`bash
-./scripts/setup.sh --agent codex
-\`\`\`
-
-### Affected Area
-Scripts (setup, installation)
-
-### Alternatives Considered
-Manually symlinking, but that defeats the purpose of the setup script.
-"
+gh issue create --repo "$HOST/$REPO" --title "$TITLE" --body "$BODY" "${LABEL_ARGS[@]}"
 ```
 
----
+If blank issues are not explicitly enabled, follow discovered contact links or stop and ask. Never publish a no-template fallback.
 
-## Label System
+## Labels And Approval
 
-### Applied Automatically on Issue Creation
+Treat labels and approval gates as conditional:
 
-| Template | Labels added |
-|----------|-------------|
-| Bug Report | `bug`, `status:needs-review` |
-| Feature Request | `enhancement`, `status:needs-review` |
+- use only labels returned by repository discovery;
+- follow contribution guidance for who may apply each label;
+- wait when repository policy requires maintainer approval before implementation;
+- do not invent a status or priority taxonomy when none is documented.
 
-### Applied by Maintainers
+## Questions And Discussions
 
-| Label | When to apply |
-|-------|--------------|
-| `status:approved` | Issue accepted for implementation — PRs can now be opened |
-| `priority:high` | Critical bug or urgent feature |
-| `priority:medium` | Important but not blocking |
-| `priority:low` | Nice to have |
+Use Discussions only when `hasDiscussionsEnabled` is true and repository guidance routes the question there. Otherwise follow documented support/contact links or ask the user where the question belongs. Never link to another repository's Discussions page.
 
----
+## Triage Decision
 
-## Maintainer Approval Workflow
+Before approving or closing an issue, verify:
 
-```
-1. New issue arrives with status:needs-review
-2. Review the issue — is it valid, clear, and in scope?
-3. If YES → add status:approved label
-4. If NO → comment with reason, close if needed
-5. Contributor can now open a PR linking this issue
-```
+- it describes a concrete bug or scoped improvement rather than an unsupported question;
+- it is not a duplicate;
+- the report contains enough evidence for an implementation decision;
+- the requested behavior is in repository scope;
+- labels and status changes follow the current repository's policy.
 
----
-
-## Decision Tree
-
-```
-Is it a bug?                    → Use Bug Report template
-Is it a new feature/improvement? → Use Feature Request template
-Is it a question?               → Use Discussions, NOT issues
-Is it a duplicate?              → Link to existing issue, close
-```
-
----
-
-## Commands
-
-```bash
-# Search existing issues before creating
-gh issue list --search "keyword"
-
-# Create bug report
-gh issue create --template "bug_report.yml" --title "fix(scope): description"
-
-# Create feature request
-gh issue create --template "feature_request.yml" --title "feat(scope): description"
-
-# Maintainer: approve an issue
-gh issue edit <number> --add-label "status:approved"
-
-# Maintainer: add priority
-gh issue edit <number> --add-label "priority:high"
-```
+If any point is uncertain, keep the issue in the repository's review state and request the smallest missing evidence.

--- a/skills/judgment-day/SKILL.md
+++ b/skills/judgment-day/SKILL.md
@@ -4,12 +4,14 @@ description: "Trigger: judgment day, judgement day, dual review, adversarial rev
 license: Apache-2.0
 metadata:
   author: gentleman-programming
-  version: "1.4"
+  version: "1.7"
 ---
 
 ## Activation Contract
 
 Load this skill only when the user explicitly requests Judgment Day, Judgement Day, dual/adversarial review, or an equivalent trigger. Resolve one exact target before starting.
+
+Judgment Day is a standalone developer tool: judges run whenever asked, on any runtime, and need no review transaction, runtime identity, or delivery-receipt machinery to start. It replaces ordinary 4R as the adversarial method for that target; never run both.
 
 Judgment Day starts only when explicitly requested and replaces ordinary review for that lineage.
 
@@ -24,6 +26,8 @@ Findings surviving round two escalate; no third-round transition exists.
 Initial discovery and scoped re-judgment are separate modes.
 
 During initial discovery, run exactly once against the supplied `initial_review_tree` and return candidate rows only.
+
+Judges hold a sweep budget: one exhaustive read-only sweep per judge is the standard budget, and at most two sweeps for a full-4R-scale target (hot auth/update/security/payments paths, or more than 400 changed lines). There is no loop-until-dry mechanism; the sweep budget is the entire discovery pass.
 
 During initial discovery, do not persist state, mutate claims, launch actors, request fixes, validate fixes, or deliver anything.
 
@@ -58,6 +62,8 @@ Do not add findings, alter frozen claims, authorize transitions, deliver, publis
 Each scoped fix returns candidate-tree and fix-diff evidence. It cannot mint authority or start re-judgment itself.
 
 ## Lifecycle Boundary
+
+A judgment issues no receipt and carries no delivery authority: it satisfies no commit, push, PR, or release gate. When the caller explicitly wants delivery authority for the same target, run the ordinary negotiated review lifecycle as its own step; a runtime that cannot uphold receipt guarantees loses the receipt, not the judgment.
 
 Pre-commit, pre-push, and PR gates validate approved receipts and exact typed targets with zero actors.
 Release from protected `main` may bypass receipt validation only when the tag targets the current immutable `origin/main` SHA, required CI for that exact SHA is successful, the remote head is rechecked before tag push, and no fresh risk evidence exists; otherwise release fails closed through native receipt validation.

--- a/skills/judgment-day/references/prompts-and-formats.md
+++ b/skills/judgment-day/references/prompts-and-formats.md
@@ -23,6 +23,8 @@ Initial discovery and scoped re-judgment are separate modes.
 
 During initial discovery, run exactly once against the supplied `initial_review_tree` and return candidate rows only.
 
+Run one exhaustive read-only sweep — at most two sweeps for a full-4R-scale target (hot auth/update/security/payments paths, or more than 400 changed lines). Do not edit, delegate, refute, or inspect unrelated scope.
+
 During initial discovery, do not persist state, mutate claims, launch actors, request fixes, validate fixes, or deliver anything.
 
 Each candidate contains stable ID, exact location, severity, evidence class, and concrete user-impact claim. WARNING and SUGGESTION are informational. Return an empty `rows` array when clean.

--- a/skills/rdd-defect-workflow/SKILL.md
+++ b/skills/rdd-defect-workflow/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: gentle-ai-rdd-defect-workflow
+description: "Trigger: RDD, receipt-driven development, review authority, receipt/lineage, correction/recovery, delivery gate/kill switch, bounded review defects. Guide work."
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## Activation Contract
+
+Load when the frontmatter trigger terms apply to a defect workflow.
+
+This skill guides public collaboration. It does not grant issue approval, label, review, exception, or merge authority.
+
+## Hard Rules
+
+- Check the user-owned RDD kill switch first. When disabled, do not start receipt reviews or fabricate approval; follow ordinary policy and report `disabled/unmanaged`.
+- Require an approved issue (`status:approved`) and clean current `main` reproduction before implementation. Audit existing PRs for supersession or conflict; stop or narrow stale claims.
+- Group by causal authority invariant. Use one issue and one PR or explicit chain per independent invariant and rollback boundary. Split independent causes; never merge a superseded or conflicting authority line.
+- Inventory every operator flow claimed by the issue or PR, including entry, mode, environment, expectation, and negative controls. Require one truthful black-box bench journey per CLI or lifecycle flow, or actual runtime E2E proof when the core bench cannot represent it. Synthetic proxy coverage never proves another runtime.
+- Use CodeGraph-first impact mapping, a dedicated worktree, and behavior-first tests. Run source-mutating normalization before candidate freeze.
+- Forecast authored changes before edits. The hard limit is 400 additions plus deletions; above it, STOP for a chain or explicit maintainer-approved exception.
+- Only when RDD is enabled, bind receipts, lineage, correction, recovery, and delivery gates to the exact candidate. Keep bounded review defects in one correction transaction.
+- Require independent read-only candidate validation before publication. Validation cannot edit source or authority; findings require a new candidate.
+- Keep communication humane and evidence-based. Repository labels and workflow metadata are maintainer-owned, never evidence of contributor blame.
+
+## Decision Gates
+
+| Condition | Action |
+| --- | --- |
+| RDD disabled | Ordinary policy; `disabled/unmanaged`; no receipt or approval claim. |
+| Issue gate or reproduction fails | Wait, stop, or narrow with evidence. |
+| Invariant or rollback is independent | Separate issue and authoritative PR line. |
+| Core bench fits / does not fit | Bench journey / actual runtime E2E; never proxy. |
+| Forecast exceeds 400 lines | Chain or approved exception before edits. |
+
+## Execution Steps
+
+1. Check mode, approval, PR conflicts, and current-main reproduction.
+2. Name invariant and rollback; isolate the worktree; CodeGraph-map code, tests, evidence, docs, distribution, and registration.
+3. Inventory flows and controls; add failing tests and the smallest correction.
+4. Normalize, enforce budget, run tests, and record each flow's exact candidate, command, scenario, and result.
+5. Freeze, validate read-only, and give the verdict, evidence, and one humane next action.
+
+## Output Contract
+
+Return `rdd_mode`, `issue_pr`, `causal_invariant`, `operator_flows`, `journey_runtime_evidence`, `changed_line_budget`, `tests`, `rollback`, and `unresolved_authority_decisions`.
+
+Identify approved and superseded/conflicting authority lines; every flow, negative control, and candidate-bound proof; additions plus deletions and chain/exception; test results; independent rollback; and unresolved maintainer decisions.
+
+## References
+
+No supporting files. Current repository policy remains authoritative.

--- a/tests/background-subagents.test.ts
+++ b/tests/background-subagents.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import { __testing } from "../extensions/gentle-ai.ts";
+
+// ---------------------------------------------------------------------------
+// Background subagents policy (issue #256).
+//
+// The policy loader mirrors loadRuntimeGuardrailsConfig: project file >
+// global file > env var > default off, strict schema decode, fail-closed to
+// "off" on any malformed input. Capability is derived from the pi-subagents
+// package presence (builtinAgentDirs probe) because no synchronous runtime
+// tool registry exists at prompt-render time.
+// ---------------------------------------------------------------------------
+
+const {
+	loadBackgroundSubagentsPolicy,
+	parseBackgroundSubagentsPolicyFile,
+	resolveBackgroundSubagentsCapability,
+	renderBackgroundSubagentsStatusLine,
+	renderOrchestratorPrompt,
+	getOrchestratorPrompt,
+} = __testing;
+
+const scratchRoots: string[] = [];
+
+function makeScratch(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	scratchRoots.push(dir);
+	return dir;
+}
+
+after(() => {
+	for (const dir of scratchRoots) rmSync(dir, { recursive: true, force: true });
+});
+
+function writePolicyFile(dir: string, policy: string): void {
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(
+		join(dir, "background-subagents.json"),
+		JSON.stringify({ schema: "gentle-pi.background-subagents/v1", policy }),
+	);
+}
+
+const EMPTY_ENV = {} as Record<string, string | undefined>;
+
+// ---------------------------------------------------------------------------
+// Strict decode
+// ---------------------------------------------------------------------------
+
+test("strict decode accepts exactly the v1 schema with policy on|off", () => {
+	assert.equal(
+		parseBackgroundSubagentsPolicyFile(
+			'{"schema":"gentle-pi.background-subagents/v1","policy":"on"}',
+		),
+		"on",
+	);
+	assert.equal(
+		parseBackgroundSubagentsPolicyFile(
+			'{"schema":"gentle-pi.background-subagents/v1","policy":"off"}',
+		),
+		"off",
+	);
+});
+
+test("strict decode rejects malformed shapes", () => {
+	for (const raw of [
+		"not json",
+		"[]",
+		"null",
+		'{"policy":"on"}',
+		'{"schema":"gentle-pi.background-subagents/v2","policy":"on"}',
+		'{"schema":"gentle-pi.background-subagents/v1","policy":"ON"}',
+		'{"schema":"gentle-pi.background-subagents/v1","policy":true}',
+		'{"schema":"gentle-pi.background-subagents/v1","policy":"on","extra":1}',
+	]) {
+		assert.equal(
+			parseBackgroundSubagentsPolicyFile(raw),
+			undefined,
+			`must reject: ${raw}`,
+		);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Cascade: project > global > env > default off
+// ---------------------------------------------------------------------------
+
+test("default is off with no file and no env", () => {
+	const cwd = makeScratch("gp-bg-none-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	assert.equal(
+		loadBackgroundSubagentsPolicy(cwd, { gentlePiConfigHome: configHome, env: EMPTY_ENV }),
+		"off",
+	);
+});
+
+test("project file overrides global file and env", () => {
+	const cwd = makeScratch("gp-bg-proj-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	writePolicyFile(join(cwd, ".pi", "gentle-ai"), "on");
+	writePolicyFile(configHome, "off");
+	assert.equal(
+		loadBackgroundSubagentsPolicy(cwd, {
+			gentlePiConfigHome: configHome,
+			env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "off" },
+		}),
+		"on",
+	);
+});
+
+test("global file overrides env when no project file exists", () => {
+	const cwd = makeScratch("gp-bg-glob-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	writePolicyFile(configHome, "on");
+	assert.equal(
+		loadBackgroundSubagentsPolicy(cwd, {
+			gentlePiConfigHome: configHome,
+			env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "off" },
+		}),
+		"on",
+	);
+});
+
+test("env var applies only when no policy file exists, and only exact on|off", () => {
+	const cwd = makeScratch("gp-bg-env-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	assert.equal(
+		loadBackgroundSubagentsPolicy(cwd, {
+			gentlePiConfigHome: configHome,
+			env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "on" },
+		}),
+		"on",
+	);
+	for (const invalid of ["1", "true", "ON", "yes", ""]) {
+		assert.equal(
+			loadBackgroundSubagentsPolicy(cwd, {
+				gentlePiConfigHome: configHome,
+				env: { GENTLE_PI_BACKGROUND_SUBAGENTS: invalid },
+			}),
+			"off",
+			`env value "${invalid}" must fail closed to off`,
+		);
+	}
+});
+
+test("a malformed higher-priority file fails closed to off instead of falling through", () => {
+	const cwd = makeScratch("gp-bg-mal-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const projectDir = join(cwd, ".pi", "gentle-ai");
+	mkdirSync(projectDir, { recursive: true });
+	writeFileSync(join(projectDir, "background-subagents.json"), "{malformed");
+	writePolicyFile(configHome, "on");
+	assert.equal(
+		loadBackgroundSubagentsPolicy(cwd, {
+			gentlePiConfigHome: configHome,
+			env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "on" },
+		}),
+		"off",
+	);
+});
+
+// ---------------------------------------------------------------------------
+// Capability degrade
+// ---------------------------------------------------------------------------
+
+test("capability is absent when no pi-subagents package directory exists", () => {
+	const cwd = makeScratch("gp-bg-cap-absent-");
+	assert.equal(resolveBackgroundSubagentsCapability(cwd), "absent");
+});
+
+test("capability is ready when a pi-subagents agents directory is discoverable", () => {
+	const cwd = makeScratch("gp-bg-cap-ready-");
+	mkdirSync(join(cwd, ".pi", "npm", "node_modules", "pi-subagents", "agents"), {
+		recursive: true,
+	});
+	assert.equal(resolveBackgroundSubagentsCapability(cwd), "ready");
+});
+
+// ---------------------------------------------------------------------------
+// Token rendering
+// ---------------------------------------------------------------------------
+
+test("status line renders policy and capability", () => {
+	assert.equal(
+		renderBackgroundSubagentsStatusLine({ policy: "on", capability: "ready" }),
+		"Background subagent policy: on (capability: ready)",
+	);
+	assert.equal(
+		renderBackgroundSubagentsStatusLine({ policy: "off", capability: "absent" }),
+		"Background subagent policy: off (capability: absent)",
+	);
+});
+
+test("renderOrchestratorPrompt substitutes the background policy token", () => {
+	const assetsDir = join(process.cwd(), "assets");
+	const rendered = renderOrchestratorPrompt(assetsDir, {
+		policy: "on",
+		capability: "ready",
+	});
+	assert.match(rendered, /Background subagent policy: on \(capability: ready\)/);
+	assert.doesNotMatch(rendered, /\{\{GENTLE_PI_BACKGROUND_POLICY\}\}/);
+});
+
+test("renderOrchestratorPrompt defaults to the fail-closed off/absent rendering", () => {
+	const assetsDir = join(process.cwd(), "assets");
+	const rendered = renderOrchestratorPrompt(assetsDir);
+	assert.match(rendered, /Background subagent policy: off \(capability: absent\)/);
+});
+
+test("getOrchestratorPrompt renders exactly one background status line", () => {
+	const rendered = getOrchestratorPrompt();
+	const matches = rendered.match(/Background subagent policy: (?:on|off) \(capability: (?:ready|absent)\)/g) ?? [];
+	assert.equal(matches.length, 1, "the always-on core must carry exactly one status line");
+});

--- a/tests/orchestrator-budget.test.ts
+++ b/tests/orchestrator-budget.test.ts
@@ -221,7 +221,11 @@ function isNormativeLine(line: string): boolean {
 const fixtureLines = readFileSync(FIXTURE_PATH, "utf8").split("\n");
 const SUPERSEDED_LIFECYCLE_REVIEW_LINES = new Set([
 	70,
+	// 74/77: the loose mode-choice background lines were replaced by the
+	// marked gentle-pi:background-subagents policy block (issue #256).
+	74,
 	76,
+	77,
 	92,
 	125,
 	126,

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1156,13 +1156,13 @@ test("v2.1.2 release package and runtime stop before publication", () => {
 	assert.doesNotMatch(runtime, /execFileSync\("(?:npm|pnpm)", \["publish"/);
 });
 
-test("bounded review keeps the Judgment Day skill contract at metadata version 1.4", () => {
+test("bounded review keeps the Judgment Day skill contract at canon metadata version 1.7", () => {
 	const frontmatter = readAgentFrontmatter(
 		join(PACKAGE_ROOT, "skills", "judgment-day", "SKILL.md"),
 	);
 
-	assert.match(frontmatter, /^  version: "1\.4"$/m);
-	assert.doesNotMatch(frontmatter, /^  version: "1\.5"$/m);
+	assert.match(frontmatter, /^  version: "1\.7"$/m);
+	assert.doesNotMatch(frontmatter, /^  version: "1\.4"$/m);
 });
 
 test("README documents bounded review transactions and the honest installed permission boundary", () => {

--- a/tests/skill-collision-prefixes.test.ts
+++ b/tests/skill-collision-prefixes.test.ts
@@ -16,6 +16,7 @@ const PREFIXED_NAMES: Record<string, string> = {
 	"chained-pr": "gentle-ai-chained-pr",
 	"issue-creation": "gentle-ai-issue-creation",
 	"judgment-day": "gentle-ai-judgment-day",
+	"rdd-defect-workflow": "gentle-ai-rdd-defect-workflow",
 	"skill-creator": "gentle-ai-skill-creator",
 	"skill-improver": "gentle-ai-skill-improver",
 };


### PR DESCRIPTION
Umbrella #256 (prompt-surface parity with the gentle-ai canon) + the pi port of the managed background-subagents policy. 22 files, +654/−199.

Parity gaps closed (from tonight's full canon audit): the invented chained-pr strategy domain replaced by the canonical ask-on-risk/auto-chain/single-pr/exception-ok (BUG), review-ledger-contract prose de-staled to the post-#320 role model, Judgment Day re-calco'd to canon v1.7 (sweep budget, no-receipt clause), Model Assignments + phase-model gate (pi-bound via /gentle:models), Chain Strategy + chained-pr forwarding, Review Workload Guard per-strategy branches, #2291 parent-token acquire exception verbatim, launch dedup, Automatic execution-mode default, Key Learnings closing, archive final-state handoff, per-store Recovery, issue-creation v1.2, rdd-defect-workflow ported, lens agents/4R chain marked manual/compat-lane, marker hygiene.

Background subagents (parity with gentle-ai's OpenCode feature, minus the launcher pi never needed): strict policy cascade (project > global > env > off, fail-closed), capability probe, {{GENTLE_PI_BACKGROUND_POLICY}} status line in the always-on prompt, and the canon addendum block (independent read-only only, max 2 concurrent, notification-only, writers/RDD/JD always foreground, non-durable, degrade-to-foreground). Consumes ~/.pi/gentle-ai/background-subagents.json which gentle-ai's pi component projects (companion gentle-ai PR in flight).

Verification: 1112 pass / 0 fail / 1 pre-existing skip; transaction-runner, provider-contract, verify-package-files green; orchestrator prompt at 10,180/10,240 B.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable background task execution with capability checks, concurrency limits, notifications, and safe defaults.
  - Added the RDD defect workflow for structured defect investigation, validation, and delivery.
  - Improved issue creation guidance to support repository-specific templates, labels, duplicates, and privacy checks.
  - Enhanced SDD workflows with delivery strategies, phase validation, model routing, and clearer recovery handling.

- **Improvements**
  - Judgment Day now operates independently from review delivery and uses bounded discovery sweeps.
  - Status and continuation guidance now supports authoritative runtime tracking and machine-readable routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->