### PR TITLE
fix(review): accept the v5 singular capture-result submission value form

### DIFF
--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -349,6 +349,14 @@ export interface ReviewCaptureSubmissionValueV1 {
 	slot: string;
 	domain: string;
 	substitutionLocation: number;
+	/**
+	 * status/v5 only: the artifact schema the substituted value must satisfy.
+	 * NEW optional member carried by the singular wire `value` form the live
+	 * 2.4.0-main binary emits for the materialize capture-result slot
+	 * (captured 2026-08-16 from 2.4.0-main.b1afef46); the legacy `values`
+	 * array rows never carry it and existing consumers stay untouched.
+	 */
+	schema?: string;
 }
 
 export interface ReviewCaptureSubmissionV1 {
@@ -1206,7 +1214,31 @@ function decodeTransitionArguments(value: unknown, label: string): readonly Revi
 	});
 }
 
-function decodeCaptureSubmission(value: unknown, label: string): ReviewCaptureSubmissionV1 {
+function decodeCaptureSubmission(value: unknown, label: string, v5: boolean): ReviewCaptureSubmissionV1 {
+	// status/v5: the live 2.4.0-main binary emits the materialize
+	// capture-result submission as a SINGULAR `value` object carrying a
+	// `schema` key (captured 2026-08-16 from 2.4.0-main.b1afef46; the
+	// emitter has been singular since gentle-ai f1a95179). The form is
+	// closed to that exact captured shape and normalizes into the typed
+	// one-entry values array the host relay already consumes. A payload
+	// carrying both wire forms at once matches no captured shape and falls
+	// through to the legacy decoder, which rejects the unknown `value` key.
+	if (v5 && typeof value === "object" && value !== null && "value" in value && !("values" in value)) {
+		const submission = exactRecord(value, label, ["operation_token", "argument_tokens", "value"]);
+		if (submission.operation_token !== "capture-result") throw new TypeError(`${label}.operation_token must be capture-result for the singular value form`);
+		const argumentTokens = stringArray(submission.argument_tokens, `${label}.argument_tokens`, { minimum: 1 });
+		const row = exactRecord(submission.value, `${label}.value`, ["slot", "domain", "schema", "substitution_location"]);
+		return {
+			operationToken: "capture-result",
+			argumentTokens,
+			values: [{
+				slot: enumeration(row.slot, ["reviewer_result"] as const, `${label}.value.slot`),
+				domain: nonempty(row.domain, `${label}.value.domain`),
+				schema: nonempty(row.schema, `${label}.value.schema`),
+				substitutionLocation: integer(row.substitution_location, `${label}.value.substitution_location`, 0, argumentTokens.length - 1),
+			}],
+		};
+	}
 	const submission = exactRecord(value, label, ["operation_token", "argument_tokens", "values"]);
 	const operationToken = text(submission.operation_token, `${label}.operation_token`, { minimum: 1, pattern: /^[a-z0-9-]+$/ });
 	const argumentTokens = stringArray(submission.argument_tokens, `${label}.argument_tokens`, { minimum: 1 });
@@ -1391,7 +1423,7 @@ function decodeCollectInput(value: unknown, label: string, v5: boolean): ReviewC
 		if (v5 && (operationToken === "finalize" || operationToken === "capture-evidence")) {
 			submissionDescriptor = decodeSubmissionDescriptorV5(input.submission, `${label}.submission`, operationToken);
 		} else {
-			submission = decodeCaptureSubmission(input.submission, `${label}.submission`);
+			submission = decodeCaptureSubmission(input.submission, `${label}.submission`, v5);
 		}
 	}
 

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -358,6 +358,14 @@ const REPOSITORY_CONTEXT_OUTCOMES = ["applied", "pending", "blocked_conflict", "
 
 
 
+
+
+
+
+
+
+
+
 // The two Go-owned non-lens provider role capture operations (gentle-pi#311
 // P4-roles; provider side gentle-ai#3264). Their collect inputs are
 // self-contained authority-advancing vectors: binding tokens plus
@@ -1207,7 +1215,31 @@ function decodeTransitionArguments(value         , label        )               
 	});
 }
 
-function decodeCaptureSubmission(value         , label        )                            {
+function decodeCaptureSubmission(value         , label        , v5         )                            {
+	// status/v5: the live 2.4.0-main binary emits the materialize
+	// capture-result submission as a SINGULAR `value` object carrying a
+	// `schema` key (captured 2026-08-16 from 2.4.0-main.b1afef46; the
+	// emitter has been singular since gentle-ai f1a95179). The form is
+	// closed to that exact captured shape and normalizes into the typed
+	// one-entry values array the host relay already consumes. A payload
+	// carrying both wire forms at once matches no captured shape and falls
+	// through to the legacy decoder, which rejects the unknown `value` key.
+	if (v5 && typeof value === "object" && value !== null && "value" in value && !("values" in value)) {
+		const submission = exactRecord(value, label, ["operation_token", "argument_tokens", "value"]);
+		if (submission.operation_token !== "capture-result") throw new TypeError(`${label}.operation_token must be capture-result for the singular value form`);
+		const argumentTokens = stringArray(submission.argument_tokens, `${label}.argument_tokens`, { minimum: 1 });
+		const row = exactRecord(submission.value, `${label}.value`, ["slot", "domain", "schema", "substitution_location"]);
+		return {
+			operationToken: "capture-result",
+			argumentTokens,
+			values: [{
+				slot: enumeration(row.slot, ["reviewer_result"]         , `${label}.value.slot`),
+				domain: nonempty(row.domain, `${label}.value.domain`),
+				schema: nonempty(row.schema, `${label}.value.schema`),
+				substitutionLocation: integer(row.substitution_location, `${label}.value.substitution_location`, 0, argumentTokens.length - 1),
+			}],
+		};
+	}
 	const submission = exactRecord(value, label, ["operation_token", "argument_tokens", "values"]);
 	const operationToken = text(submission.operation_token, `${label}.operation_token`, { minimum: 1, pattern: /^[a-z0-9-]+$/ });
 	const argumentTokens = stringArray(submission.argument_tokens, `${label}.argument_tokens`, { minimum: 1 });
@@ -1392,7 +1424,7 @@ function decodeCollectInput(value         , label        , v5         )         
 		if (v5 && (operationToken === "finalize" || operationToken === "capture-evidence")) {
 			submissionDescriptor = decodeSubmissionDescriptorV5(input.submission, `${label}.submission`, operationToken);
 		} else {
-			submission = decodeCaptureSubmission(input.submission, `${label}.submission`);
+			submission = decodeCaptureSubmission(input.submission, `${label}.submission`, v5);
 		}
 	}
 

--- a/tests/fixtures/devbinary/status-v5-capture-result-submission.captured.json
+++ b/tests/fixtures/devbinary/status-v5-capture-result-submission.captured.json
@@ -1,0 +1,184 @@
+{
+  "schema": "gentle-ai.review-integration.status/v5",
+  "contract": "gentle-ai.review-integration/v2",
+  "operation": "review.status",
+  "applicability": "current_target",
+  "authority": {
+    "version": "compact-v2",
+    "lineage_id": "review-c15e3de5404ab556",
+    "state": "reviewing",
+    "generation": 1,
+    "revision": "sha256:d6f2eeddd50606fb387daff489a17b612e923e501dc714c2952142a3c1d0e073"
+  },
+  "receipt": {
+    "status": "expected_missing"
+  },
+  "action": "finalize",
+  "replayability": "not_replayable",
+  "frozen": {
+    "tier": "medium",
+    "original_changed_lines": 3,
+    "correction_budget": 2
+  },
+  "target_identity": "sha256:c15e3de5404ab556a237a0a94f1d8d99e33e2ac6664877b2eefee0e210f8252a",
+  "projection": {
+    "schema": "gentle-ai.review-integration.projection/v1",
+    "kind": "current-changes",
+    "projection": "workspace",
+    "base_tree": "96c8f6a2eee2da821f202ee686b70c211bd9fd37",
+    "initial_review_tree": "6812ab6b7a19550f0dc49cee57518528c4479756",
+    "current_candidate_tree": "6812ab6b7a19550f0dc49cee57518528c4479756",
+    "paths_digest": "sha256:e9ec59a8b57bb461f3e06d58e57517e472c4d90560af0da03adcb8e80328cd25",
+    "paths": [
+      "src/add.js"
+    ],
+    "intended_untracked": [],
+    "intended_untracked_proof": "sha256:b97229718d4c7fe50a8892eb474ae5aa6491697bccb400e3e31dbaca4894d2f3",
+    "initial_snapshot_identity": "sha256:c15e3de5404ab556a237a0a94f1d8d99e33e2ac6664877b2eefee0e210f8252a",
+    "current_snapshot_identity": "sha256:c15e3de5404ab556a237a0a94f1d8d99e33e2ac6664877b2eefee0e210f8252a"
+  },
+  "repair": {
+    "schema": "gentle-ai.review-authority-repair-assessment/v1",
+    "status": "unsupported",
+    "counts": {
+      "lineages": 0,
+      "compact_lineages": 0,
+      "legacy_lineages": 0,
+      "events": 0,
+      "bytes": 0,
+      "eligible_candidates": 0,
+      "unsupported_lineages": 0,
+      "conflicts": 0
+    },
+    "supported_operations": [
+      "review/complete-fix",
+      "review/validate-fix"
+    ],
+    "authorization_schema": "gentle-ai.review-repair-authorization/v1"
+  },
+  "candidates": [],
+  "forecast": {
+    "horizon": "partial",
+    "steps": [
+      {
+        "step": 1,
+        "kind": "collect",
+        "reason_code": "reviewer_results_required",
+        "description": "Reviewer lens artifacts required for current revision"
+      }
+    ]
+  },
+  "next_transition": {
+    "kind": "collect",
+    "reason_code": "reviewer_results_required",
+    "collect": {
+      "inputs": [
+        {
+          "name": "reviewer_result",
+          "schema": "https://gentle-ai.dev/schema/review/reviewer/v1",
+          "capture_operation": "review.capture-result",
+          "arguments": [
+            {
+              "name": "lineage",
+              "value": "review-c15e3de5404ab556",
+              "token": "--lineage=review-c15e3de5404ab556"
+            },
+            {
+              "name": "expected-revision",
+              "value": "sha256:d6f2eeddd50606fb387daff489a17b612e923e501dc714c2952142a3c1d0e073",
+              "token": "--expected-revision=sha256:d6f2eeddd50606fb387daff489a17b612e923e501dc714c2952142a3c1d0e073"
+            },
+            {
+              "name": "target",
+              "value": "sha256:c15e3de5404ab556a237a0a94f1d8d99e33e2ac6664877b2eefee0e210f8252a",
+              "token": "--target=sha256:c15e3de5404ab556a237a0a94f1d8d99e33e2ac6664877b2eefee0e210f8252a"
+            },
+            {
+              "name": "repository-context",
+              "value": "rctx1_383ac1f99ddd81b78db104959b5c7d853de3514ed5cbcccddf53463a05e22989",
+              "token": "--repository-context=rctx1_383ac1f99ddd81b78db104959b5c7d853de3514ed5cbcccddf53463a05e22989"
+            },
+            {
+              "name": "lens",
+              "value": "review-reliability",
+              "token": "--lens=review-reliability"
+            },
+            {
+              "name": "order",
+              "value": "0",
+              "token": "--order=0"
+            },
+            {
+              "name": "subject-hash",
+              "value": "sha256:717aafba627b961e8bf8c1d40e20961475e7e48da7addb635172c62f2c8b8c15",
+              "token": "--subject-hash=sha256:717aafba627b961e8bf8c1d40e20961475e7e48da7addb635172c62f2c8b8c15"
+            },
+            {
+              "name": "agent",
+              "value": "pi",
+              "token": "--agent=pi"
+            },
+            {
+              "name": "materialize",
+              "value": "true",
+              "token": "--materialize=true"
+            }
+          ],
+          "submission": {
+            "operation_token": "capture-result",
+            "argument_tokens": [
+              "--lineage=review-c15e3de5404ab556",
+              "--expected-revision=sha256:d6f2eeddd50606fb387daff489a17b612e923e501dc714c2952142a3c1d0e073",
+              "--target=sha256:c15e3de5404ab556a237a0a94f1d8d99e33e2ac6664877b2eefee0e210f8252a",
+              "--repository-context=rctx1_383ac1f99ddd81b78db104959b5c7d853de3514ed5cbcccddf53463a05e22989",
+              "--lens=review-reliability",
+              "--order=0",
+              "--subject-hash=sha256:717aafba627b961e8bf8c1d40e20961475e7e48da7addb635172c62f2c8b8c15",
+              "--input={{value}}"
+            ],
+            "value": {
+              "slot": "reviewer_result",
+              "domain": "artifact_path_or_stdin",
+              "schema": "https://gentle-ai.dev/schema/review/reviewer/v1",
+              "substitution_location": 7
+            }
+          },
+          "artifact_subject": {
+            "schema": "gentle-ai.review-artifact-subject/v2",
+            "subject_hash": "sha256:717aafba627b961e8bf8c1d40e20961475e7e48da7addb635172c62f2c8b8c15",
+            "lineage_id": "review-c15e3de5404ab556",
+            "authority_revision": "sha256:d6f2eeddd50606fb387daff489a17b612e923e501dc714c2952142a3c1d0e073",
+            "target_identity": "sha256:c15e3de5404ab556a237a0a94f1d8d99e33e2ac6664877b2eefee0e210f8252a",
+            "base_tree": "96c8f6a2eee2da821f202ee686b70c211bd9fd37",
+            "candidate_tree": "6812ab6b7a19550f0dc49cee57518528c4479756",
+            "changed_path_manifest_sha256": "sha256:247cb9ffff17f6f97cf3fbeca795889a281805f676c53c204b319735a3eaf4dd",
+            "lens": "review-reliability",
+            "selected_order": 0
+          },
+          "base_tree": "96c8f6a2eee2da821f202ee686b70c211bd9fd37",
+          "candidate_tree": "6812ab6b7a19550f0dc49cee57518528c4479756",
+          "changed_path_manifest": [
+            {
+              "path": "src/add.js",
+              "status": "M",
+              "old_mode": "100644",
+              "new_mode": "100644",
+              "deleted": false,
+              "type_changed": false,
+              "mode_only": false,
+              "intended_untracked": false
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "repository_context": {
+    "capability": "review.opaque_repository_context",
+    "handle": "rctx1_383ac1f99ddd81b78db104959b5c7d853de3514ed5cbcccddf53463a05e22989",
+    "revision": "sha256:d6f2eeddd50606fb387daff489a17b612e923e501dc714c2952142a3c1d0e073",
+    "target_identity": "sha256:c15e3de5404ab556a237a0a94f1d8d99e33e2ac6664877b2eefee0e210f8252a",
+    "event_id": "sha256:de35d1d7dc457f1157752f9d1bca95b15dd964d82ecabd8c9f2ffacc6ceacc2d",
+    "outcome": "applied"
+  }
+}

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -74,6 +74,21 @@ import {
 //   the path form re-ran the exact same admitted slot with --cwd instead,
 //   which discovers the identical canonical bytes and answers with the
 //   provider-owned store path. Both agree on every binding field.
+// - status-v5-capture-result-submission.captured.json was captured 2026-08-16
+//   from the real binary at /home/gentleman/.cargo/bin/gentle-ai reporting
+//   "gentle-ai 2.4.0-main.b1afef46", in a scratch git repository holding a
+//   committed src/add.js baseline plus an uncommitted double() helper
+//   (medium tier, one review-reliability lens), with
+//   GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1 exported:
+//   negotiated STATUS (--agent pi), the rendered consent/v3 START, its exact
+//   granted invocation, then
+//     gentle-ai review status --contract gentle-ai.review-integration/v2 \
+//       --cwd <scratch> --agent pi --next-transition
+//   at reviewer_results_required. Its materialize capture-result collect
+//   input carries the submission descriptor as a SINGULAR `value` object
+//   with a `schema` key (emitter: gentle-ai f1a95179, singular from its
+//   first commit) — not the `values` array this decoder was originally
+//   written against. The capture is authoritative.
 
 const fixtureRoot = join(import.meta.dirname, "fixtures", "devbinary");
 const fixture = <T = Record<string, unknown>>(name: string): T => JSON.parse(readFileSync(join(fixtureRoot, name), "utf8")) as T;
@@ -318,6 +333,72 @@ test("a v5 provider role task input decodes and is confined to external.run_prov
 	const misplaced = fixture<JsonObject>("status-v5.captured.json");
 	(((misplaced.next_transition as JsonObject).collect as JsonObject).inputs as JsonObject[])[0]!.provider_task = providerTask;
 	assert.throws(() => decodeReviewStatusV3(misplaced), /provider_task/);
+});
+
+// --- v5 pi materialize capture-result submission: the singular `value` form ---
+
+test("the captured v5 materialize capture-result submission decodes its singular value form", () => {
+	const status = decodeReviewStatusV3(fixture("status-v5-capture-result-submission.captured.json"));
+	assert.equal(status.authority?.state, "reviewing");
+	assert.equal(status.nextTransition?.reasonCode, "reviewer_results_required");
+	const input = status.nextTransition?.collect?.inputs[0];
+	assert.equal(input?.captureOperation, "review.capture-result");
+	assert.equal(input?.submissionDescriptor, undefined);
+	assert.equal(input?.submission?.operationToken, "capture-result");
+	// The singular wire `value` normalizes into the typed one-entry values
+	// array the host relay already consumes.
+	assert.deepEqual(input?.submission?.values, [{
+		slot: "reviewer_result",
+		domain: "artifact_path_or_stdin",
+		schema: "https://gentle-ai.dev/schema/review/reviewer/v1",
+		substitutionLocation: 7,
+	}]);
+});
+
+test("the v5 singular capture-result value form is closed to its captured shape", () => {
+	const base = fixture<JsonObject>("status-v5-capture-result-submission.captured.json");
+	const withSubmission = (mutate: (submission: JsonObject) => void): JsonObject => {
+		const body = clone(base);
+		mutate((((body.next_transition as JsonObject).collect as JsonObject).inputs as JsonObject[])[0]!.submission as JsonObject);
+		return body;
+	};
+	// Carrying both wire forms at once matches no captured shape.
+	assert.throws(() => decodeReviewStatusV3(withSubmission((submission) => {
+		submission.values = [submission.value];
+	})), /value/);
+	// The singular form owns no numeric or enumerated domain: minimum,
+	// maximum, and allowed_values belong to the finalize/capture-evidence
+	// descriptor forms only.
+	for (const [key, smuggled] of [["minimum", 1], ["maximum", 2], ["allowed_values", ["x"]]] as const) {
+		assert.throws(() => decodeReviewStatusV3(withSubmission((submission) => {
+			(submission.value as JsonObject)[key] = smuggled;
+		})), /not allowed/);
+	}
+	// The captured form always names its reviewer schema and slot.
+	assert.throws(() => decodeReviewStatusV3(withSubmission((submission) => {
+		delete (submission.value as JsonObject).schema;
+	})), /schema/);
+	assert.throws(() => decodeReviewStatusV3(withSubmission((submission) => {
+		(submission.value as JsonObject).slot = "validation";
+	})), /slot/);
+	assert.throws(() => decodeReviewStatusV3(withSubmission((submission) => {
+		submission.operation_token = "finalize-relay";
+	})), /operation_token/);
+	// The legacy values-array rows stay exactly as they were: they never
+	// learned the schema key the singular form carries.
+	assert.throws(() => decodeReviewStatusV3(withSubmission((submission) => {
+		const row = submission.value as JsonObject;
+		delete submission.value;
+		submission.values = [row];
+	})), /not allowed/);
+});
+
+test("the v3 identity keeps rejecting the singular capture-result value form", () => {
+	const body = clone(fixture<JsonObject>("status-v5-capture-result-submission.captured.json"));
+	body.schema = "gentle-ai.review-integration.status/v3";
+	delete body.forecast;
+	delete body.repository_context;
+	assert.throws(() => decodeReviewStatusV3(body), /values is required/);
 });
 
 test("the v3 next transition keeps rejecting every v5-only surface", () => {


### PR DESCRIPTION
## What

The battery's with-host tier found the capture-result submission decoder rejecting gentle-ai main's live shape: `decodeCaptureSubmission` demanded a `values` ARRAY that the emitter NEVER produced for capture-result (singular `value` + `schema` from birth — no fixture was ever captured when the decoder was written). Negotiated STATUS at `reviewer_results_required --agent pi` failed to decode entirely under the dev-binary override; battery/forward-only (no published tag emits this submission).

v5-identity-gated singular branch closed to the captured shape (token `capture-result`, slot `reviewer_result`, mandatory `schema`), normalized into the existing typed array so the host-relay consumer is untouched; legacy `values` path byte-identical; cross-shape/cross-identity rejections pinned; fixture captured with full provenance.

## Verification

Full `pnpm test` 1233 pass / 0 fail (override aside + restored, sha verified); transaction-runner/provider-contract/package-files green; `pnpm test:cross-lane` 10/10 with the override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for singular `value` payloads in v5 `capture-result` submissions.
  - Capture results can now include an optional schema identifier.
  - Valid v5 payloads are normalized for consistent downstream processing.

- **Bug Fixes**
  - Added validation for operation, slot, schema, and substitution details.
  - Invalid or conflicting payload fields are rejected.

- **Compatibility**
  - Existing multi-value and legacy submission formats continue to work unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->