### PR TITLE
fix(runtime): decode consent/v3 and forward start/v3 context fields

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -142,7 +142,7 @@ import {
 	type NativeStartResult,
 	type NativeValidateResult,
 } from "../lib/native-review-cli.ts";
-import type { ReviewConsentV2, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+import type { ReviewConsentEnvelope, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 import { assertDistinctCorrectionEvidence, resolveCorrectionStep, type CorrectionEvidence, type CorrectionOutcome, type CorrectionStep } from "../lib/review-correction-lifecycle.ts";
 import { recordReviewConsentLatch } from "../lib/review-consent-latch.ts";
 
@@ -4821,7 +4821,7 @@ interface PendingReviewConsent {
 	repositoryCwd: string;
 	authorityCwd: string;
 	candidateView: CandidateView;
-	consent: ReviewConsentV2;
+	consent: ReviewConsentEnvelope;
 	consentDigest: string;
 	expiresAt: number;
 	expiry?: ReturnType<typeof setTimeout>;
@@ -4856,7 +4856,7 @@ function pruneExpiredReviewConsents(pendingReviewConsents: Map<string, PendingRe
 	}
 }
 
-function reviewConsentDigest(consent: ReviewConsentV2): string {
+function reviewConsentDigest(consent: ReviewConsentEnvelope): string {
 	return createHash("sha256").update(JSON.stringify(consent)).digest("hex");
 }
 

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -11,13 +11,14 @@ import {
 	REVIEW_INTEGRATION_CONTRACT,
 	decodeReviewCapabilitiesV2,
 	decodeReviewConsentV2,
+	decodeReviewConsentV3,
 	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewRepairV2,
 	decodeReviewStartV3,
 	decodeReviewStatusV3,
 	type ReviewCapabilitiesV2,
-	type ReviewConsentV2,
+	type ReviewConsentEnvelope,
 	type ReviewFailureV2,
 	type ReviewRepairV2,
 	type ReviewStartState,
@@ -444,7 +445,7 @@ export interface NativeReviewVerificationEvidenceV2 {
 export interface NativeStartRequest { cwd: string; baseRef?: string; committedOnly?: boolean; lineageId?: string; policyPath?: string; focus?: string; targetIdentity?: string; projection?: "workspace" | "staged"; signal?: AbortSignal; }
 export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "declined" } as const;
 export type NativeReviewConsentAnswer = (typeof NATIVE_REVIEW_CONSENT_ANSWER)[keyof typeof NATIVE_REVIEW_CONSENT_ANSWER];
-export interface NativeReviewConsentAnswerRequest { cwd: string; consent: ReviewConsentV2; answer: NativeReviewConsentAnswer; signal?: AbortSignal; }
+export interface NativeReviewConsentAnswerRequest { cwd: string; consent: ReviewConsentEnvelope; answer: NativeReviewConsentAnswer; signal?: AbortSignal; }
 export interface NativeReviewConsentDeclinedResult {
 	kind: "declined";
 	targetIdentity: string;
@@ -1795,15 +1796,16 @@ export class NativeReviewIntegrationError extends Error {
 	}
 }
 
-// Raised when negotiated START answers `consent/v2` (action:
+// Raised when negotiated START answers a consent question (`consent/v2` from
+// the pinned line, `consent/v3` from gentle-ai >= 2.3.0; action:
 // "consent_required") instead of `start/v3`. The provider has frozen no
 // authority yet: Pi must relay this complete candidate-scoped question and may
 // answer only through one of the exact invocations carried by the envelope.
 export class NativeReviewConsentRequiredError extends Error {
-	readonly consent: ReviewConsentV2;
+	readonly consent: ReviewConsentEnvelope;
 	readonly launchAttempted = true;
 	readonly mutationOutcome = "none";
-	constructor(consent: ReviewConsentV2) {
+	constructor(consent: ReviewConsentEnvelope) {
 		super(consent.headline);
 		this.name = "NativeReviewConsentRequiredError";
 		this.consent = consent;
@@ -2188,12 +2190,20 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			...(request.focus === undefined ? [] : ["--focus", request.focus]),
 			"--consent", "relay",
 		], true, request.signal);
-		// A negotiated v2 START may answer `consent/v2` (action:
+		// A negotiated v2 START may answer a consent question (action:
 		// "consent_required") instead of `start/v3` when the provider needs an
 		// explicit answer it cannot infer. Discriminate before decode and surface
-		// the complete envelope; only the caller can map a human answer.
+		// the complete envelope; only the caller can map a human answer. The
+		// body's own schema string selects the identity-exact decoder: the
+		// pinned 2.2.x line emits consent/v2, gentle-ai >= 2.3.0 (capabilities
+		// v2.1+) emits consent/v3, and any other identity fails closed inside
+		// the v3 decoder's exact identity gate.
 		if (execution.body.action === "consent_required") {
-			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewConsentV2(execution.body));
+			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => (
+				execution.body.schema === "gentle-ai.review-integration.consent/v2"
+					? decodeReviewConsentV2(execution.body)
+					: decodeReviewConsentV3(execution.body)
+			));
 			if (consent.targetIdentity !== targetIdentity || consent.projection !== projection) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent target binding mismatch");
 			throw new NativeReviewConsentRequiredError(consent);
 		}

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -252,7 +252,18 @@ export interface ReviewRepositoryContextV2 {
 	handle: string;
 	revision: string;
 	targetIdentity: string;
+	// Optional additive members on the same start/v3 identity (gentle-ai main,
+	// Go `ReviewRepositoryContextReference` with `omitempty`): the compact
+	// effects event this context applied and its recorded outcome. Ground
+	// truth is the captured granted start from a 2.4.0-main binary
+	// (tests/fixtures/devbinary/start-v3-consent-granted.captured.json); the
+	// published start.schema.json is narrower than the emitter here.
+	eventId?: string;
+	outcome?: ReviewRepositoryContextOutcomeV1;
 }
+
+const REPOSITORY_CONTEXT_OUTCOMES = ["applied", "pending", "blocked_conflict", "durability_limited"] as const;
+export type ReviewRepositoryContextOutcomeV1 = (typeof REPOSITORY_CONTEXT_OUTCOMES)[number];
 
 export interface ReviewStartV3 {
 	contract: typeof REVIEW_INTEGRATION_CONTRACT;
@@ -523,6 +534,19 @@ export interface ReviewConsentV2 {
 	offPath: { note: string; command: "gentle-ai review mode disable" };
 	raw: Readonly<Record<string, unknown>>;
 }
+
+// consent/v3 (gentle-ai >= 2.3.0, capabilities/v2.1+): the same per-candidate
+// blocking question with one net-new required member, the provider-fixed
+// `agent` runtime binding. Everything shared with v2 keeps its exact shape so
+// consumers of either identity read one structural surface.
+export interface ReviewConsentV3 extends Omit<ReviewConsentV2, "schema"> {
+	schema: "gentle-ai.review-integration.consent/v3";
+	agent: "claude-code";
+}
+
+// Either accepted consent identity. Consumers that relay the envelope (rather
+// than decode it) accept both; each decoder still admits exactly one schema.
+export type ReviewConsentEnvelope = ReviewConsentV2 | ReviewConsentV3;
 
 const FAILURE_REQUIRED_INPUTS = [
 	"lineage_id",
@@ -988,13 +1012,15 @@ export function decodeReviewStartV3(value: unknown): ReviewStartV3 {
 
 	let repositoryContext: ReviewRepositoryContextV2 | undefined;
 	if (body.repository_context !== undefined) {
-		const source = exactRecord(body.repository_context, "start.repository_context", ["capability", "handle", "revision", "target_identity"]);
+		const source = exactRecord(body.repository_context, "start.repository_context", ["capability", "handle", "revision", "target_identity"], ["event_id", "outcome"]);
 		if (source.capability !== "review.opaque_repository_context") throw new TypeError("start.repository_context.capability is unsupported");
 		repositoryContext = {
 			capability: "review.opaque_repository_context",
 			handle: text(source.handle, "start.repository_context.handle", { pattern: /^rctx1_[0-9a-f]{64}$/ }),
 			revision: sha256(source.revision, "start.repository_context.revision"),
 			targetIdentity: sha256(source.target_identity, "start.repository_context.target_identity"),
+			...(source.event_id === undefined ? {} : { eventId: sha256(source.event_id, "start.repository_context.event_id") }),
+			...(source.outcome === undefined ? {} : { outcome: enumeration(source.outcome, REPOSITORY_CONTEXT_OUTCOMES, "start.repository_context.outcome") }),
 		};
 	}
 
@@ -1616,11 +1642,10 @@ function decodeConsentChoice(value: unknown, label: string, answer: "granted" | 
 	};
 }
 
-export function decodeReviewConsentV2(value: unknown): ReviewConsentV2 {
-	const body = exactRecord(value, "consent", [
-		"schema", "contract", "operation", "action", "blocking", "target_identity", "projection", "risk_level", "changed_files", "changed_lines", "headline", "reason", "value", "risk_evidence", "choices", "off_path",
-	]);
-	requireIdentity(body, "gentle-ai.review-integration.consent/v2", "review.start");
+// The semantic surface shared verbatim by both accepted consent identities.
+// Every label and guard predates consent/v3, so the v2 decode stays
+// byte-identical (test-locked) while v3 adds only its own identity gate.
+function decodeConsentSemantics(body: Record<string, unknown>): Omit<ReviewConsentV2, "schema" | "raw"> {
 	if (body.action !== "consent_required") throw new TypeError("consent.action must be consent_required");
 	if (body.blocking !== true) throw new TypeError("consent.blocking must be true");
 
@@ -1637,7 +1662,6 @@ export function decodeReviewConsentV2(value: unknown): ReviewConsentV2 {
 	if (offPathSource.command !== "gentle-ai review mode disable") throw new TypeError("consent.off_path.command is unsupported");
 
 	return {
-		schema: "gentle-ai.review-integration.consent/v2",
 		contract: REVIEW_INTEGRATION_CONTRACT,
 		operation: "review.start",
 		action: "consent_required",
@@ -1653,6 +1677,39 @@ export function decodeReviewConsentV2(value: unknown): ReviewConsentV2 {
 		riskEvidence: stringArray(body.risk_evidence, "consent.risk_evidence"),
 		choices: [granted, declined],
 		offPath: { note: nonempty(offPathSource.note, "consent.off_path.note"), command: "gentle-ai review mode disable" },
+	};
+}
+
+const CONSENT_KEYS_V2 = Object.freeze([
+	"schema", "contract", "operation", "action", "blocking", "target_identity", "projection", "risk_level", "changed_files", "changed_lines", "headline", "reason", "value", "risk_evidence", "choices", "off_path",
+] as const);
+
+export function decodeReviewConsentV2(value: unknown): ReviewConsentV2 {
+	const body = exactRecord(value, "consent", CONSENT_KEYS_V2);
+	requireIdentity(body, "gentle-ai.review-integration.consent/v2", "review.start");
+	return {
+		schema: "gentle-ai.review-integration.consent/v2",
+		...decodeConsentSemantics(body),
+		raw: body,
+	};
+}
+
+// consent/v3 (gentle-ai >= 2.3.0): the v2 surface plus the required, fixed
+// `agent` runtime binding. Ground truth is the captured envelope from a
+// 2.4.0-main binary (tests/fixtures/devbinary/consent-v3.captured.json) plus
+// gentle-ai main contracts/review-integration/v2/schemas/consent-v3.schema.json.
+// The choice-invocation shape deliberately stays the shared v2 pattern: the
+// published v3 schema demands an `--agent claude-code` token that the live
+// emitter omits when the caller declared no --agent, so the capture is
+// authoritative and Pi replays whichever provider-owned invocation arrived.
+export function decodeReviewConsentV3(value: unknown): ReviewConsentV3 {
+	const body = exactRecord(value, "consent", [...CONSENT_KEYS_V2, "agent"]);
+	requireIdentity(body, "gentle-ai.review-integration.consent/v3", "review.start");
+	if (body.agent !== "claude-code") throw new TypeError("consent.agent must be claude-code");
+	return {
+		schema: "gentle-ai.review-integration.consent/v3",
+		agent: "claude-code",
+		...decodeConsentSemantics(body),
 		raw: body,
 	};
 }

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -12,6 +12,7 @@ import {
 	REVIEW_INTEGRATION_CONTRACT,
 	decodeReviewCapabilitiesV2,
 	decodeReviewConsentV2,
+	decodeReviewConsentV3,
 	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewRepairV2,
@@ -1796,15 +1797,16 @@ export class NativeReviewIntegrationError extends Error {
 	}
 }
 
-// Raised when negotiated START answers `consent/v2` (action:
+// Raised when negotiated START answers a consent question (`consent/v2` from
+// the pinned line, `consent/v3` from gentle-ai >= 2.3.0; action:
 // "consent_required") instead of `start/v3`. The provider has frozen no
 // authority yet: Pi must relay this complete candidate-scoped question and may
 // answer only through one of the exact invocations carried by the envelope.
 export class NativeReviewConsentRequiredError extends Error {
-	         consent                 ;
+	         consent                       ;
 	         launchAttempted = true;
 	         mutationOutcome = "none";
-	constructor(consent                 ) {
+	constructor(consent                       ) {
 		super(consent.headline);
 		this.name = "NativeReviewConsentRequiredError";
 		this.consent = consent;
@@ -2189,12 +2191,20 @@ export class NativeReviewCliV216                            {
 			...(request.focus === undefined ? [] : ["--focus", request.focus]),
 			"--consent", "relay",
 		], true, request.signal);
-		// A negotiated v2 START may answer `consent/v2` (action:
+		// A negotiated v2 START may answer a consent question (action:
 		// "consent_required") instead of `start/v3` when the provider needs an
 		// explicit answer it cannot infer. Discriminate before decode and surface
-		// the complete envelope; only the caller can map a human answer.
+		// the complete envelope; only the caller can map a human answer. The
+		// body's own schema string selects the identity-exact decoder: the
+		// pinned 2.2.x line emits consent/v2, gentle-ai >= 2.3.0 (capabilities
+		// v2.1+) emits consent/v3, and any other identity fails closed inside
+		// the v3 decoder's exact identity gate.
 		if (execution.body.action === "consent_required") {
-			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewConsentV2(execution.body));
+			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => (
+				execution.body.schema === "gentle-ai.review-integration.consent/v2"
+					? decodeReviewConsentV2(execution.body)
+					: decodeReviewConsentV3(execution.body)
+			));
 			if (consent.targetIdentity !== targetIdentity || consent.projection !== projection) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent target binding mismatch");
 			throw new NativeReviewConsentRequiredError(consent);
 		}

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -263,6 +263,17 @@ const REQUIRED_MANDATORY_FEATURES = Object.freeze(FEATURE_NAMES.filter((name) =>
 
 
 
+const REPOSITORY_CONTEXT_OUTCOMES = ["applied", "pending", "blocked_conflict", "durability_limited"]         ;
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -523,6 +534,19 @@ export const REVIEW_PROVIDER_ROLE_CAPTURE_OPERATIONS = Object.freeze(Object.valu
 
 
 
+
+
+// consent/v3 (gentle-ai >= 2.3.0, capabilities/v2.1+): the same per-candidate
+// blocking question with one net-new required member, the provider-fixed
+// `agent` runtime binding. Everything shared with v2 keeps its exact shape so
+// consumers of either identity read one structural surface.
+
+
+
+
+
+// Either accepted consent identity. Consumers that relay the envelope (rather
+// than decode it) accept both; each decoder still admits exactly one schema.
 
 
 const FAILURE_REQUIRED_INPUTS = [
@@ -989,13 +1013,15 @@ export function decodeReviewStartV3(value         )                {
 
 	let repositoryContext                                       ;
 	if (body.repository_context !== undefined) {
-		const source = exactRecord(body.repository_context, "start.repository_context", ["capability", "handle", "revision", "target_identity"]);
+		const source = exactRecord(body.repository_context, "start.repository_context", ["capability", "handle", "revision", "target_identity"], ["event_id", "outcome"]);
 		if (source.capability !== "review.opaque_repository_context") throw new TypeError("start.repository_context.capability is unsupported");
 		repositoryContext = {
 			capability: "review.opaque_repository_context",
 			handle: text(source.handle, "start.repository_context.handle", { pattern: /^rctx1_[0-9a-f]{64}$/ }),
 			revision: sha256(source.revision, "start.repository_context.revision"),
 			targetIdentity: sha256(source.target_identity, "start.repository_context.target_identity"),
+			...(source.event_id === undefined ? {} : { eventId: sha256(source.event_id, "start.repository_context.event_id") }),
+			...(source.outcome === undefined ? {} : { outcome: enumeration(source.outcome, REPOSITORY_CONTEXT_OUTCOMES, "start.repository_context.outcome") }),
 		};
 	}
 
@@ -1617,11 +1643,10 @@ function decodeConsentChoice(value         , label        , answer              
 	};
 }
 
-export function decodeReviewConsentV2(value         )                  {
-	const body = exactRecord(value, "consent", [
-		"schema", "contract", "operation", "action", "blocking", "target_identity", "projection", "risk_level", "changed_files", "changed_lines", "headline", "reason", "value", "risk_evidence", "choices", "off_path",
-	]);
-	requireIdentity(body, "gentle-ai.review-integration.consent/v2", "review.start");
+// The semantic surface shared verbatim by both accepted consent identities.
+// Every label and guard predates consent/v3, so the v2 decode stays
+// byte-identical (test-locked) while v3 adds only its own identity gate.
+function decodeConsentSemantics(body                         )                                          {
 	if (body.action !== "consent_required") throw new TypeError("consent.action must be consent_required");
 	if (body.blocking !== true) throw new TypeError("consent.blocking must be true");
 
@@ -1638,7 +1663,6 @@ export function decodeReviewConsentV2(value         )                  {
 	if (offPathSource.command !== "gentle-ai review mode disable") throw new TypeError("consent.off_path.command is unsupported");
 
 	return {
-		schema: "gentle-ai.review-integration.consent/v2",
 		contract: REVIEW_INTEGRATION_CONTRACT,
 		operation: "review.start",
 		action: "consent_required",
@@ -1654,6 +1678,39 @@ export function decodeReviewConsentV2(value         )                  {
 		riskEvidence: stringArray(body.risk_evidence, "consent.risk_evidence"),
 		choices: [granted, declined],
 		offPath: { note: nonempty(offPathSource.note, "consent.off_path.note"), command: "gentle-ai review mode disable" },
+	};
+}
+
+const CONSENT_KEYS_V2 = Object.freeze([
+	"schema", "contract", "operation", "action", "blocking", "target_identity", "projection", "risk_level", "changed_files", "changed_lines", "headline", "reason", "value", "risk_evidence", "choices", "off_path",
+]         );
+
+export function decodeReviewConsentV2(value         )                  {
+	const body = exactRecord(value, "consent", CONSENT_KEYS_V2);
+	requireIdentity(body, "gentle-ai.review-integration.consent/v2", "review.start");
+	return {
+		schema: "gentle-ai.review-integration.consent/v2",
+		...decodeConsentSemantics(body),
+		raw: body,
+	};
+}
+
+// consent/v3 (gentle-ai >= 2.3.0): the v2 surface plus the required, fixed
+// `agent` runtime binding. Ground truth is the captured envelope from a
+// 2.4.0-main binary (tests/fixtures/devbinary/consent-v3.captured.json) plus
+// gentle-ai main contracts/review-integration/v2/schemas/consent-v3.schema.json.
+// The choice-invocation shape deliberately stays the shared v2 pattern: the
+// published v3 schema demands an `--agent claude-code` token that the live
+// emitter omits when the caller declared no --agent, so the capture is
+// authoritative and Pi replays whichever provider-owned invocation arrived.
+export function decodeReviewConsentV3(value         )                  {
+	const body = exactRecord(value, "consent", [...CONSENT_KEYS_V2, "agent"]);
+	requireIdentity(body, "gentle-ai.review-integration.consent/v3", "review.start");
+	if (body.agent !== "claude-code") throw new TypeError("consent.agent must be claude-code");
+	return {
+		schema: "gentle-ai.review-integration.consent/v3",
+		agent: "claude-code",
+		...decodeConsentSemantics(body),
 		raw: body,
 	};
 }

--- a/tests/fixtures/devbinary/consent-v3.captured.json
+++ b/tests/fixtures/devbinary/consent-v3.captured.json
@@ -1,0 +1,37 @@
+{
+  "schema": "gentle-ai.review-integration.consent/v3",
+  "contract": "gentle-ai.review-integration/v2",
+  "operation": "review.start",
+  "action": "consent_required",
+  "agent": "claude-code",
+  "blocking": true,
+  "target_identity": "sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988",
+  "projection": "workspace",
+  "risk_level": "high",
+  "changed_files": 2,
+  "changed_lines": 12,
+  "headline": "Gentle AI can review this change before you call it done.",
+  "reason": "this change gets a deeper review because it touches code that starts other processes in internal/runner/runner.go.",
+  "value": "Reviewing takes a bit longer, and it makes the result substantially safer.",
+  "risk_evidence": [
+    "code that starts other processes in internal/runner/runner.go"
+  ],
+  "choices": [
+    {
+      "answer": "granted",
+      "label": "Run the review now",
+      "effect": "Reviews this exact frozen candidate now; nothing is granted for later candidates, so each later medium- or high-risk candidate asks again.",
+      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /tmp/claude-1000/-home-gentleman-work-gentle-ai/7629c2de-8b8b-4005-b117-ab45c0869f70/scratchpad/consentcap/repo --target sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988 --projection workspace --consent granted"
+    },
+    {
+      "answer": "declined",
+      "label": "Not now, just this once",
+      "effect": "Skips the review for this exact candidate only; no review lineage or receipt is created, and ordinary delivery is unmanaged by candidate choice. The next candidate is asked again. This is not the kill switch.",
+      "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /tmp/claude-1000/-home-gentleman-work-gentle-ai/7629c2de-8b8b-4005-b117-ab45c0869f70/scratchpad/consentcap/repo --target sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988 --projection workspace --consent declined"
+    }
+  ],
+  "off_path": {
+    "note": "To turn reviews off for good, run 'gentle-ai review mode disable'.",
+    "command": "gentle-ai review mode disable"
+  }
+}

--- a/tests/fixtures/devbinary/start-v3-consent-declined.captured.json
+++ b/tests/fixtures/devbinary/start-v3-consent-declined.captured.json
@@ -1,0 +1,19 @@
+{
+  "operation": "review/start",
+  "action": "declined",
+  "lenses_required": false,
+  "lineage_id": "",
+  "state": "",
+  "risk_level": "high",
+  "selected_lenses": [],
+  "lens_bindings": [],
+  "projection": "workspace",
+  "target_identity": "sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988",
+  "changed_files": 2,
+  "changed_lines": 12,
+  "correction_budget": 0,
+  "risk_evidence": [
+    "code that starts other processes in internal/runner/runner.go"
+  ],
+  "consent": "declined_this_candidate"
+}

--- a/tests/fixtures/devbinary/start-v3-consent-granted.captured.json
+++ b/tests/fixtures/devbinary/start-v3-consent-granted.captured.json
@@ -1,0 +1,109 @@
+{
+  "schema": "gentle-ai.review-integration.start/v3",
+  "contract": "gentle-ai.review-integration/v2",
+  "operation": "review.start",
+  "action": "created",
+  "lenses_required": true,
+  "lineage_id": "review-377c60e10b852cfc",
+  "state": "reviewing",
+  "risk_level": "high",
+  "selected_lenses": [
+    "review-risk",
+    "review-resilience",
+    "review-readability",
+    "review-reliability"
+  ],
+  "projection": "workspace",
+  "base_tree": "6f76421f34880aec8e73618ca7ce69b2f894cb47",
+  "candidate_tree": "b6d3cea0ddd081a71e83120d003953872754a617",
+  "changed_files": 2,
+  "changed_lines": 12,
+  "correction_budget": 6,
+  "risk_reasons": [
+    {
+      "code": "process_boundary",
+      "signal": "shell_process",
+      "path": "internal/runner/runner.go"
+    }
+  ],
+  "artifact_subjects": [
+    {
+      "schema": "gentle-ai.review-artifact-subject/v2",
+      "subject_hash": "sha256:83a75b97a02e17dca2a466f2a247466751d3d610ed5b18ea45cc6b258dbc4a31",
+      "lineage_id": "review-377c60e10b852cfc",
+      "authority_revision": "sha256:fe7f383e1b3b0854f8974c94b60597b59a4384c8c6f30c04779d13c6ec32fb66",
+      "target_identity": "sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988",
+      "base_tree": "6f76421f34880aec8e73618ca7ce69b2f894cb47",
+      "candidate_tree": "b6d3cea0ddd081a71e83120d003953872754a617",
+      "changed_path_manifest_sha256": "sha256:487bf2f5df250d6f9d76a28fded97bfad6aec57c62f92e2b997bfd9bf25e7a53",
+      "lens": "review-risk",
+      "selected_order": 0
+    },
+    {
+      "schema": "gentle-ai.review-artifact-subject/v2",
+      "subject_hash": "sha256:5abb925fdd448ca0add3f1ce95e84c9f4742e0c1241bade2bde0b3205f3879d8",
+      "lineage_id": "review-377c60e10b852cfc",
+      "authority_revision": "sha256:fe7f383e1b3b0854f8974c94b60597b59a4384c8c6f30c04779d13c6ec32fb66",
+      "target_identity": "sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988",
+      "base_tree": "6f76421f34880aec8e73618ca7ce69b2f894cb47",
+      "candidate_tree": "b6d3cea0ddd081a71e83120d003953872754a617",
+      "changed_path_manifest_sha256": "sha256:487bf2f5df250d6f9d76a28fded97bfad6aec57c62f92e2b997bfd9bf25e7a53",
+      "lens": "review-resilience",
+      "selected_order": 1
+    },
+    {
+      "schema": "gentle-ai.review-artifact-subject/v2",
+      "subject_hash": "sha256:cbf59cec5a008893a97b46248c214f4c007ac1b9a18052bfd4f478eaf560e04c",
+      "lineage_id": "review-377c60e10b852cfc",
+      "authority_revision": "sha256:fe7f383e1b3b0854f8974c94b60597b59a4384c8c6f30c04779d13c6ec32fb66",
+      "target_identity": "sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988",
+      "base_tree": "6f76421f34880aec8e73618ca7ce69b2f894cb47",
+      "candidate_tree": "b6d3cea0ddd081a71e83120d003953872754a617",
+      "changed_path_manifest_sha256": "sha256:487bf2f5df250d6f9d76a28fded97bfad6aec57c62f92e2b997bfd9bf25e7a53",
+      "lens": "review-readability",
+      "selected_order": 2
+    },
+    {
+      "schema": "gentle-ai.review-artifact-subject/v2",
+      "subject_hash": "sha256:4a3d37cc911e1b39b03acb15df07be6e3cb041a6c2d493dd4aa9e7446f4b7dfa",
+      "lineage_id": "review-377c60e10b852cfc",
+      "authority_revision": "sha256:fe7f383e1b3b0854f8974c94b60597b59a4384c8c6f30c04779d13c6ec32fb66",
+      "target_identity": "sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988",
+      "base_tree": "6f76421f34880aec8e73618ca7ce69b2f894cb47",
+      "candidate_tree": "b6d3cea0ddd081a71e83120d003953872754a617",
+      "changed_path_manifest_sha256": "sha256:487bf2f5df250d6f9d76a28fded97bfad6aec57c62f92e2b997bfd9bf25e7a53",
+      "lens": "review-reliability",
+      "selected_order": 3
+    }
+  ],
+  "changed_path_manifest": [
+    {
+      "path": "internal/runner/runner.go",
+      "status": "M",
+      "old_mode": "100644",
+      "new_mode": "100644",
+      "deleted": false,
+      "type_changed": false,
+      "mode_only": false,
+      "intended_untracked": false
+    },
+    {
+      "path": "internal/runner/runner_test.go",
+      "status": "M",
+      "old_mode": "100644",
+      "new_mode": "100644",
+      "deleted": false,
+      "type_changed": false,
+      "mode_only": false,
+      "intended_untracked": false
+    }
+  ],
+  "repository_context": {
+    "capability": "review.opaque_repository_context",
+    "handle": "rctx1_5ce64550b975f58fae189cf4ae1da04aea489928f386dc9f17b45f12d26de8e8",
+    "revision": "sha256:fe7f383e1b3b0854f8974c94b60597b59a4384c8c6f30c04779d13c6ec32fb66",
+    "target_identity": "sha256:377c60e10b852cfcbcca6cd101e6ee7def9621a24a9f4b361d32137a3b0b3988",
+    "event_id": "sha256:48ac0c2d153f410d4292a24e6dfa20ae16599cb6c3d5416bb87fa7f515007b71",
+    "outcome": "applied"
+  }
+}

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -296,3 +296,71 @@ test("declined consent decodes the provider's explicit empty authority fields wi
 	assert.equal("lineageId" in result, false);
 	assert.deepEqual(queue.calls.at(-1), consent.choices[1].invocation.split(" ").slice(1));
 });
+
+// --- consent/v3 (dev-binary field-test lane) ---
+//
+// Fixture provenance: consent-v3.captured.json, start-v3-consent-granted
+// .captured.json, and start-v3-consent-declined.captured.json were captured
+// 2026-08-16 from the real binary at /home/gentleman/.cargo/bin/gentle-ai
+// reporting "gentle-ai 2.4.0-main.b1afef46"; full capture commands are
+// documented in tests/review-integration-v2-forward.test.ts.
+
+const devbinaryFixtureRoot = join(process.cwd(), "tests", "fixtures", "devbinary");
+const devbinaryFixture = <T = Record<string, unknown>>(name: string): T => JSON.parse(readFileSync(join(devbinaryFixtureRoot, name), "utf8")) as T;
+
+test("negotiated START surfaces the captured consent/v3 envelope instead of failing schema-incompatible", async () => {
+	const consent = devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json");
+	const target = String(consent.target_identity);
+	const queue = queuedAdapter([capabilities(), unrelatedStatus(target), consent]);
+	await assert.rejects(
+		() => client(queue.adapter).start({ cwd: "/repo" }),
+		(error: unknown) => {
+			assert.ok(error instanceof NativeReviewConsentRequiredError, `expected NativeReviewConsentRequiredError, got ${String(error)}`);
+			assert.deepEqual(error.consent.raw, consent);
+			assert.equal(error.consent.schema, "gentle-ai.review-integration.consent/v3");
+			assert.equal(error.consent.targetIdentity, target);
+			return true;
+		},
+	);
+	assert.deepEqual(queue.calls.at(-1), [
+		"review", "start", "--contract", "gentle-ai.review-integration/v2", "--cwd", "/repo",
+		"--target", target, "--projection", "workspace", "--consent", "relay",
+	]);
+
+	const runtimeQueue = queuedAdapter([capabilities(), unrelatedStatus(target), structuredClone(consent)]);
+	await assert.rejects(
+		() => runtimeClient(runtimeQueue.adapter).start({ cwd: "/repo" }),
+		(error: unknown) => (error as Error).name === "NativeReviewConsentRequiredError",
+	);
+});
+
+test("a granted consent/v3 answer decodes the captured start/v3 result with its event binding", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json"));
+	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
+	const started = devbinaryFixture<Record<string, unknown>>("start-v3-consent-granted.captured.json");
+	const queue = queuedAdapter([capabilities(), started]);
+	const result = await client(queue.adapter).answerConsent!({ cwd, consent: decoded, answer: "granted" });
+	assert.equal(result.kind, "started");
+	assert.ok(result.kind === "started");
+	assert.equal(result.start.lineageId, "review-377c60e10b852cfc");
+	assert.equal(result.start.selectedLenses.length, 4);
+	// The follow-up runs the provider-owned invocation verbatim, exactly once.
+	assert.deepEqual(queue.calls.at(-1), decoded.choices[0].invocation.split(" ").slice(1));
+	assert.equal(queue.calls.filter((arguments_) => arguments_.includes("granted")).length, 1);
+
+	const runtimeQueue = queuedAdapter([capabilities(), structuredClone(started)]);
+	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd, consent: decoded, answer: "granted" });
+	assert.equal(runtimeResult.kind, "started");
+});
+
+test("a declined consent/v3 answer accepts the captured declined result and creates no authority", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json"));
+	const cwd = decoded.choices[1].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
+	const declined = devbinaryFixture<Record<string, unknown>>("start-v3-consent-declined.captured.json");
+	const queue = queuedAdapter([capabilities(), declined]);
+	const result = await client(queue.adapter).answerConsent!({ cwd, consent: decoded, answer: "declined" });
+	assert.equal(result.kind, "declined");
+	assert.ok(result.kind === "declined");
+	assert.equal(result.consent, "declined_this_candidate");
+	assert.equal(result.targetIdentity, decoded.targetIdentity);
+});

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -4,6 +4,9 @@ import { join } from "node:path";
 import test from "node:test";
 import {
 	decodeReviewCapabilitiesV2,
+	decodeReviewConsentV2,
+	decodeReviewConsentV3,
+	decodeReviewStartV3,
 	decodeReviewStatusV3,
 } from "../lib/review-integration-v2.ts";
 
@@ -27,6 +30,24 @@ import {
 //   submission descriptor forms) are constructed from gentle-ai origin/main
 //   contracts/review-integration/v2/schemas/status-v5.schema.json and
 //   contracts/review-integration/v1/schemas/correction-plan-request.schema.json.
+// - consent-v3.captured.json, start-v3-consent-granted.captured.json, and
+//   start-v3-consent-declined.captured.json were captured 2026-08-16 from the
+//   real binary at /home/gentleman/.cargo/bin/gentle-ai reporting
+//   "gentle-ai 2.4.0-main.b1afef46", in a scratch git repository holding a
+//   committed internal/runner/{runner.go,runner_test.go} baseline plus 12
+//   uncommitted changed lines that add a process-starting helper (risk signal
+//   shell_process, high tier):
+//     gentle-ai review status --contract gentle-ai.review-integration/v2 \
+//       --cwd <scratch> --projection workspace --next-transition   # target source
+//     gentle-ai review start --contract gentle-ai.review-integration/v2 \
+//       --cwd <scratch> --target <identity> --projection workspace \
+//       --consent relay                                            # consent-v3
+//   then the envelope's exact declined invocation (declined capture, which
+//   persists nothing) followed by its exact granted invocation (granted
+//   start/v3 capture). Note: the live granted/declined invocations carry no
+//   --agent token even though the envelope pins agent: claude-code — the
+//   published consent-v3.schema.json invocation pattern is narrower than the
+//   emitter, so the capture is authoritative (parity playbook, known traps).
 
 const fixtureRoot = join(import.meta.dirname, "fixtures", "devbinary");
 const fixture = <T = Record<string, unknown>>(name: string): T => JSON.parse(readFileSync(join(fixtureRoot, name), "utf8")) as T;
@@ -273,4 +294,98 @@ test("the v3 next transition keeps rejecting every v5-only surface", () => {
 	assert.throws(() => decodeReviewStatusV3(asV3((transition) => {
 		(((transition.collect as JsonObject).inputs as JsonObject[])[0]!).submission = { operation_token: "finalize", argument_tokens: ["--correction-lines={{value}}"], value: { slot: "correction_lines", domain: "positive_correction_lines", minimum: 1, maximum: 25, substitution_location: 6 } };
 	})), /submission|values/);
+});
+
+// --- consent/v3 — the negotiated v2.1+ consent question (adds `agent`) ---
+
+test("the captured consent/v3 envelope decodes with its fixed agent binding", () => {
+	const consent = decodeReviewConsentV3(fixture("consent-v3.captured.json"));
+	assert.equal(consent.schema, "gentle-ai.review-integration.consent/v3");
+	assert.equal(consent.agent, "claude-code");
+	assert.equal(consent.action, "consent_required");
+	assert.equal(consent.blocking, true);
+	assert.equal(consent.riskLevel, "high");
+	assert.equal(consent.changedFiles, 2);
+	assert.equal(consent.changedLines, 12);
+	assert.equal(consent.choices[0].answer, "granted");
+	assert.equal(consent.choices[1].answer, "declined");
+	for (const choice of consent.choices) {
+		assert.ok(choice.invocation.includes(` --target ${consent.targetIdentity} `));
+	}
+	assert.equal(consent.offPath.command, "gentle-ai review mode disable");
+});
+
+test("consent identities never cross-decode", () => {
+	const v3 = fixture<JsonObject>("consent-v3.captured.json");
+	const v2 = v2Fixture<JsonObject>("consent.fixture.json");
+	// The old identity never accepts the new surface, and vice versa.
+	assert.throws(() => decodeReviewConsentV2(clone(v3)), /agent|schema/);
+	assert.throws(() => decodeReviewConsentV3(clone(v2)), /agent|schema/);
+	// A schema-swapped v3 body keeps its agent key, which the v2 identity
+	// still rejects as an unadvertised surface.
+	const downgraded = clone(v3);
+	downgraded.schema = "gentle-ai.review-integration.consent/v2";
+	assert.throws(() => decodeReviewConsentV2(downgraded), /agent/);
+	// A schema-swapped v2 body is missing the agent key v3 requires.
+	const upgraded = clone(v2);
+	upgraded.schema = "gentle-ai.review-integration.consent/v3";
+	assert.throws(() => decodeReviewConsentV3(upgraded), /agent/);
+});
+
+test("consent/v3 keeps every v2 semantic guard and pins its agent constant", () => {
+	const base = fixture<JsonObject>("consent-v3.captured.json");
+	const wrongAgent = clone(base);
+	wrongAgent.agent = "opencode";
+	assert.throws(() => decodeReviewConsentV3(wrongAgent), /agent/);
+	const swapped = clone(base);
+	swapped.choices = [...(swapped.choices as JsonObject[])].reverse();
+	assert.throws(() => decodeReviewConsentV3(swapped), /answer/);
+	const badInvocation = clone(base);
+	((badInvocation.choices as JsonObject[])[0]!).invocation = "gentle-ai review finalize --consent granted";
+	assert.throws(() => decodeReviewConsentV3(badInvocation), /invocation/);
+	const differentTarget = clone(base);
+	differentTarget.target_identity = sha("d");
+	assert.throws(() => decodeReviewConsentV3(differentTarget), /target|invocation/);
+	const notBlocking = clone(base);
+	notBlocking.blocking = false;
+	assert.throws(() => decodeReviewConsentV3(notBlocking), /blocking/);
+	const extraKey = clone(base);
+	extraKey.unadvertised = true;
+	assert.throws(() => decodeReviewConsentV3(extraKey), /not allowed/);
+});
+
+test("the pinned consent/v2 fixture still decodes unchanged", () => {
+	const consent = decodeReviewConsentV2(v2Fixture("consent.fixture.json"));
+	assert.equal(consent.schema, "gentle-ai.review-integration.consent/v2");
+	assert.equal(consent.action, "consent_required");
+});
+
+// --- start/v3 — main extends repository_context with event_id/outcome ---
+
+test("the captured granted start/v3 decodes with its repository context event binding", () => {
+	const start = decodeReviewStartV3(fixture("start-v3-consent-granted.captured.json"));
+	assert.equal(start.lineageId, "review-377c60e10b852cfc");
+	assert.equal(start.state, "reviewing");
+	assert.equal(start.riskLevel, "high");
+	assert.equal(start.selectedLenses.length, 4);
+	assert.equal(start.correctionBudget, 6);
+	assert.equal(start.repositoryContext?.outcome, "applied");
+	assert.match(start.repositoryContext?.eventId ?? "", /^sha256:[0-9a-f]{64}$/);
+});
+
+test("start/v3 repository context event fields stay optional and exact", () => {
+	// The pinned fixture carries neither field and still decodes unchanged.
+	const pinned = decodeReviewStartV3(v2Fixture("start.fixture.json"));
+	assert.equal(pinned.repositoryContext?.eventId, undefined);
+	assert.equal(pinned.repositoryContext?.outcome, undefined);
+	const base = fixture<JsonObject>("start-v3-consent-granted.captured.json");
+	const badEvent = clone(base);
+	(badEvent.repository_context as JsonObject).event_id = "not-a-digest";
+	assert.throws(() => decodeReviewStartV3(badEvent), /event_id/);
+	const badOutcome = clone(base);
+	(badOutcome.repository_context as JsonObject).outcome = "unheard-of";
+	assert.throws(() => decodeReviewStartV3(badOutcome), /outcome/);
+	const extraKey = clone(base);
+	(extraKey.repository_context as JsonObject).unadvertised = true;
+	assert.throws(() => decodeReviewStartV3(extraKey), /not allowed/);
 });


### PR DESCRIPTION
## What

The direct Pi controller lane discriminated consent by `action` but decoded with the consent/v2-pinned decoder, so any medium/high candidate against gentle-ai ≥ 2.3.0 (which emits `consent/v3`, adding `agent`) failed `schema-incompatible` before the question could be relayed (observed live with the dev-binary override on 2.4.0-main; engram #12418).

- `decodeReviewConsentV3`: identity-exact, `agent` const, v2 semantic guards shared via one extracted helper; discrimination by the body's schema string — consent/v2 lane byte-identical (test-locked), unknown schemas fail closed.
- Latent second defect fixed: granted `start/v3` from main carries optional `repository_context.event_id`/`outcome` the decoder rejected — extended exactly (capture-authoritative), cross-identity rejections pinned.
- Fixtures captured 2026-08-16 from the real binary with provenance; no pin or NATIVE_CLI_CONTRACTS change (capabilities rows already promise consent/v3 for v2.1+).

## Verification

Full `pnpm test` 1213 pass / 0 fail (dev-binary registration moved aside and restored, sha verified); `check:provider-contract`, `check:transaction-runner`, `verify-package-files` green; live smoke with the override: start → consent/v3 surfaced → granted → reviewing with 4 lenses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for consent v3 during review-start flows, including required agent identification.
  - Added repository-context event identifiers and outcomes such as applied, pending, blocked, and durability-limited.
  - Consent-required responses now preserve review details, choices, risk evidence, and invocation information.

- **Bug Fixes**
  - Improved validation for unsupported consent formats and invalid repository-context values.
  - Maintained compatibility with existing consent v2 responses.

- **Tests**
  - Added coverage for granted and declined consent flows, event binding, and v2 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->