### PR TITLE
feat(review): add maintainer provider relay matrix

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test": "node --experimental-strip-types --test tests/*.test.ts && pnpm run check:provider-contract && pnpm run test:harness",
     "test:harness": "node --experimental-strip-types tests/runtime-harness.mjs",
     "test:dev-binary": "node --experimental-strip-types --test tests/devbinary/*.devtest.ts",
+    "test:maintainer": "node --experimental-strip-types --test tests/maintainer/*.maintest.ts",
 	"test:packed-runner": "node scripts/test-packed-runner.mjs",
     "prepack": "pnpm test && node scripts/verify-package-files.mjs",
     "prepublishOnly": "pnpm test && node scripts/verify-package-files.mjs && pnpm run test:packed-runner"

--- a/scripts/maintainer/provider-relay-matrix.mjs
+++ b/scripts/maintainer/provider-relay-matrix.mjs
@@ -9,7 +9,8 @@
 // `pnpm test` never imports it; `pnpm run test:maintainer` runs the tests;
 // the CLI is the entry point the separate verifier uses for the real organic
 // positive journey after a user-visible forecast.
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, resolveReviewHostRelaySubmission, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
 export const DESCRIPTOR_SCHEMA = "gentle-pi.maintainer.provider-relay-descriptor/v1";
@@ -119,6 +120,14 @@ export function resolveDeclaredExecutable(executable) {
 	return null;
 }
 const missingReason = (executable, label) => `${label} "${executable}" is not an existing executable; arm the descriptor with a real binary, or set GENTLE_PI_REQUIRE_MAINTAINER=1 to fail instead of block.`;
+// A guaranteed-nonexistent pi path inside a fresh private directory. mkdtemp
+// picks an unpredictable name and 0700 keeps it ours, so nothing can race a
+// file into the slot between the mkdtemp and the spawn.
+function unlaunchablePi() {
+	const directory = mkdtempSync(join(tmpdir(), "gentle-pi-maintainer-no-pi-"));
+	chmodSync(directory, 0o700);
+	return { directory, executable: join(directory, "pi-must-never-launch") };
+}
 // Runs the matrix against the REAL relay. A case that cannot run honestly is
 // `blocked` (never `pass`); `fail` is an armed case whose outcome mismatched.
 export async function runMatrix(descriptor, options = {}) {
@@ -142,7 +151,20 @@ export async function runMatrix(descriptor, options = {}) {
 				continue;
 			}
 		}
-		const request = { captureArgumentTokens: caseEntry.captureArgumentTokens, submission: caseEntry.submission, gentleAiExecutable: gentleAiPath, piExecutable: descriptor.piExecutable, ...(options.signal === undefined ? {} : { signal: options.signal }) };
+		// `relay-unavailable` is a NEGATIVE CONTROL: it must never launch pi and
+		// never submit. The maintainer-declared `kind` is not evidence that the
+		// declared binary is actually incapable, so the arm gate cannot key off
+		// the declaration alone. Pointed at a mis-declared CAPABLE binary, a
+		// declaration-only gate materializes, runs a REAL pi model, and executes
+		// a REAL `capture-result --input=...` submission, and only then reports
+		// `fail` — the mutation already happened. So give the negative control a
+		// pi that cannot exist: an incapable binary still classifies
+		// relay-unavailable at materialize (the control stays genuine, since it
+		// never reached pi anyway), while a capable one fails closed at the pi
+		// stage as kind=pi-launch-failed stage=pi mutationOutcome=none, with
+		// zero pi launch and zero submission.
+		const negativeControl = caseEntry.kind === "relay-unavailable" ? unlaunchablePi() : null;
+		const request = { captureArgumentTokens: caseEntry.captureArgumentTokens, submission: caseEntry.submission, gentleAiExecutable: gentleAiPath, piExecutable: negativeControl === null ? descriptor.piExecutable : negativeControl.executable, ...(options.signal === undefined ? {} : { signal: options.signal }) };
 		try {
 			const result = await runReviewHostRelaySlot(request);
 			if (caseEntry.kind === "relay-unavailable") {
@@ -166,6 +188,8 @@ export async function runMatrix(descriptor, options = {}) {
 			} else {
 				verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "fail", reason: `unexpected non-relay error: ${error instanceof Error ? error.message : String(error)}` });
 			}
+		} finally {
+			if (negativeControl !== null) rmSync(negativeControl.directory, { recursive: true, force: true });
 		}
 	}
 	return verdicts;

--- a/scripts/maintainer/provider-relay-matrix.mjs
+++ b/scripts/maintainer/provider-relay-matrix.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// Maintainer provider-relay matrix (gentle-pi#311, first direct work unit).
+//
+// Read-only maintainer harness driving the REAL Pi host relay
+// (lib/review-host-relay.ts#runReviewHostRelaySlot) through explicit
+// maintainer runtime descriptors. Validates an EXACT descriptor shape, uses
+// ONLY declared executables (never re-resolves the production binary), and
+// emits one machine-readable NDJSON verdict per case. Not a production path:
+// `pnpm test` never imports it; `pnpm run test:maintainer` runs the tests;
+// the CLI is the entry point the separate verifier uses for the real organic
+// positive journey after a user-visible forecast.
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, resolveReviewHostRelaySubmission, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
+export const DESCRIPTOR_SCHEMA = "gentle-pi.maintainer.provider-relay-descriptor/v1";
+export const CASE_KINDS = Object.freeze(["relay-unavailable", "positive-lens"]);
+// The positive lens runs only when explicitly armed: the organic journey
+// needs a real capable binary, a real pi, and a real review session. Without
+// the arm the runner blocks the positive leg before materialize.
+export const ARM_POSITIVE_ENV = "GENTLE_PI_MAINTAINER_ARM_POSITIVE";
+export const POSITIVE_JOURNEY_COMMAND =
+	"GENTLE_PI_MAINTAINER_ARM_POSITIVE=1 node --experimental-strip-types scripts/maintainer/provider-relay-matrix.mjs --descriptor <descriptor.json>  # needs a real capable gentle-ai binary + real pi on PATH + real binding tokens from a live review session (gentle-ai review status --next-transition)";
+export class DescriptorValidationError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = "DescriptorValidationError";
+	}
+}
+const isObj = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
+const isStr = (value) => typeof value === "string" && value.length > 0;
+const isStrArr = (value) => Array.isArray(value) && value.length > 0 && value.every(isStr);
+const fail = (message) => {
+	throw new DescriptorValidationError(message);
+};
+// Reject any key outside an exact allowed set; keeps the descriptor shape
+// strict so a maintainer cannot smuggle production overrides through it.
+const exactKeys = (obj, allowed, label) => {
+	for (const key of Object.keys(obj)) {
+		if (!allowed.has(key)) fail(`${label}.${key} is not allowed; exact shape is {${[...allowed].join(",")}}`);
+	}
+};
+// Strict, exact-shape descriptor validation: no defaults, no production
+// resolution. The submission is validated through the REAL relay resolver so
+// the completing form is provably bindable before any process launches.
+export function validateDescriptor(value) {
+	if (!isObj(value)) fail("descriptor must be a JSON object");
+	exactKeys(value, new Set(["schema", "gentleAiExecutable", "piExecutable", "cases"]), "descriptor");
+	if (value.schema !== DESCRIPTOR_SCHEMA) fail(`descriptor.schema must be exactly "${DESCRIPTOR_SCHEMA}"`);
+	if (!isStr(value.gentleAiExecutable) || !isAbsolute(value.gentleAiExecutable)) fail("descriptor.gentleAiExecutable must be a non-empty absolute path; the runner never re-resolves the production binary");
+	if (!isStr(value.piExecutable)) fail("descriptor.piExecutable must be a non-empty string");
+	if (!Array.isArray(value.cases) || value.cases.length === 0) fail("descriptor.cases must be a non-empty array");
+	const seen = new Set();
+	return { schema: value.schema, gentleAiExecutable: value.gentleAiExecutable, piExecutable: value.piExecutable, cases: value.cases.map((entry, index) => {
+			if (!isObj(entry)) fail(`descriptor.cases[${index}] must be an object`);
+			exactKeys(entry, new Set(["name", "kind", "captureArgumentTokens", "submission"]), `descriptor.cases[${index}]`);
+			if (!isStr(entry.name)) fail(`descriptor.cases[${index}].name must be a non-empty string`);
+			if (seen.has(entry.name)) fail(`descriptor.cases[${index}].name "${entry.name}" is duplicated`);
+			seen.add(entry.name);
+			if (!CASE_KINDS.includes(entry.kind)) fail(`descriptor.cases[${index}].kind must be one of ${JSON.stringify([...CASE_KINDS])}`);
+			if (!isStrArr(entry.captureArgumentTokens)) fail(`descriptor.cases[${index}].captureArgumentTokens must be a non-empty array of non-empty strings`);
+			// A real host-relay materialize slot is the provider-issued
+			// --agent=pi --materialize=true pair; the descriptor must declare
+			// exactly that so the negative control exercises the unknown-flag
+			// refusal and the positive leg exercises the real surface.
+			for (const required of ["--agent=pi", "--materialize=true"]) {
+				if (!entry.captureArgumentTokens.includes(required)) fail(`descriptor.cases[${index}].captureArgumentTokens must include the provider-issued "${required}" token`);
+			}
+			const submission = entry.submission;
+			if (!isObj(submission)) fail(`descriptor.cases[${index}].submission must be an object; a materialize slot without a provider submission is a contract mismatch, never synthesized`);
+			exactKeys(submission, new Set(["operationToken", "argumentTokens", "values"]), `descriptor.cases[${index}].submission`);
+			if (!isStr(submission.operationToken)) fail(`descriptor.cases[${index}].submission.operationToken must be a non-empty string`);
+			if (!isStrArr(submission.argumentTokens)) fail(`descriptor.cases[${index}].submission.argumentTokens must be a non-empty array of non-empty strings`);
+			if (!Array.isArray(submission.values) || submission.values.length === 0 || !submission.values.every(isObj)) {
+				fail(`descriptor.cases[${index}].submission.values must be a non-empty array of objects`);
+			}
+			for (const [vi, ve] of submission.values.entries()) {
+				exactKeys(ve, new Set(["slot", "domain", "substitutionLocation"]), `descriptor.cases[${index}].submission.values[${vi}]`);
+				if (!isStr(ve.slot) || !isStr(ve.domain)) fail(`descriptor.cases[${index}].submission.values[${vi}] must have non-empty string slot and domain`);
+			}
+			// Delegate binding semantics (count, substitution location, the
+			// {{value}} slot) to the REAL relay resolver so they never drift.
+			try {
+				resolveReviewHostRelaySubmission({
+					operationToken: submission.operationToken,
+					argumentTokens: submission.argumentTokens,
+					values: submission.values.map((ve) => ({ slot: ve.slot, domain: ve.domain, substitutionLocation: ve.substitutionLocation })),
+				});
+			} catch (error) {
+				fail(`descriptor.cases[${index}].submission is not a bindable provider form: ${error instanceof Error ? error.message : String(error)}`);
+			}
+			return { name: entry.name, kind: entry.kind, captureArgumentTokens: [...entry.captureArgumentTokens], submission: { operationToken: submission.operationToken, argumentTokens: [...submission.argumentTokens], values: submission.values.map((ve) => ({ ...ve })) } };
+		}),
+	};
+}
+export function loadDescriptor(path) {
+	if (!isStr(path)) fail("a descriptor path is required");
+	let raw, parsed;
+	try {
+		raw = readFileSync(path, "utf8");
+	} catch (error) {
+		fail(`could not read descriptor at ${path}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		fail(`descriptor at ${path} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	return validateDescriptor(parsed);
+}
+// Resolves a declared executable without a shell: absolute path checked
+// verbatim, bare name searched on PATH. Never re-resolves production.
+export function resolveDeclaredExecutable(executable) {
+	if (isAbsolute(executable)) return existsSync(executable) && statSync(executable).isFile() ? executable : null;
+	for (const directory of (process.env.PATH ?? "").split(process.platform === "win32" ? ";" : ":")) {
+		if (!directory) continue;
+		const candidate = join(directory, executable);
+		if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+	}
+	return null;
+}
+const missingReason = (executable, label) => `${label} "${executable}" is not an existing executable; arm the descriptor with a real binary, or set GENTLE_PI_REQUIRE_MAINTAINER=1 to fail instead of block.`;
+// Runs the matrix against the REAL relay. A case that cannot run honestly is
+// `blocked` (never `pass`); `fail` is an armed case whose outcome mismatched.
+export async function runMatrix(descriptor, options = {}) {
+	const positiveArmed = options.armPositive ?? (process.env[ARM_POSITIVE_ENV] === "1");
+	const verdicts = [];
+	for (const caseEntry of descriptor.cases) {
+		const gentleAiPath = resolveDeclaredExecutable(descriptor.gentleAiExecutable);
+		if (gentleAiPath === null) {
+			verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "blocked", reason: missingReason(descriptor.gentleAiExecutable, "gentleAiExecutable") });
+			continue;
+		}
+		// The positive lens needs a real pi AND an explicit arm; the negative
+		// control never launches pi (fails closed at materialize).
+		if (caseEntry.kind === "positive-lens") {
+			if (resolveDeclaredExecutable(descriptor.piExecutable) === null) {
+				verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "blocked", reason: missingReason(descriptor.piExecutable, "piExecutable"), command: POSITIVE_JOURNEY_COMMAND });
+				continue;
+			}
+			if (!positiveArmed) {
+				verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "blocked", reason: `positive-lens case is not explicitly armed; set ${ARM_POSITIVE_ENV}=1 with a real capable gentle-ai binary, a real pi, and a real review session (real binding tokens from \`gentle-ai review status --next-transition\`) to run the organic journey. The runner never synthesizes a provider result.`, command: POSITIVE_JOURNEY_COMMAND });
+				continue;
+			}
+		}
+		const request = { captureArgumentTokens: caseEntry.captureArgumentTokens, submission: caseEntry.submission, gentleAiExecutable: gentleAiPath, piExecutable: descriptor.piExecutable, ...(options.signal === undefined ? {} : { signal: options.signal }) };
+		try {
+			const result = await runReviewHostRelaySlot(request);
+			if (caseEntry.kind === "relay-unavailable") {
+				verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "fail", reason: "expected relay-unavailable (runtime without --materialize) but the relay succeeded; the descriptor's binary is unexpectedly capable" });
+			} else {
+				verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "pass", promptByteLength: result.promptByteLength, resultByteLength: result.resultByteLength, submissionByteLength: result.submission.length });
+			}
+		} catch (error) {
+			if (error instanceof ReviewHostRelayError) {
+				if (caseEntry.kind === "relay-unavailable") {
+					if (error.kind === REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE && error.stage === "materialize" && error.mutationOutcome === "none") {
+						verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "pass", stage: error.stage, mutationOutcome: error.mutationOutcome, reason: REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE });
+					} else {
+						verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "fail", reason: `expected relay-unavailable at materialize with zero mutation, got kind=${error.kind} stage=${error.stage} mutationOutcome=${error.mutationOutcome}`, stderr: error.stderr });
+					}
+				} else if (error.kind === REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE) {
+					verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "blocked", stage: error.stage, reason: `the declared gentle-ai binary lacks the pi host relay surface: ${error.message}`, command: POSITIVE_JOURNEY_COMMAND });
+				} else {
+					verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "fail", reason: `relay error kind=${error.kind} stage=${error.stage} mutationOutcome=${error.mutationOutcome}: ${error.message}`, stderr: error.stderr });
+				}
+			} else {
+				verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "fail", reason: `unexpected non-relay error: ${error instanceof Error ? error.message : String(error)}` });
+			}
+		}
+	}
+	return verdicts;
+}
+async function main() {
+	const argv = process.argv.slice(2);
+	const index = argv.indexOf("--descriptor");
+	if (index === -1 || argv[index + 1] === undefined) {
+		process.stderr.write("usage: provider-relay-matrix.mjs --descriptor <path.json>\n");
+		process.exitCode = 2;
+		return;
+	}
+	let descriptor;
+	try {
+		descriptor = loadDescriptor(argv[index + 1]);
+	} catch (error) {
+		process.stderr.write(`descriptor validation failed: ${error instanceof Error ? error.message : String(error)}\n`);
+		process.exitCode = 2;
+		return;
+	}
+	const verdicts = await runMatrix(descriptor, { armPositive: process.env[ARM_POSITIVE_ENV] === "1" });
+	for (const verdict of verdicts) {
+		process.stdout.write(`${JSON.stringify(verdict)}\n`);
+		if (verdict.verdict !== "pass") process.exitCode = 1;
+	}
+}
+if (process.argv[1]?.endsWith("provider-relay-matrix.mjs")) await main();

--- a/tests/maintainer/provider-relay.maintest.ts
+++ b/tests/maintainer/provider-relay.maintest.ts
@@ -9,7 +9,7 @@
 // them via env. The baseline is described generically; external evidence
 // establishes whether it is the immutable RC8 runtime.
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -18,7 +18,15 @@ import { ARM_POSITIVE_ENV, CASE_KINDS, DESCRIPTOR_SCHEMA, DescriptorValidationEr
 const BASELINE_ENV = "GENTLE_PI_MAINTAINER_BASELINE_BINARY";
 const CAPABLE_ENV = "GENTLE_PI_MAINTAINER_CAPABLE_BINARY";
 const REQUIRE_ENV = "GENTLE_PI_REQUIRE_MAINTAINER";
-const PLACEHOLDER_BINARY = "/tmp/gentle-pi-maintainer-not-a-real-binary";
+// Every declared-but-nonexistent executable path these tests use lives inside
+// one private sandbox. A predictable /tmp path is squattable: another user can
+// pre-create it between runs, and a test that resolves it would then spawn a
+// file it never wrote. mkdtemp's unpredictable name plus 0700 removes that.
+const SANDBOX = mkdtempSync(join(tmpdir(), "gentle-pi-maintainer-sandbox-"));
+chmodSync(SANDBOX, 0o700);
+process.on("exit", () => rmSync(SANDBOX, { recursive: true, force: true }));
+const sandboxPath = (name: string) => join(SANDBOX, name);
+const PLACEHOLDER_BINARY = sandboxPath("not-a-real-gentle-ai-binary");
 const baselineBinary = process.env[BASELINE_ENV];
 const capableBinary = process.env[CAPABLE_ENV];
 const armed = process.env[REQUIRE_ENV] === "1";
@@ -105,14 +113,79 @@ test("loadDescriptor reads and validates a descriptor file", (t) => {
 // never falls through to the package-local production binary.
 // ---------------------------------------------------------------------------
 test("runMatrix uses only the declared executable, never the production resolver", async () => {
-	const [verdict] = await runMatrix(validateDescriptor({ ...descriptor(), gentleAiExecutable: "/tmp/opencode/not-a-gentle-ai-binary" }));
+	const [verdict] = await runMatrix(validateDescriptor({ ...descriptor(), gentleAiExecutable: sandboxPath("not-a-gentle-ai-binary") }));
 	assert.equal(verdict!.verdict, "blocked");
 	assert.match(verdict!.reason, /gentleAiExecutable/);
 	assert.notEqual(verdict!.verdict, "pass");
 });
 test("resolveDeclaredExecutable checks absolute paths verbatim and bare names on PATH only", () => {
-	assert.equal(resolveDeclaredExecutable("/tmp/opencode/nonexistent-absolute-123"), null);
+	assert.equal(resolveDeclaredExecutable(sandboxPath("nonexistent-absolute-123")), null);
 	assert.equal(resolveDeclaredExecutable(""), null);
+});
+
+// ---------------------------------------------------------------------------
+// Mis-declared capable binary — a `relay-unavailable` case is a negative
+// control, so the arm gate must not trust the maintainer-declared `kind`. A
+// declaration-only gate pointed at a CAPABLE binary would materialize, launch
+// a REAL pi model, and run a REAL `capture-result --input=...` submission
+// before reporting `fail`: the mutation would already have happened. Driven by
+// local stub executables (the repo's fake-executable idiom), so it is
+// deterministic and needs no arming.
+// ---------------------------------------------------------------------------
+function capableStubHarness(t: test.TestContext) {
+	const directory = mkdtempSync(join(tmpdir(), "gentle-pi-maintainer-capable-stub-"));
+	chmodSync(directory, 0o700);
+	t.after(() => rmSync(directory, { recursive: true, force: true }));
+	const materializeLog = join(directory, "materialized");
+	const submitLog = join(directory, "submitted");
+	const piLog = join(directory, "pi-launched");
+	const gentleAi = join(directory, "gentle-ai");
+	// Deliberately CAPABLE: it honours --materialize=true and would accept a
+	// submission, exactly like a binary a maintainer mis-declared as incapable.
+	writeFileSync(
+		gentleAi,
+		`#!/usr/bin/env node
+const fs = require("node:fs");
+const argv = process.argv.slice(2);
+if (argv.includes("--materialize=true")) {
+	fs.writeFileSync(${JSON.stringify(materializeLog)}, JSON.stringify(argv));
+	process.stdout.write("prompt-bytes");
+	process.exit(0);
+}
+fs.writeFileSync(${JSON.stringify(submitLog)}, JSON.stringify(argv));
+process.stdout.write(JSON.stringify({ schema: "gentle-ai.review-result-artifact/v2", admission_decision: "completed" }));
+process.exit(0);
+`,
+	);
+	chmodSync(gentleAi, 0o755);
+	const pi = join(directory, "pi");
+	writeFileSync(
+		pi,
+		`#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(piLog)}, "launched");
+const chunks = [];
+process.stdin.on("data", (chunk) => chunks.push(chunk));
+process.stdin.on("end", () => { process.stdout.write("pi-result-bytes"); process.exit(0); });
+`,
+	);
+	chmodSync(pi, 0o755);
+	return { gentleAi, pi, materializeLog, submitLog, piLog };
+}
+test("a relay-unavailable case against a CAPABLE binary fails closed at pi: zero pi launch, zero submission", async (t) => {
+	const stub = capableStubHarness(t);
+	const [verdict] = await runMatrix(validateDescriptor({ ...descriptor(), gentleAiExecutable: stub.gentleAi, piExecutable: stub.pi }));
+	// The declared binary really is capable, so the negative control cannot
+	// pass — but it must fail WITHOUT mutating anything.
+	assert.equal(verdict!.verdict, "fail");
+	assert.match(verdict!.reason, /kind=pi-launch-failed stage=pi mutationOutcome=none/);
+	// The load-bearing assertions: the real pi never ran and the real
+	// submission never fired.
+	assert.equal(existsSync(stub.piLog), false, "pi must never launch for a relay-unavailable case");
+	assert.equal(existsSync(stub.submitLog), false, "a relay-unavailable case must never reach submit");
+	// Materialize still happens: it is the honest capability probe, and it is
+	// read-only (mutationOutcome stays "none" before submit).
+	assert.equal(existsSync(stub.materializeLog), true);
 });
 // ---------------------------------------------------------------------------
 // Negative control — a baseline runtime without --materialize fails closed as
@@ -180,7 +253,7 @@ test("positive arming/skip: an unarmed positive leg blocks loudly and never fake
 	assert.notEqual(verdict!.verdict, "fail");
 });
 test("positive arming/skip: a missing pi blocks at the pi pre-arm before materialize", { skip: !capableArmed }, async () => {
-	const [verdict] = await runMatrix(positiveDescriptor(capableBinary, "/tmp/opencode/not-a-real-pi"));
+	const [verdict] = await runMatrix(positiveDescriptor(capableBinary, sandboxPath("not-a-real-pi")));
 	assert.equal(verdict!.verdict, "blocked");
 	assert.match(verdict!.reason, /piExecutable/);
 	assert.equal(verdict!.command, POSITIVE_JOURNEY_COMMAND);

--- a/tests/maintainer/provider-relay.maintest.ts
+++ b/tests/maintainer/provider-relay.maintest.ts
@@ -1,0 +1,192 @@
+// Maintainer provider-relay matrix — behavior-first tests (gentle-pi#311).
+//
+// `pnpm test` never picks this up: it globs `tests/*.test.ts` only, and this
+// file lives one directory deeper and ends in `.maintest.ts`. It runs only
+// via `pnpm run test:maintainer`. Strict validation + no-production-resolution
+// always run; real-binary tests run only when env-supplied maintainer binaries
+// exist (self-skip; fail-loud under GENTLE_PI_REQUIRE_MAINTAINER=1). Never fakes
+// green. Tests never hardcode machine-specific paths; the verifier supplies
+// them via env. The baseline is described generically; external evidence
+// establishes whether it is the immutable RC8 runtime.
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
+import { ARM_POSITIVE_ENV, CASE_KINDS, DESCRIPTOR_SCHEMA, DescriptorValidationError, POSITIVE_JOURNEY_COMMAND, loadDescriptor, resolveDeclaredExecutable, runMatrix, validateDescriptor } from "../../scripts/maintainer/provider-relay-matrix.mjs";
+const BASELINE_ENV = "GENTLE_PI_MAINTAINER_BASELINE_BINARY";
+const CAPABLE_ENV = "GENTLE_PI_MAINTAINER_CAPABLE_BINARY";
+const REQUIRE_ENV = "GENTLE_PI_REQUIRE_MAINTAINER";
+const PLACEHOLDER_BINARY = "/tmp/gentle-pi-maintainer-not-a-real-binary";
+const baselineBinary = process.env[BASELINE_ENV];
+const capableBinary = process.env[CAPABLE_ENV];
+const armed = process.env[REQUIRE_ENV] === "1";
+
+const BINDING_TOKENS = Object.freeze([
+	"--lineage=review-1d5aadacc600e167",
+	`--expected-revision=sha256:${"c".repeat(64)}`,
+	`--target=sha256:${"d".repeat(64)}`,
+	`--repository-context=rctx1_${"e".repeat(64)}`,
+	"--lens=review-reliability",
+	"--order=0",
+	`--subject-hash=sha256:${"a".repeat(64)}`,
+]);
+const CAPTURE_TOKENS = Object.freeze([...BINDING_TOKENS, "--agent=pi", "--materialize=true"]);
+const SUBMISSION = Object.freeze({
+	operationToken: "capture-result",
+	argumentTokens: Object.freeze([...BINDING_TOKENS, "--input={{value}}"]),
+	values: Object.freeze([{ slot: "reviewer_result", domain: "artifact_path_or_stdin", substitutionLocation: BINDING_TOKENS.length }]),
+});
+
+function descriptor(overrides = {}) {
+	return {
+		schema: DESCRIPTOR_SCHEMA,
+		gentleAiExecutable: PLACEHOLDER_BINARY,
+		piExecutable: "pi",
+		cases: [{ name: "baseline-negative-control", kind: "relay-unavailable", captureArgumentTokens: [...CAPTURE_TOKENS], submission: structuredClone(SUBMISSION) }],
+		...overrides,
+	};
+}
+function rejects(obj, fragment) {
+	assert.throws(() => validateDescriptor(obj), (error) => error instanceof DescriptorValidationError && error.message.includes(fragment));
+}
+function tempDescriptor(t, obj) {
+	const directory = mkdtempSync(join(tmpdir(), "gentle-pi-maintainer-"));
+	t.after(() => rmSync(directory, { recursive: true, force: true }));
+	const path = join(directory, "d.json");
+	writeFileSync(path, JSON.stringify(obj));
+	return path;
+}
+
+// ---------------------------------------------------------------------------
+// Strict descriptor validation — exact shape, no defaults, no production
+// resolution. Pure/deterministic; always runs.
+// ---------------------------------------------------------------------------
+test("valid descriptor validates and returns a normalized copy", () => {
+	const d = validateDescriptor(descriptor());
+	assert.equal(d.schema, DESCRIPTOR_SCHEMA);
+	assert.deepEqual(d.cases[0]!.captureArgumentTokens, [...CAPTURE_TOKENS]);
+	assert.deepEqual(d.cases[0]!.submission.values, SUBMISSION.values);
+});
+test("rejects malformed descriptor fields with exact-shape errors (no defaults, no production resolution)", () => {
+	rejects({ ...descriptor(), schema: "gentle-pi.maintainer.provider-relay-descriptor/v2" }, "descriptor.schema must be exactly");
+	rejects({ ...descriptor(), gentleAiExecutable: "gentle-ai" }, "absolute path");
+	rejects({ ...descriptor(), gentleAiExecutable: undefined }, "absolute path");
+	rejects({ ...descriptor(), extra: 1 }, "descriptor.extra");
+	rejects({ ...descriptor(), cases: [{ ...descriptor().cases[0]!, extra: 1 }] }, "extra");
+	assert.deepEqual([...CASE_KINDS], ["relay-unavailable", "positive-lens"]);
+	rejects({ ...descriptor(), cases: [{ ...descriptor().cases[0]!, kind: "bogus" }] }, "kind must be one of");
+	const dup = { ...descriptor().cases[0]!, name: "dup" };
+	rejects({ ...descriptor(), cases: [structuredClone(dup), structuredClone(dup)] }, "duplicated");
+	// Every case must declare the real provider-issued materialize slot.
+	rejects({ ...descriptor(), cases: [{ ...descriptor().cases[0]!, captureArgumentTokens: [...CAPTURE_TOKENS].filter((t) => t !== "--agent=pi") }] }, "--agent=pi");
+	rejects({ ...descriptor(), cases: [{ ...descriptor().cases[0]!, captureArgumentTokens: [...CAPTURE_TOKENS].filter((t) => t !== "--materialize=true") }] }, "--materialize=true");
+});
+test("submission is validated through the real relay resolver before any process launches (exact shape)", () => {
+	const twoValues = structuredClone(SUBMISSION);
+	twoValues.values = [...SUBMISSION.values, { slot: "extra", domain: "artifact_path_or_stdin", substitutionLocation: 0 }];
+	rejects({ ...descriptor(), cases: [{ ...descriptor().cases[0]!, submission: twoValues }] }, "not a bindable provider form");
+	const noSlot = structuredClone(SUBMISSION);
+	noSlot.argumentTokens = [...BINDING_TOKENS, "--input=/no/value/slot"];
+	rejects({ ...descriptor(), cases: [{ ...descriptor().cases[0]!, submission: noSlot }] }, "not a bindable provider form");
+	rejects({ ...descriptor(), cases: [{ ...descriptor().cases[0]!, submission: { ...structuredClone(SUBMISSION), extra: 1 } }] }, "extra");
+});
+test("loadDescriptor reads and validates a descriptor file", (t) => {
+	const path = tempDescriptor(t, descriptor());
+	assert.equal(loadDescriptor(path).schema, DESCRIPTOR_SCHEMA);
+	assert.throws(() => loadDescriptor(join(dirname(path), "missing.json")), /could not read descriptor/);
+	writeFileSync(join(dirname(path), "bad.json"), "{not json");
+	assert.throws(() => loadDescriptor(join(dirname(path), "bad.json")), /not valid JSON/);
+});
+
+// ---------------------------------------------------------------------------
+// No-production-resolution — the runner uses only declared executables and
+// never falls through to the package-local production binary.
+// ---------------------------------------------------------------------------
+test("runMatrix uses only the declared executable, never the production resolver", async () => {
+	const [verdict] = await runMatrix(validateDescriptor({ ...descriptor(), gentleAiExecutable: "/tmp/opencode/not-a-gentle-ai-binary" }));
+	assert.equal(verdict!.verdict, "blocked");
+	assert.match(verdict!.reason, /gentleAiExecutable/);
+	assert.notEqual(verdict!.verdict, "pass");
+});
+test("resolveDeclaredExecutable checks absolute paths verbatim and bare names on PATH only", () => {
+	assert.equal(resolveDeclaredExecutable("/tmp/opencode/nonexistent-absolute-123"), null);
+	assert.equal(resolveDeclaredExecutable(""), null);
+});
+// ---------------------------------------------------------------------------
+// Negative control — a baseline runtime without --materialize fails closed as
+// relay-unavailable with zero Pi launch and zero submission. The baseline is
+// env-supplied (GENTLE_PI_MAINTAINER_BASELINE_BINARY); external evidence
+// establishes whether it is the immutable RC8 runtime. Self-skip / fail-loud.
+// ---------------------------------------------------------------------------
+const baselineArmed = typeof baselineBinary === "string" && baselineBinary.length > 0 && baselineBinary.startsWith("/") && existsSync(baselineBinary);
+const baselineReason = () => `${BASELINE_ENV} is unset or not an existing absolute path; supply the baseline gentle-ai binary (external evidence establishes whether it is RC8), or set ${REQUIRE_ENV}=1 to fail instead of skip.`;
+if (!baselineArmed && armed) throw new Error(baselineReason());
+if (!baselineArmed) console.log(`tests/maintainer/provider-relay.maintest.ts: ${baselineReason()}`);
+function baselineDescriptor(kind = "relay-unavailable" as const) {
+	return validateDescriptor({ ...descriptor(), gentleAiExecutable: baselineBinary, cases: [{ name: "baseline-negative-control", kind, captureArgumentTokens: [...CAPTURE_TOKENS], submission: structuredClone(SUBMISSION) }] });
+}
+test("negative control: runMatrix proves the baseline fails closed as relay-unavailable with zero mutation", { skip: !baselineArmed }, async () => {
+	const [verdict] = await runMatrix(baselineDescriptor());
+	assert.equal(verdict!.kind, "relay-unavailable");
+	assert.equal(verdict!.verdict, "pass");
+	assert.equal(verdict!.stage, "materialize");
+	assert.equal(verdict!.mutationOutcome, "none");
+	assert.equal(verdict!.reason, REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE);
+});
+test("negative control: the real relay returns a typed relay-unavailable error before Pi launches", { skip: !baselineArmed }, async () => {
+	// The baseline lacks --materialize, so it fails at materialize before any
+	// pi launch; RELAY_UNAVAILABLE at materialize proves Pi never launched.
+	let caught: unknown;
+	try {
+		await runReviewHostRelaySlot({ captureArgumentTokens: [...CAPTURE_TOKENS], submission: structuredClone(SUBMISSION), gentleAiExecutable: baselineBinary!, piExecutable: "pi" });
+	} catch (error) {
+		caught = error;
+	}
+	assert.ok(caught instanceof ReviewHostRelayError);
+	const e = caught as ReviewHostRelayError;
+	assert.equal(e.kind, REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE);
+	assert.equal(e.stage, "materialize");
+	assert.equal(e.mutationOutcome, "none");
+	assert.match(e.stderr, /flag provided but not defined: -(?:materialize|agent)/);
+});
+test("negative control: an armed positive-lens against the baseline blocks because it lacks the surface", { skip: !baselineArmed }, async () => {
+	const [verdict] = await runMatrix(baselineDescriptor("positive-lens"), { armPositive: true });
+	assert.equal(verdict!.verdict, "blocked");
+	assert.match(verdict!.reason, /lacks the pi host relay surface/);
+	assert.equal(verdict!.command, POSITIVE_JOURNEY_COMMAND);
+});
+// ---------------------------------------------------------------------------
+// Honest positive arming/skip — the organic journey needs a real capable
+// binary, a real pi, and a real review session (lifecycle machinery beyond
+// this work unit). The runner blocks the positive leg before materialize
+// unless armed. These tests run WITHOUT the arm (the verifier arms it).
+// ---------------------------------------------------------------------------
+const capableArmed = typeof capableBinary === "string" && capableBinary.length > 0 && capableBinary.startsWith("/") && existsSync(capableBinary);
+const capableReason = () => `${CAPABLE_ENV} is unset or not an existing absolute path; supply a capable gentle-ai binary (local build of origin/main with the pi host-relay surface), or set ${REQUIRE_ENV}=1 to fail instead of skip.`;
+if (!capableArmed && armed) throw new Error(capableReason());
+if (!capableArmed) console.log(`tests/maintainer/provider-relay.maintest.ts: ${capableReason()}`);
+function positiveDescriptor(gentleAi = capableBinary, pi = "pi") {
+	return validateDescriptor({ ...descriptor(), gentleAiExecutable: gentleAi!, piExecutable: pi, cases: [{ name: "positive-lens-relay", kind: "positive-lens", captureArgumentTokens: [...CAPTURE_TOKENS], submission: structuredClone(SUBMISSION) }] });
+}
+test("positive arming/skip: an unarmed positive leg blocks loudly and never fakes green", { skip: !capableArmed }, async () => {
+	const [verdict] = await runMatrix(positiveDescriptor());
+	assert.equal(verdict!.kind, "positive-lens");
+	assert.equal(verdict!.verdict, "blocked");
+	assert.match(verdict!.reason, new RegExp(ARM_POSITIVE_ENV));
+	assert.equal(verdict!.command, POSITIVE_JOURNEY_COMMAND);
+	assert.notEqual(verdict!.verdict, "pass");
+	assert.notEqual(verdict!.verdict, "fail");
+});
+test("positive arming/skip: a missing pi blocks at the pi pre-arm before materialize", { skip: !capableArmed }, async () => {
+	const [verdict] = await runMatrix(positiveDescriptor(capableBinary, "/tmp/opencode/not-a-real-pi"));
+	assert.equal(verdict!.verdict, "blocked");
+	assert.match(verdict!.reason, /piExecutable/);
+	assert.equal(verdict!.command, POSITIVE_JOURNEY_COMMAND);
+});
+test("positive arming/skip: the exact next evidence command is surfaced for the separate verifier", { skip: !capableArmed }, async () => {
+	const [verdict] = await runMatrix(positiveDescriptor());
+	assert.match(verdict!.command!, /node --experimental-strip-types scripts\/maintainer\/provider-relay-matrix.mjs --descriptor/);
+	assert.match(verdict!.command!, /GENTLE_PI_MAINTAINER_ARM_POSITIVE=1/);
+});


### PR DESCRIPTION
Implements #311 P7 (maintainer field-test slice).

## What changed

- Adds a descriptor-driven maintainer matrix over the real `runReviewHostRelaySlot` seam.
- Proves an immutable RC8 baseline fails closed as `relay-unavailable` at materialization with zero mutation and no Pi launch.
- Adds an explicitly armed organic path for a capable local provider plus the real Pi runtime. Missing binaries or bindings block loudly and never fake green.
- Keeps maintainer checks outside ordinary `pnpm test` through the dedicated `test:maintainer` script.

## Evidence

- Full suite: 1,112 passing tests and 1 intentional platform skip.
- Maintainer matrix plus existing relay suite: 32/32 passing.
- Organic Pi lens relay: 8,266 prompt bytes, 1,014 result bytes, 603 submitted bytes, native admission `completed`.
- Native review receipt: `sha256:7f96f742a8af4bade6424d2cb020f0088c3c82e035aa59e9a8ed3de9d2bf1039`.
- `pre-commit`, `pre-push`, and `pre-pr` gates: `ALLOW`.

## Review path

1. Review `scripts/maintainer/provider-relay-matrix.mjs` for strict descriptor validation and fail-closed execution.
2. Review `tests/maintainer/provider-relay.maintest.ts` for negative controls, explicit arming, and no-production-resolution coverage.
3. Confirm `package.json` only exposes the isolated maintainer test command.

## Out of scope

This slice does not change the production Gentle AI pin. Remaining #311 work includes restart/retry identity proof, organic refuter and targeted-validator coverage, the complete fail-closed matrix, and P8 release promotion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maintainer tool for validating provider relay configurations and reporting pass, fail, or blocked results.
  * Added support for running real relay validation scenarios with controlled positive-test activation.

* **Tests**
  * Added comprehensive maintainer tests covering descriptor validation, executable handling, relay availability, and error reporting.
  * Added an npm command for running maintainer-specific tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->