### PR TITLE
fix(review): execute provider-rendered collect submission tokens verbatim

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -136,13 +136,14 @@ import {
 	sanitizeForeignNativeReviewDiagnostics,
 	type NativeReviewCli,
 	type NativeFinalizeResult,
+	type NativeReviewVerificationEvidenceV2,
 	type NativeReviewModeOperation,
 	type NativeReviewModeSource,
 	type NativeReviewProcessDiagnostics,
 	type NativeStartResult,
 	type NativeValidateResult,
 } from "../lib/native-review-cli.ts";
-import type { ReviewConsentEnvelope, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+import type { ReviewCollectInputV3, ReviewConsentEnvelope, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 import { assertDistinctCorrectionEvidence, resolveCorrectionStep, type CorrectionEvidence, type CorrectionOutcome, type CorrectionStep } from "../lib/review-correction-lifecycle.ts";
 import { recordReviewConsentLatch } from "../lib/review-consent-latch.ts";
 
@@ -5127,7 +5128,7 @@ function isTargetedValidationCollectInput(input: { captureOperation: string }): 
 	return input.captureOperation === "external.run_targeted_validation" || input.captureOperation === "review.capture-validation";
 }
 
-function requireEvidenceCollection(status: ReviewStatusV3): void {
+function requireEvidenceCollection(status: ReviewStatusV3): ReviewCollectInputV3 {
 	const inputs = status.nextTransition?.kind === "collect" ? status.nextTransition.collect?.inputs ?? [] : [];
 	// An offered validation STEP is a targeted-validation collect input. The
 	// bare `validation_request` field is descriptive context both live
@@ -5138,9 +5139,133 @@ function requireEvidenceCollection(status: ReviewStatusV3): void {
 	if (inputs.some(isTargetedValidationCollectInput)) {
 		throw new CandidateViewError("targeted validation was offered before correction evidence was captured", "evidence-first-ordering");
 	}
-	if (inputs.filter((input) => input.captureOperation === "review.capture-evidence").length !== 1) {
+	const evidence = inputs.filter((input) => input.captureOperation === "review.capture-evidence");
+	if (evidence.length !== 1) {
 		throw new CandidateViewError("provider status must collect exactly one correction evidence record before targeted validation", "evidence-first-ordering");
 	}
+	return evidence[0]!;
+}
+
+interface EvidenceCaptureBinding {
+	/** The identity the collect slot demands; the top-level status identity only as a pre-slot compatibility fallback. */
+	readonly targetIdentity: string;
+	readonly expectedRevision: string;
+	/** True when the slot rendered its own target identity; the record binds the slot's (fix-diff) scope, not the frozen projection scope. */
+	readonly slotBound: boolean;
+	readonly submission?: {
+		readonly argumentTokens: readonly string[];
+		readonly outcomeSubstitutionLocation: number;
+		readonly inputSubstitutionLocation: number;
+		readonly carriesRepositoryContext: boolean;
+	};
+}
+
+// Field defect (fambig, 2026-08-16): at every evidence-pending sub-state the
+// collect slot renders the identity native demands — for a correction that is
+// the FIX-DIFF identity, never the top-level live workspace snapshot identity.
+// Collect satisfaction binds to the slot's rendered arguments and submission
+// tokens; top-level status fields remain only a compatibility fallback for
+// pre-v5 emitters whose slots render no identities.
+function resolveEvidenceCaptureBinding(slot: ReviewCollectInputV3, status: ReviewStatusV3, lineageId: string, outcome: CorrectionOutcome): EvidenceCaptureBinding {
+	const named = new Map(slot.arguments.map((argument) => [argument.name, argument.value]));
+	const slotLineage = named.get("lineage");
+	if (slotLineage !== undefined && slotLineage !== lineageId) {
+		throw new CandidateViewError("provider evidence collect slot is bound to a different lineage", "correction-evidence-binding-drift");
+	}
+	const slotRevision = named.get("expected-revision");
+	if (slotRevision !== undefined && slotRevision !== status.authority?.revision) {
+		throw new CandidateViewError("provider evidence collect slot is bound to a different authority revision", "correction-evidence-binding-drift");
+	}
+	const slotTarget = named.get("target");
+	const binding = {
+		targetIdentity: slotTarget ?? status.targetIdentity,
+		expectedRevision: slotRevision ?? status.authority!.revision,
+		slotBound: slotTarget !== undefined,
+	};
+	const descriptor = slot.submissionDescriptor;
+	if (descriptor === undefined || descriptor.operationToken !== "capture-evidence") return binding;
+	const outcomeSlot = descriptor.values?.find((value) => value.slot === "outcome");
+	const inputSlot = descriptor.values?.find((value) => value.slot === "input");
+	if (outcomeSlot === undefined || inputSlot === undefined) {
+		throw new CandidateViewError("provider capture-evidence submission descriptor must render the outcome and input slots", "correction-evidence-binding-drift");
+	}
+	if (outcomeSlot.allowedValues !== undefined && !outcomeSlot.allowedValues.includes(outcome)) {
+		throw new CandidateViewError(`provider capture-evidence submission does not admit outcome ${outcome}`, "correction-evidence-binding-drift");
+	}
+	return {
+		...binding,
+		submission: {
+			argumentTokens: descriptor.argumentTokens,
+			outcomeSubstitutionLocation: outcomeSlot.substitutionLocation,
+			inputSubstitutionLocation: inputSlot.substitutionLocation,
+			carriesRepositoryContext: descriptor.argumentTokens.some((token) => token === "--repository-context" || token.startsWith("--repository-context=")),
+		},
+	};
+}
+
+async function captureEvidenceForCollection(
+	nativeReviewCli: NativeReviewCli,
+	binding: EvidenceCaptureBinding,
+	cwd: string,
+	lineageId: string,
+	outcome: CorrectionOutcome,
+	evidenceDocument: string,
+	signal: AbortSignal | undefined,
+): Promise<NativeReviewVerificationEvidenceV2> {
+	if (binding.submission !== undefined) {
+		if (nativeReviewCli.captureEvidenceSubmission === undefined) throw new CandidateViewError("native capture-evidence submission execution is unavailable", "evidence-first-ordering");
+		return nativeReviewCli.captureEvidenceSubmission({
+			// The slot's --repository-context is cwd-independent and
+			// authoritative; a path is passed only when the slot renders none.
+			...(binding.submission.carriesRepositoryContext ? {} : { cwd }),
+			argumentTokens: binding.submission.argumentTokens,
+			outcomeSubstitutionLocation: binding.submission.outcomeSubstitutionLocation,
+			inputSubstitutionLocation: binding.submission.inputSubstitutionLocation,
+			outcome,
+			evidenceDocument,
+			...(signal === undefined ? {} : { signal }),
+		});
+	}
+	if (nativeReviewCli.captureEvidence === undefined) throw new CandidateViewError("native capture-evidence execution is unavailable", "evidence-first-ordering");
+	return nativeReviewCli.captureEvidence({
+		cwd,
+		lineageId,
+		targetIdentity: binding.targetIdentity,
+		expectedRevision: binding.expectedRevision,
+		outcome,
+		evidenceDocument,
+		...(signal === undefined ? {} : { signal }),
+	});
+}
+
+// Same misbinding class as capture-evidence (live smoke, 2026-08-16): the
+// correction PLAN and TARGETED VALIDATION collect slots render `finalize`
+// submission descriptors. When one is rendered, the reconstructed legacy
+// `--correction-lines`/`--validation` argv fails the live emitter's
+// committed-intent reconciliation, so the rendered tokens execute verbatim.
+function finalizeSubmissionSlot(
+	status: ReviewStatusV3,
+	slot: "correction_lines" | "validation",
+): { argumentTokens: readonly string[]; value: NonNullable<NonNullable<ReviewCollectInputV3["submissionDescriptor"]>["value"]> } | undefined {
+	const inputs = status.nextTransition?.kind === "collect" ? status.nextTransition.collect?.inputs ?? [] : [];
+	for (const input of inputs) {
+		const descriptor = input.submissionDescriptor;
+		if (descriptor?.operationToken === "finalize" && descriptor.value?.slot === slot) {
+			return { argumentTokens: descriptor.argumentTokens, value: descriptor.value };
+		}
+	}
+	return undefined;
+}
+
+// A slot-bound record covers the slot-demanded (fix-diff) scope: its paths are
+// a subset of the frozen projection paths and its digest binds the record's
+// own paths (captured 2026-08-16, lineage review-2b6206ed68fb9128). Only the
+// pre-slot compatibility fallback still demands projection-exact paths.
+function evidencePathsDrift(captured: NativeReviewVerificationEvidenceV2, binding: EvidenceCaptureBinding, status: ReviewStatusV3): boolean {
+	if (binding.slotBound) {
+		return captured.paths.length === 0 || captured.paths.some((path) => !status.projection.paths.includes(path));
+	}
+	return captured.pathsDigest !== status.projection.pathsDigest || JSON.stringify([...captured.paths].sort()) !== JSON.stringify([...status.projection.paths].sort());
 }
 
 function requireTargetedValidationAfterEvidence(status: ReviewStatusV3): NonNullable<ReviewStatusV3["validationRequest"]> {
@@ -5153,7 +5278,10 @@ function requireTargetedValidationAfterEvidence(status: ReviewStatusV3): NonNull
 		// `validating` is retained for pre-existing fixture compatibility.
 		(status.authority?.state !== "validating" && status.authority?.state !== "correction_required") || targeted.length !== 1 || targeted[0]?.validationRequest === undefined || request === undefined ||
 		JSON.stringify(targeted[0].validationRequest) !== JSON.stringify(request) || request.lineageId !== status.authority.lineageId ||
-		request.expectedRevision !== status.authority.revision || request.targetIdentity !== status.targetIdentity ||
+		// The live emitter binds the request to the FROZEN authority target
+		// identity; the top-level target identity is the live workspace
+		// snapshot, which already contains the fix (probed 2026-08-16).
+		request.expectedRevision !== status.authority.revision || request.targetIdentity !== (status.authorityTargetIdentity ?? status.targetIdentity) ||
 		request.correctionCandidateTree !== status.projection.currentCandidateTree ||
 		JSON.stringify([...request.correctionPaths].sort()) !== JSON.stringify([...status.projection.paths].sort()) ||
 		request.correctionPathsDigest !== status.projection.pathsDigest
@@ -5787,6 +5915,21 @@ async function executeReviewControllerOperation(
 					provisionalCandidateView = undefined;
 					candidateView = undefined;
 				}
+				// Live smoke root cause (2026-08-16, dev binary 2.4.0-main):
+				// status/v5 mints the opaque --repository-context handle bound to
+				// the STATUS query root, and every rendered payload embeds it. A
+				// context minted from a frozen candidate-view root fails the live
+				// emitter's committed-intent reconciliation on the next lifecycle
+				// operation, so on v5 the lane rebinds its negotiated STATUS to
+				// the workspace root before executing any rendered payload.
+				// Pinned pre-v5 emitters keep the frozen-view status untouched.
+				if (statusCandidateRoot !== defaultCwd && (negotiatedStatus.raw as { schema?: unknown }).schema === "gentle-ai.review-integration.status/v5") {
+					const workspaceStatus = await nativeReviewCli.targetStatus({ cwd: defaultCwd, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
+					if (workspaceStatus.authority?.lineageId !== parameters.lineageId || workspaceStatus.authority.revision !== negotiatedStatus.authority.revision) {
+						throw new CandidateViewError("workspace-root status no longer matches the negotiated lifecycle authority", "workspace-status-rebind-drift");
+					}
+					negotiatedStatus = workspaceStatus;
+				}
 				// gentle-pi#311 P4: pi-slot capture inputs route through the host
 				// relay ONLY when the provider issued the --materialize token on
 				// the collect input. Every other slot and lane stays untouched.
@@ -5841,26 +5984,19 @@ async function executeReviewControllerOperation(
 						candidateViews.cleanup(candidateView.token);
 						candidateView = undefined;
 					}
-					if (nativeReviewCli.captureEvidence === undefined) throw new CandidateViewError("native final verification evidence capture is unavailable", "final-verification-provider-owned");
+					if (nativeReviewCli.captureEvidence === undefined && nativeReviewCli.captureEvidenceSubmission === undefined) throw new CandidateViewError("native final verification evidence capture is unavailable", "final-verification-provider-owned");
 					const outcome = correctionOutcome(input);
 					if (outcome === undefined || negotiatedStatus.authority === undefined) throw new CandidateViewError("native final verification evidence requires one authoritative outcome-bound status", "final-verification-provider-owned");
 					if (input.validation !== undefined) {
 						throw new CandidateViewError("native final verification is provider-owned; a targeted validation document is not admissible at state validating", "final-verification-provider-owned");
 					}
-					requireEvidenceCollection(negotiatedStatus);
-					const captured = await nativeReviewCli.captureEvidence({
-						cwd: defaultCwd,
-						lineageId: parameters.lineageId,
-						targetIdentity: negotiatedStatus.targetIdentity,
-						expectedRevision: negotiatedStatus.authority.revision,
-						outcome,
-						evidenceDocument: input.final_evidence!,
-						...(signal === undefined ? {} : { signal }),
-					});
+					const evidenceSlot = requireEvidenceCollection(negotiatedStatus);
+					const evidenceBinding = resolveEvidenceCaptureBinding(evidenceSlot, negotiatedStatus, parameters.lineageId, outcome);
+					const captured = await captureEvidenceForCollection(nativeReviewCli, evidenceBinding, defaultCwd, parameters.lineageId, outcome, input.final_evidence!, signal);
 					if (
-						captured.lineageId !== parameters.lineageId || captured.authorityRevision !== negotiatedStatus.authority.revision ||
-						captured.targetIdentity !== negotiatedStatus.targetIdentity || captured.candidateTree !== negotiatedStatus.projection.currentCandidateTree ||
-						captured.pathsDigest !== negotiatedStatus.projection.pathsDigest || JSON.stringify([...captured.paths].sort()) !== JSON.stringify([...negotiatedStatus.projection.paths].sort()) ||
+						captured.lineageId !== parameters.lineageId || captured.authorityRevision !== evidenceBinding.expectedRevision ||
+						captured.targetIdentity !== evidenceBinding.targetIdentity || captured.candidateTree !== negotiatedStatus.projection.currentCandidateTree ||
+						evidencePathsDrift(captured, evidenceBinding, negotiatedStatus) ||
 						captured.outcome !== outcome
 					) {
 						throw new CandidateViewError("captured final verification evidence does not match the requested lineage, target, and outcome", "correction-evidence-binding-drift");
@@ -5905,23 +6041,16 @@ async function executeReviewControllerOperation(
 					}
 				}
 				if (validationAttempt && !ordinaryFinalVerification && candidateView && parameters.lineageId) {
-					if (nativeReviewCli.captureEvidence === undefined) throw new CandidateViewError("native correction evidence capture is unavailable", "evidence-first-ordering");
+					if (nativeReviewCli.captureEvidence === undefined && nativeReviewCli.captureEvidenceSubmission === undefined) throw new CandidateViewError("native correction evidence capture is unavailable", "evidence-first-ordering");
 					const outcome = correctionOutcome(input);
 					if (outcome === undefined || negotiatedStatus.authority === undefined) throw new CandidateViewError("native correction evidence requires one authoritative outcome-bound status", "evidence-first-ordering");
-					requireEvidenceCollection(negotiatedStatus);
-					const captured = await nativeReviewCli.captureEvidence({
-						cwd: candidateView.root,
-						lineageId: parameters.lineageId,
-						targetIdentity: negotiatedStatus.targetIdentity,
-						expectedRevision: negotiatedStatus.authority.revision,
-						outcome,
-						evidenceDocument: input.final_evidence!,
-						...(signal === undefined ? {} : { signal }),
-					});
+					const evidenceSlot = requireEvidenceCollection(negotiatedStatus);
+					const evidenceBinding = resolveEvidenceCaptureBinding(evidenceSlot, negotiatedStatus, parameters.lineageId, outcome);
+					const captured = await captureEvidenceForCollection(nativeReviewCli, evidenceBinding, candidateView.root, parameters.lineageId, outcome, input.final_evidence!, signal);
 					if (
-						captured.lineageId !== parameters.lineageId || captured.authorityRevision !== negotiatedStatus.authority.revision ||
-						captured.targetIdentity !== negotiatedStatus.targetIdentity || captured.candidateTree !== negotiatedStatus.projection.currentCandidateTree || captured.candidateTree !== candidateView.candidateTree ||
-						captured.pathsDigest !== negotiatedStatus.projection.pathsDigest || JSON.stringify([...captured.paths].sort()) !== JSON.stringify([...negotiatedStatus.projection.paths].sort()) ||
+						captured.lineageId !== parameters.lineageId || captured.authorityRevision !== evidenceBinding.expectedRevision ||
+						captured.targetIdentity !== evidenceBinding.targetIdentity || captured.candidateTree !== negotiatedStatus.projection.currentCandidateTree || captured.candidateTree !== candidateView.candidateTree ||
+						evidencePathsDrift(captured, evidenceBinding, negotiatedStatus) ||
 						captured.outcome !== outcome
 					) {
 						throw new CandidateViewError("captured correction evidence does not match the requested lineage, target, and outcome", "correction-evidence-binding-drift");
@@ -5943,12 +6072,14 @@ async function executeReviewControllerOperation(
 					}
 					correctionStep = resolveCorrectionStep({
 						lineageId: parameters.lineageId,
-						targetIdentity: negotiatedStatus.targetIdentity,
-						authorityRevision: negotiatedStatus.authority.revision,
+						targetIdentity: evidenceBinding.targetIdentity,
+						authorityRevision: evidenceBinding.expectedRevision,
 						correctionBudget: negotiatedStatus.frozen?.correctionBudget ?? 0,
 						changedLinesCharged: 0,
 					}, evidence);
-					const afterEvidence = await nativeReviewCli.targetStatus({ cwd: candidateView.root, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
+					// Workspace-bound like the pre-capture rebind above: rendered
+					// validation payloads embed the context this status mints.
+					const afterEvidence = await nativeReviewCli.targetStatus({ cwd: defaultCwd, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
 					if (afterEvidence.authority?.lineageId !== parameters.lineageId) throw new CandidateViewError("post-evidence status lost the correction lineage", "correction-evidence-binding-drift");
 					if (correctionStep.kind === "recapture-required") {
 						assertNoTargetedValidation(afterEvidence);
@@ -5999,6 +6130,31 @@ async function executeReviewControllerOperation(
 					if (input.validation.request_hash !== validationRequest.requestHash.replace(/^sha256:/, "") || JSON.stringify([...input.validation.correction_ids].sort()) !== JSON.stringify([...validationRequest.fixFindingIds].sort())) {
 						throw new CandidateViewError("targeted validation document does not match the provider request", "targeted-validation-binding-drift");
 					}
+					const validationSubmission = finalizeSubmissionSlot(negotiatedStatus, "validation");
+					if (validationSubmission !== undefined) {
+						if (nativeReviewCli.finalizeSubmission === undefined) throw new CandidateViewError("native finalize submission execution is unavailable", "finalize-transition-binding-drift");
+						nativeResult = await nativeReviewCli.finalizeSubmission({
+							// The rendered tokens are self-contained (the opaque
+							// --repository-context binds the repository); the process
+							// runs from the authority workspace root — a frozen
+							// candidate-view root is a different toplevel of the same
+							// store and fails the live emitter's effect binding.
+							cwd: defaultCwd,
+							argumentTokens: validationSubmission.argumentTokens,
+							valueSubstitutionLocation: validationSubmission.value.substitutionLocation,
+							// The rendered submission consumes the raw validator
+							// artifact, so the request binding rides inside it.
+							valueDocument: JSON.stringify({
+								targeted_validation_request_hash: validationRequest.requestHash,
+								correction_target_identity: validationRequest.correctionTargetIdentity,
+								...toNativeValidatorDocument(input.validation),
+							}),
+							...(signal === undefined ? {} : { signal }),
+						});
+						if (nativeResult.lineageId !== parameters.lineageId) {
+							throw new CandidateViewError("provider finalize submission answered for a different lineage", "finalize-transition-binding-drift");
+						}
+					}
 				}
 				// gentle-pi#311 P5: when the provider's negotiated transition IS a
 				// review.finalize execution (captured_results_ready), run it exactly
@@ -6020,7 +6176,13 @@ async function executeReviewControllerOperation(
 						throw new CandidateViewError("provider finalize transition is bound to a different lineage", "finalize-transition-binding-drift");
 					}
 					nativeResult = await nativeReviewCli.finalizeTransition({
-						cwd: candidateView?.root ?? defaultCwd,
+						// The provider binds this transition's effects to the root
+						// the lifecycle runs from (live smoke, 2026-08-16): running
+						// the rendered vector from a frozen candidate-view root
+						// records a mismatched repository binding that fails every
+						// later committed-intent reconciliation. The workspace root
+						// IS the frozen candidate here; run from it.
+						cwd: defaultCwd,
 						// The exact rendered tokens, verbatim and in provider order.
 						// The provider tokenizes each argument itself; the hyphenated
 						// fallback mirrors its published rendering rule for older
@@ -6032,14 +6194,35 @@ async function executeReviewControllerOperation(
 						throw new CandidateViewError("provider finalize transition answered for a different lineage", "finalize-transition-binding-drift");
 					}
 				} else if (nativeResult === undefined) {
-					nativeResult = await nativeReviewCli.finalize({
-						cwd: candidateView?.root ?? defaultCwd,
-						...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
-						...(input.correction_line_forecast === undefined ? {} : { correctionLines: input.correction_line_forecast }),
-						...(input.validation === undefined ? {} : { validationDocument: toNativeValidatorDocument(input.validation) }),
-						...(input.final_evidence === undefined ? {} : { evidenceDocument: input.final_evidence, failed: input.final_verification_passed === false }),
-						...(signal === undefined ? {} : { signal }),
-					});
+					const planSubmission = input.correction_line_forecast === undefined ? undefined : finalizeSubmissionSlot(negotiatedStatus, "correction_lines");
+					if (planSubmission !== undefined) {
+						if (nativeReviewCli.finalizeSubmission === undefined) throw new CandidateViewError("native finalize submission execution is unavailable", "finalize-transition-binding-drift");
+						const forecast = input.correction_line_forecast!;
+						if ((planSubmission.value.minimum !== undefined && forecast < planSubmission.value.minimum) || (planSubmission.value.maximum !== undefined && forecast > planSubmission.value.maximum)) {
+							throw new CandidateViewError(`correction line forecast ${forecast} is outside the provider-rendered bounds`, "correction-forecast-out-of-bounds");
+						}
+						nativeResult = await nativeReviewCli.finalizeSubmission({
+							// Self-contained rendered tokens; run from the authority
+							// workspace root, never a frozen candidate-view root.
+							cwd: defaultCwd,
+							argumentTokens: planSubmission.argumentTokens,
+							valueSubstitutionLocation: planSubmission.value.substitutionLocation,
+							valueLiteral: String(forecast),
+							...(signal === undefined ? {} : { signal }),
+						});
+						if (parameters.lineageId !== undefined && nativeResult.lineageId !== parameters.lineageId) {
+							throw new CandidateViewError("provider finalize submission answered for a different lineage", "finalize-transition-binding-drift");
+						}
+					} else {
+						nativeResult = await nativeReviewCli.finalize({
+							cwd: candidateView?.root ?? defaultCwd,
+							...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
+							...(input.correction_line_forecast === undefined ? {} : { correctionLines: input.correction_line_forecast }),
+							...(input.validation === undefined ? {} : { validationDocument: toNativeValidatorDocument(input.validation) }),
+							...(input.final_evidence === undefined ? {} : { evidenceDocument: input.final_evidence, failed: input.final_verification_passed === false }),
+							...(signal === undefined ? {} : { signal }),
+						});
+					}
 				}
 			} catch (error) {
 				if (provisionalCandidateView && candidateViews) {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4999,6 +4999,7 @@ async function reconcileNativeMutationFailure(
 	error: unknown,
 	nativeReviewCli: NativeReviewCli,
 	target: { cwd: string; lineageId?: string; baseRef?: string; projection?: "workspace" | "staged" },
+	preOperationRevision?: string,
 ): Promise<Record<string, unknown>> {
 	const failure = nativeOperationFailure(operation, error);
 	if (!nativeMutationRequiresStatus(error)) return failure;
@@ -5022,6 +5023,28 @@ async function reconcileNativeMutationFailure(
 				reconciliation: status.raw,
 				authority_applicability: status.applicability,
 				...reconcileFinalizeRouting(status, target.lineageId, operation === REVIEW_CONTROLLER_OPERATION.FINALIZE),
+			};
+		}
+		// Field defect (fambig, 2026-08-16): an envelope-less mutating failure
+		// is stamped mutationOutcome "unknown", but a reconciled authority
+		// revision identical to the pre-operation revision PROVES the failed
+		// call never mutated. Report that proof as mutation_outcome none and
+		// claim no replay prohibition for it. Every genuinely ambiguous result
+		// — revision moved, no pre-operation revision held, or STATUS
+		// unavailable — stays fail-closed exactly as before.
+		if (preOperationRevision !== undefined && status.authority?.revision === preOperationRevision) {
+			const { replayability: staleReplayability, ...provenBase } = reconciledBase;
+			void staleReplayability;
+			return {
+				...provenBase,
+				outcome: "native-mutation-status-reconciled",
+				reconciliation: status.raw,
+				authority_applicability: status.applicability,
+				provider_action: status.action,
+				mutation_performed: false,
+				mutation_outcome: "none",
+				mutation_outcome_reason: `authority revision unchanged across reconciliation (${preOperationRevision}); the failed operation provably did not mutate`,
+				next_action: status.action,
 			};
 		}
 		return {
@@ -6235,7 +6258,7 @@ async function executeReviewControllerOperation(
 					cwd: candidateView?.root ?? defaultCwd,
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 					projection: "workspace",
-				});
+				}, negotiatedStatus?.authority?.revision);
 			}
 			try {
 				if (correctionCompletion && candidateViews && parameters.lineageId) candidateViews.promoteCorrected(parameters.lineageId, candidateView!.token);

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -139,6 +139,10 @@ export interface NativeReviewCli {
 	// evidence-first correction lifecycle's collection step.
 	repair?(request: NativeReviewRepairRequest): Promise<ReviewRepairV2>;
 	captureEvidence?(request: NativeReviewCaptureEvidenceRequest): Promise<NativeReviewVerificationEvidenceV2>;
+	// Executes one provider-rendered capture-evidence submission exactly as
+	// rendered (verbatim tokens with only the {{outcome}}/{{input}} slot
+	// substitutions); the preferred form whenever the collect slot renders one.
+	captureEvidenceSubmission?(request: NativeReviewCaptureEvidenceSubmissionRequest): Promise<NativeReviewVerificationEvidenceV2>;
 	// gentle-pi#311 P4-roles: executes one provider-rendered self-contained
 	// role capture vector exactly as rendered (verbatim tokens, foreground).
 	captureProviderRole?(request: NativeReviewProviderRoleCaptureRequest): Promise<NativeReviewProviderRoleCaptureArtifact>;
@@ -147,6 +151,10 @@ export interface NativeReviewCli {
 	// --captured-results=true`); the host never assembles reviewer, refuter,
 	// or validator documents for it.
 	finalizeTransition?(request: NativeReviewFinalizeTransitionRequest): Promise<NativeFinalizeResult>;
+	// Executes one provider-rendered `finalize` submission descriptor exactly
+	// as rendered, substituting only its {{value}} slot (plan line-count
+	// literal, or a staged validation artifact path).
+	finalizeSubmission?(request: NativeReviewFinalizeSubmissionRequest): Promise<NativeFinalizeResult>;
 	// Dark until a negotiated version reports the `mode` capability true
 	// (Design Decision #7, organic-rdd-parity). Plain versioned CLI operation,
 	// outside the negotiated review-integration protocol — same shape as
@@ -427,6 +435,27 @@ export interface NativeReviewCaptureEvidenceRequest {
 	signal?: AbortSignal;
 }
 
+// Field defect (fambig, 2026-08-16): the evidence collect slot renders the
+// exact submission tokens native admits — fix-diff `--target`,
+// `--expected-revision`, and an opaque cwd-independent `--repository-context` —
+// with `{{outcome}}`/`{{input}}` substitution slots. Satisfying the slot means
+// executing those tokens verbatim with only the two slot substitutions, the
+// same discipline captureResult uses; identities are never reconstructed from
+// top-level status fields.
+export interface NativeReviewCaptureEvidenceSubmissionRequest {
+	/** Process working directory; forbidden when the tokens carry --repository-context (the context is cwd-independent). */
+	cwd?: string;
+	/** Provider-rendered submission argument tokens, verbatim, in provider order. */
+	argumentTokens: readonly string[];
+	/** Index of the token carrying the {{outcome}} substitution slot. */
+	outcomeSubstitutionLocation: number;
+	/** Index of the token carrying the {{input}} substitution slot. */
+	inputSubstitutionLocation: number;
+	outcome: NativeReviewCaptureOutcome;
+	evidenceDocument: string;
+	signal?: AbortSignal;
+}
+
 export interface NativeReviewVerificationEvidenceV2 {
 	schema: "gentle-ai.review-verification-evidence/v2";
 	version: 2;
@@ -482,6 +511,24 @@ export interface NativeFinalizeRequest extends NativeReviewFinalizeCapturedResul
 export interface NativeReviewFinalizeTransitionRequest {
 	readonly cwd: string;
 	readonly argumentTokens: readonly string[];
+	readonly signal?: AbortSignal;
+}
+
+// The provider-rendered `finalize` submission descriptor forms (status/v5):
+// the correction PLAN slot substitutes a positive line-count literal into its
+// {{value}} token; the TARGETED VALIDATION slot substitutes a staged validator
+// artifact path. The tokens are self-contained and execute verbatim.
+export interface NativeReviewFinalizeSubmissionRequest {
+	/** Process working directory only; the rendered tokens are self-contained. */
+	readonly cwd: string;
+	/** Provider-rendered submission argument tokens, verbatim, in provider order. */
+	readonly argumentTokens: readonly string[];
+	/** Index of the token carrying the {{value}} substitution slot. */
+	readonly valueSubstitutionLocation: number;
+	/** The literal substitution (correction_lines). Exactly one of valueLiteral/valueDocument. */
+	readonly valueLiteral?: string;
+	/** The document to stage as a 0o600 artifact whose path substitutes {{value}} (validation). */
+	readonly valueDocument?: string;
 	readonly signal?: AbortSignal;
 }
 
@@ -2472,6 +2519,49 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			"review", "finalize",
 			...request.argumentTokens,
 		], true, request.signal);
+		return this.decodeFinalizeTransitionExecution(execution);
+	}
+
+	// Same misbinding class as capture-evidence (live smoke, 2026-08-16): the
+	// correction PLAN and TARGETED VALIDATION collect slots render `finalize`
+	// submission descriptors whose tokens are self-contained (--contract,
+	// --lineage, --expected-revision, --target, --request-hash,
+	// --repository-context) plus exactly one {{value}} slot. Executing anything
+	// other than those rendered tokens fails the live emitter's committed-
+	// intent reconciliation, so the tokens pass through verbatim with only the
+	// {{value}} substitution: a literal for correction_lines, a staged 0o600
+	// artifact path for a validation document.
+	async finalizeSubmission(request: NativeReviewFinalizeSubmissionRequest): Promise<NativeFinalizeResult> {
+		if (request.argumentTokens.length === 0) throw new TypeError("Native FINALIZE submission requires the provider-rendered argument tokens");
+		if (request.argumentTokens.some((token) => typeof token !== "string" || token.length === 0)) throw new TypeError("Native FINALIZE submission argument tokens must all be non-empty strings");
+		if ((request.valueLiteral === undefined) === (request.valueDocument === undefined)) throw new TypeError("Native FINALIZE submission takes exactly one of valueLiteral or valueDocument");
+		const valueToken = request.argumentTokens[request.valueSubstitutionLocation];
+		if (valueToken === undefined || !valueToken.includes("{{value}}")) throw new TypeError("Native FINALIZE submission must render exactly one {{value}} slot token");
+		if (request.valueDocument !== undefined && request.valueDocument.length === 0) throw new TypeError("Native FINALIZE submission value document must contain at least one byte");
+		const directory = request.valueDocument === undefined ? undefined : await mkdtemp(join(tmpdir(), "gentle-ai-finalize-submission-"));
+		try {
+			let substituted: string;
+			if (directory !== undefined) {
+				await chmod(directory, 0o700);
+				const valueFile = join(directory, "value.json");
+				await writeFile(valueFile, request.valueDocument!, { encoding: "utf8", mode: 0o600 });
+				await chmod(valueFile, 0o600);
+				substituted = valueFile;
+			} else {
+				substituted = request.valueLiteral!;
+			}
+			const resolved = request.argumentTokens.map((token, index) => index === request.valueSubstitutionLocation ? token.replaceAll("{{value}}", substituted) : token);
+			const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.FINALIZE, request.cwd, [
+				"review", "finalize",
+				...resolved,
+			], true, request.signal);
+			return this.decodeFinalizeTransitionExecution(execution);
+		} finally {
+			if (directory !== undefined) await this.cleanupDirectory(directory).catch(() => undefined);
+		}
+	}
+
+	private decodeFinalizeTransitionExecution(execution: { body: unknown }): NativeFinalizeResult {
 		return decode(NATIVE_REVIEW_OPERATION.FINALIZE, true, () => {
 			const body = object(execution.body);
 			// A transition rendered with `--contract` answers with the negotiated
@@ -2521,6 +2611,45 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 				"--expected-revision", request.expectedRevision,
 				"--outcome", request.outcome,
 				"--input", evidenceFile,
+			], true, request.signal);
+			return decode(NATIVE_REVIEW_OPERATION.CAPTURE_EVIDENCE, true, () => decodeNativeReviewVerificationEvidence(execution.body));
+		} finally {
+			await this.cleanupDirectory(directory).catch(() => undefined);
+		}
+	}
+
+	// Field defect (fambig, 2026-08-16): at every evidence-pending sub-state
+	// the collect slot renders the identity native demands — for a correction
+	// that is the fix-diff `--target`, not the live workspace snapshot — so the
+	// slot's rendered submission tokens execute verbatim, with only the
+	// {{outcome}} and {{input}} slots substituted. Same verbatim-token
+	// discipline as captureResult; --repository-context is authoritative and
+	// mutually exclusive with a path.
+	async captureEvidenceSubmission(request: NativeReviewCaptureEvidenceSubmissionRequest): Promise<NativeReviewVerificationEvidenceV2> {
+		if (!(NATIVE_REVIEW_CAPTURE_OUTCOME as readonly string[]).includes(request.outcome)) throw new TypeError("Native CAPTURE_EVIDENCE outcome must be passed, verification_failed, or procedural_tooling_failed");
+		if (request.evidenceDocument.length === 0) throw new TypeError("Native CAPTURE_EVIDENCE evidence must contain at least one byte");
+		if (request.argumentTokens.length === 0) throw new TypeError("Native CAPTURE_EVIDENCE submission requires the provider-rendered argument tokens");
+		if (request.argumentTokens.some((token) => typeof token !== "string" || token.length === 0)) throw new TypeError("Native CAPTURE_EVIDENCE submission argument tokens must all be non-empty strings");
+		const outcomeToken = request.argumentTokens[request.outcomeSubstitutionLocation];
+		const inputToken = request.argumentTokens[request.inputSubstitutionLocation];
+		if (request.outcomeSubstitutionLocation === request.inputSubstitutionLocation || outcomeToken === undefined || !outcomeToken.includes("{{outcome}}")) throw new TypeError("Native CAPTURE_EVIDENCE submission must render exactly one {{outcome}} slot token");
+		if (inputToken === undefined || !inputToken.includes("{{input}}")) throw new TypeError("Native CAPTURE_EVIDENCE submission must render exactly one {{input}} slot token");
+		const carriesContext = request.argumentTokens.some((token) => token === "--repository-context" || token.startsWith("--repository-context="));
+		if (carriesContext && request.cwd !== undefined) throw new TypeError("Native CAPTURE_EVIDENCE submission takes a repository context or --cwd, never both");
+		const directory = await mkdtemp(join(tmpdir(), "gentle-ai-capture-evidence-"));
+		try {
+			await chmod(directory, 0o700);
+			const evidenceFile = await this.stageEvidence(directory, request.evidenceDocument);
+			const resolved = request.argumentTokens.map((token, index) =>
+				index === request.outcomeSubstitutionLocation
+					? token.replaceAll("{{outcome}}", request.outcome)
+					: index === request.inputSubstitutionLocation
+						? token.replaceAll("{{input}}", evidenceFile)
+						: token);
+			const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.CAPTURE_EVIDENCE, request.cwd ?? process.cwd(), [
+				"review", "capture-evidence",
+				...resolved,
+				...(carriesContext || request.cwd === undefined ? [] : ["--cwd", request.cwd]),
 			], true, request.signal);
 			return decode(NATIVE_REVIEW_OPERATION.CAPTURE_EVIDENCE, true, () => decodeNativeReviewVerificationEvidence(execution.body));
 		} finally {

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -93,6 +93,18 @@ export const REVIEW_STATUS_ACTION_DISPOSITION = {
 export type ReviewStatusActionDisposition = (typeof REVIEW_STATUS_ACTION_DISPOSITION)[keyof typeof REVIEW_STATUS_ACTION_DISPOSITION];
 const RECEIPT_STATUSES = ["expected_missing", "present", "publication_pending", "not_applicable"] as const;
 const REQUIRED_OPERATIONS = Object.freeze(Object.values(REVIEW_INTEGRATION_OPERATION));
+// failure/v2 operations: the capability floor plus the four collect-capture
+// verbs that emit typed refusals on the gentle-ai main line (commit a2d57117,
+// fix/capture-evidence-typed-refusal; exact strings from that branch's
+// published failure.schema.json 12-value operation enum). Additive forward
+// surface: every operation outside the published enum still rejects.
+const FAILURE_OPERATIONS = Object.freeze([
+	...REQUIRED_OPERATIONS,
+	"review.capture-result",
+	"review.capture-evidence",
+	"review.capture-refuter",
+	"review.capture-validation",
+] as const);
 const REQUIRED_GATES = Object.freeze(["post-apply", "pre-commit", "pre-push", "pre-pr", "release"] as const);
 const REQUIRED_PROJECTIONS = Object.freeze(Object.values(REVIEW_PROJECTION));
 // The schema floor shared by every accepted capabilities identity. Each minor
@@ -613,10 +625,12 @@ export interface ReviewFailureContextV2 {
 	bindingRevision?: ReviewFailureBindingRevisionV1;
 }
 
+export type ReviewFailureOperation = ReviewIntegrationOperation | "review.capture-result" | "review.capture-evidence" | "review.capture-refuter" | "review.capture-validation";
+
 export interface ReviewFailureV2 {
 	schema: "gentle-ai.review-integration.failure/v2";
 	contract: typeof REVIEW_INTEGRATION_CONTRACT;
-	operation: ReviewIntegrationOperation;
+	operation: ReviewFailureOperation;
 	phase: "preflight" | "pre_native" | "native_running" | "native_committed" | "reconciliation";
 	code: string;
 	message: string;
@@ -1831,7 +1845,7 @@ export function decodeReviewFailureV2(value: unknown): ReviewFailureV2 {
 		"schema", "contract", "operation", "phase", "code", "message", "mutation_outcome", "authority_applicability", "retry_safe", "replayability", "required_inputs", "next_action",
 	], ["lineage_id", "request_digest", "progress_identity", "cause_category", "cause", "context"]);
 	requireIdentity(body, "gentle-ai.review-integration.failure/v2");
-	const operation = enumeration(body.operation, REQUIRED_OPERATIONS, "failure.operation");
+	const operation = enumeration(body.operation, FAILURE_OPERATIONS, "failure.operation");
 
 	if (body.progress_identity !== undefined) {
 		if (body.lineage_id === undefined || body.request_digest === undefined) throw new TypeError("failure.progress_identity requires lineage_id and request_digest");

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -150,6 +150,14 @@ export const NATIVE_SDD_ARTIFACT_STATE = {
 
 
 
+
+
+
+
+
+
+
+
 	                                                       
 
 
@@ -428,6 +436,27 @@ export const NATIVE_REVIEW_PROVIDER_ROLE_CAPTURE_SCHEMA = "gentle-ai.review-prov
 
 
 
+// Field defect (fambig, 2026-08-16): the evidence collect slot renders the
+// exact submission tokens native admits — fix-diff `--target`,
+// `--expected-revision`, and an opaque cwd-independent `--repository-context` —
+// with `{{outcome}}`/`{{input}}` substitution slots. Satisfying the slot means
+// executing those tokens verbatim with only the two slot substitutions, the
+// same discipline captureResult uses; identities are never reconstructed from
+// top-level status fields.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -480,6 +509,24 @@ export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "dec
 // exact rendered tokens of one provider-returned `review.finalize` execute
 // transition (e.g. `--lineage=<id> --captured-results=true`), passed through
 // verbatim and never synthesized or reordered by the host.
+
+
+
+
+
+
+// The provider-rendered `finalize` submission descriptor forms (status/v5):
+// the correction PLAN slot substitutes a positive line-count literal into its
+// {{value}} token; the TARGETED VALIDATION slot substitutes a staged validator
+// artifact path. The tokens are self-contained and execute verbatim.
+
+
+
+
+
+
+
+
 
 
 
@@ -2473,6 +2520,49 @@ export class NativeReviewCliV216                            {
 			"review", "finalize",
 			...request.argumentTokens,
 		], true, request.signal);
+		return this.decodeFinalizeTransitionExecution(execution);
+	}
+
+	// Same misbinding class as capture-evidence (live smoke, 2026-08-16): the
+	// correction PLAN and TARGETED VALIDATION collect slots render `finalize`
+	// submission descriptors whose tokens are self-contained (--contract,
+	// --lineage, --expected-revision, --target, --request-hash,
+	// --repository-context) plus exactly one {{value}} slot. Executing anything
+	// other than those rendered tokens fails the live emitter's committed-
+	// intent reconciliation, so the tokens pass through verbatim with only the
+	// {{value}} substitution: a literal for correction_lines, a staged 0o600
+	// artifact path for a validation document.
+	async finalizeSubmission(request                                       )                                {
+		if (request.argumentTokens.length === 0) throw new TypeError("Native FINALIZE submission requires the provider-rendered argument tokens");
+		if (request.argumentTokens.some((token) => typeof token !== "string" || token.length === 0)) throw new TypeError("Native FINALIZE submission argument tokens must all be non-empty strings");
+		if ((request.valueLiteral === undefined) === (request.valueDocument === undefined)) throw new TypeError("Native FINALIZE submission takes exactly one of valueLiteral or valueDocument");
+		const valueToken = request.argumentTokens[request.valueSubstitutionLocation];
+		if (valueToken === undefined || !valueToken.includes("{{value}}")) throw new TypeError("Native FINALIZE submission must render exactly one {{value}} slot token");
+		if (request.valueDocument !== undefined && request.valueDocument.length === 0) throw new TypeError("Native FINALIZE submission value document must contain at least one byte");
+		const directory = request.valueDocument === undefined ? undefined : await mkdtemp(join(tmpdir(), "gentle-ai-finalize-submission-"));
+		try {
+			let substituted        ;
+			if (directory !== undefined) {
+				await chmod(directory, 0o700);
+				const valueFile = join(directory, "value.json");
+				await writeFile(valueFile, request.valueDocument , { encoding: "utf8", mode: 0o600 });
+				await chmod(valueFile, 0o600);
+				substituted = valueFile;
+			} else {
+				substituted = request.valueLiteral ;
+			}
+			const resolved = request.argumentTokens.map((token, index) => index === request.valueSubstitutionLocation ? token.replaceAll("{{value}}", substituted) : token);
+			const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.FINALIZE, request.cwd, [
+				"review", "finalize",
+				...resolved,
+			], true, request.signal);
+			return this.decodeFinalizeTransitionExecution(execution);
+		} finally {
+			if (directory !== undefined) await this.cleanupDirectory(directory).catch(() => undefined);
+		}
+	}
+
+	        decodeFinalizeTransitionExecution(execution                   )                       {
 		return decode(NATIVE_REVIEW_OPERATION.FINALIZE, true, () => {
 			const body = object(execution.body);
 			// A transition rendered with `--contract` answers with the negotiated
@@ -2522,6 +2612,45 @@ export class NativeReviewCliV216                            {
 				"--expected-revision", request.expectedRevision,
 				"--outcome", request.outcome,
 				"--input", evidenceFile,
+			], true, request.signal);
+			return decode(NATIVE_REVIEW_OPERATION.CAPTURE_EVIDENCE, true, () => decodeNativeReviewVerificationEvidence(execution.body));
+		} finally {
+			await this.cleanupDirectory(directory).catch(() => undefined);
+		}
+	}
+
+	// Field defect (fambig, 2026-08-16): at every evidence-pending sub-state
+	// the collect slot renders the identity native demands — for a correction
+	// that is the fix-diff `--target`, not the live workspace snapshot — so the
+	// slot's rendered submission tokens execute verbatim, with only the
+	// {{outcome}} and {{input}} slots substituted. Same verbatim-token
+	// discipline as captureResult; --repository-context is authoritative and
+	// mutually exclusive with a path.
+	async captureEvidenceSubmission(request                                              )                                              {
+		if (!(NATIVE_REVIEW_CAPTURE_OUTCOME                     ).includes(request.outcome)) throw new TypeError("Native CAPTURE_EVIDENCE outcome must be passed, verification_failed, or procedural_tooling_failed");
+		if (request.evidenceDocument.length === 0) throw new TypeError("Native CAPTURE_EVIDENCE evidence must contain at least one byte");
+		if (request.argumentTokens.length === 0) throw new TypeError("Native CAPTURE_EVIDENCE submission requires the provider-rendered argument tokens");
+		if (request.argumentTokens.some((token) => typeof token !== "string" || token.length === 0)) throw new TypeError("Native CAPTURE_EVIDENCE submission argument tokens must all be non-empty strings");
+		const outcomeToken = request.argumentTokens[request.outcomeSubstitutionLocation];
+		const inputToken = request.argumentTokens[request.inputSubstitutionLocation];
+		if (request.outcomeSubstitutionLocation === request.inputSubstitutionLocation || outcomeToken === undefined || !outcomeToken.includes("{{outcome}}")) throw new TypeError("Native CAPTURE_EVIDENCE submission must render exactly one {{outcome}} slot token");
+		if (inputToken === undefined || !inputToken.includes("{{input}}")) throw new TypeError("Native CAPTURE_EVIDENCE submission must render exactly one {{input}} slot token");
+		const carriesContext = request.argumentTokens.some((token) => token === "--repository-context" || token.startsWith("--repository-context="));
+		if (carriesContext && request.cwd !== undefined) throw new TypeError("Native CAPTURE_EVIDENCE submission takes a repository context or --cwd, never both");
+		const directory = await mkdtemp(join(tmpdir(), "gentle-ai-capture-evidence-"));
+		try {
+			await chmod(directory, 0o700);
+			const evidenceFile = await this.stageEvidence(directory, request.evidenceDocument);
+			const resolved = request.argumentTokens.map((token, index) =>
+				index === request.outcomeSubstitutionLocation
+					? token.replaceAll("{{outcome}}", request.outcome)
+					: index === request.inputSubstitutionLocation
+						? token.replaceAll("{{input}}", evidenceFile)
+						: token);
+			const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.CAPTURE_EVIDENCE, request.cwd ?? process.cwd(), [
+				"review", "capture-evidence",
+				...resolved,
+				...(carriesContext || request.cwd === undefined ? [] : ["--cwd", request.cwd]),
 			], true, request.signal);
 			return decode(NATIVE_REVIEW_OPERATION.CAPTURE_EVIDENCE, true, () => decodeNativeReviewVerificationEvidence(execution.body));
 		} finally {

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -94,6 +94,18 @@ export const REVIEW_STATUS_ACTION_DISPOSITION = {
 
 const RECEIPT_STATUSES = ["expected_missing", "present", "publication_pending", "not_applicable"]         ;
 const REQUIRED_OPERATIONS = Object.freeze(Object.values(REVIEW_INTEGRATION_OPERATION));
+// failure/v2 operations: the capability floor plus the four collect-capture
+// verbs that emit typed refusals on the gentle-ai main line (commit a2d57117,
+// fix/capture-evidence-typed-refusal; exact strings from that branch's
+// published failure.schema.json 12-value operation enum). Additive forward
+// surface: every operation outside the published enum still rejects.
+const FAILURE_OPERATIONS = Object.freeze([
+	...REQUIRED_OPERATIONS,
+	"review.capture-result",
+	"review.capture-evidence",
+	"review.capture-refuter",
+	"review.capture-validation",
+]         );
 const REQUIRED_GATES = Object.freeze(["post-apply", "pre-commit", "pre-push", "pre-pr", "release"]         );
 const REQUIRED_PROJECTIONS = Object.freeze(Object.values(REVIEW_PROJECTION));
 // The schema floor shared by every accepted capabilities identity. Each minor
@@ -586,6 +598,8 @@ const FAILURE_NEXT_ACTIONS = ["correct_request", "retry", "retry_with_bounded_ba
 // cause_category is diagnostic metadata (nothing routes on it), so unknown
 // snake_case values are tolerated for forward compatibility.
 const FAILURE_CAUSE_CATEGORIES = ["inventory_io_or_layout", "lock_ambiguous", "reset_residue", "record_or_graph_invalid", "inventory_incomplete", "incomplete_store_entry"]         ;
+
+
 
 
 
@@ -1832,7 +1846,7 @@ export function decodeReviewFailureV2(value         )                  {
 		"schema", "contract", "operation", "phase", "code", "message", "mutation_outcome", "authority_applicability", "retry_safe", "replayability", "required_inputs", "next_action",
 	], ["lineage_id", "request_digest", "progress_identity", "cause_category", "cause", "context"]);
 	requireIdentity(body, "gentle-ai.review-integration.failure/v2");
-	const operation = enumeration(body.operation, REQUIRED_OPERATIONS, "failure.operation");
+	const operation = enumeration(body.operation, FAILURE_OPERATIONS, "failure.operation");
 
 	if (body.progress_identity !== undefined) {
 		if (body.lineage_id === undefined || body.request_digest === undefined) throw new TypeError("failure.progress_identity requires lineage_id and request_digest");

--- a/tests/fixtures/devbinary/failure-v2-capture-evidence.captured.json
+++ b/tests/fixtures/devbinary/failure-v2-capture-evidence.captured.json
@@ -1,0 +1,16 @@
+{
+  "schema": "gentle-ai.review-integration.failure/v2",
+  "contract": "gentle-ai.review-integration/v2",
+  "operation": "review.capture-evidence",
+  "phase": "preflight",
+  "code": "verification_evidence_binding_mismatch",
+  "message": "The verification evidence binding does not match the current validating or correction authority; re-derive the exact next transition before retrying.",
+  "mutation_outcome": "not_started",
+  "authority_applicability": "not_evaluated",
+  "retry_safe": true,
+  "replayability": "not_replayable",
+  "lineage_id": "review-ceeb2b862bd39709",
+  "required_inputs": [],
+  "next_action": "review.status",
+  "cause": "verification evidence binding does not match the current validating or correction authority"
+}

--- a/tests/review-controller-native-recovery.test.ts
+++ b/tests/review-controller-native-recovery.test.ts
@@ -1091,3 +1091,136 @@ test("finalizeTransition runs the provider-rendered tokens verbatim and decodes 
 	assert.equal(negotiated.storeRevision, `sha256:${"f".repeat(64)}`);
 	await assert.rejects(cli.finalizeTransition({ cwd: "/repo", argumentTokens: [] }), /requires the provider-rendered argument tokens/);
 });
+
+// Field defect (fambig, 2026-08-16): the evidence collect slot renders the
+// exact `review capture-evidence` submission tokens — fix-diff `--target`,
+// `--expected-revision`, and an opaque cwd-independent `--repository-context` —
+// with `{{outcome}}`/`{{input}}` slots. Satisfying the slot means executing
+// those tokens verbatim with only the two slot substitutions, exactly like
+// captureResult; identities are never reconstructed on the client.
+test("captureEvidenceSubmission executes the provider-rendered submission tokens verbatim with slot substitution", async (t) => {
+	t.after(() => clearNativeReviewCapabilitiesCacheForTesting());
+	const capabilities = v2Fixture<Record<string, unknown>>("capabilities.fixture.json");
+	const capabilitiesBody = { ...capabilities, package: { ...(capabilities.package as Record<string, unknown>), version: GENTLE_AI_VERSION } };
+	const record = {
+		schema: "gentle-ai.review-verification-evidence/v2",
+		version: 2,
+		lineage_id: "review-evidence-lineage",
+		authority_revision: `sha256:${"a".repeat(64)}`,
+		target_identity: `sha256:${"b".repeat(64)}`,
+		candidate_tree: "c".repeat(40),
+		paths_digest: `sha256:${"d".repeat(64)}`,
+		paths: ["calc.go"],
+		ledger_ids: ["R3-1"],
+		raw_payload_sha256: `sha256:${"e".repeat(64)}`,
+		raw_payload_bytes: 24,
+		outcome: "passed",
+		record_digest: `sha256:${"f".repeat(64)}`,
+	};
+	const argumentTokens = [
+		`--lineage=${record.lineage_id}`,
+		`--expected-revision=${record.authority_revision}`,
+		`--target=${record.target_identity}`,
+		`--repository-context=rctx1_${"e".repeat(64)}`,
+		"--outcome={{outcome}}",
+		"--input={{input}}",
+	];
+	let staged = "";
+	const calls: Array<{ arguments: readonly string[] }> = [];
+	const cli = new NativeReviewCliV216(async (request) => {
+		calls.push({ arguments: request.arguments });
+		if (request.arguments[1] === "capabilities") return { stdout: JSON.stringify(capabilitiesBody), stderr: "", exitCode: 0, signal: null, timedOut: false, outputLimitExceeded: false };
+		const inputToken = request.arguments.find((token) => token.startsWith("--input="));
+		assert.ok(inputToken !== undefined);
+		staged = readFileSync(inputToken.slice("--input=".length), "utf8");
+		return { stdout: JSON.stringify(record), stderr: "", exitCode: 0, signal: null, timedOut: false, outputLimitExceeded: false };
+	}, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024, async () => undefined, () => "dcc846103b16d365eaeeb9d7f289c23fc4f2897f23def1cb3fe7f05557b64705");
+	const evidence = "verification: go test ./... passed\n";
+	const captured = await cli.captureEvidenceSubmission({
+		argumentTokens,
+		outcomeSubstitutionLocation: 4,
+		inputSubstitutionLocation: 5,
+		outcome: "passed",
+		evidenceDocument: evidence,
+	});
+	assert.equal(staged, evidence, "the evidence bytes must be staged exactly");
+	assert.equal(captured.recordDigest, record.record_digest);
+	assert.equal(captured.targetIdentity, record.target_identity);
+	const argv = calls[1]!.arguments;
+	assert.deepEqual(argv.slice(0, 2), ["review", "capture-evidence"]);
+	assert.deepEqual(argv.slice(2, 6), argumentTokens.slice(0, 4), "the identity-bearing tokens must pass through verbatim, in provider order");
+	assert.equal(argv[6], "--outcome=passed");
+	assert.match(String(argv[7]), /^--input=./);
+	assert.equal(argv.length, 8);
+	assert.equal(argv.includes("--cwd"), false, "the repository context is authoritative and cwd-independent");
+	assert.equal(argv.includes("--contract"), false);
+	await assert.rejects(
+		cli.captureEvidenceSubmission({ cwd: "/repo", argumentTokens, outcomeSubstitutionLocation: 4, inputSubstitutionLocation: 5, outcome: "passed", evidenceDocument: evidence }),
+		/repository context or --cwd, never both/,
+	);
+	await assert.rejects(
+		cli.captureEvidenceSubmission({ argumentTokens, outcomeSubstitutionLocation: 4, inputSubstitutionLocation: 5, outcome: "failed" as never, evidenceDocument: evidence }),
+		/outcome must be passed, verification_failed, or procedural_tooling_failed/,
+	);
+	await assert.rejects(
+		cli.captureEvidenceSubmission({ argumentTokens: argumentTokens.slice(0, 4), outcomeSubstitutionLocation: 0, inputSubstitutionLocation: 1, outcome: "passed", evidenceDocument: evidence }),
+		/\{\{outcome\}\}/,
+	);
+	assert.equal(calls.length, 2, "every rejected submission must fail before another native launch");
+});
+
+test("finalizeSubmission executes the rendered finalize submission tokens verbatim with the {{value}} substitution", async (t) => {
+	t.after(() => clearNativeReviewCapabilitiesCacheForTesting());
+	const capabilities = v2Fixture<Record<string, unknown>>("capabilities.fixture.json");
+	const capabilitiesBody = { ...capabilities, package: { ...(capabilities.package as Record<string, unknown>), version: GENTLE_AI_VERSION } };
+	const finalizeBody = {
+		schema: "gentle-ai.review-integration.operation/v2",
+		contract: "gentle-ai.review-integration/v2",
+		operation: "review.finalize",
+		result: { operation: "review/finalize", lineage_id: "review-1d5aadacc600e167", state: "correction_required", action: "continue the current review state", store_revision: `sha256:${"f".repeat(64)}` },
+	};
+	const planTokens = [
+		"--contract=gentle-ai.review-integration/v2",
+		"--lineage=review-1d5aadacc600e167",
+		`--expected-revision=sha256:${"a".repeat(64)}`,
+		`--target=sha256:${"b".repeat(64)}`,
+		`--request-hash=sha256:${"c".repeat(64)}`,
+		`--repository-context=rctx1_${"e".repeat(64)}`,
+		"--correction-lines={{value}}",
+	];
+	const calls: Array<{ arguments: readonly string[] }> = [];
+	let staged: string | undefined;
+	const cli = new NativeReviewCliV216(async (request) => {
+		calls.push({ arguments: request.arguments });
+		if (request.arguments[1] === "capabilities") return { stdout: JSON.stringify(capabilitiesBody), stderr: "", exitCode: 0, signal: null, timedOut: false, outputLimitExceeded: false };
+		const validationToken = request.arguments.find((token) => token.startsWith("--validation="));
+		if (validationToken !== undefined) staged = readFileSync(validationToken.slice("--validation=".length), "utf8");
+		return { stdout: JSON.stringify(finalizeBody), stderr: "", exitCode: 0, signal: null, timedOut: false, outputLimitExceeded: false };
+	}, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024, async () => undefined, () => "dcc846103b16d365eaeeb9d7f289c23fc4f2897f23def1cb3fe7f05557b64705");
+
+	// Plan form: literal substitution, every other token verbatim.
+	const planned = await cli.finalizeSubmission({ cwd: "/repo", argumentTokens: planTokens, valueSubstitutionLocation: 6, valueLiteral: "2" });
+	assert.equal(planned.state, "correction_required");
+	const planArgv = calls[1]!.arguments;
+	assert.deepEqual(planArgv.slice(0, 2), ["review", "finalize"]);
+	assert.deepEqual(planArgv.slice(2, 8), planTokens.slice(0, 6), "identity-bearing tokens must pass through verbatim, in provider order");
+	assert.equal(planArgv[8], "--correction-lines=2");
+	assert.equal(planArgv.length, 9);
+
+	// Validation form: the document is staged to a 0o600 artifact whose path substitutes {{value}}.
+	const validationTokens = [...planTokens.slice(0, 6), "--validation={{value}}"];
+	const document = JSON.stringify({ targeted_validation_request_hash: `sha256:${"9".repeat(64)}`, original_criteria: { passed: true, evidence: ["ok"] } });
+	await cli.finalizeSubmission({ cwd: "/repo", argumentTokens: validationTokens, valueSubstitutionLocation: 6, valueDocument: document });
+	assert.equal(staged, document, "the validation document must be staged byte-exact");
+
+	// Guards: exactly one substitution form, and a real {{value}} slot.
+	await assert.rejects(
+		cli.finalizeSubmission({ cwd: "/repo", argumentTokens: planTokens, valueSubstitutionLocation: 6, valueLiteral: "2", valueDocument: document }),
+		/exactly one of valueLiteral or valueDocument/,
+	);
+	await assert.rejects(
+		cli.finalizeSubmission({ cwd: "/repo", argumentTokens: planTokens.slice(0, 6), valueSubstitutionLocation: 0, valueLiteral: "2" }),
+		/\{\{value\}\}/,
+	);
+	assert.equal(calls.length, 3, "rejected submissions must fail before another native launch");
+});

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -5404,6 +5404,54 @@ test("ordinary final verification at validating captures evidence through the sl
 	assert.equal((details.result as { state?: string } | undefined)?.state, "approved");
 });
 
+// Field defect amplifier (fambig, 2026-08-16): an envelope-less mutating
+// failure is stamped mutationOutcome "unknown", and the reconciler KEPT
+// "unknown" even after fresh STATUS proved the authority revision identical to
+// the pre-operation revision — reporting a replay prohibition for an operation
+// that provably never mutated. A proven non-mutation must be reported as
+// mutation_outcome none with the proof named; a genuinely ambiguous result
+// (revision moved, or STATUS unavailable) stays fail-closed unknown.
+test("finalize reconciliation downgrades an envelope-less unknown to proven non-mutation when the authority revision is unchanged", async (t) => {
+	const cwd = repository(t);
+	let statuses = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			statuses += 1;
+			return targetStatusFixture({ lineageId: "unchanged-revision" });
+		},
+		finalize: async () => {
+			throw Object.assign(new Error("stderr-only native failure without a typed envelope"), { mutationOutcome: "unknown", nextAction: "review.status" });
+		},
+	}));
+	const details = (await controller.execute("proven-none", { operation: "finalize", lineageId: "unchanged-revision", input: "{}" }, undefined, undefined, context(cwd))).details as Record<string, unknown>;
+	assert.equal(details.outcome, "native-mutation-status-reconciled");
+	assert.equal(details.mutation_performed, false, "a reconciled unchanged revision proves the operation did not mutate");
+	assert.equal(details.mutation_outcome, "none");
+	assert.match(String(details.mutation_outcome_reason), /revision unchanged/i, "the downgrade must name its proof");
+	assert.equal("replayability" in details, false, "a proven non-mutation must not claim replay prohibition");
+	assert.equal(details.next_action, "finalize");
+	assert.equal(statuses, 2);
+});
+
+test("finalize reconciliation preserves fail-closed unknown when the reconciled authority revision moved", async (t) => {
+	const cwd = repository(t);
+	const moved = targetStatusFixture({ lineageId: "moved-revision" });
+	moved.authority!.revision = `sha256:${"b".repeat(64)}`;
+	let statuses = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			statuses += 1;
+			return statuses === 1 ? targetStatusFixture({ lineageId: "moved-revision" }) : moved;
+		},
+		finalize: async () => {
+			throw Object.assign(new Error("stderr-only native failure without a typed envelope"), { mutationOutcome: "unknown", nextAction: "review.status" });
+		},
+	}));
+	const details = (await controller.execute("kept-unknown", { operation: "finalize", lineageId: "moved-revision", input: "{}" }, undefined, undefined, context(cwd))).details as Record<string, unknown>;
+	assert.equal(details.outcome, "native-mutation-status-reconciled");
+	assert.equal(details.mutation_outcome, "unknown", "a moved revision is genuinely ambiguous and must stay fail-closed");
+	assert.equal(details.replayability, "not_replayable");
+});
 
 // Same misbinding class, remaining finalize-form slots (live smoke,
 // 2026-08-16, dev binary 2.4.0-main): the correction PLAN and TARGETED

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -5208,3 +5208,468 @@ test("large repository end-to-end: tiny candidate diff reaches START, reviewer d
 		frozen.cleanup();
 	}
 });
+
+// Field defect (fambig, 2026-08-16, dev binary 2.4.0-main): at every
+// evidence-pending sub-state the provider renders the `review.capture-evidence`
+// collect slot with the identity native demands — for a correction that is the
+// FIX-DIFF `--target` identity plus an opaque `--repository-context`, never the
+// top-level live workspace snapshot identity. Rebinding the capture to
+// `negotiatedStatus.targetIdentity` failed deterministically with
+// "verification evidence binding does not match the current authority
+// revision". Collect satisfaction must execute the slot's rendered submission
+// tokens verbatim, exactly like captureResult does.
+const EVIDENCE_SLOT_FIX_TARGET = `sha256:${"e".repeat(64)}`;
+const EVIDENCE_SLOT_REPOSITORY_CONTEXT = `rctx1_${"f".repeat(64)}`;
+
+function bindEvidenceSubmissionCollection(status: ReviewStatusV3, fixTargetIdentity = EVIDENCE_SLOT_FIX_TARGET, repositoryContext = EVIDENCE_SLOT_REPOSITORY_CONTEXT): ReviewStatusV3 {
+	const lineageId = status.authority!.lineageId;
+	const revision = status.authority!.revision;
+	const argumentTokens = [
+		`--lineage=${lineageId}`,
+		`--expected-revision=${revision}`,
+		`--target=${fixTargetIdentity}`,
+		`--repository-context=${repositoryContext}`,
+		"--outcome={{outcome}}",
+		"--input={{input}}",
+	];
+	status.nextTransition = {
+		kind: "collect",
+		reasonCode: "correction_repository_verification_required",
+		collect: { inputs: [{
+			name: "evidence",
+			schema: "https://gentle-ai.dev/schema/review/verification-evidence/v1",
+			captureOperation: "review.capture-evidence",
+			arguments: [
+				{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` },
+				{ name: "expected-revision", value: revision, token: `--expected-revision=${revision}` },
+				{ name: "target", value: fixTargetIdentity, token: `--target=${fixTargetIdentity}` },
+				{ name: "repository-context", value: repositoryContext, token: `--repository-context=${repositoryContext}` },
+			],
+			submissionDescriptor: {
+				operationToken: "capture-evidence",
+				argumentTokens,
+				values: [
+					{ slot: "outcome", domain: "verification_outcome", allowedValues: ["passed", "verification_failed", "procedural_tooling_failed"], substitutionLocation: 4 },
+					{ slot: "input", domain: "artifact_path_or_stdin", schema: "https://gentle-ai.dev/schema/review/verification-evidence/v1", substitutionLocation: 5 },
+				],
+			},
+		}] },
+	};
+	delete status.validationRequest;
+	return status;
+}
+
+// The record the live binary returns for a slot-bound capture: it binds the
+// slot's fix-diff target identity, and its paths digest covers the record's
+// own (fix-diff) paths — NOT the frozen projection digest (captured 2026-08-16,
+// lineage review-2b6206ed68fb9128: record paths ["calc.go"] against projection
+// paths ["calc.go", "util.go"]).
+function capturedSlotEvidence(status: ReviewStatusV3, outcome: "passed" | "verification_failed" | "procedural_tooling_failed", identityDigit: string) {
+	return {
+		...capturedCorrectionEvidence(status, outcome, identityDigit),
+		targetIdentity: EVIDENCE_SLOT_FIX_TARGET,
+		pathsDigest: `sha256:${identityDigit.repeat(64)}`,
+	};
+}
+
+test("correction evidence capture executes the collect slot's rendered submission tokens verbatim", async (t) => {
+	for (const [outcome, expectedKind] of [
+		["passed", "run-targeted-validation"],
+		["verification_failed", "recapture-required"],
+	] as const) {
+		await t.test(outcome, async (scenario) => {
+			const cwd = repository(scenario);
+			writeFileSync(join(cwd, "app.ts"), `export const outcome = ${JSON.stringify(outcome)};\n`);
+			const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+			const beforeCapture = bindEvidenceSubmissionCollection(targetStatusFixture({
+				lineageId: `slot-correction-${outcome.replaceAll("_", "-")}`,
+				authorityState: "correction_required",
+				baseTree: frozen.baseTree,
+				currentCandidateTree: frozen.candidateTree,
+				paths: frozen.paths,
+			}));
+			const expectedTokens = beforeCapture.nextTransition!.collect!.inputs[0]!.submissionDescriptor!.argumentTokens;
+			const afterCapture = targetStatusFixture({
+				lineageId: beforeCapture.authority!.lineageId,
+				authorityState: outcome === "passed" ? "validating" : "correction_required",
+				baseTree: frozen.baseTree,
+				currentCandidateTree: frozen.candidateTree,
+				paths: frozen.paths,
+			});
+			if (outcome === "passed") bindTargetedValidation(afterCapture);
+			else bindEvidenceSubmissionCollection(afterCapture);
+			frozen.cleanup();
+			const misboundCaptures: Array<Record<string, unknown>> = [];
+			const submissions: Array<Record<string, unknown>> = [];
+			let statuses = 0;
+			let finalizes = 0;
+			const { controller } = runtime(fakeNative({
+				targetStatus: async () => {
+					statuses += 1;
+					return statuses === 1 ? beforeCapture : afterCapture;
+				},
+				captureEvidence: async (request) => {
+					misboundCaptures.push(request as unknown as Record<string, unknown>);
+					throw new Error("misbound capture: the collect slot's rendered submission tokens were bypassed");
+				},
+				captureEvidenceSubmission: async (request: Record<string, unknown>) => {
+					submissions.push(request);
+					return capturedSlotEvidence(beforeCapture, outcome, outcome === "passed" ? "1" : "2");
+				},
+				finalize: async () => {
+					finalizes += 1;
+					return { lineageId: beforeCapture.authority!.lineageId, state: "approved", action: "approved", storeRevision: "r-final" };
+				},
+			} as unknown as Partial<NativeReviewCli>), undefined, undefined, undefined, new CandidateViewRegistry());
+			const validation = outcome === "passed" ? {
+				request_hash: "9".repeat(64), correction_ids: [],
+				original_criteria: { passed: true, evidence: ["acceptance passes"] },
+				correction_regression: { passed: true, evidence: ["regression passes"] },
+				fix_caused_findings: [], follow_ups: [],
+			} : undefined;
+			const result = await controller.execute(`slot-correction-${outcome}`, {
+				operation: "finalize",
+				lineageId: beforeCapture.authority!.lineageId,
+				input: JSON.stringify({ final_evidence: `evidence: ${outcome}`, final_verification_outcome: outcome, ...(validation === undefined ? {} : { validation }) }),
+			}, undefined, undefined, context(cwd));
+			const details = result.details as Record<string, unknown>;
+			assert.deepEqual(misboundCaptures, [], "capture-evidence must never rebind to the top-level live workspace identity");
+			assert.equal(submissions.length, 1, "the slot submission must be executed exactly once");
+			const submission = submissions[0]!;
+			assert.deepEqual(submission.argumentTokens, expectedTokens, "the provider-rendered submission tokens must be passed verbatim, in provider order");
+			assert.equal(submission.outcomeSubstitutionLocation, 4);
+			assert.equal(submission.inputSubstitutionLocation, 5);
+			assert.equal(submission.cwd, undefined, "the slot's --repository-context is authoritative; never pass --cwd alongside it");
+			assert.equal(submission.outcome, outcome);
+			assert.equal(submission.evidenceDocument, `evidence: ${outcome}`);
+			assert.equal((details.correction_step as { kind?: string } | undefined)?.kind, expectedKind);
+			assert.equal(finalizes, outcome === "passed" ? 1 : 0);
+		});
+	}
+});
+
+test("ordinary final verification at validating captures evidence through the slot's rendered submission tokens", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const finalSlot = true;\n");
+	const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	const beforeCapture = bindEvidenceSubmissionCollection(targetStatusFixture({
+		lineageId: "final-verification-slot",
+		authorityState: "validating",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}));
+	const expectedTokens = beforeCapture.nextTransition!.collect!.inputs[0]!.submissionDescriptor!.argumentTokens;
+	const afterCapture = bindFinalVerificationTransition(targetStatusFixture({
+		lineageId: "final-verification-slot",
+		authorityState: "validating",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}), "passed");
+	frozen.cleanup();
+	const misboundCaptures: Array<Record<string, unknown>> = [];
+	const submissions: Array<Record<string, unknown>> = [];
+	const transitions: Array<readonly string[]> = [];
+	let statuses = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			statuses += 1;
+			return statuses === 1 ? beforeCapture : afterCapture;
+		},
+		captureEvidence: async (request) => {
+			misboundCaptures.push(request as unknown as Record<string, unknown>);
+			throw new Error("misbound capture: the collect slot's rendered submission tokens were bypassed");
+		},
+		captureEvidenceSubmission: async (request: Record<string, unknown>) => {
+			submissions.push(request);
+			return capturedSlotEvidence(beforeCapture, "passed", "3");
+		},
+		finalizeTransition: async (request) => {
+			transitions.push(request.argumentTokens);
+			return { lineageId: "final-verification-slot", state: "approved", action: "terminal", storeRevision: "r2", receiptPath: "/opaque/receipt" };
+		},
+	} as unknown as Partial<NativeReviewCli>), undefined, undefined, undefined, new CandidateViewRegistry());
+	const result = await controller.execute("final-verification-slot", {
+		operation: "finalize",
+		lineageId: "final-verification-slot",
+		input: JSON.stringify({ final_evidence: "verification run: passed", final_verification_outcome: "passed" }),
+	}, undefined, undefined, context(cwd));
+	const details = result.details as Record<string, unknown>;
+	assert.deepEqual(misboundCaptures, [], "capture-evidence must never rebind to the top-level live workspace identity");
+	assert.equal(submissions.length, 1);
+	assert.deepEqual(submissions[0]!.argumentTokens, expectedTokens);
+	assert.equal(submissions[0]!.cwd, undefined, "the slot's --repository-context is authoritative; never pass --cwd alongside it");
+	assert.deepEqual(transitions, [["--lineage=final-verification-slot", "--captured-evidence=true"]]);
+	assert.equal((details.result as { state?: string } | undefined)?.state, "approved");
+});
+
+
+// Same misbinding class, remaining finalize-form slots (live smoke,
+// 2026-08-16, dev binary 2.4.0-main): the correction PLAN and TARGETED
+// VALIDATION collect slots render `finalize` submission descriptors whose
+// tokens carry --contract/--lineage/--expected-revision/--target/
+// --request-hash/--repository-context plus one {{value}} slot. The legacy
+// reconstructed `finalize --correction-lines/--validation` argv fails on the
+// live emitter with "reconcile compact predecessor effects: repository
+// context effect binding or payload does not match committed intent". Collect
+// satisfaction must execute the rendered tokens verbatim.
+function bindPlanSubmissionCollection(status: ReviewStatusV3, repositoryContext = EVIDENCE_SLOT_REPOSITORY_CONTEXT): ReviewStatusV3 {
+	const lineageId = status.authority!.lineageId;
+	const revision = status.authority!.revision;
+	status.nextTransition = {
+		kind: "collect",
+		reasonCode: "correction_plan_required",
+		collect: { inputs: [{
+			name: "correction_lines",
+			schema: "gentle-ai.review-correction-plan/v1",
+			captureOperation: "external.plan_correction",
+			arguments: [
+				{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` },
+				{ name: "expected-revision", value: revision, token: `--expected-revision=${revision}` },
+				{ name: "target", value: status.targetIdentity, token: `--target=${status.targetIdentity}` },
+			],
+			submissionDescriptor: {
+				operationToken: "finalize",
+				argumentTokens: [
+					"--contract=gentle-ai.review-integration/v2",
+					`--lineage=${lineageId}`,
+					`--expected-revision=${revision}`,
+					`--target=${status.targetIdentity}`,
+					`--request-hash=sha256:${"c".repeat(64)}`,
+					`--repository-context=${repositoryContext}`,
+					"--correction-lines={{value}}",
+				],
+				value: { slot: "correction_lines", domain: "positive_correction_lines", minimum: 1, maximum: 9, substitutionLocation: 6 },
+			},
+		}] },
+	};
+	delete status.validationRequest;
+	return status;
+}
+
+test("correction plan forecast executes the collect slot's rendered finalize submission tokens verbatim", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const plan = true;\n");
+	const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	const status = bindPlanSubmissionCollection(targetStatusFixture({
+		lineageId: "plan-submission",
+		authorityState: "correction_required",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}));
+	const expectedTokens = status.nextTransition!.collect!.inputs[0]!.submissionDescriptor!.argumentTokens;
+	frozen.cleanup();
+	const legacyFinalizes: Array<Record<string, unknown>> = [];
+	const submissions: Array<Record<string, unknown>> = [];
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => status,
+		finalize: async (request) => {
+			legacyFinalizes.push(request as unknown as Record<string, unknown>);
+			throw new Error("misbound plan: the collect slot's rendered finalize submission tokens were bypassed");
+		},
+		finalizeSubmission: async (request: Record<string, unknown>) => {
+			submissions.push(request);
+			return { lineageId: "plan-submission", state: "correction_required", action: "continue the current review state", storeRevision: "r-plan" };
+		},
+	} as unknown as Partial<NativeReviewCli>), undefined, undefined, undefined, new CandidateViewRegistry());
+	const planned = await controller.execute("plan-submission", {
+		operation: "finalize",
+		lineageId: "plan-submission",
+		input: JSON.stringify({ correction_line_forecast: 2 }),
+	}, undefined, undefined, context(cwd));
+	const details = planned.details as Record<string, unknown>;
+	assert.deepEqual(legacyFinalizes, [], "the legacy reconstructed --correction-lines argv must never run when the slot renders submission tokens");
+	assert.equal(submissions.length, 1);
+	assert.deepEqual(submissions[0]!.argumentTokens, expectedTokens, "the provider-rendered submission tokens must be passed verbatim, in provider order");
+	assert.equal(submissions[0]!.valueSubstitutionLocation, 6);
+	assert.equal(submissions[0]!.valueLiteral, "2");
+	assert.equal((details.result as { state?: string } | undefined)?.state, "correction_required");
+
+	// An out-of-bounds forecast fails closed before any native launch.
+	const outOfBounds = await controller.execute("plan-submission-oob", {
+		operation: "finalize",
+		lineageId: "plan-submission",
+		input: JSON.stringify({ correction_line_forecast: 99 }),
+	}, undefined, undefined, context(cwd));
+	assert.equal((outOfBounds.details as { outcome?: string }).outcome, "native-operation-failed");
+	assert.match(JSON.stringify(outOfBounds.details), /correction-forecast-out-of-bounds/);
+	assert.equal(submissions.length, 1);
+	assert.deepEqual(legacyFinalizes, []);
+	execFileSync("chmod", ["-R", "u+w", cwd]);
+});
+
+function bindTargetedValidationSubmission(status: ReviewStatusV3): ReviewStatusV3 {
+	bindTargetedValidation(status);
+	const input = status.nextTransition!.collect!.inputs[0]! as { submissionDescriptor?: unknown };
+	const lineageId = status.authority!.lineageId;
+	const revision = status.authority!.revision;
+	input.submissionDescriptor = {
+		operationToken: "finalize",
+		argumentTokens: [
+			"--contract=gentle-ai.review-integration/v2",
+			`--lineage=${lineageId}`,
+			`--expected-revision=${revision}`,
+			`--target=${status.targetIdentity}`,
+			`--request-hash=${status.validationRequest!.requestHash}`,
+			`--repository-context=${EVIDENCE_SLOT_REPOSITORY_CONTEXT}`,
+			"--validation={{value}}",
+		],
+		value: { slot: "validation", domain: "artifact_path_or_stdin", substitutionLocation: 6 },
+	};
+	return status;
+}
+
+test("targeted validation executes the collect slot's rendered finalize submission tokens verbatim", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const validated = true;\n");
+	const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	const beforeCapture = bindEvidenceSubmissionCollection(targetStatusFixture({
+		lineageId: "validation-submission",
+		authorityState: "correction_required",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}));
+	const afterCapture = bindTargetedValidationSubmission(targetStatusFixture({
+		lineageId: "validation-submission",
+		authorityState: "validating",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}));
+	const expectedTokens = (afterCapture.nextTransition!.collect!.inputs[0]! as { submissionDescriptor: { argumentTokens: readonly string[] } }).submissionDescriptor.argumentTokens;
+	frozen.cleanup();
+	const legacyFinalizes: Array<Record<string, unknown>> = [];
+	const submissions: Array<Record<string, unknown>> = [];
+	let statuses = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			statuses += 1;
+			return statuses === 1 ? beforeCapture : afterCapture;
+		},
+		captureEvidenceSubmission: async () => capturedSlotEvidence(beforeCapture, "passed", "7"),
+		finalize: async (request) => {
+			legacyFinalizes.push(request as unknown as Record<string, unknown>);
+			throw new Error("misbound validation: the collect slot's rendered finalize submission tokens were bypassed");
+		},
+		finalizeSubmission: async (request: Record<string, unknown>) => {
+			submissions.push(request);
+			return { lineageId: "validation-submission", state: "approved", action: "approved", storeRevision: "r-approved" };
+		},
+	} as unknown as Partial<NativeReviewCli>), undefined, undefined, undefined, new CandidateViewRegistry());
+	const completed = await controller.execute("validation-submission", {
+		operation: "finalize",
+		lineageId: "validation-submission",
+		input: JSON.stringify({
+			final_evidence: "evidence: passed",
+			final_verification_outcome: "passed",
+			validation: {
+				request_hash: "9".repeat(64), correction_ids: [],
+				original_criteria: { passed: true, evidence: ["acceptance passes"] },
+				correction_regression: { passed: true, evidence: ["regression passes"] },
+				fix_caused_findings: [], follow_ups: [],
+			},
+		}),
+	}, undefined, undefined, context(cwd));
+	const details = completed.details as Record<string, unknown>;
+	assert.deepEqual(legacyFinalizes, [], "the legacy reconstructed --validation argv must never run when the slot renders submission tokens");
+	assert.equal(submissions.length, 1);
+	assert.deepEqual(submissions[0]!.argumentTokens, expectedTokens, "the provider-rendered submission tokens must be passed verbatim, in provider order");
+	assert.equal(submissions[0]!.valueSubstitutionLocation, 6);
+	const staged = JSON.parse(String(submissions[0]!.valueDocument)) as Record<string, unknown>;
+	assert.equal(staged.targeted_validation_request_hash, afterCapture.validationRequest!.requestHash);
+	assert.equal(staged.correction_target_identity, afterCapture.validationRequest!.correctionTargetIdentity);
+	assert.deepEqual(staged.original_criteria, { passed: true, evidence: ["acceptance passes"] });
+	assert.equal((details.result as { state?: string } | undefined)?.state, "approved");
+});
+
+// Live smoke root cause (2026-08-16, dev binary 2.4.0-main): status/v5 mints
+// the opaque --repository-context handle BOUND TO THE STATUS QUERY ROOT, and
+// every rendered payload embeds it. The finalize lane queries negotiated
+// STATUS from a frozen candidate-view root, so every rendered submission it
+// executed carried a context bound to the wrong root and failed the live
+// emitter's committed-intent reconciliation ("repository context effect
+// binding or payload does not match committed intent"). On v5 the lane must
+// rebind its negotiated STATUS to the workspace root before executing any
+// rendered payload; pinned pre-v5 emitters keep the frozen-view status.
+test("status/v5 finalize lane rebinds negotiated status to the workspace root before executing rendered payloads", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const rebind = true;\n");
+	const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	const viewContext = `rctx1_${"a".repeat(64)}`;
+	const workspaceContext = `rctx1_${"b".repeat(64)}`;
+	const makeBefore = (repositoryContext: string) => {
+		const status = bindEvidenceSubmissionCollection(targetStatusFixture({
+			lineageId: "v5-rebind",
+			authorityState: "correction_required",
+			baseTree: frozen.baseTree,
+			currentCandidateTree: frozen.candidateTree,
+			paths: frozen.paths,
+		}), EVIDENCE_SLOT_FIX_TARGET, repositoryContext);
+		(status.raw as Record<string, unknown>).schema = "gentle-ai.review-integration.status/v5";
+		return status;
+	};
+	const viewBefore = makeBefore(viewContext);
+	const workspaceBefore = makeBefore(workspaceContext);
+	const workspaceAfter = bindTargetedValidationSubmission(targetStatusFixture({
+		lineageId: "v5-rebind",
+		authorityState: "validating",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}));
+	(workspaceAfter.raw as Record<string, unknown>).schema = "gentle-ai.review-integration.status/v5";
+	// Live post-evidence shape (2026-08-16): the validation request binds the
+	// FROZEN authority target identity while the top-level target identity is
+	// the live workspace snapshot (which now contains the fix).
+	workspaceAfter.authorityTargetIdentity = workspaceAfter.validationRequest!.targetIdentity;
+	workspaceAfter.targetIdentity = `sha256:${"d".repeat(64)}`;
+	const expectedEvidenceTokens = workspaceBefore.nextTransition!.collect!.inputs[0]!.submissionDescriptor!.argumentTokens;
+	const expectedValidationTokens = (workspaceAfter.nextTransition!.collect!.inputs[0]! as { submissionDescriptor: { argumentTokens: readonly string[] } }).submissionDescriptor.argumentTokens;
+	frozen.cleanup();
+	const statusRoots: string[] = [];
+	const evidenceSubmissions: Array<Record<string, unknown>> = [];
+	const finalizeSubmissions: Array<Record<string, unknown>> = [];
+	let workspaceStatuses = 0;
+	const { controller } = runtime(fakeNative({
+		targetStatus: async (request) => {
+			statusRoots.push(request.cwd);
+			if (request.cwd !== cwd) return viewBefore;
+			workspaceStatuses += 1;
+			return workspaceStatuses === 1 ? workspaceBefore : workspaceAfter;
+		},
+		captureEvidenceSubmission: async (request: Record<string, unknown>) => {
+			evidenceSubmissions.push(request);
+			return capturedSlotEvidence(workspaceBefore, "passed", "8");
+		},
+		finalizeSubmission: async (request: Record<string, unknown>) => {
+			finalizeSubmissions.push(request);
+			return { lineageId: "v5-rebind", state: "approved", action: "approved", storeRevision: "r-approved" };
+		},
+	} as unknown as Partial<NativeReviewCli>), undefined, undefined, undefined, new CandidateViewRegistry());
+	const completed = await controller.execute("v5-rebind", {
+		operation: "finalize",
+		lineageId: "v5-rebind",
+		input: JSON.stringify({
+			final_evidence: "evidence: passed",
+			final_verification_outcome: "passed",
+			validation: {
+				request_hash: "9".repeat(64), correction_ids: [],
+				original_criteria: { passed: true, evidence: ["acceptance passes"] },
+				correction_regression: { passed: true, evidence: ["regression passes"] },
+				fix_caused_findings: [], follow_ups: [],
+			},
+		}),
+	}, undefined, undefined, context(cwd));
+	const details = completed.details as Record<string, unknown>;
+	assert.notEqual(statusRoots[0], cwd, "the first status query still freezes through the candidate view root");
+	assert.equal(statusRoots[1], cwd, "a v5 status must be rebound to the workspace root before any rendered payload executes");
+	assert.equal(evidenceSubmissions.length, 1);
+	assert.deepEqual(evidenceSubmissions[0]!.argumentTokens, expectedEvidenceTokens, "the evidence submission must carry the workspace-root-minted tokens");
+	assert.equal(finalizeSubmissions.length, 1);
+	assert.deepEqual(finalizeSubmissions[0]!.argumentTokens, expectedValidationTokens, "the validation submission must carry the workspace-root-minted tokens");
+	assert.equal(statusRoots.filter((root) => root === cwd).length, 2, "post-evidence status must also be workspace-bound");
+	assert.equal((details.result as { state?: string } | undefined)?.state, "approved");
+});

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -6,6 +6,7 @@ import {
 	decodeReviewCapabilitiesV2,
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
+	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
@@ -590,4 +591,41 @@ test("result artifact identities never cross-decode", () => {
 		captured: true,
 	}));
 	assert.throws(() => decodeReviewResultArtifactV2(v2Fixture("status.fixture.json")));
+});
+
+// Fixture provenance:
+// - failure-v2-capture-evidence.captured.json was captured 2026-08-16 from a
+//   binary built at gentle-ai commit a2d57117 (branch
+//   fix/capture-evidence-typed-refusal, `go build ./cmd/gentle-ai`, version
+//   banner "gentle-ai dev"), in a scratch git repository driven to the
+//   correction evidence-pending state (medium start with consent granted,
+//   one deterministic BLOCKER capture-result, rendered finalize transition,
+//   rendered plan-correction submission, bounded fix edit), then a
+//   deliberately misbound capture:
+//     gentle-ai review capture-evidence --cwd <scratch> --lineage <lineage> \
+//       --target <live workspace identity> --expected-revision <revision> \
+//       --outcome passed --input <evidence file>
+//   The live workspace identity instead of the slot's fix-diff --target is
+//   the exact fambig misbinding shape; the branch answers it with the typed
+//   failure/v2 envelope on stdout (operation review.capture-evidence, code
+//   verification_evidence_binding_mismatch, mutation_outcome not_started)
+//   instead of a bare stderr line.
+// - The other three capture-verb operations are constructed from the same
+//   captured envelope, grounded in that branch's
+//   contracts/review-integration/v2/schemas/failure.schema.json 12-value
+//   operation enum; no cheap live flow provokes them individually.
+test("failure/v2 decodes the four collect-capture operations the typed-refusal branch emits", () => {
+	const captured = JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "failure-v2-capture-evidence.captured.json"), "utf8")) as Record<string, unknown>;
+	const decoded = decodeReviewFailureV2(captured);
+	assert.equal(decoded.operation, "review.capture-evidence");
+	assert.equal(decoded.code, "verification_evidence_binding_mismatch");
+	assert.equal(decoded.mutationOutcome, "not_started");
+	assert.equal(decoded.nextAction, "review.status");
+	for (const operation of ["review.capture-result", "review.capture-refuter", "review.capture-validation"]) {
+		assert.equal(decodeReviewFailureV2({ ...captured, operation }).operation, operation, operation);
+	}
+	// Cross-pinned rejection preserved: an operation outside the published
+	// 12-value enum never decodes.
+	assert.throws(() => decodeReviewFailureV2({ ...captured, operation: "review.capture-bogus" }), /failure\.operation/);
+	assert.throws(() => decodeReviewFailureV2({ ...captured, operation: "review.recover" }), /failure\.operation/);
 });


### PR DESCRIPTION
## What

The controller rebuilt collect-satisfying invocations from top-level status fields instead of the provider-rendered slot tokens — deterministic binding mismatches at every evidence/plan/validation sub-state (the maintainer's live 'ambiguous FINALIZE'). Three layers:

- Every collect submission now executes the rendered tokens verbatim (evidence, correction plan, targeted validation); legacy reconstructed argv paths deleted.
- Root cause of the field wedge: status/v5 mints `--repository-context` bound to the STATUS query root — the finalize lane now rebinds STATUS to the workspace root before executing rendered payloads (pre-v5 lanes byte-identical, pinned).
- Reconciliation truth: an envelope-less failure with a PROVEN unchanged authority revision reports non-mutation instead of `unknown` + false retry prohibition (moved-revision stays fail-closed).
- Forward decode of the four collect-capture typed refusals (gentle-ai a2d57117), captured fixture; vendored schema stays at pinned bytes (enum forwarded in the decoder, vendoring at the next pin advance).

## Verification

Full `pnpm test` 1245 pass / 0 fail (override aside+restored, sha verified); transaction-runner/provider-contract/package-files green; `pnpm test:cross-lane` 10/10; live controller-lane smoke end-to-end: START→consent→BLOCKER→correction plan→bounded fix→evidence via slot tokens (fix-diff target ≠ live identity, the exact field shape)→targeted validation→**approved receipt**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-rendered submission support for evidence capture and finalization workflows.
  * Added support for literal or document-based correction submissions.
  * Expanded recognition of capture-related failure operations.

* **Bug Fixes**
  * Improved handling of ambiguous mutations and reconciliation outcomes.
  * Strengthened validation of submission targets, revisions, tokens, and scoped paths.
  * Ensured final verification uses the correct workspace context.

* **Tests**
  * Added comprehensive coverage for submission validation, token preservation, routing, and failure decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->