### PR TITLE
fix(runtime): decode the review result-artifact envelope strictly

### DIFF
--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -15,6 +15,7 @@ import {
 	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewRepairV2,
+	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
 	decodeReviewStatusV3,
 	type ReviewCapabilitiesV2,
@@ -1973,27 +1974,19 @@ interface NegotiatedExecution {
 }
 
 function decodeNativeAdmittedResultManifest(value: unknown): NativeReviewAdmittedResultManifest {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new TypeError("native capture-result manifest must be an object");
-	const body = value as Record<string, unknown>;
-	const text = (key: string): string => {
-		const found = body[key];
-		if (typeof found !== "string" || found.trim() !== found || found.length === 0) throw new TypeError(`native capture-result manifest ${key} must be a non-empty trimmed string`);
-		return found;
-	};
-	const schema = text("schema");
-	if (schema !== "gentle-ai.review-result-artifact/v2") throw new TypeError(`native capture-result manifest schema must be gentle-ai.review-result-artifact/v2, received ${schema}`);
-	const admission = text("admission_decision");
-	if (admission !== "completed") throw new TypeError(`native capture-result manifest admission_decision must be completed, received ${admission}`);
-	// Exactly one locator: a provider-owned path OR an opaque reference. Both or
-	// neither means the manifest cannot be handed to FINALIZE.
-	const hasPath = body.path !== undefined, hasReference = body.reference !== undefined;
-	if (hasPath === hasReference) throw new TypeError("native capture-result manifest must carry exactly one of path or reference");
+	// The admission answer routes through the exact-identity forward decoder
+	// (decoder-freshness discipline): the complete live envelope — identity
+	// constants, binding fields, and the exactly-one-locator rule — is
+	// validated before anything is handed to FINALIZE, and an unknown field
+	// grown by gentle-ai main is rejected instead of silently dropped.
+	const artifact = decodeReviewResultArtifactV2(value);
 	return Object.freeze({
-		schema,
-		subjectHash: text("subject_hash"),
-		admissionDecision: admission,
-		...(body.lens === undefined ? {} : { lens: text("lens") }),
-		...(hasPath ? { path: text("path") } : { reference: text("reference") }),
+		schema: artifact.schema,
+		subjectHash: artifact.subjectHash,
+		admissionDecision: artifact.admissionDecision,
+		lens: artifact.lens,
+		...(artifact.path === undefined ? {} : { path: artifact.path }),
+		...(artifact.reference === undefined ? {} : { reference: artifact.reference }),
 	});
 }
 

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1969,3 +1969,54 @@ export function decodeReviewRepairV2(value: unknown): ReviewRepairV2 {
 		raw: body,
 	};
 }
+
+// ---------------------------------------------------------------------------
+// result-artifact/v2 — the `review capture-result` admission answer
+// ---------------------------------------------------------------------------
+
+// The provider's admitted-reviewer-result envelope, printed by `review
+// capture-result` when a reviewer result is admitted and re-discovered by
+// STATUS artifact discovery. Unlike the negotiated envelopes above it carries
+// no `contract`/`operation` identity pair — the schema constant plus the
+// capability constant are its complete identity (vendored ground truth:
+// contracts/review-integration/v1/schemas/result-artifact-v2.schema.json,
+// confirmed against a live 2.4.0-main capture; the v2.2.3 pinned emitter
+// shares the exact same struct). Exactly one locator is present: a
+// provider-owned store `path`, or the opaque `rart1_` `reference` minted for
+// repository-context captures.
+export interface ReviewResultArtifactV2 {
+	schema: "gentle-ai.review-result-artifact/v2";
+	capability: "review.native_result_artifact";
+	sha256: string;
+	lineageId: string;
+	targetIdentity: string;
+	lens: (typeof REVIEW_LENSES)[number];
+	selectedOrder: number;
+	subjectHash: string;
+	admissionDecision: "completed";
+	path?: string;
+	reference?: string;
+	raw: Record<string, unknown>;
+}
+
+export function decodeReviewResultArtifactV2(value: unknown): ReviewResultArtifactV2 {
+	const body = exactRecord(value, "result_artifact", ["schema", "capability", "sha256", "lineage_id", "target_identity", "lens", "selected_order", "subject_hash", "admission_decision"], ["path", "reference"]);
+	if (body.schema !== "gentle-ai.review-result-artifact/v2") throw new TypeError("result_artifact.schema must be gentle-ai.review-result-artifact/v2");
+	if (body.capability !== "review.native_result_artifact") throw new TypeError("result_artifact.capability must be review.native_result_artifact");
+	if (body.admission_decision !== "completed") throw new TypeError("result_artifact.admission_decision must be completed");
+	if ((body.path === undefined) === (body.reference === undefined)) throw new TypeError("result_artifact must carry exactly one of path or reference");
+	return {
+		schema: "gentle-ai.review-result-artifact/v2",
+		capability: "review.native_result_artifact",
+		sha256: sha256(body.sha256, "result_artifact.sha256"),
+		lineageId: lineage(body.lineage_id, "result_artifact.lineage_id"),
+		targetIdentity: sha256(body.target_identity, "result_artifact.target_identity"),
+		lens: enumeration(body.lens, REVIEW_LENSES, "result_artifact.lens"),
+		selectedOrder: integer(body.selected_order, "result_artifact.selected_order", 0, 3),
+		subjectHash: sha256(body.subject_hash, "result_artifact.subject_hash"),
+		admissionDecision: "completed",
+		...(body.path === undefined ? {} : { path: nonempty(body.path, "result_artifact.path") }),
+		...(body.reference === undefined ? {} : { reference: text(body.reference, "result_artifact.reference", { pattern: /^rart1_[0-9a-f]{64}$/ }) }),
+		raw: body,
+	};
+}

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -16,6 +16,7 @@ import {
 	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewRepairV2,
+	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
 	decodeReviewStatusV3,
 
@@ -1974,27 +1975,19 @@ function defaultExecutableDigest(path        )         {
 
 
 function decodeNativeAdmittedResultManifest(value         )                                     {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new TypeError("native capture-result manifest must be an object");
-	const body = value                           ;
-	const text = (key        )         => {
-		const found = body[key];
-		if (typeof found !== "string" || found.trim() !== found || found.length === 0) throw new TypeError(`native capture-result manifest ${key} must be a non-empty trimmed string`);
-		return found;
-	};
-	const schema = text("schema");
-	if (schema !== "gentle-ai.review-result-artifact/v2") throw new TypeError(`native capture-result manifest schema must be gentle-ai.review-result-artifact/v2, received ${schema}`);
-	const admission = text("admission_decision");
-	if (admission !== "completed") throw new TypeError(`native capture-result manifest admission_decision must be completed, received ${admission}`);
-	// Exactly one locator: a provider-owned path OR an opaque reference. Both or
-	// neither means the manifest cannot be handed to FINALIZE.
-	const hasPath = body.path !== undefined, hasReference = body.reference !== undefined;
-	if (hasPath === hasReference) throw new TypeError("native capture-result manifest must carry exactly one of path or reference");
+	// The admission answer routes through the exact-identity forward decoder
+	// (decoder-freshness discipline): the complete live envelope — identity
+	// constants, binding fields, and the exactly-one-locator rule — is
+	// validated before anything is handed to FINALIZE, and an unknown field
+	// grown by gentle-ai main is rejected instead of silently dropped.
+	const artifact = decodeReviewResultArtifactV2(value);
 	return Object.freeze({
-		schema,
-		subjectHash: text("subject_hash"),
-		admissionDecision: admission,
-		...(body.lens === undefined ? {} : { lens: text("lens") }),
-		...(hasPath ? { path: text("path") } : { reference: text("reference") }),
+		schema: artifact.schema,
+		subjectHash: artifact.subjectHash,
+		admissionDecision: artifact.admissionDecision,
+		lens: artifact.lens,
+		...(artifact.path === undefined ? {} : { path: artifact.path }),
+		...(artifact.reference === undefined ? {} : { reference: artifact.reference }),
 	});
 }
 

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1970,3 +1970,54 @@ export function decodeReviewRepairV2(value         )                 {
 		raw: body,
 	};
 }
+
+// ---------------------------------------------------------------------------
+// result-artifact/v2 — the `review capture-result` admission answer
+// ---------------------------------------------------------------------------
+
+// The provider's admitted-reviewer-result envelope, printed by `review
+// capture-result` when a reviewer result is admitted and re-discovered by
+// STATUS artifact discovery. Unlike the negotiated envelopes above it carries
+// no `contract`/`operation` identity pair — the schema constant plus the
+// capability constant are its complete identity (vendored ground truth:
+// contracts/review-integration/v1/schemas/result-artifact-v2.schema.json,
+// confirmed against a live 2.4.0-main capture; the v2.2.3 pinned emitter
+// shares the exact same struct). Exactly one locator is present: a
+// provider-owned store `path`, or the opaque `rart1_` `reference` minted for
+// repository-context captures.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+export function decodeReviewResultArtifactV2(value         )                         {
+	const body = exactRecord(value, "result_artifact", ["schema", "capability", "sha256", "lineage_id", "target_identity", "lens", "selected_order", "subject_hash", "admission_decision"], ["path", "reference"]);
+	if (body.schema !== "gentle-ai.review-result-artifact/v2") throw new TypeError("result_artifact.schema must be gentle-ai.review-result-artifact/v2");
+	if (body.capability !== "review.native_result_artifact") throw new TypeError("result_artifact.capability must be review.native_result_artifact");
+	if (body.admission_decision !== "completed") throw new TypeError("result_artifact.admission_decision must be completed");
+	if ((body.path === undefined) === (body.reference === undefined)) throw new TypeError("result_artifact must carry exactly one of path or reference");
+	return {
+		schema: "gentle-ai.review-result-artifact/v2",
+		capability: "review.native_result_artifact",
+		sha256: sha256(body.sha256, "result_artifact.sha256"),
+		lineageId: lineage(body.lineage_id, "result_artifact.lineage_id"),
+		targetIdentity: sha256(body.target_identity, "result_artifact.target_identity"),
+		lens: enumeration(body.lens, REVIEW_LENSES, "result_artifact.lens"),
+		selectedOrder: integer(body.selected_order, "result_artifact.selected_order", 0, 3),
+		subjectHash: sha256(body.subject_hash, "result_artifact.subject_hash"),
+		admissionDecision: "completed",
+		...(body.path === undefined ? {} : { path: nonempty(body.path, "result_artifact.path") }),
+		...(body.reference === undefined ? {} : { reference: text(body.reference, "result_artifact.reference", { pattern: /^rart1_[0-9a-f]{64}$/ }) }),
+		raw: body,
+	};
+}

--- a/tests/crosslane/cross-lane.mjs
+++ b/tests/crosslane/cross-lane.mjs
@@ -39,6 +39,7 @@ import {
 	decodeReviewCapabilitiesV2,
 	decodeReviewConsentV3,
 	decodeReviewOperationV2,
+	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
 	decodeReviewStatusV3,
 } from "../../runtime/review-integration-v2.mjs";
@@ -456,6 +457,8 @@ function decoderFor(schema, binaryDigest) {
 			return (body) => decodeReviewConsentV3(body);
 		case "gentle-ai.review-integration.operation/v2":
 			return (body) => decodeReviewOperationV2(body);
+		case "gentle-ai.review-result-artifact/v2":
+			return (body) => decodeReviewResultArtifactV2(body);
 		case "gentle-ai.review-integration.capabilities/v2":
 		case "gentle-ai.review-integration.capabilities/v2.1":
 		case "gentle-ai.review-integration.capabilities/v2.2":

--- a/tests/fixtures/devbinary/result-artifact-v2-path.captured.json
+++ b/tests/fixtures/devbinary/result-artifact-v2-path.captured.json
@@ -1,0 +1,12 @@
+{
+  "schema": "gentle-ai.review-result-artifact/v2",
+  "capability": "review.native_result_artifact",
+  "path": "/tmp/claude-1000/-home-gentleman-work-gentle-ai/7629c2de-8b8b-4005-b117-ab45c0869f70/scratchpad/rart-capture/.git/gentle-ai/review-transactions/v2/review-ceeb2b862bd39709/reviewer-results/00-review-reliability.json",
+  "sha256": "sha256:c8b2d0ce70f22ff924447fe591dab4b4008e0b6cd7d4ac884439eaf6e47bd26e",
+  "lineage_id": "review-ceeb2b862bd39709",
+  "target_identity": "sha256:ceeb2b862bd39709a0c1d2642ba89711127de7e859d6c008bf1add73e4dc783e",
+  "lens": "review-reliability",
+  "selected_order": 0,
+  "subject_hash": "sha256:6952f7ea0b589d882201943449b3f4ab9505551ad306460ee7bebc6b4671ae1e",
+  "admission_decision": "completed"
+}

--- a/tests/fixtures/devbinary/result-artifact-v2.captured.json
+++ b/tests/fixtures/devbinary/result-artifact-v2.captured.json
@@ -1,0 +1,12 @@
+{
+  "schema": "gentle-ai.review-result-artifact/v2",
+  "capability": "review.native_result_artifact",
+  "reference": "rart1_ade967893b51f2e280f5393f154fe9e232b6cb8c22fd60b2ba65b301e8e23d47",
+  "sha256": "sha256:c8b2d0ce70f22ff924447fe591dab4b4008e0b6cd7d4ac884439eaf6e47bd26e",
+  "lineage_id": "review-ceeb2b862bd39709",
+  "target_identity": "sha256:ceeb2b862bd39709a0c1d2642ba89711127de7e859d6c008bf1add73e4dc783e",
+  "lens": "review-reliability",
+  "selected_order": 0,
+  "subject_hash": "sha256:6952f7ea0b589d882201943449b3f4ab9505551ad306460ee7bebc6b4671ae1e",
+  "admission_decision": "completed"
+}

--- a/tests/review-controller-native-recovery.test.ts
+++ b/tests/review-controller-native-recovery.test.ts
@@ -845,13 +845,20 @@ test("REPAIR_LEGACY_ALIAS derives fixed inputs from fresh inventory and requires
 // Pi passes the transition's tokens through verbatim and adds only --input.
 test("captureResult passes the provider tokens through verbatim and carries no --contract", async (t) => {
 	t.after(() => clearNativeReviewCapabilitiesCacheForTesting());
+	// The full live envelope shape, confirmed against real capture-result runs
+	// on both the pinned line and gentle-ai main (tests/fixtures/devbinary/
+	// result-artifact-v2.captured.json): the opaque locator prefix is rart1_.
 	const manifest = {
 		schema: "gentle-ai.review-result-artifact/v2",
 		capability: "review.native_result_artifact",
+		reference: "rart1_" + "b".repeat(64),
+		sha256: "sha256:" + "f".repeat(64),
+		lineage_id: "review-1d5aadacc600e167",
+		target_identity: "sha256:" + "d".repeat(64),
+		lens: "review-reliability",
+		selected_order: 0,
 		subject_hash: "sha256:" + "a".repeat(64),
 		admission_decision: "completed",
-		lens: "review-reliability",
-		reference: "rref1_" + "b".repeat(64),
 	};
 	const { adapter, calls } = queuedAdapter([{ stdout: JSON.stringify(manifest) }]);
 	const cli = new NativeReviewCliV216(adapter, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024, async () => undefined, () => "dcc846103b16d365eaeeb9d7f289c23fc4f2897f23def1cb3fe7f05557b64705");
@@ -882,6 +889,45 @@ test("captureResult passes the provider tokens through verbatim and carries no -
 	assert.equal(argv.at(-2), "--input");
 	assert.match(argv.at(-1) as string, /\S/);
 	assert.equal(argv.length, 2 + tokens.length + 2);
+});
+
+// The admission answer routes through the exact-identity forward decoder:
+// a manifest missing its binding fields (the shape no real binary ever
+// emitted) or carrying a foreign locator prefix is refused, never partially
+// consumed. This is the decoder-freshness discipline reaching the consumer.
+test("captureResult refuses an under-specified or foreign-locator manifest", async (t) => {
+	t.after(() => clearNativeReviewCapabilitiesCacheForTesting());
+	const full = {
+		schema: "gentle-ai.review-result-artifact/v2",
+		capability: "review.native_result_artifact",
+		reference: "rart1_" + "b".repeat(64),
+		sha256: "sha256:" + "f".repeat(64),
+		lineage_id: "review-1d5aadacc600e167",
+		target_identity: "sha256:" + "d".repeat(64),
+		lens: "review-reliability",
+		selected_order: 0,
+		subject_hash: "sha256:" + "a".repeat(64),
+		admission_decision: "completed",
+	};
+	const legacyPartial = {
+		schema: full.schema,
+		capability: full.capability,
+		subject_hash: full.subject_hash,
+		admission_decision: full.admission_decision,
+		lens: full.lens,
+		reference: full.reference,
+	};
+	for (const body of [
+		legacyPartial,
+		{ ...full, reference: "rref1_" + "b".repeat(64) },
+		{ ...full, unadvertised: true },
+	]) {
+		const cli = new NativeReviewCliV216(async () => ({ stdout: JSON.stringify(body), stderr: "", exitCode: 0, signal: null, timedOut: false, outputLimitExceeded: false }), "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024, async () => undefined, () => "dcc846103b16d365eaeeb9d7f289c23fc4f2897f23def1cb3fe7f05557b64705");
+		await assert.rejects(cli.captureResult({
+			argumentTokens: ["--lineage=review-1d5aadacc600e167", "--repository-context=rctx1_" + "e".repeat(64)],
+			resultDocument: JSON.stringify({ subject_hash: full.subject_hash, inspection: { status: "completed", paths: ["a.ts"] }, findings: [], evidence: ["reviewed the complete frozen candidate scope"] }),
+		}));
+	}
 });
 
 test("captureEvidence stages exact bytes, uses the closed outcome argv, and decodes the native record", async (t) => {

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -6,6 +6,8 @@ import {
 	decodeReviewCapabilitiesV2,
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
+	decodeReviewOperationV2,
+	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
 	decodeReviewStatusV3,
 } from "../lib/review-integration-v2.ts";
@@ -60,6 +62,18 @@ import {
 //   live binary but MISSING from the published status-v5.schema.json
 //   (additionalProperties: false) at the same commit — the capture is
 //   authoritative (parity playbook, known traps).
+// - result-artifact-v2.captured.json and result-artifact-v2-path.captured.json
+//   were captured 2026-08-16 from the real binary at
+//   /home/gentleman/.cargo/bin/gentle-ai reporting
+//   "gentle-ai 2.4.0-main.b1afef46", in a scratch git repository holding a
+//   committed src/greet.js baseline plus an uncommitted shout() helper
+//   (medium tier, one review-reliability lens): consent-granted START, then
+//   the STATUS transition's exact `review capture-result` collect arguments
+//   with a completed reviewer input document. The reference form is the
+//   stdout of the --repository-context invocation (opaque rart1_ locator);
+//   the path form re-ran the exact same admitted slot with --cwd instead,
+//   which discovers the identical canonical bytes and answers with the
+//   provider-owned store path. Both agree on every binding field.
 
 const fixtureRoot = join(import.meta.dirname, "fixtures", "devbinary");
 const fixture = <T = Record<string, unknown>>(name: string): T => JSON.parse(readFileSync(join(fixtureRoot, name), "utf8")) as T;
@@ -418,4 +432,81 @@ test("start/v3 repository context event fields stay optional and exact", () => {
 	const extraKey = clone(base);
 	(extraKey.repository_context as JsonObject).unadvertised = true;
 	assert.throws(() => decodeReviewStartV3(extraKey), /not allowed/);
+});
+
+// --- result-artifact/v2: the `review capture-result` admission envelope ---
+
+test("the captured reference-form result artifact decodes with its rart1 locator", () => {
+	const artifact = decodeReviewResultArtifactV2(fixture("result-artifact-v2.captured.json"));
+	assert.equal(artifact.schema, "gentle-ai.review-result-artifact/v2");
+	assert.equal(artifact.capability, "review.native_result_artifact");
+	assert.match(artifact.reference ?? "", /^rart1_[0-9a-f]{64}$/);
+	assert.equal(artifact.path, undefined);
+	assert.equal(artifact.lineageId, "review-ceeb2b862bd39709");
+	assert.equal(artifact.lens, "review-reliability");
+	assert.equal(artifact.selectedOrder, 0);
+	assert.equal(artifact.admissionDecision, "completed");
+	assert.match(artifact.sha256, /^sha256:[0-9a-f]{64}$/);
+	assert.match(artifact.subjectHash, /^sha256:[0-9a-f]{64}$/);
+	assert.match(artifact.targetIdentity, /^sha256:[0-9a-f]{64}$/);
+});
+
+test("the captured path-form result artifact decodes with its provider-owned path", () => {
+	const artifact = decodeReviewResultArtifactV2(fixture("result-artifact-v2-path.captured.json"));
+	assert.equal(artifact.reference, undefined);
+	assert.match(artifact.path ?? "", /reviewer-results\/00-review-reliability\.json$/);
+	// Same admitted slot through both locator forms: every binding agrees.
+	const reference = decodeReviewResultArtifactV2(fixture("result-artifact-v2.captured.json"));
+	assert.equal(artifact.sha256, reference.sha256);
+	assert.equal(artifact.subjectHash, reference.subjectHash);
+	assert.equal(artifact.lineageId, reference.lineageId);
+	assert.equal(artifact.targetIdentity, reference.targetIdentity);
+});
+
+test("a result artifact carries exactly one locator", () => {
+	const base = fixture<JsonObject>("result-artifact-v2.captured.json");
+	const both = clone(base);
+	both.path = "/store/reviewer-results/00-review-reliability.json";
+	assert.throws(() => decodeReviewResultArtifactV2(both), /exactly one/);
+	const neither = clone(base);
+	delete neither.reference;
+	assert.throws(() => decodeReviewResultArtifactV2(neither), /exactly one/);
+});
+
+test("a result artifact rejects unknown keys and weakened bindings", () => {
+	const base = fixture<JsonObject>("result-artifact-v2.captured.json");
+	const extra = clone(base);
+	extra.unadvertised = true;
+	assert.throws(() => decodeReviewResultArtifactV2(extra), /not allowed/);
+	const wrongCapability = clone(base);
+	wrongCapability.capability = "review.result_artifact";
+	assert.throws(() => decodeReviewResultArtifactV2(wrongCapability), /capability/);
+	const unadmitted = clone(base);
+	unadmitted.admission_decision = "quarantined";
+	assert.throws(() => decodeReviewResultArtifactV2(unadmitted), /admission_decision/);
+	const foreignLocator = clone(base);
+	foreignLocator.reference = `rref1_${"b".repeat(64)}`;
+	assert.throws(() => decodeReviewResultArtifactV2(foreignLocator), /reference/);
+	const outOfRange = clone(base);
+	outOfRange.selected_order = 4;
+	assert.throws(() => decodeReviewResultArtifactV2(outOfRange), /selected_order/);
+});
+
+test("result artifact identities never cross-decode", () => {
+	// A prior identity rejects the new surface (it carries no negotiated
+	// contract/operation identity pair at all)...
+	assert.throws(() => decodeReviewOperationV2(fixture("result-artifact-v2.captured.json")), /contract|schema/);
+	// ...the new decoder pins its own exact identity...
+	const downgraded = clone(fixture<JsonObject>("result-artifact-v2.captured.json"));
+	downgraded.schema = "gentle-ai.review-result-artifact/v1";
+	assert.throws(() => decodeReviewResultArtifactV2(downgraded), /schema/);
+	// ...and rejects prior surfaces wholesale.
+	assert.throws(() => decodeReviewResultArtifactV2({
+		schema: "gentle-ai.review-provider-role-capture/v1",
+		lineage_id: "review-1d5aadacc600e167",
+		target_identity: `sha256:${"9".repeat(64)}`,
+		role: "targeted-validator",
+		captured: true,
+	}));
+	assert.throws(() => decodeReviewResultArtifactV2(v2Fixture("status.fixture.json")));
 });


### PR DESCRIPTION
## What

The cross-lane battery's freshness lane found no forward decoder for `gentle-ai.review-result-artifact/v2` (the `review capture-result` manifest). Battery-only gap — nothing broke live — but the direct lane's local parser read only 4 of the envelope's 10 fields and would never notice main growing or renaming one.

- `decodeReviewResultArtifactV2`: exact-record, identity consts pinned, `rart1_` pattern, exactly-one-of path/reference, cross-identity rejections locked both ways; the direct-lane consumer now delegates to it (pinned-safe: the 2.2.3 emitter shares the same struct); battery freshness lane maps the schema.
- Fixtures captured 2026-08-16 from the real binary (reference + path forms) with full provenance.

## Verification

Full `pnpm test` 1230 pass / 0 fail (override aside + restored, sha verified); provider-contract/transaction-runner/package-files green; `pnpm test:cross-lane` 10/10 with the override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for validated review-result artifacts using either file paths or opaque references.
  - Review results now preserve normalized metadata, including source identity, hashes, lineage, ordering, and review context.

- **Bug Fixes**
  - Strengthened result capture validation to reject incomplete, mismatched, duplicated, or unexpected data.
  - Invalid locator formats and results from unrelated sources are now rejected consistently.

- **Tests**
  - Added coverage for valid path- and reference-based artifacts, admission status, binding checks, and cross-identity rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->