### PR TITLE
chore(review): reuse resolved Pi executable in relay matrix

### DIFF
--- a/scripts/maintainer/provider-relay-matrix.mjs
+++ b/scripts/maintainer/provider-relay-matrix.mjs
@@ -11,7 +11,7 @@
 // positive journey after a user-visible forecast.
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, isAbsolute, join } from "node:path";
+import { delimiter, isAbsolute, join, resolve } from "node:path";
 import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, resolveReviewHostRelaySubmission, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
 export const DESCRIPTOR_SCHEMA = "gentle-pi.maintainer.provider-relay-descriptor/v1";
 export const CASE_KINDS = Object.freeze(["relay-unavailable", "positive-lens"]);
@@ -109,12 +109,14 @@ export function loadDescriptor(path) {
 	return validateDescriptor(parsed);
 }
 // Resolves a declared executable without a shell: absolute path checked
-// verbatim, bare name searched on PATH. Never re-resolves production.
+// verbatim, bare name searched on PATH. Never re-resolves production. PATH
+// matches are normalized to absolute paths (a relative component like `.`
+// must not yield a relative candidate; the relay launches from scratch).
 export function resolveDeclaredExecutable(executable) {
 	if (isAbsolute(executable)) return existsSync(executable) && statSync(executable).isFile() ? executable : null;
 	for (const directory of (process.env.PATH ?? "").split(delimiter)) {
 		if (!directory) continue;
-		const candidate = join(directory, executable);
+		const candidate = resolve(directory, executable);
 		if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
 	}
 	return null;

--- a/scripts/maintainer/provider-relay-matrix.mjs
+++ b/scripts/maintainer/provider-relay-matrix.mjs
@@ -11,7 +11,7 @@
 // positive journey after a user-visible forecast.
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { isAbsolute, join } from "node:path";
+import { delimiter, isAbsolute, join } from "node:path";
 import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, resolveReviewHostRelaySubmission, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
 export const DESCRIPTOR_SCHEMA = "gentle-pi.maintainer.provider-relay-descriptor/v1";
 export const CASE_KINDS = Object.freeze(["relay-unavailable", "positive-lens"]);
@@ -112,7 +112,7 @@ export function loadDescriptor(path) {
 // verbatim, bare name searched on PATH. Never re-resolves production.
 export function resolveDeclaredExecutable(executable) {
 	if (isAbsolute(executable)) return existsSync(executable) && statSync(executable).isFile() ? executable : null;
-	for (const directory of (process.env.PATH ?? "").split(process.platform === "win32" ? ";" : ":")) {
+	for (const directory of (process.env.PATH ?? "").split(delimiter)) {
 		if (!directory) continue;
 		const candidate = join(directory, executable);
 		if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
@@ -132,6 +132,11 @@ function unlaunchablePi() {
 // `blocked` (never `pass`); `fail` is an armed case whose outcome mismatched.
 export async function runMatrix(descriptor, options = {}) {
 	const positiveArmed = options.armPositive ?? (process.env[ARM_POSITIVE_ENV] === "1");
+	// Smallest test seam: an optional injected relay function. Defaults to
+	// the real relay so production CLI behavior is identical when unset; tests
+	// inject a fake to assert the exact resolved path reaches the boundary
+	// without executing a real subprocess (platform-neutral #324 evidence).
+	const relay = options.relay ?? runReviewHostRelaySlot;
 	const verdicts = [];
 	for (const caseEntry of descriptor.cases) {
 		const gentleAiPath = resolveDeclaredExecutable(descriptor.gentleAiExecutable);
@@ -140,9 +145,15 @@ export async function runMatrix(descriptor, options = {}) {
 			continue;
 		}
 		// The positive lens needs a real pi AND an explicit arm; the negative
-		// control never launches pi (fails closed at materialize).
+		// control never launches pi (fails closed at materialize). The precheck
+		// resolves the declared Pi executable ONCE and reuses that exact
+		// concrete path for launch; a bare declaration is never re-resolved
+		// between precheck and spawn, so the relay launches exactly the
+		// executable the harness checked (issue #324).
+		let piPath = null;
 		if (caseEntry.kind === "positive-lens") {
-			if (resolveDeclaredExecutable(descriptor.piExecutable) === null) {
+			piPath = resolveDeclaredExecutable(descriptor.piExecutable);
+			if (piPath === null) {
 				verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "blocked", reason: missingReason(descriptor.piExecutable, "piExecutable"), command: POSITIVE_JOURNEY_COMMAND });
 				continue;
 			}
@@ -164,9 +175,9 @@ export async function runMatrix(descriptor, options = {}) {
 		// stage as kind=pi-launch-failed stage=pi mutationOutcome=none, with
 		// zero pi launch and zero submission.
 		const negativeControl = caseEntry.kind === "relay-unavailable" ? unlaunchablePi() : null;
-		const request = { captureArgumentTokens: caseEntry.captureArgumentTokens, submission: caseEntry.submission, gentleAiExecutable: gentleAiPath, piExecutable: negativeControl === null ? descriptor.piExecutable : negativeControl.executable, ...(options.signal === undefined ? {} : { signal: options.signal }) };
+		const request = { captureArgumentTokens: caseEntry.captureArgumentTokens, submission: caseEntry.submission, gentleAiExecutable: gentleAiPath, piExecutable: negativeControl === null ? piPath : negativeControl.executable, ...(options.signal === undefined ? {} : { signal: options.signal }) };
 		try {
-			const result = await runReviewHostRelaySlot(request);
+			const result = await relay(request);
 			if (caseEntry.kind === "relay-unavailable") {
 				verdicts.push({ name: caseEntry.name, kind: caseEntry.kind, verdict: "fail", reason: "expected relay-unavailable (runtime without --materialize) but the relay succeeded; the descriptor's binary is unexpectedly capable" });
 			} else {

--- a/tests/maintainer/provider-relay.maintest.ts
+++ b/tests/maintainer/provider-relay.maintest.ts
@@ -11,7 +11,7 @@
 import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join, relative } from "node:path";
+import { delimiter, dirname, isAbsolute, join, relative } from "node:path";
 import test from "node:test";
 import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
 import { ARM_POSITIVE_ENV, CASE_KINDS, DESCRIPTOR_SCHEMA, DescriptorValidationError, POSITIVE_JOURNEY_COMMAND, loadDescriptor, resolveDeclaredExecutable, runMatrix, validateDescriptor } from "../../scripts/maintainer/provider-relay-matrix.mjs";
@@ -252,7 +252,9 @@ test("a bare Pi declaration is resolved once: the relay never falls through to a
 // shebang/chmod/.cmd execution is involved. No real model or network.
 // ---------------------------------------------------------------------------
 test("platform-neutral: runMatrix passes the first resolved concrete Pi path into the relay boundary (no second resolution)", async (t) => {
-	const root = mkdtempSync(join(tmpdir(), "gentle-pi-maintainer-portable-"));
+	// Keep the fixture on the same Windows volume as process.cwd() so the
+	// first PATH component genuinely exercises relative-path normalization.
+	const root = mkdtempSync(join(process.cwd(), ".gentle-pi-maintainer-portable-"));
 	chmodSync(root, 0o700);
 	t.after(() => rmSync(root, { recursive: true, force: true }));
 	const dirA = join(root, "path-a");
@@ -272,6 +274,7 @@ test("platform-neutral: runMatrix passes the first resolved concrete Pi path int
 	// First PATH component is RELATIVE to process.cwd(): a relative component
 	// must still normalize to the same absolute firstPi the precheck resolved.
 	const dirARelative = relative(process.cwd(), dirA);
+	assert.equal(isAbsolute(dirARelative), false, "fixture must keep the first PATH component relative");
 	const savedPath = process.env.PATH;
 	process.env.PATH = [dirARelative, dirB, savedPath].join(delimiter);
 	t.after(() => { process.env.PATH = savedPath; });

--- a/tests/maintainer/provider-relay.maintest.ts
+++ b/tests/maintainer/provider-relay.maintest.ts
@@ -9,9 +9,9 @@
 // them via env. The baseline is described generically; external evidence
 // establishes whether it is the immutable RC8 runtime.
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import test from "node:test";
 import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
 import { ARM_POSITIVE_ENV, CASE_KINDS, DESCRIPTOR_SCHEMA, DescriptorValidationError, POSITIVE_JOURNEY_COMMAND, loadDescriptor, resolveDeclaredExecutable, runMatrix, validateDescriptor } from "../../scripts/maintainer/provider-relay-matrix.mjs";
@@ -187,6 +187,119 @@ test("a relay-unavailable case against a CAPABLE binary fails closed at pi: zero
 	// read-only (mutationOutcome stays "none" before submit).
 	assert.equal(existsSync(stub.materializeLog), true);
 });
+// ---------------------------------------------------------------------------
+// Resolve-once (POSIX subprocess proof) — a bare Pi declaration is resolved
+// exactly once at the precheck and never re-resolved between precheck and
+// launch. Deterministic local stub scenario: the first PATH candidate is
+// resolved at precheck, a capable gentle-ai removes it during materialization,
+// and a second same-name PATH candidate remains. The fixed code must attempt
+// only the first concrete path (now gone) and fail closed — never fall through
+// to launch the second. This is a POSIX shebang/executable fixture: it spawns
+// real subprocesses with `shell:false`, which cannot execute `.bat`/`.cmd`
+// launchers on Windows. Windows native launcher execution is #311 P8 evidence,
+// not silently claimed here.
+// ---------------------------------------------------------------------------
+test("a bare Pi declaration is resolved once: the relay never falls through to a second PATH candidate after materialization removes the first", { skip: process.platform === "win32" && "POSIX shebang/executable subprocess fixture; Windows .cmd launcher execution (shell:false) is #311 P8 evidence, not claimed here" }, async (t) => {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-maintainer-resolve-once-"));
+	chmodSync(root, 0o700);
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const dirA = join(root, "path-a");
+	const dirB = join(root, "path-b");
+	mkdirSync(dirA, { recursive: true });
+	mkdirSync(dirB, { recursive: true });
+	chmodSync(dirA, 0o700);
+	chmodSync(dirB, 0o700);
+	const firstPiLog = join(root, "pi-first-launched");
+	const secondPiLog = join(root, "pi-second-launched");
+	const firstPi = join(dirA, "pi");
+	const secondPi = join(dirB, "pi");
+	// First PATH candidate: the one the precheck resolves.
+	writeFileSync(firstPi, `#!/usr/bin/env node\nrequire("node:fs").writeFileSync(${JSON.stringify(firstPiLog)}, "launched");\nprocess.exit(0);\n`);
+	chmodSync(firstPi, 0o755);
+	// Second PATH candidate: must NEVER launch under the fix.
+	writeFileSync(secondPi, `#!/usr/bin/env node\nrequire("node:fs").writeFileSync(${JSON.stringify(secondPiLog)}, "launched");\nprocess.exit(0);\n`);
+	chmodSync(secondPi, 0o755);
+	// A capable gentle-ai that removes the FIRST pi candidate during
+	// materialization, simulating a provider that cleans up its own runtime
+	// while a same-name second candidate remains on PATH.
+	const gentleAi = join(root, "gentle-ai");
+	writeFileSync(gentleAi, `#!/usr/bin/env node\nconst fs = require("node:fs");\nconst argv = process.argv.slice(2);\nif (argv.includes("--materialize=true")) {\n\ttry { fs.rmSync(${JSON.stringify(firstPi)}, { force: true }); } catch {}\n\tprocess.stdout.write("prompt-bytes");\n\tprocess.exit(0);\n}\nprocess.stdout.write(JSON.stringify({ schema: "gentle-ai.review-result-artifact/v2", admission_decision: "completed" }));\nprocess.exit(0);\n`);
+	chmodSync(gentleAi, 0o755);
+	const savedPath = process.env.PATH;
+	process.env.PATH = [dirA, dirB, savedPath].join(delimiter);
+	t.after(() => { process.env.PATH = savedPath; });
+	const [verdict] = await runMatrix(validateDescriptor({
+		...descriptor(),
+		gentleAiExecutable: gentleAi,
+		piExecutable: "pi",
+		cases: [{ name: "resolve-once", kind: "positive-lens", captureArgumentTokens: [...CAPTURE_TOKENS], submission: structuredClone(SUBMISSION) }],
+	}), { armPositive: true });
+	// The first pi was removed during materialization, so the relay must
+	// fail closed at pi-launch — never fall through to the second candidate.
+	assert.equal(verdict!.verdict, "fail");
+	assert.match(verdict!.reason, /pi-launch-failed/);
+	// The load-bearing assertion: the second PATH candidate never launched.
+	assert.equal(existsSync(secondPiLog), false, "the relay must never fall through to a second PATH candidate; the bare declaration is resolved once at precheck");
+	assert.equal(existsSync(firstPiLog), false, "the first candidate was removed during materialization and must not launch");
+});
+// ---------------------------------------------------------------------------
+// Resolve-once (platform-neutral boundary proof) — runs on Windows AND POSIX.
+// Proves runMatrix passes the first resolved concrete Pi path into the relay
+// boundary, not the bare declaration and not a second PATH candidate. Uses the
+// smallest dependency-injection seam in the existing options object: an
+// optional `relay` function defaulting to the real relay. The injected fake
+// records request.piExecutable and never executes a real subprocess, so no
+// shebang/chmod/.cmd execution is involved. No real model or network.
+// ---------------------------------------------------------------------------
+test("platform-neutral: runMatrix passes the first resolved concrete Pi path into the relay boundary (no second resolution)", async (t) => {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-maintainer-portable-"));
+	chmodSync(root, 0o700);
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const dirA = join(root, "path-a");
+	const dirB = join(root, "path-b");
+	mkdirSync(dirA, { recursive: true });
+	mkdirSync(dirB, { recursive: true });
+	chmodSync(dirA, 0o700);
+	chmodSync(dirB, 0o700);
+	const firstPi = join(dirA, "pi");
+	const secondPi = join(dirB, "pi");
+	// Ordinary files (no shebang/chmod needed): the injected relay never
+	// executes them. Only the precheck's existsSync/statSync touches them.
+	writeFileSync(firstPi, "first");
+	writeFileSync(secondPi, "second");
+	const gentleAi = join(root, "gentle-ai");
+	writeFileSync(gentleAi, "gentle-ai");
+	const savedPath = process.env.PATH;
+	process.env.PATH = [dirA, dirB, savedPath].join(delimiter);
+	t.after(() => { process.env.PATH = savedPath; });
+	let receivedPiExecutable: string | undefined;
+	const [verdict] = await runMatrix(validateDescriptor({
+		...descriptor(),
+		gentleAiExecutable: gentleAi,
+		piExecutable: "pi",
+		cases: [{ name: "portable-resolve-once", kind: "positive-lens", captureArgumentTokens: [...CAPTURE_TOKENS], submission: structuredClone(SUBMISSION) }],
+	}), {
+		armPositive: true,
+		relay: async (request) => {
+			receivedPiExecutable = request.piExecutable;
+			// Simulate materialization removing the first candidate; the
+			// path was captured at precheck and must not be re-resolved.
+			rmSync(firstPi, { force: true });
+			return { promptByteLength: 1, resultByteLength: 1, submission: "{}" };
+		},
+	});
+	// The relay boundary received the EXACT first concrete resolved path —
+	// not the bare "pi" declaration and not the second candidate.
+	assert.equal(receivedPiExecutable, firstPi);
+	assert.notEqual(receivedPiExecutable, secondPi);
+	assert.notEqual(receivedPiExecutable, "pi");
+	assert.equal(verdict!.verdict, "pass");
+	// The first candidate was removed during the relay call; the second is
+	// untouched, proving no fallthrough resolution occurred.
+	assert.equal(existsSync(firstPi), false);
+	assert.equal(existsSync(secondPi), true);
+});
+
 // ---------------------------------------------------------------------------
 // Negative control — a baseline runtime without --materialize fails closed as
 // relay-unavailable with zero Pi launch and zero submission. The baseline is

--- a/tests/maintainer/provider-relay.maintest.ts
+++ b/tests/maintainer/provider-relay.maintest.ts
@@ -11,7 +11,7 @@
 import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, join, relative } from "node:path";
 import test from "node:test";
 import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
 import { ARM_POSITIVE_ENV, CASE_KINDS, DESCRIPTOR_SCHEMA, DescriptorValidationError, POSITIVE_JOURNEY_COMMAND, loadDescriptor, resolveDeclaredExecutable, runMatrix, validateDescriptor } from "../../scripts/maintainer/provider-relay-matrix.mjs";
@@ -269,8 +269,11 @@ test("platform-neutral: runMatrix passes the first resolved concrete Pi path int
 	writeFileSync(secondPi, "second");
 	const gentleAi = join(root, "gentle-ai");
 	writeFileSync(gentleAi, "gentle-ai");
+	// First PATH component is RELATIVE to process.cwd(): a relative component
+	// must still normalize to the same absolute firstPi the precheck resolved.
+	const dirARelative = relative(process.cwd(), dirA);
 	const savedPath = process.env.PATH;
-	process.env.PATH = [dirA, dirB, savedPath].join(delimiter);
+	process.env.PATH = [dirARelative, dirB, savedPath].join(delimiter);
 	t.after(() => { process.env.PATH = savedPath; });
 	let receivedPiExecutable: string | undefined;
 	const [verdict] = await runMatrix(validateDescriptor({
@@ -288,8 +291,8 @@ test("platform-neutral: runMatrix passes the first resolved concrete Pi path int
 			return { promptByteLength: 1, resultByteLength: 1, submission: "{}" };
 		},
 	});
-	// The relay boundary received the EXACT first concrete resolved path —
-	// not the bare "pi" declaration and not the second candidate.
+	// The relay received the EXACT first concrete resolved path — equality to
+	// the absolute fixture proves normalization held under a relative PATH.
 	assert.equal(receivedPiExecutable, firstPi);
 	assert.notEqual(receivedPiExecutable, secondPi);
 	assert.notEqual(receivedPiExecutable, "pi");


### PR DESCRIPTION
Closes #324

## Summary

- Reuse the exact Pi executable path resolved by the maintainer precheck instead of passing the bare declaration into the relay.
- Use `node:path.delimiter` for platform-correct PATH parsing.
- Add POSIX process evidence plus a platform-neutral boundary test that runs on Windows and POSIX.

## Why

The matrix previously confirmed one executable existed, discarded that concrete path, and passed the bare name to `spawn()`. That allowed PATH to be resolved a second time between precheck and launch. This change keeps the checked path and uses it at the relay boundary.

## Changes

| File | Change |
|------|--------|
| `scripts/maintainer/provider-relay-matrix.mjs` | Retains the resolved Pi path, passes it to the relay, uses the platform PATH delimiter, and exposes a default-preserving test seam. |
| `tests/maintainer/provider-relay.maintest.ts` | Proves no fallback to a second PATH candidate and verifies the exact concrete path reaches the relay on every platform. |

## Verification

- `git diff --check origin/main...HEAD`
- `pnpm test`: 1,204 passed, 0 failed, 1 platform skip
- `pnpm run test:maintainer`: 9 passed, 0 failed, 6 environment-gated skips
- `node scripts/verify-package-files.mjs`: 162 files, 64 exact contract artifacts
- Native review receipt: `sha256:0dd4254996048d673dc2c112a30bfb18d77cafeec6dd169b4884ce338c834704`
- Native `pre-push` and `pre-pr` gates: `ALLOW`

## Review path

1. Review the resolve-once flow in `provider-relay-matrix.mjs`.
2. Review the platform-neutral boundary assertion in `provider-relay.maintest.ts`.
3. Confirm the negative-control sandbox remains unchanged.

## Out of scope

This PR does not add Windows `.cmd`/PATHEXT launcher execution, change the production Gentle AI pin, or alter the relay contract. Native Windows launcher coverage remains part of #311.

## Checklist

- [x] Linked approved issue #324
- [x] Conventional commit
- [x] Full and maintainer suites pass
- [x] No shell files changed; ShellCheck is not applicable
- [x] No public contract or documentation update required
- [x] No Co-Authored-By trailer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform handling of executable paths.
  * Ensured the selected executable is resolved consistently before launch.
  * Prevented fallback to a different executable after the initial selection.

* **Tests**
  * Added coverage validating executable resolution across platforms and launch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->