### PR TITLE
fix(review): follow the native transition after final verification evidence

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5129,7 +5129,13 @@ function isTargetedValidationCollectInput(input: { captureOperation: string }): 
 
 function requireEvidenceCollection(status: ReviewStatusV3): void {
 	const inputs = status.nextTransition?.kind === "collect" ? status.nextTransition.collect?.inputs ?? [] : [];
-	if (status.validationRequest !== undefined || inputs.some(isTargetedValidationCollectInput)) {
+	// An offered validation STEP is a targeted-validation collect input. The
+	// bare `validation_request` field is descriptive context both live
+	// emitters (pinned 2.2.3 and 2.4.0-main, probed 2026-08-16) publish
+	// alongside the evidence collect at `correction_required`; treating it as
+	// an offered step made the controller demand its validation phase before
+	// capturing the evidence the state itself demanded (field defect).
+	if (inputs.some(isTargetedValidationCollectInput)) {
 		throw new CandidateViewError("targeted validation was offered before correction evidence was captured", "evidence-first-ordering");
 	}
 	if (inputs.filter((input) => input.captureOperation === "review.capture-evidence").length !== 1) {
@@ -5142,7 +5148,10 @@ function requireTargetedValidationAfterEvidence(status: ReviewStatusV3): NonNull
 	const targeted = inputs.filter(isTargetedValidationCollectInput);
 	const request = status.validationRequest;
 	if (
-		status.authority?.state !== "validating" || targeted.length !== 1 || targeted[0]?.validationRequest === undefined || request === undefined ||
+		// Both live emitters (pinned 2.2.3 and 2.4.0-main, probed 2026-08-16)
+		// keep the post-evidence authority state at `correction_required`;
+		// `validating` is retained for pre-existing fixture compatibility.
+		(status.authority?.state !== "validating" && status.authority?.state !== "correction_required") || targeted.length !== 1 || targeted[0]?.validationRequest === undefined || request === undefined ||
 		JSON.stringify(targeted[0].validationRequest) !== JSON.stringify(request) || request.lineageId !== status.authority.lineageId ||
 		request.expectedRevision !== status.authority.revision || request.targetIdentity !== status.targetIdentity ||
 		request.correctionCandidateTree !== status.projection.currentCandidateTree ||
@@ -5156,7 +5165,10 @@ function requireTargetedValidationAfterEvidence(status: ReviewStatusV3): NonNull
 
 function assertNoTargetedValidation(status: ReviewStatusV3): void {
 	const inputs = status.nextTransition?.kind === "collect" ? status.nextTransition.collect?.inputs ?? [] : [];
-	if (status.validationRequest !== undefined || inputs.some(isTargetedValidationCollectInput)) {
+	// Same rule as requireEvidenceCollection: only an offered targeted-
+	// validation collect input counts; the descriptive `validation_request`
+	// context rides along on non-passing outcomes too.
+	if (inputs.some(isTargetedValidationCollectInput)) {
 		throw new CandidateViewError("non-passing evidence unexpectedly unlocked targeted validation", "evidence-first-ordering");
 	}
 }
@@ -5743,7 +5755,7 @@ async function executeReviewControllerOperation(
 			let negotiatedStatus: ReviewStatusV3 | undefined;
 			let candidateView: ReturnType<CandidateViewRegistry["create"]> | undefined;
 			let provisionalCandidateView: ReturnType<CandidateViewRegistry["create"]> | undefined;
-			let nativeResult: NativeFinalizeResult;
+			let nativeResult: NativeFinalizeResult | undefined;
 			let correctionStep: CorrectionStep | undefined;
 			try {
 				if (parameters.lineageId === undefined) throw new CandidateViewError("Native FINALIZE requires an explicit lineage");
@@ -5794,7 +5806,23 @@ async function executeReviewControllerOperation(
 				if (roleVectorSlots.length > 0 && input.final_evidence === undefined && input.correction_line_forecast === undefined && input.validation === undefined) {
 					return await executeProviderRoleVectorCollection(parameters.operation, parameters.lineageId, roleVectorSlots, nativeReviewCli, defaultCwd, signal);
 				}
-				if (candidateViews && !candidateViews.hasProjection(parameters.lineageId)) {
+				// Ordinary final verification (field defect, 2026-08-16): at
+				// native state `validating` the provider collects one final
+				// `review.capture-evidence` record and then offers exactly one
+				// execute `review.finalize --captured-evidence` transition. This
+				// lane is provider-owned end to end: it is not a correction
+				// transaction, no targeted validation exists in it, and no
+				// candidate view is materialized — the workspace root IS the
+				// unchanged frozen candidate, native FINALIZE validates the live
+				// snapshot itself, and the provider binds its repository-context
+				// effects to the root the lifecycle runs from. The correction
+				// lane keeps its pre-capture state `correction_required` and
+				// stays byte-identical below.
+				const ordinaryFinalVerification = validationAttempt &&
+					negotiatedStatus.authority?.state === "validating" &&
+					negotiatedStatus.validationRequest === undefined &&
+					!(negotiatedStatus.nextTransition?.kind === "collect" && (negotiatedStatus.nextTransition.collect?.inputs ?? []).some(isTargetedValidationCollectInput));
+				if (candidateViews && !ordinaryFinalVerification && !candidateViews.hasProjection(parameters.lineageId)) {
 					const projection = negotiatedStatus.projection;
 					candidateView = validationAttempt
 						? (candidateViews.restoreProjectionFromNative(parameters.lineageId, defaultCwd, projection), undefined)
@@ -5803,9 +5831,80 @@ async function executeReviewControllerOperation(
 				// Fail closed before any native mutation when the frozen projection
 				// belongs to a different worktree than the requested workspace (#169).
 				if (candidateViews && parameters.lineageId && candidateViews.hasProjection(parameters.lineageId)) candidateViews.resolveProjection(parameters.lineageId, defaultCwd);
-				candidateView ??= candidateViews && parameters.lineageId ? (correctionCompletion || validationAttempt) ? candidateViews.createCorrected(parameters.lineageId, defaultCwd, replayKey) : candidateViews.resolveForFinalize(parameters.lineageId) : undefined;
+				candidateView ??= candidateViews && parameters.lineageId && !ordinaryFinalVerification ? (correctionCompletion || validationAttempt) ? candidateViews.createCorrected(parameters.lineageId, defaultCwd, replayKey) : candidateViews.resolveForFinalize(parameters.lineageId) : undefined;
 				if (candidateView !== undefined) assertNativeFinalizeCandidateBinding(candidateView, negotiatedStatus);
-				if (validationAttempt && candidateView && parameters.lineageId) {
+				if (ordinaryFinalVerification && parameters.lineageId) {
+					// A projection held by this process routes the top-of-try path
+					// through createCorrected before the lane is known; that view
+					// is unused here — the lifecycle runs from the workspace root.
+					if (candidateView !== undefined && candidateViews) {
+						candidateViews.cleanup(candidateView.token);
+						candidateView = undefined;
+					}
+					if (nativeReviewCli.captureEvidence === undefined) throw new CandidateViewError("native final verification evidence capture is unavailable", "final-verification-provider-owned");
+					const outcome = correctionOutcome(input);
+					if (outcome === undefined || negotiatedStatus.authority === undefined) throw new CandidateViewError("native final verification evidence requires one authoritative outcome-bound status", "final-verification-provider-owned");
+					if (input.validation !== undefined) {
+						throw new CandidateViewError("native final verification is provider-owned; a targeted validation document is not admissible at state validating", "final-verification-provider-owned");
+					}
+					requireEvidenceCollection(negotiatedStatus);
+					const captured = await nativeReviewCli.captureEvidence({
+						cwd: defaultCwd,
+						lineageId: parameters.lineageId,
+						targetIdentity: negotiatedStatus.targetIdentity,
+						expectedRevision: negotiatedStatus.authority.revision,
+						outcome,
+						evidenceDocument: input.final_evidence!,
+						...(signal === undefined ? {} : { signal }),
+					});
+					if (
+						captured.lineageId !== parameters.lineageId || captured.authorityRevision !== negotiatedStatus.authority.revision ||
+						captured.targetIdentity !== negotiatedStatus.targetIdentity || captured.candidateTree !== negotiatedStatus.projection.currentCandidateTree ||
+						captured.pathsDigest !== negotiatedStatus.projection.pathsDigest || JSON.stringify([...captured.paths].sort()) !== JSON.stringify([...negotiatedStatus.projection.paths].sort()) ||
+						captured.outcome !== outcome
+					) {
+						throw new CandidateViewError("captured final verification evidence does not match the requested lineage, target, and outcome", "correction-evidence-binding-drift");
+					}
+					// Follow the provider transition faithfully: re-query
+					// negotiated STATUS and execute only the exact rendered
+					// `review.finalize` transition it offers for the captured
+					// evidence. Never demand targeted validation here and never
+					// substitute the validate gate.
+					const afterEvidence = await nativeReviewCli.targetStatus({ cwd: defaultCwd, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
+					if (afterEvidence.authority?.lineageId !== parameters.lineageId) throw new CandidateViewError("post-evidence status lost the final-verification lineage", "correction-evidence-binding-drift");
+					if (afterEvidence.validationRequest !== undefined || (afterEvidence.nextTransition?.kind === "collect" && (afterEvidence.nextTransition.collect?.inputs ?? []).some(isTargetedValidationCollectInput))) {
+						throw new CandidateViewError("final verification evidence unexpectedly unlocked targeted validation", "final-verification-provider-owned");
+					}
+					const evidenceTransition = afterEvidence.nextTransition?.kind === "execute" && afterEvidence.nextTransition.execute?.operation === "review.finalize"
+						? afterEvidence.nextTransition.execute
+						: undefined;
+					if (evidenceTransition === undefined || nativeReviewCli.finalizeTransition === undefined) {
+						// Fail closed on an unrecognized transition: report the
+						// committed capture and the provider's own status verbatim.
+						return {
+							...mapNativeTargetStatus(parameters.operation, afterEvidence, parameters.lineageId),
+							outcome: "final-verification-transition-unavailable",
+							verification_evidence: { outcome: captured.outcome, record_digest: captured.recordDigest },
+							mutation_performed: true,
+							mutation_outcome: "committed",
+						};
+					}
+					if (evidenceTransition.binding.lineageId !== undefined && evidenceTransition.binding.lineageId !== parameters.lineageId) {
+						throw new CandidateViewError("provider finalize transition is bound to a different lineage", "finalize-transition-binding-drift");
+					}
+					nativeResult = await nativeReviewCli.finalizeTransition({
+						cwd: defaultCwd,
+						// The exact rendered tokens, verbatim and in provider
+						// order; the hyphenated fallback mirrors the provider's
+						// published rendering rule for older payloads.
+						argumentTokens: evidenceTransition.arguments.map((argument) => argument.token ?? `--${argument.name.replaceAll("_", "-")}=${argument.value}`),
+						...(signal === undefined ? {} : { signal }),
+					});
+					if (nativeResult.lineageId !== parameters.lineageId) {
+						throw new CandidateViewError("provider finalize transition answered for a different lineage", "finalize-transition-binding-drift");
+					}
+				}
+				if (validationAttempt && !ordinaryFinalVerification && candidateView && parameters.lineageId) {
 					if (nativeReviewCli.captureEvidence === undefined) throw new CandidateViewError("native correction evidence capture is unavailable", "evidence-first-ordering");
 					const outcome = correctionOutcome(input);
 					if (outcome === undefined || negotiatedStatus.authority === undefined) throw new CandidateViewError("native correction evidence requires one authoritative outcome-bound status", "evidence-first-ordering");
@@ -5913,6 +6012,7 @@ async function executeReviewControllerOperation(
 					? negotiatedStatus.nextTransition.execute
 					: undefined;
 				if (
+					nativeResult === undefined &&
 					finalizeTransition !== undefined && nativeReviewCli.finalizeTransition !== undefined &&
 					input.validation === undefined && input.final_evidence === undefined && input.correction_line_forecast === undefined
 				) {
@@ -5931,7 +6031,7 @@ async function executeReviewControllerOperation(
 					if (parameters.lineageId !== undefined && nativeResult.lineageId !== parameters.lineageId) {
 						throw new CandidateViewError("provider finalize transition answered for a different lineage", "finalize-transition-binding-drift");
 					}
-				} else {
+				} else if (nativeResult === undefined) {
 					nativeResult = await nativeReviewCli.finalize({
 						cwd: candidateView?.root ?? defaultCwd,
 						...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -505,6 +505,13 @@ export interface ReviewStatusV3 {
 	finalVerificationRetry?: ReviewFinalVerificationRetryV1;
 	/** status/v5 only: the descriptive, non-routing transition preview. */
 	forecast?: ReviewForecastV1;
+	/**
+	 * status/v5 only: the opaque repository-context reference the live
+	 * 2.4.0-main binary publishes once a reviewing lineage has bound one.
+	 * NEW struct member — captured 2026-08-16 from 2.4.0-main.b1afef46; the
+	 * published status-v5.schema.json omits it (capture is authoritative).
+	 */
+	repositoryContext?: ReviewRepositoryContextV2;
 	raw: Readonly<Record<string, unknown>>;
 }
 
@@ -1522,7 +1529,7 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 	const v5 = typeof value === "object" && value !== null && (value as Record<string, unknown>).schema === "gentle-ai.review-integration.status/v5";
 	const body = exactRecord(value, "status", [
 		"schema", "contract", "operation", "applicability", "receipt", "action", "replayability", "target_identity", "projection", "repair", "candidates",
-	], ["authority", "frozen", "reconciliation", "action_disposition", "eligibility", "next_transition", "authority_target_identity", "validation_request", "final_verification_retry", ...(v5 ? ["forecast"] : [])]);
+	], ["authority", "frozen", "reconciliation", "action_disposition", "eligibility", "next_transition", "authority_target_identity", "validation_request", "final_verification_retry", ...(v5 ? ["forecast", "repository_context"] : [])]);
 	requireIdentity(body, v5 ? "gentle-ai.review-integration.status/v5" : "gentle-ai.review-integration.status/v3", REVIEW_INTEGRATION_OPERATION.STATUS);
 
 	const applicability = enumeration(body.applicability, ["current_target", "unrelated", "ambiguous", "corrupted"] as const, "status.applicability");
@@ -1603,6 +1610,24 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 		throw new TypeError("status.final_verification_retry is only valid for the retry_final_verification action");
 	}
 
+	// status/v5 additive top-level repository context reference (captured
+	// 2026-08-16 from 2.4.0-main.b1afef46; missing from the published
+	// status-v5.schema.json, so the live capture is authoritative). Same
+	// reference shape as start/v3's repository_context.
+	let repositoryContext: ReviewRepositoryContextV2 | undefined;
+	if (body.repository_context !== undefined) {
+		const source = exactRecord(body.repository_context, "status.repository_context", ["capability", "handle", "revision", "target_identity"], ["event_id", "outcome"]);
+		if (source.capability !== "review.opaque_repository_context") throw new TypeError("status.repository_context.capability is unsupported");
+		repositoryContext = {
+			capability: "review.opaque_repository_context",
+			handle: text(source.handle, "status.repository_context.handle", { pattern: /^rctx1_[0-9a-f]{64}$/ }),
+			revision: sha256(source.revision, "status.repository_context.revision"),
+			targetIdentity: sha256(source.target_identity, "status.repository_context.target_identity"),
+			...(source.event_id === undefined ? {} : { eventId: sha256(source.event_id, "status.repository_context.event_id") }),
+			...(source.outcome === undefined ? {} : { outcome: enumeration(source.outcome, REPOSITORY_CONTEXT_OUTCOMES, "status.repository_context.outcome") }),
+		};
+	}
+
 	return {
 		contract: REVIEW_INTEGRATION_CONTRACT,
 		applicability,
@@ -1622,6 +1647,7 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 		...(validationRequest === undefined ? {} : { validationRequest }),
 		...(finalVerificationRetry === undefined ? {} : { finalVerificationRetry }),
 		...(forecast === undefined ? {} : { forecast }),
+		...(repositoryContext === undefined ? {} : { repositoryContext }),
 		raw: body,
 	};
 }

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -509,6 +509,13 @@ export const REVIEW_PROVIDER_ROLE_CAPTURE_OPERATIONS = Object.freeze(Object.valu
 
 
 
+	                      
+
+
+
+
+
+
 
 
 
@@ -1523,7 +1530,7 @@ export function decodeReviewStatusV3(value         )                 {
 	const v5 = typeof value === "object" && value !== null && (value                           ).schema === "gentle-ai.review-integration.status/v5";
 	const body = exactRecord(value, "status", [
 		"schema", "contract", "operation", "applicability", "receipt", "action", "replayability", "target_identity", "projection", "repair", "candidates",
-	], ["authority", "frozen", "reconciliation", "action_disposition", "eligibility", "next_transition", "authority_target_identity", "validation_request", "final_verification_retry", ...(v5 ? ["forecast"] : [])]);
+	], ["authority", "frozen", "reconciliation", "action_disposition", "eligibility", "next_transition", "authority_target_identity", "validation_request", "final_verification_retry", ...(v5 ? ["forecast", "repository_context"] : [])]);
 	requireIdentity(body, v5 ? "gentle-ai.review-integration.status/v5" : "gentle-ai.review-integration.status/v3", REVIEW_INTEGRATION_OPERATION.STATUS);
 
 	const applicability = enumeration(body.applicability, ["current_target", "unrelated", "ambiguous", "corrupted"]         , "status.applicability");
@@ -1604,6 +1611,24 @@ export function decodeReviewStatusV3(value         )                 {
 		throw new TypeError("status.final_verification_retry is only valid for the retry_final_verification action");
 	}
 
+	// status/v5 additive top-level repository context reference (captured
+	// 2026-08-16 from 2.4.0-main.b1afef46; missing from the published
+	// status-v5.schema.json, so the live capture is authoritative). Same
+	// reference shape as start/v3's repository_context.
+	let repositoryContext                                       ;
+	if (body.repository_context !== undefined) {
+		const source = exactRecord(body.repository_context, "status.repository_context", ["capability", "handle", "revision", "target_identity"], ["event_id", "outcome"]);
+		if (source.capability !== "review.opaque_repository_context") throw new TypeError("status.repository_context.capability is unsupported");
+		repositoryContext = {
+			capability: "review.opaque_repository_context",
+			handle: text(source.handle, "status.repository_context.handle", { pattern: /^rctx1_[0-9a-f]{64}$/ }),
+			revision: sha256(source.revision, "status.repository_context.revision"),
+			targetIdentity: sha256(source.target_identity, "status.repository_context.target_identity"),
+			...(source.event_id === undefined ? {} : { eventId: sha256(source.event_id, "status.repository_context.event_id") }),
+			...(source.outcome === undefined ? {} : { outcome: enumeration(source.outcome, REPOSITORY_CONTEXT_OUTCOMES, "status.repository_context.outcome") }),
+		};
+	}
+
 	return {
 		contract: REVIEW_INTEGRATION_CONTRACT,
 		applicability,
@@ -1623,6 +1648,7 @@ export function decodeReviewStatusV3(value         )                 {
 		...(validationRequest === undefined ? {} : { validationRequest }),
 		...(finalVerificationRetry === undefined ? {} : { finalVerificationRetry }),
 		...(forecast === undefined ? {} : { forecast }),
+		...(repositoryContext === undefined ? {} : { repositoryContext }),
 		raw: body,
 	};
 }

--- a/tests/fixtures/devbinary/status-v5-repository-context.captured.json
+++ b/tests/fixtures/devbinary/status-v5-repository-context.captured.json
@@ -1,0 +1,138 @@
+{
+  "schema": "gentle-ai.review-integration.status/v5",
+  "contract": "gentle-ai.review-integration/v2",
+  "operation": "review.status",
+  "applicability": "current_target",
+  "authority": {
+    "version": "compact-v2",
+    "lineage_id": "review-bbfbf9af2dc27936",
+    "state": "reviewing",
+    "generation": 1,
+    "revision": "sha256:b330774b56c764047e6041de2b9071b16a772abf7cdc311c2f77cb4ecaa3a707"
+  },
+  "receipt": {
+    "status": "expected_missing"
+  },
+  "action": "finalize",
+  "replayability": "not_replayable",
+  "frozen": {
+    "tier": "medium",
+    "original_changed_lines": 1,
+    "correction_budget": 1
+  },
+  "target_identity": "sha256:bbfbf9af2dc27936d5fbc0c30579d5122d65bf4ccc65d9a00cde816f3aa6d3ab",
+  "projection": {
+    "schema": "gentle-ai.review-integration.projection/v1",
+    "kind": "current-changes",
+    "projection": "workspace",
+    "base_tree": "7bee507cb7f5aa4dce34e6962366eeea27935c74",
+    "initial_review_tree": "a044376c6cfb84e30c676ff7307e92bcfef5b6ec",
+    "current_candidate_tree": "a044376c6cfb84e30c676ff7307e92bcfef5b6ec",
+    "paths_digest": "sha256:4d916b1a185d946866be1c2f945425ea650ea045dec13bb0ec972744f0f9bd61",
+    "paths": [
+      "file.txt"
+    ],
+    "intended_untracked": [],
+    "intended_untracked_proof": "sha256:b97229718d4c7fe50a8892eb474ae5aa6491697bccb400e3e31dbaca4894d2f3",
+    "initial_snapshot_identity": "sha256:bbfbf9af2dc27936d5fbc0c30579d5122d65bf4ccc65d9a00cde816f3aa6d3ab",
+    "current_snapshot_identity": "sha256:bbfbf9af2dc27936d5fbc0c30579d5122d65bf4ccc65d9a00cde816f3aa6d3ab"
+  },
+  "repair": {
+    "schema": "gentle-ai.review-authority-repair-assessment/v1",
+    "status": "unsupported",
+    "counts": {
+      "lineages": 0,
+      "compact_lineages": 0,
+      "legacy_lineages": 0,
+      "events": 0,
+      "bytes": 0,
+      "eligible_candidates": 0,
+      "unsupported_lineages": 0,
+      "conflicts": 0
+    },
+    "supported_operations": [
+      "review/complete-fix",
+      "review/validate-fix"
+    ],
+    "authorization_schema": "gentle-ai.review-repair-authorization/v1"
+  },
+  "candidates": [],
+  "forecast": {
+    "horizon": "partial",
+    "steps": [
+      {
+        "step": 1,
+        "kind": "execute",
+        "reason_code": "captured_results_ready",
+        "description": "Captured reviewer results are complete and ready for finalization"
+      }
+    ]
+  },
+  "next_transition": {
+    "kind": "execute",
+    "reason_code": "captured_results_ready",
+    "execute": {
+      "operation": "review.finalize",
+      "command": "gentle-ai review finalize --lineage=review-bbfbf9af2dc27936 --captured-results=true --contract=gentle-ai.review-integration/v2 --agent=claude-code",
+      "arguments": [
+        {
+          "name": "lineage",
+          "value": "review-bbfbf9af2dc27936",
+          "token": "--lineage=review-bbfbf9af2dc27936"
+        },
+        {
+          "name": "captured_results",
+          "value": "true",
+          "token": "--captured-results=true"
+        },
+        {
+          "name": "contract",
+          "value": "gentle-ai.review-integration/v2",
+          "token": "--contract=gentle-ai.review-integration/v2"
+        },
+        {
+          "name": "agent",
+          "value": "claude-code",
+          "token": "--agent=claude-code"
+        }
+      ],
+      "preconditions": [
+        {
+          "name": "state",
+          "value": "reviewing"
+        },
+        {
+          "name": "captured_artifacts",
+          "value": "complete"
+        }
+      ],
+      "binding": {
+        "lineage_id": "review-bbfbf9af2dc27936",
+        "revision": "sha256:b330774b56c764047e6041de2b9071b16a772abf7cdc311c2f77cb4ecaa3a707",
+        "target_identity": "sha256:bbfbf9af2dc27936d5fbc0c30579d5122d65bf4ccc65d9a00cde816f3aa6d3ab",
+        "repository_context": "rctx1_7da80fda377da87da8aae62204c531e697bd6a4a6bbd5de21ddd3861150fb725"
+      },
+      "artifacts": [
+        {
+          "schema": "gentle-ai.review-result-artifact/v2",
+          "capability": "review.native_result_artifact",
+          "sha256": "sha256:02a403472b0bb0c7ad5dddd1010b006af257f516e425795996f276d423d33c9d",
+          "lineage_id": "review-bbfbf9af2dc27936",
+          "target_identity": "sha256:bbfbf9af2dc27936d5fbc0c30579d5122d65bf4ccc65d9a00cde816f3aa6d3ab",
+          "lens": "review-reliability",
+          "selected_order": 0,
+          "subject_hash": "sha256:620703b2e6f074e031712f501eb9fe460bb17bd0cbbd70db10be5dc4fa2dfead",
+          "admission_decision": "completed"
+        }
+      ]
+    }
+  },
+  "repository_context": {
+    "capability": "review.opaque_repository_context",
+    "handle": "rctx1_7da80fda377da87da8aae62204c531e697bd6a4a6bbd5de21ddd3861150fb725",
+    "revision": "sha256:b330774b56c764047e6041de2b9071b16a772abf7cdc311c2f77cb4ecaa3a707",
+    "target_identity": "sha256:bbfbf9af2dc27936d5fbc0c30579d5122d65bf4ccc65d9a00cde816f3aa6d3ab",
+    "event_id": "sha256:5d2588ff1422f4568588986a2e2872bae60f0fef4131df81a6e3bdad9f8fa76a",
+    "outcome": "applied"
+  }
+}

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1308,6 +1308,270 @@ test("production correction routing rejects a second capture that reuses failed 
 	execFileSync("chmod", ["-R", "u+w", cwd]);
 });
 
+// Live-emitter correction shapes (probed 2026-08-16 against BOTH the pinned
+// 2.2.3 binary and dev 2.4.0-main.b1afef46, scripted correction lane):
+// - The evidence-collect status at `correction_required` carries the
+//   `validation_request` CONTEXT alongside its single `review.capture-evidence`
+//   input (reason correction_repository_verification_required). The request
+//   context is not an offered validation step.
+// - The post-evidence targeted-validation status keeps state
+//   `correction_required` (never `validating`), and its
+//   `external.run_targeted_validation` input embeds the identical
+//   validation_request.
+test("production correction routing accepts the live emitters' early validation-request context and correction_required post-evidence state", async (t) => {
+	for (const [outcome, expectedKind] of [
+		["passed", "run-targeted-validation"],
+		["verification_failed", "recapture-required"],
+	] as const) {
+		await t.test(outcome, async (scenario) => {
+			const cwd = repository(scenario);
+			writeFileSync(join(cwd, "app.ts"), `export const live = ${JSON.stringify(outcome)};\n`);
+			const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+			const beforeCapture = bindCorrectionCollection(targetStatusFixture({
+				lineageId: `live-correction-${outcome.replaceAll("_", "-")}`,
+				authorityState: "correction_required",
+				baseTree: frozen.baseTree,
+				currentCandidateTree: frozen.candidateTree,
+				paths: frozen.paths,
+			}));
+			// The live emitters publish the request context BEFORE evidence.
+			beforeCapture.validationRequest = bindTargetedValidation(targetStatusFixture({
+				lineageId: beforeCapture.authority!.lineageId,
+				authorityState: "correction_required",
+				baseTree: frozen.baseTree,
+				currentCandidateTree: frozen.candidateTree,
+				paths: frozen.paths,
+			})).validationRequest;
+			const afterCapture = targetStatusFixture({
+				lineageId: beforeCapture.authority!.lineageId,
+				// Live post-evidence state on both emitters.
+				authorityState: "correction_required",
+				baseTree: frozen.baseTree,
+				currentCandidateTree: frozen.candidateTree,
+				paths: frozen.paths,
+			});
+			if (outcome === "passed") bindTargetedValidation(afterCapture);
+			else {
+				bindCorrectionCollection(afterCapture);
+				afterCapture.validationRequest = beforeCapture.validationRequest;
+			}
+			frozen.cleanup();
+			const calls: string[] = [];
+			let statuses = 0;
+			let finalizes = 0;
+			const { controller } = runtime(fakeNative({
+				targetStatus: async () => {
+					calls.push("status");
+					statuses += 1;
+					return statuses === 1 ? beforeCapture : afterCapture;
+				},
+				captureEvidence: async (request) => {
+					calls.push("capture-evidence");
+					assert.equal(request.outcome, outcome);
+					return capturedCorrectionEvidence(beforeCapture, outcome, outcome === "passed" ? "7" : "8");
+				},
+				finalize: async () => {
+					calls.push("finalize");
+					finalizes += 1;
+					return { lineageId: beforeCapture.authority!.lineageId, state: "approved", action: "approved", storeRevision: "r-final" };
+				},
+			}), undefined, undefined, undefined, new CandidateViewRegistry());
+			const validation = outcome === "passed" ? {
+				request_hash: "9".repeat(64), correction_ids: [],
+				original_criteria: { passed: true, evidence: ["acceptance passes"] },
+				correction_regression: { passed: true, evidence: ["regression passes"] },
+				fix_caused_findings: [], follow_ups: [],
+			} : undefined;
+			const result = await controller.execute(`live-correction-${outcome}`, {
+				operation: "finalize",
+				lineageId: beforeCapture.authority!.lineageId,
+				input: JSON.stringify({ final_evidence: `evidence: ${outcome}`, final_verification_outcome: outcome, ...(validation === undefined ? {} : { validation }) }),
+			}, undefined, undefined, context(cwd));
+			const details = result.details as Record<string, unknown>;
+			assert.deepEqual(calls.slice(0, 3), ["status", "capture-evidence", "status"], "the early validation-request context must not block the evidence capture the state demands");
+			assert.equal((details.correction_step as { kind?: string } | undefined)?.kind, expectedKind);
+			assert.equal(finalizes, outcome === "passed" ? 1 : 0);
+		});
+	}
+});
+
+// Ordinary final verification (field defect, dev binary 2.4.0-main.b1afef46,
+// reproduced identically on the pinned 2.2.3 binary): after FINALIZE with
+// captured results the native state is `validating` and the provider collects
+// exactly one `review.capture-evidence` record, then offers one execute
+// `review.finalize --captured-evidence=true` transition. The controller must
+// follow that transition faithfully — it must never demand its correction-lane
+// targeted-validation phase, and never substitute the validate gate.
+function bindFinalVerificationTransition(status: ReviewStatusV3, outcome: "passed" | "verification_failed" | "procedural_tooling_failed"): ReviewStatusV3 {
+	const reasonCode = outcome === "passed"
+		? "captured_verification_evidence_passed"
+		: outcome === "verification_failed" ? "captured_verification_failed" : "captured_verification_tooling_failed";
+	status.nextTransition = {
+		kind: "execute",
+		reasonCode,
+		execute: {
+			operation: "review.finalize",
+			// The second argument deliberately omits `token` to pin the
+			// provider's published hyphenation fallback (captured_evidence ->
+			// --captured-evidence=true); the host never invents another form.
+			arguments: [
+				{ name: "lineage", value: status.authority!.lineageId, token: `--lineage=${status.authority!.lineageId}` },
+				{ name: "captured_evidence", value: "true" },
+			],
+			preconditions: [{ name: "state", value: "validating" }, { name: "verification_outcome", value: outcome }],
+			binding: { targetIdentity: status.targetIdentity, lineageId: status.authority!.lineageId },
+		},
+	};
+	delete status.validationRequest;
+	return status;
+}
+
+test("ordinary final verification at validating captures evidence then executes the provider finalize transition, never targeted validation", async (t) => {
+	for (const [outcome, terminalState] of [
+		["passed", "approved"],
+		["verification_failed", "escalated"],
+		["procedural_tooling_failed", "escalated"],
+	] as const) {
+		await t.test(outcome, async (scenario) => {
+			const cwd = repository(scenario);
+			writeFileSync(join(cwd, "app.ts"), `export const outcome = ${JSON.stringify(outcome)};\n`);
+			const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+			const beforeCapture = bindCorrectionCollection(targetStatusFixture({
+				lineageId: "final-verification",
+				authorityState: "validating",
+				baseTree: frozen.baseTree,
+				currentCandidateTree: frozen.candidateTree,
+				paths: frozen.paths,
+			}));
+			const afterCapture = bindFinalVerificationTransition(targetStatusFixture({
+				lineageId: "final-verification",
+				authorityState: "validating",
+				baseTree: frozen.baseTree,
+				currentCandidateTree: frozen.candidateTree,
+				paths: frozen.paths,
+			}), outcome);
+			frozen.cleanup();
+			const calls: string[] = [];
+			const transitions: Array<readonly string[]> = [];
+			let statuses = 0;
+			const { controller } = runtime(fakeNative({
+				targetStatus: async () => {
+					calls.push("status");
+					statuses += 1;
+					return statuses === 1 ? beforeCapture : afterCapture;
+				},
+				captureEvidence: async (request) => {
+					calls.push("capture-evidence");
+					assert.equal(request.outcome, outcome);
+					return capturedCorrectionEvidence(beforeCapture, outcome, "6");
+				},
+				finalize: async () => {
+					calls.push("finalize");
+					return { lineageId: "final-verification", state: terminalState, action: "terminal", storeRevision: "r2" };
+				},
+				finalizeTransition: async (request) => {
+					calls.push("finalize-transition");
+					transitions.push(request.argumentTokens);
+					return { lineageId: "final-verification", state: terminalState, action: "terminal", storeRevision: "r2", receiptPath: "/opaque/receipt" };
+				},
+			}), undefined, undefined, undefined, new CandidateViewRegistry());
+			const result = await controller.execute(`final-verification-${outcome}`, {
+				operation: "finalize",
+				lineageId: "final-verification",
+				input: JSON.stringify({ final_evidence: `verification run: ${outcome}`, final_verification_outcome: outcome }),
+			}, undefined, undefined, context(cwd));
+			const details = result.details as Record<string, unknown>;
+			assert.deepEqual(calls, ["status", "capture-evidence", "status", "finalize-transition"], "the controller must follow the provider transition after evidence capture");
+			assert.deepEqual(transitions, [["--lineage=final-verification", "--captured-evidence=true"]]);
+			assert.equal((details.result as { state?: string } | undefined)?.state, terminalState);
+			assert.equal("correction_step" in details, false, "ordinary final verification is not a correction transaction");
+		});
+	}
+});
+
+test("ordinary final verification rejects a Pi-authored targeted validation document before any capture", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 1;\n");
+	const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	const status = bindCorrectionCollection(targetStatusFixture({
+		lineageId: "final-verification",
+		authorityState: "validating",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}));
+	frozen.cleanup();
+	let captures = 0;
+	let finalizes = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => status,
+		captureEvidence: async () => { captures += 1; return capturedCorrectionEvidence(status, "passed", "4"); },
+		finalize: async () => { finalizes += 1; return { lineageId: "final-verification", state: "approved", action: "approved", storeRevision: "r1" }; },
+	}), undefined, undefined, undefined, new CandidateViewRegistry());
+	const result = await controller.execute("final-verification-validation-doc", {
+		operation: "finalize",
+		lineageId: "final-verification",
+		input: JSON.stringify({
+			final_evidence: "verification run: passed",
+			final_verification_outcome: "passed",
+			validation: { request_hash: "9".repeat(64), correction_ids: [], original_criteria: { passed: true, evidence: ["passes"] }, correction_regression: { passed: true, evidence: ["passes"] }, fix_caused_findings: [], follow_ups: [] },
+		}),
+	}, undefined, undefined, context(cwd));
+	assert.equal((result.details as { outcome?: string }).outcome, "native-operation-failed");
+	assert.match(JSON.stringify(result.details), /final-verification-provider-owned/);
+	assert.equal(captures, 0, "an inadmissible payload must fail closed before the single evidence capture is consumed");
+	assert.equal(finalizes, 0);
+});
+
+test("ordinary final verification fails closed without substituting a step when the provider offers no finalize transition", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	const beforeCapture = bindCorrectionCollection(targetStatusFixture({
+		lineageId: "final-verification",
+		authorityState: "validating",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}));
+	const afterCapture = targetStatusFixture({
+		lineageId: "final-verification",
+		authorityState: "validating",
+		action: "stop",
+		replayability: "manual_action_required",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	});
+	frozen.cleanup();
+	let statuses = 0;
+	let finalizes = 0;
+	let transitions = 0;
+	let validates = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			statuses += 1;
+			return statuses === 1 ? beforeCapture : afterCapture;
+		},
+		captureEvidence: async () => capturedCorrectionEvidence(beforeCapture, "passed", "5"),
+		finalize: async () => { finalizes += 1; return { lineageId: "final-verification", state: "approved", action: "approved", storeRevision: "r1" }; },
+		finalizeTransition: async () => { transitions += 1; return { lineageId: "final-verification", state: "approved", action: "approved", storeRevision: "r1" }; },
+		validate: async () => { validates += 1; return { allowed: true, result: "allow", action: "continue", reason: "ok", gateContext: nativeGateContext() }; },
+	}), undefined, undefined, undefined, new CandidateViewRegistry());
+	const result = await controller.execute("final-verification-no-transition", {
+		operation: "finalize",
+		lineageId: "final-verification",
+		input: JSON.stringify({ final_evidence: "verification run: passed", final_verification_outcome: "passed" }),
+	}, undefined, undefined, context(cwd));
+	const details = result.details as Record<string, unknown>;
+	assert.equal(details.outcome, "final-verification-transition-unavailable");
+	assert.equal(details.mutation_performed, true, "the committed evidence capture must never be reported as zero mutations");
+	assert.equal(details.mutation_outcome, "committed");
+	assert.equal(finalizes, 0, "no substitute finalize form may be invented");
+	assert.equal(transitions, 0);
+	assert.equal(validates, 0, "the validate gate must never be substituted for a missing transition");
+});
+
 // gentle-pi#311 P4-roles fixture: one provider-rendered SELF-CONTAINED role
 // capture vector (binding tokens + --agent=pi --execute=true, no submission).
 function bindProviderRoleVector(status: ReviewStatusV3, role: "refuter" | "targeted-validator"): ReviewStatusV3 {

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -48,6 +48,18 @@ import {
 //   --agent token even though the envelope pins agent: claude-code — the
 //   published consent-v3.schema.json invocation pattern is narrower than the
 //   emitter, so the capture is authoritative (parity playbook, known traps).
+// - status-v5-repository-context.captured.json was captured 2026-08-16 from
+//   the real binary at /home/gentleman/.cargo/bin/gentle-ai reporting
+//   "gentle-ai 2.4.0-main.b1afef46", in a scratch git repository with one
+//   medium-tier lineage in state `reviewing` whose single reviewer result was
+//   already admitted (consent granted start, then review capture-result):
+//     gentle-ai review status --contract gentle-ai.review-integration/v2 \
+//       --cwd <scratch> --agent claude-code --lineage <lineage> \
+//       --projection workspace --next-transition
+//   The top-level `repository_context` reference it carries is emitted by the
+//   live binary but MISSING from the published status-v5.schema.json
+//   (additionalProperties: false) at the same commit — the capture is
+//   authoritative (parity playbook, known traps).
 
 const fixtureRoot = join(import.meta.dirname, "fixtures", "devbinary");
 const fixture = <T = Record<string, unknown>>(name: string): T => JSON.parse(readFileSync(join(fixtureRoot, name), "utf8")) as T;
@@ -110,6 +122,24 @@ test("the captured status/v5 payload decodes with its forecast and base-ref coll
 test("the pinned status/v3 fixture still decodes unchanged", () => {
 	const status = decodeReviewStatusV3(v2Fixture("status.fixture.json"));
 	assert.equal(status.contract, "gentle-ai.review-integration/v2");
+});
+
+test("the captured status/v5 payload decodes its top-level repository context reference", () => {
+	const status = decodeReviewStatusV3(fixture("status-v5-repository-context.captured.json"));
+	assert.equal(status.authority?.state, "reviewing");
+	assert.equal(status.repositoryContext?.capability, "review.opaque_repository_context");
+	assert.match(status.repositoryContext?.handle ?? "", /^rctx1_[0-9a-f]{64}$/);
+	assert.equal(status.repositoryContext?.revision, status.authority?.revision);
+	assert.equal(status.repositoryContext?.targetIdentity, status.targetIdentity);
+	assert.equal(status.repositoryContext?.outcome, "applied");
+});
+
+test("a status/v3 payload never carries a top-level repository context", () => {
+	const v5 = fixture<JsonObject>("status-v5-repository-context.captured.json");
+	const downgraded = clone(v5);
+	downgraded.schema = "gentle-ai.review-integration.status/v3";
+	delete downgraded.forecast; // forecast is rejected first; isolate the field under test
+	assert.throws(() => decodeReviewStatusV3(downgraded), /repository_context/);
 });
 
 test("a status/v3 payload never carries v5 fields", () => {


### PR DESCRIPTION
## What

The direct-lane controller treated EVERY evidence capture as the correction lifecycle: after capturing final verification evidence at `validating` it demanded the targeted-validation phase (correction lane) instead of executing the rendered `finalize --captured-evidence=true`, and reported the committed capture as `mutation_performed: false` (the maintainer's field report: validation offered before the evidence the state demanded).

- Ordinary lane: new provider-owned branch — capture evidence, re-query STATUS, execute the exact rendered finalize verbatim; unknown transition fails closed reporting the committed mutation; validate is never substituted.
- Correction lane: only an offered targeted-validation collect input counts as a validation step; post-evidence accepts the live `correction_required` state (the pinned fixtures encoded a state both live emitters never produce).
- Plus the status/v5 top-level `repository_context` forward decoder (v5-gated, captured fixture with provenance, v3 cross-identity rejection pinned) that gated the whole direct lifecycle.

Diagnosis note: native STATUS/finalize behaved identically on the pinned 2.2.3 and 2.4.0-main emitters — no gentle-ai defect; the published status-v5 schema omission is handled separately in gentle-ai.

## Verification

Full `pnpm test` 1224 pass / 0 fail (registration aside + restored, sha verified); provider-contract/transaction-runner/package-files green; live smoke: medium candidate start→granted→lens→finalize→capture-evidence→finalize→**approved receipt**→validate gate allow; cross-lane battery sequencing/lifecycle/freshness lanes PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for repository context in review status information, including associated event and outcome details.
  * Added provider-owned final verification during finalization when supported, with evidence capture and transition validation.

* **Bug Fixes**
  * Improved validation detection to avoid false evidence-ordering errors.
  * Correctly handles post-evidence correction states and safely rejects incomplete or inconsistent finalization transitions.

* **Tests**
  * Expanded coverage for correction routing, final verification, repository context validation, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->