### PR TITLE
fix(background): probe live tool registry for subagent capability

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -309,18 +309,86 @@ function loadBackgroundSubagentsPolicy(
 	}
 }
 
+const SUBAGENTS_PACKAGE_NAMES = ["pi-subagents-j0k3r", "pi-subagents"] as const;
+const SUBAGENT_RUN_TOOL = "subagent_run";
+
 /**
- * `subagent_run` availability probe. The extension has no synchronous runtime
- * tool registry at prompt-render time, so capability is derived from the
- * pi-subagents package presence via the builtinAgentDirs() probe.
+ * Roots where an installed subagents package may live. These are the same
+ * roots builtinAgentDirs() walks, minus its `/agents` suffix.
+ *
+ * builtinAgentDirs() looks for markdown agent definitions, which the package
+ * legitimately may not ship. Capability is a different question, so it must
+ * not reuse that path: pi-subagents-j0k3r v1.5.2 ships index.ts, src/, skills/
+ * and scripts/ and no agents/ directory at all, so an agents-dir probe reports
+ * "absent" on every real install and leaves the background policy inert.
+ */
+function subagentsPackageRoots(cwd: string): string[] {
+	return SUBAGENTS_PACKAGE_NAMES.flatMap((packageName) => [
+		join(PACKAGE_ROOT, "..", packageName),
+		join(cwd, ".pi", "npm", "node_modules", packageName),
+		join(homedir(), ".local", "lib", "node_modules", packageName),
+	]);
+}
+
+/** A package root counts as installed only when it carries its own manifest. */
+function hasInstalledSubagentsPackage(cwd: string): boolean {
+	return subagentsPackageRoots(cwd).some((root) =>
+		existsSync(join(root, "package.json")),
+	);
+}
+
+function hasSubagentRunTool(activeTools: readonly string[]): boolean {
+	return activeTools.some(
+		(name) => name === SUBAGENT_RUN_TOOL || name.endsWith(`.${SUBAGENT_RUN_TOOL}`),
+	);
+}
+
+/**
+ * Read the live pi tool registry, or undefined when it carries no signal.
+ *
+ * An absent handle, a non-array result, a throwing registry, and an empty list
+ * are all "no signal" rather than "no subagents": reporting absent from an
+ * uninformative registry would reproduce the very defect this probe fixes.
+ */
+function readActiveToolNames(pi: unknown): readonly string[] | undefined {
+	try {
+		const getActiveTools = (pi as { getActiveTools?: () => unknown })
+			?.getActiveTools;
+		if (typeof getActiveTools !== "function") return undefined;
+		const tools = getActiveTools.call(pi);
+		if (!Array.isArray(tools)) return undefined;
+		const names = tools
+			.map((tool) =>
+				typeof tool === "string"
+					? tool
+					: isRecord(tool) && typeof tool.name === "string"
+						? tool.name
+						: "",
+			)
+			.filter((name) => name.length > 0);
+		return names.length > 0 ? names : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * `subagent_run` availability probe.
+ *
+ * The live tool registry answers the question directly and wins whenever it
+ * carries any signal. Without it -- prompt rendering outside a session, or a
+ * runtime with no getActiveTools -- capability falls back to the presence of
+ * an installed subagents package.
  */
 function resolveBackgroundSubagentsCapability(
 	cwd: string,
+	activeTools?: readonly string[],
 ): BackgroundSubagentsCapability {
 	try {
-		return builtinAgentDirs(cwd).some((dir) => existsSync(dir))
-			? "ready"
-			: "absent";
+		if (activeTools !== undefined && activeTools.length > 0) {
+			return hasSubagentRunTool(activeTools) ? "ready" : "absent";
+		}
+		return hasInstalledSubagentsPackage(cwd) ? "ready" : "absent";
 	} catch {
 		return "absent";
 	}
@@ -335,10 +403,13 @@ function renderBackgroundSubagentsStatusLine(
 // Rendered prompts are memoized per background policy/capability key for the
 // process lifetime; the assets bytes themselves are read once per key.
 const orchestratorPromptCache = new Map<string, string>();
-function getOrchestratorPrompt(cwd: string = process.cwd()): string {
+function getOrchestratorPrompt(
+	cwd: string = process.cwd(),
+	activeTools?: readonly string[],
+): string {
 	const background: BackgroundSubagentsRendering = {
 		policy: loadBackgroundSubagentsPolicy(cwd),
-		capability: resolveBackgroundSubagentsCapability(cwd),
+		capability: resolveBackgroundSubagentsCapability(cwd, activeTools),
 	};
 	const cacheKey = `${background.policy}:${background.capability}`;
 	let prompt = orchestratorPromptCache.get(cacheKey);
@@ -409,7 +480,11 @@ const NEUTRAL_PERSONA_PROMPT = `Persona:
 - Push back when the user asks for code without enough context or understanding.
 - Correct errors directly, explain why, and show the better path.`;
 
-function buildGentlePrompt(persona: PersonaMode, cwd: string = process.cwd()): string {
+function buildGentlePrompt(
+	persona: PersonaMode,
+	cwd: string = process.cwd(),
+	activeTools?: readonly string[],
+): string {
 	const personaPrompt =
 		persona === "neutral" ? NEUTRAL_PERSONA_PROMPT : GENTLEMAN_PERSONA_PROMPT;
 	const languageBoundary =
@@ -443,7 +518,7 @@ Harness principles:
 - Protect the human reviewer: avoid oversized changes, surface review workload risk, and ask before turning one task into a large multi-area change.
 - Never claim persistent memory is available because of this package. Memory is provided by separate packages or MCP tools when installed and callable.
 
-${getOrchestratorPrompt(cwd)}`;
+${getOrchestratorPrompt(cwd, activeTools)}`;
 }
 
 // Matches `git [global-flags] push` — tolerates flags like -C /repo or --work-tree=/tmp
@@ -6353,6 +6428,7 @@ export const __testing = {
 	loadBackgroundSubagentsPolicy,
 	parseBackgroundSubagentsPolicyFile,
 	resolveBackgroundSubagentsCapability,
+	readActiveToolNames,
 	renderBackgroundSubagentsStatusLine,
 	resolveControllerSddStatus,
 	resolveStartupControllerSddStatus,
@@ -6591,7 +6667,7 @@ function createGentleAiExtensionForTesting(
 			: "";
 		const gentlePrompt = isNamedAgent || isSddAgent
 			? ""
-			: `\n\n${buildGentlePrompt(readPersonaMode(ctx.cwd), ctx.cwd)}`;
+			: `\n\n${buildGentlePrompt(readPersonaMode(ctx.cwd), ctx.cwd, readActiveToolNames(pi))}`;
 		return {
 			systemPrompt: `${event.systemPrompt}${gentlePrompt}${sddPrompt}${nativeStatusPrompt}`,
 		};

--- a/tests/background-subagents.test.ts
+++ b/tests/background-subagents.test.ts
@@ -10,15 +10,23 @@ import { __testing } from "../extensions/gentle-ai.ts";
 //
 // The policy loader mirrors loadRuntimeGuardrailsConfig: project file >
 // global file > env var > default off, strict schema decode, fail-closed to
-// "off" on any malformed input. Capability is derived from the pi-subagents
-// package presence (builtinAgentDirs probe) because no synchronous runtime
-// tool registry exists at prompt-render time.
+// "off" on any malformed input.
+//
+// Capability answers one question: is `subagent_run` callable? The live pi
+// tool registry answers it directly and wins when it carries any signal. With
+// no registry handle (prompt rendering outside a session, or a runtime without
+// getActiveTools) capability falls back to the installed pi-subagents package.
+// That fallback probes the package root's own package.json, NOT an `agents/`
+// subdirectory: pi-subagents-j0k3r v1.5.2 ships index.ts, src/, skills/ and
+// scripts/ and no agents/ at all, so the old agents-dir probe reported
+// "absent" on every real install and left the background policy inert.
 // ---------------------------------------------------------------------------
 
 const {
 	loadBackgroundSubagentsPolicy,
 	parseBackgroundSubagentsPolicyFile,
 	resolveBackgroundSubagentsCapability,
+	readActiveToolNames,
 	renderBackgroundSubagentsStatusLine,
 	renderOrchestratorPrompt,
 	getOrchestratorPrompt,
@@ -45,6 +53,29 @@ function writePolicyFile(dir: string, policy: string): void {
 }
 
 const EMPTY_ENV = {} as Record<string, string | undefined>;
+
+/**
+ * Materialize an installed subagents package under the cwd-relative candidate
+ * root. `agentsDir` reproduces the hypothetical legacy layout; omitting it
+ * reproduces the real published layout, which ships no agents/ directory.
+ */
+function installSubagentsPackage(
+	cwd: string,
+	packageName: string,
+	options: { agentsDir?: boolean } = {},
+): void {
+	const root = join(cwd, ".pi", "npm", "node_modules", packageName);
+	mkdirSync(root, { recursive: true });
+	writeFileSync(
+		join(root, "package.json"),
+		JSON.stringify({ name: packageName, version: "1.5.2", type: "module" }),
+	);
+	// The real package ships these; none of them is an agents/ directory.
+	for (const shipped of ["src", "skills", "scripts"]) {
+		mkdirSync(join(root, shipped), { recursive: true });
+	}
+	if (options.agentsDir) mkdirSync(join(root, "agents"), { recursive: true });
+}
 
 // ---------------------------------------------------------------------------
 // Strict decode
@@ -166,17 +197,100 @@ test("a malformed higher-priority file fails closed to off instead of falling th
 // Capability degrade
 // ---------------------------------------------------------------------------
 
-test("capability is absent when no pi-subagents package directory exists", () => {
+test("capability is absent when no subagents package exists anywhere", () => {
 	const cwd = makeScratch("gp-bg-cap-absent-");
 	assert.equal(resolveBackgroundSubagentsCapability(cwd), "absent");
 });
 
-test("capability is ready when a pi-subagents agents directory is discoverable", () => {
-	const cwd = makeScratch("gp-bg-cap-ready-");
-	mkdirSync(join(cwd, ".pi", "npm", "node_modules", "pi-subagents", "agents"), {
+// Regression: the exact shape of a real install. pi-subagents-j0k3r v1.5.2
+// ships no agents/ directory, so the previous agents-dir probe reported
+// "absent" while subagent_run was in fact installed and callable.
+test("capability is ready when the subagents package is installed without an agents directory", () => {
+	const cwd = makeScratch("gp-bg-cap-real-");
+	installSubagentsPackage(cwd, "pi-subagents-j0k3r");
+	assert.equal(resolveBackgroundSubagentsCapability(cwd), "ready");
+});
+
+test("capability is ready for either supported package name", () => {
+	for (const packageName of ["pi-subagents-j0k3r", "pi-subagents"]) {
+		const cwd = makeScratch("gp-bg-cap-name-");
+		installSubagentsPackage(cwd, packageName);
+		assert.equal(
+			resolveBackgroundSubagentsCapability(cwd),
+			"ready",
+			`package name ${packageName} must be detected`,
+		);
+	}
+});
+
+test("capability stays ready for a layout that does ship an agents directory", () => {
+	const cwd = makeScratch("gp-bg-cap-legacy-");
+	installSubagentsPackage(cwd, "pi-subagents", { agentsDir: true });
+	assert.equal(resolveBackgroundSubagentsCapability(cwd), "ready");
+});
+
+test("a bare directory with no package.json is not an installed package", () => {
+	const cwd = makeScratch("gp-bg-cap-bare-");
+	mkdirSync(join(cwd, ".pi", "npm", "node_modules", "pi-subagents-j0k3r", "agents"), {
 		recursive: true,
 	});
-	assert.equal(resolveBackgroundSubagentsCapability(cwd), "ready");
+	assert.equal(resolveBackgroundSubagentsCapability(cwd), "absent");
+});
+
+// ---------------------------------------------------------------------------
+// Live tool registry outranks the filesystem fallback
+// ---------------------------------------------------------------------------
+
+test("a live tool registry listing subagent_run reports ready with no package on disk", () => {
+	const cwd = makeScratch("gp-bg-cap-tools-ready-");
+	assert.equal(
+		resolveBackgroundSubagentsCapability(cwd, ["read", "bash", "subagent_run"]),
+		"ready",
+	);
+	assert.equal(
+		resolveBackgroundSubagentsCapability(cwd, ["pi-subagents-j0k3r.subagent_run"]),
+		"ready",
+		"a namespaced tool name must still count",
+	);
+});
+
+test("a live tool registry without subagent_run outranks an installed package", () => {
+	const cwd = makeScratch("gp-bg-cap-tools-absent-");
+	installSubagentsPackage(cwd, "pi-subagents-j0k3r");
+	assert.equal(resolveBackgroundSubagentsCapability(cwd, ["read", "bash"]), "absent");
+});
+
+test("an empty tool list carries no signal and falls back to the package probe", () => {
+	const cwd = makeScratch("gp-bg-cap-tools-empty-");
+	installSubagentsPackage(cwd, "pi-subagents-j0k3r");
+	assert.equal(resolveBackgroundSubagentsCapability(cwd, []), "ready");
+});
+
+test("readActiveToolNames reads the pi registry and degrades to undefined", () => {
+	assert.deepEqual(
+		readActiveToolNames({ getActiveTools: () => ["read", "subagent_run"] }),
+		["read", "subagent_run"],
+	);
+	assert.deepEqual(
+		readActiveToolNames({ getActiveTools: () => [{ name: "subagent_run" }, 7, ""] }),
+		["subagent_run"],
+		"non-string entries are normalized and blanks dropped",
+	);
+	assert.equal(readActiveToolNames({}), undefined, "no handle means no signal");
+	assert.equal(
+		readActiveToolNames({ getActiveTools: () => "nope" }),
+		undefined,
+		"a non-array result means no signal",
+	);
+	assert.equal(
+		readActiveToolNames({
+			getActiveTools: () => {
+				throw new Error("registry unavailable");
+			},
+		}),
+		undefined,
+		"a throwing registry means no signal",
+	);
 });
 
 // ---------------------------------------------------------------------------
@@ -208,6 +322,32 @@ test("renderOrchestratorPrompt defaults to the fail-closed off/absent rendering"
 	const assetsDir = join(process.cwd(), "assets");
 	const rendered = renderOrchestratorPrompt(assetsDir);
 	assert.match(rendered, /Background subagent policy: off \(capability: absent\)/);
+});
+
+// The project policy file pins the policy half of the status line so these
+// assertions never depend on the developer's ambient global config.
+test("the rendered status line flips to ready when the subagents package is installed", () => {
+	const cwd = makeScratch("gp-bg-cap-render-");
+	writePolicyFile(join(cwd, ".pi", "gentle-ai"), "on");
+	assert.match(
+		getOrchestratorPrompt(cwd),
+		/Background subagent policy: on \(capability: absent\)/,
+		"no package installed yet",
+	);
+	installSubagentsPackage(cwd, "pi-subagents-j0k3r");
+	assert.match(
+		getOrchestratorPrompt(cwd),
+		/Background subagent policy: on \(capability: ready\)/,
+	);
+});
+
+test("the rendered status line reports ready from a live registry alone", () => {
+	const cwd = makeScratch("gp-bg-cap-render-tools-");
+	writePolicyFile(join(cwd, ".pi", "gentle-ai"), "on");
+	assert.match(
+		getOrchestratorPrompt(cwd, ["read", "subagent_run"]),
+		/Background subagent policy: on \(capability: ready\)/,
+	);
 });
 
 test("getOrchestratorPrompt renders exactly one background status line", () => {


### PR DESCRIPTION
## What

The background-subagents capability probe checked `<pkg>/agents`, a directory pi-subagents-j0k3r does not ship, so the capability was permanently reported absent on real installs.

- Primary probe: live tool registry (`pi.getActiveTools()`) checking for the `subagent_run` primary.
- Fallback: package presence in `package.json`.

Found on the first real Pi install field test.

## Verification

Suite green; probe verified against a real pi-subagents-j0k3r install (capability now reports active).

Separate issue to file: `listBuiltinAgentNames` — the "builtin" agent source is permanently empty; independent of this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background subagent capability detection using currently available session tools.
  * Added fallback detection for supported installed packages when live tool information is unavailable.
  * Improved handling of legacy package layouts, missing manifests, and tool registry errors.
  * Updated prompts to accurately reflect available background subagent capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->