### PR TITLE
fix(review): recovered-lineage dispatch binding and finalize routing

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5485,6 +5485,41 @@ async function executeProviderRoleVectorCollection(
 	};
 }
 
+// The provider-named lenses still awaiting a reviewer result: one lens per
+// pending `review.capture-result` collect input, in provider order.
+function pendingReviewerLenses(status: ReviewStatusV3): readonly string[] {
+	if (status.nextTransition?.kind !== "collect") return [];
+	return [...new Set((status.nextTransition.collect?.inputs ?? [])
+		.filter((input) => input.captureOperation === "review.capture-result")
+		.map((input) => input.artifactSubject?.lens)
+		.filter((lens): lens is NonNullable<typeof lens> => lens !== undefined))];
+}
+
+// Live defect (2026-08-16, Engram #12461): a successor lineage created by
+// native `review recover` exists only in native authority — this controller
+// never saw its START, so direct reviewer dispatch refused with
+// current-binding-missing even though the controller itself had just decoded
+// the successor's authoritative STATUS. Mirror the START-time registration
+// from STATUS discovery: when an unknown-but-live lineage still collecting
+// reviewer results appears in a status this controller decoded, restore its
+// frozen projection from the native descriptor and bind the dispatch-facing
+// current candidate view with the provider-named pending lenses. Best-effort
+// by design: when the live candidate no longer matches the frozen descriptor,
+// dispatch keeps its own typed refusal.
+function hydrateDispatchBindingFromStatus(candidateViews: CandidateViewRegistry | null, contributorRoot: string, status: ReviewStatusV3): void {
+	if (candidateViews === null || candidateViews.hasCurrentBinding()) return;
+	const lineageId = status.authority?.lineageId;
+	if (lineageId === undefined || status.applicability !== "current_target" || candidateViews.hasProjection(lineageId)) return;
+	const lenses = pendingReviewerLenses(status);
+	if (lenses.length === 0) return;
+	try {
+		candidateViews.restoreCurrentForDispatchFromNative(lineageId, contributorRoot, status.projection, lenses);
+	} catch {
+		// Dispatch surfaces its own typed refusal when the live candidate
+		// cannot be bound; a read-only STATUS never fails on hydration.
+	}
+}
+
 async function executeReviewControllerOperation(
 	parametersValue: unknown,
 	sessionCwd: string,
@@ -5979,6 +6014,36 @@ async function executeReviewControllerOperation(
 				if (roleVectorSlots.length > 0 && input.final_evidence === undefined && input.correction_line_forecast === undefined && input.validation === undefined) {
 					return await executeProviderRoleVectorCollection(parameters.operation, parameters.lineageId, roleVectorSlots, nativeReviewCli, defaultCwd, signal);
 				}
+				// Live defect (2026-08-16, Engram #12466): FINALIZE on a lineage
+				// still at reviewer_results_required misrouted into the correction
+				// evidence-first-ordering lane and failed. Route strictly from the
+				// provider transition: a collect naming review.capture-result means
+				// reviewer results are still outstanding — no correction-evidence
+				// or targeted-validation lane is ever admissible here, so any
+				// document-carrying FINALIZE stops with the provider-offered step.
+				// A document-free FINALIZE stops too on the live status/v5 lane
+				// (the same v5 keying as the workspace rebind above); the pinned
+				// pre-v5 raw-finalize fallback keeps its native captured-results
+				// discovery unchanged. Materialize-marked pi slots were already
+				// routed through the host relay above.
+				const reviewerResultsOutstanding = negotiatedStatus.nextTransition?.kind === "collect"
+					&& (negotiatedStatus.nextTransition.collect?.inputs ?? []).some((collectInput) => collectInput.captureOperation === "review.capture-result");
+				const finalizeDocumentsPresent = input.final_evidence !== undefined || input.validation !== undefined || input.correction_line_forecast !== undefined;
+				if (reviewerResultsOutstanding && (finalizeDocumentsPresent || (negotiatedStatus.raw as { schema?: unknown }).schema === "gentle-ai.review-integration.status/v5")) {
+					const outstandingReviewerLenses = pendingReviewerLenses(negotiatedStatus);
+					if (candidateView !== undefined && candidateViews && (correctionCompletion || validationAttempt)) candidateViews.cleanup(candidateView.token);
+					return {
+						operation: parameters.operation,
+						status: "blocked",
+						outcome: "reviewer-results-required",
+						reason: "Capture the reviewer result first; the provider offers review.capture-result. Correction evidence and targeted validation are never admissible while reviewer results are outstanding.",
+						...(outstandingReviewerLenses.length === 0 ? {} : { pending_lenses: outstandingReviewerLenses }),
+						result: negotiatedStatus.raw,
+						mutation_performed: false,
+						mutation_outcome: "none",
+						next_action: "review.capture-result",
+					};
+				}
 				// Ordinary final verification (field defect, 2026-08-16): at
 				// native state `validating` the provider collects one final
 				// `review.capture-evidence` record and then offers exactly one
@@ -6335,6 +6400,7 @@ async function executeReviewControllerOperation(
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 					...(signal === undefined ? {} : { signal }),
 				});
+				hydrateDispatchBindingFromStatus(candidateViews, defaultCwd, status);
 				return mapNativeTargetStatus(parameters.operation, status, parameters.lineageId);
 			} catch (error) {
 				return nativeOperationFailure(parameters.operation, error);

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -1105,6 +1105,36 @@ export class CandidateViewRegistry {
 		}
 	}
 
+	/**
+	 * Mirrors the START-time dispatch registration for a lineage this
+	 * controller never started (live defect 2026-08-16: a successor created
+	 * by native `review recover` exists only in native authority). The
+	 * authoritative STATUS descriptor supplies the frozen projection; the
+	 * live candidate is re-materialized and must match it exactly before the
+	 * dispatch-facing current binding is established with the provider-named
+	 * pending lenses.
+	 */
+	restoreCurrentForDispatchFromNative(lineageId: string, contributorRoot: string, descriptor: NativeCandidateProjectionDescriptor, selectedLenses: readonly string[]): void {
+		if (this.current !== undefined) throw new CandidateViewError("candidate view already has a current lineage binding", "current-binding-already-established");
+		const lenses = this.validateSelectedLenses(selectedLenses);
+		this.restoreProjectionFromNative(lineageId, contributorRoot, descriptor);
+		const projection = this.resolveProjection(lineageId, contributorRoot);
+		const record = materializeCandidateView({ contributorRoot, baseRef: projection.baseCommit, committedOnly: projection.committedOnly }, this.gitExecutor);
+		try {
+			if (record.baseTree !== projection.baseTree || record.candidateTree !== projection.candidateTree || JSON.stringify(record.scope.paths) !== JSON.stringify(projection.paths)) {
+				throw new CandidateViewError("live candidate does not match the native frozen projection");
+			}
+			this.records.set(record.token, record);
+			this.bindRecord(record.token, lineageId, lenses);
+			this.current = { lineageId, token: record.token };
+		} catch (error) {
+			this.projections.delete(lineageId);
+			this.records.delete(record.token);
+			this.remove(record);
+			throw error;
+		}
+	}
+
 	resolveProjection(lineageId: string, contributorRoot: string): FrozenCandidateProjection {
 		const projection = this.projections.get(lineageId);
 		if (!projection || realpathSync(contributorRoot) !== projection.contributorRoot) {

--- a/tests/crosslane/cross-lane.mjs
+++ b/tests/crosslane/cross-lane.mjs
@@ -44,6 +44,11 @@ import {
 	decodeReviewStartV3,
 	decodeReviewStatusV3,
 } from "../../runtime/review-integration-v2.mjs";
+// The recovered-successor checks drive the CONTROLLER (not just the runtime
+// adapter) against the live binary; Node's default type stripping loads the
+// authored TypeScript directly.
+import { __testing } from "../../extensions/gentle-ai.ts";
+import { CandidateViewRegistry, injectReviewCandidateView } from "../../lib/review-candidate-view.ts";
 
 const WITH_MODEL = process.argv.includes("--with-model");
 const CONTRACT = "gentle-ai.review-integration/v2";
@@ -496,6 +501,138 @@ async function abandonLifecycle(binary, cli, root) {
 	return "adapter-built nine-line v2 binding accepted natively; quarantine record committed; post-abandon status offers only a fresh start";
 }
 
+// recoveredSuccessorLifecycle reproduces the maintainer's live scenario
+// (2026-08-16, Engram #12461/#12466): a lineage recovered EXTERNALLY through
+// the native CLI, then driven by the Pi controller from STATUS alone.
+//   1. approve a low documentation lineage;
+//   2. change the scope with a code edit (medium risk);
+//   3. native `review recover --disposition scope_changed` with the explicit
+//      LF-only gentle-ai.review-recovery-authorization/v1 binding (an ACTIVE
+//      reviewing predecessor refuses recovery, so approval comes first);
+//   4. defect A: the controller's dispatch binding must hydrate from the
+//      STATUS the controller itself decodes — before that STATUS, dispatch
+//      refuses with current-binding-missing;
+//   5. defect B: finalize at reviewer_results_required must surface the
+//      provider-offered review.capture-result step, never the correction
+//      evidence-first-ordering lane;
+//   6. the drive completes to one really captured lens.
+async function recoveredSuccessorLifecycle(binary, cli, root) {
+	const cwd = scratchRepo(root, "pi-recovered");
+	write(cwd, "docs/recover-guide.md", "# Recover guide\n\nline one\n");
+	write(cwd, "src/mul.js", "export function mul(a, b) {\n  return a * b;\n}\n");
+	commitAll(cwd, "feat: base");
+	write(cwd, "docs/recover-guide.md", "# Recover guide\n\nline one\nline two, purely passive documentation\n");
+
+	// Low predecessor to approval.
+	let raw = rawStatus(binary, cwd);
+	let status = await cli.targetStatus({ cwd });
+	assertOfferedStepMatchesNative("pre-start", status, raw);
+	const start = await cli.start({ cwd, targetIdentity: status.targetIdentity, projection: "workspace" });
+	if (start.riskLevel !== "low" || start.state !== "reviewing") throw new Error(`predecessor start risk=${start.riskLevel} state=${start.state}`);
+	status = await cli.targetStatus({ cwd });
+	if (status.nextTransition?.execute?.operation !== "review.finalize") {
+		throw new Error(`expected review.finalize, got ${summarizeDecoded(status.nextTransition)}`);
+	}
+	const finalize = await cli.finalizeTransition({ cwd, argumentTokens: executeTokens(status.nextTransition) });
+	if (finalize.state !== "approved") throw new Error(`predecessor finalize state=${finalize.state}`);
+
+	// External scope change: code joins the approved documentation change.
+	write(cwd, "src/mul.js", "export function mul(a, b) {\n  return a * b;\n}\nexport function twice(a) {\n  return a + a;\n}\n");
+	raw = rawStatus(binary, cwd);
+	const successor = "recovered-successor-crosslane";
+	const authorization = [
+		"gentle-ai.review-recovery-authorization/v1",
+		`predecessor_lineage=${finalize.lineageId}`,
+		`predecessor_revision=${finalize.storeRevision}`,
+		`target_identity=${raw.target_identity}`,
+		"actor=cross-lane-battery",
+		"reason=scope changed after approval",
+	].join("\n");
+	rawInvoke(binary, cwd, [
+		"review", "recover", "--cwd", cwd,
+		"--predecessor-lineage", finalize.lineageId,
+		"--expected-predecessor-revision", finalize.storeRevision,
+		"--successor-lineage", successor,
+		"--disposition", "scope_changed",
+		"--actor", "cross-lane-battery",
+		"--reason", "scope changed after approval",
+		"--maintainer-authorization", authorization,
+	]);
+
+	const registry = new CandidateViewRegistry();
+	try {
+		// Defect A: before the controller decodes the successor's STATUS, the
+		// dispatch registry knows nothing — the refusal is the pre-fix shape.
+		let refused = false;
+		try {
+			injectReviewCandidateView({ agent: "review-reliability", task: "probe", mode: "task" }, registry);
+		} catch (error) {
+			refused = /no current controller-owned candidate view lineage binding/.test(String(error instanceof Error ? error.message : error));
+		}
+		if (!refused) throw new Error("pre-STATUS dispatch unexpectedly resolved a binding for the recovered successor");
+		await __testing.executeReviewControllerOperation({ operation: "status", lineageId: successor }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
+		if (!registry.hasCurrentBinding()) {
+			throw new Error("controller STATUS did not hydrate the candidate-view dispatch binding for the recovered successor");
+		}
+		const dispatch = { agent: "review-reliability", task: "review the recovered successor", mode: "task" };
+		injectReviewCandidateView(dispatch, registry);
+		if (!dispatch.task.includes(successor)) throw new Error("hydrated dispatch context is not bound to the recovered successor lineage");
+		pass(
+			"recovered binding: STATUS hydrates controller dispatch",
+			"external scope_changed successor driven from STATUS alone: pre-STATUS dispatch refused, post-STATUS dispatch injected the successor candidate context (a controller without STATUS hydration fails here)",
+		);
+
+		// Defect B: document-free finalize at reviewer_results_required.
+		const finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({}) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
+		if (finalizeEnvelope.status !== "blocked" || finalizeEnvelope.outcome !== "reviewer-results-required" || finalizeEnvelope.mutation_performed !== false) {
+			throw new Error(`finalize routed to ${String(finalizeEnvelope.outcome ?? finalizeEnvelope.status)} instead of the blocked reviewer-results-required step`);
+		}
+		if (!/capture the reviewer result first/i.test(String(finalizeEnvelope.reason)) || !String(finalizeEnvelope.reason).includes("review.capture-result")) {
+			throw new Error("finalize block is missing the actionable review.capture-result direction");
+		}
+		if (JSON.stringify(finalizeEnvelope).includes("evidence-first-ordering")) {
+			throw new Error("finalize still leaked the correction evidence-first-ordering lane");
+		}
+		pass(
+			"recovered routing: finalize offers capture-result, never evidence ordering",
+			"document-free finalize at reviewer_results_required returned the actionable review.capture-result block with zero mutations (a finalize that misroutes into evidence ordering fails here)",
+		);
+
+		// Complete the drive to one really captured lens through the exact
+		// provider collect input.
+		raw = rawStatus(binary, cwd);
+		const input = raw.next_transition?.collect?.inputs?.[0];
+		if (input?.capture_operation !== "review.capture-result") throw new Error(`expected review.capture-result, got ${summarizeRaw(raw.next_transition)}`);
+		const args = rawArgumentValues(input);
+		const reviewerFile = join(root, "pi-recovered-reviewer.json");
+		writeFileSync(reviewerFile, JSON.stringify({
+			subject_hash: args["subject-hash"],
+			inspection: { status: "completed", paths: (input.changed_path_manifest ?? []).map((entry) => entry.path) },
+			evidence: ["twice(a) returns a + a: pure arithmetic introduced by the candidate hunk with no external effects"],
+			findings: [],
+		}));
+		const artifact = rawInvoke(binary, cwd, [
+			"review", "capture-result",
+			"--lineage", args.lineage,
+			"--expected-revision", args["expected-revision"],
+			"--target", args.target,
+			"--repository-context", args["repository-context"],
+			"--lens", args.lens,
+			"--order", args.order,
+			"--subject-hash", args["subject-hash"],
+			"--input", reviewerFile,
+		]);
+		if (artifact?.schema !== "gentle-ai.review-result-artifact/v2") throw new Error(`successor lens capture returned schema=${artifact?.schema}`);
+		return "low predecessor approved -> native scope_changed recover (explicit v1 binding) -> controller drove the successor from STATUS alone to one captured lens";
+	} finally {
+		try {
+			registry.cleanup(registry.resolveCurrentForLens("review-reliability").token);
+		} catch {
+			// No hydrated view to clean when the check failed before binding.
+		}
+	}
+}
+
 async function modelReview(binary, cli, cwd) {
 	const raw = rawStatus(binary, cwd);
 	const input = raw.next_transition?.collect?.inputs?.[0];
@@ -615,6 +752,12 @@ async function main() {
 			pass("audited abandon end-to-end (v2 discarded-work binding)", await abandonLifecycle(binary, cli, root));
 		} catch (error) {
 			fail("audited abandon end-to-end (v2 discarded-work binding)", knownRedParity(describeError(error)));
+		}
+
+		try {
+			pass("external native recover to captured successor lens", await recoveredSuccessorLifecycle(binary, cli, root));
+		} catch (error) {
+			fail("external native recover to captured successor lens", knownRedParity(describeError(error)));
 		}
 
 		if (WITH_MODEL && mediumRepo !== undefined) {

--- a/tests/review-recovered-lineage-routing.test.ts
+++ b/tests/review-recovered-lineage-routing.test.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { __testing } from "../extensions/gentle-ai.ts";
+import type { NativeReviewCli } from "../lib/native-review-cli.ts";
+import { CandidateViewRegistry, injectReviewCandidateView } from "../lib/review-candidate-view.ts";
+import type { ReviewCollectInputV3, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+
+// Live-confirmed adapter defects (2026-08-16, gentle-ai 2.4.0-main, Engram
+// #12461/#12466), both around a lineage recovered EXTERNALLY through native
+// `gentle-ai review recover` (disposition scope_changed):
+//
+//   A. The controller never saw the successor's START, so direct reviewer
+//      dispatch refused with `no current controller-owned candidate view
+//      lineage binding` even though the controller itself had just decoded
+//      the successor's authoritative STATUS.
+//   B. `gentle_review finalize` on a lineage still at reviewer_results_required
+//      misrouted into the correction evidence-first-ordering lane and failed
+//      instead of surfacing the provider-offered review.capture-result step.
+
+const SHA = `sha256:${"1".repeat(64)}`;
+
+function git(cwd: string, ...arguments_: string[]): string {
+	return execFileSync("git", arguments_, { cwd, encoding: "utf8" }).trim();
+}
+
+function repository(t: test.TestContext): string {
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-recovered-routing-"));
+	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	git(cwd, "init", "-b", "main");
+	writeFileSync(join(cwd, "tracked.txt"), "base\n");
+	git(cwd, "add", "tracked.txt");
+	git(cwd, "-c", "user.name=Recovered Test", "-c", "user.email=recovered@example.invalid", "commit", "-m", "base");
+	return cwd;
+}
+
+function reviewerResultCollectInput(lineageId: string, lens: string, order: number): ReviewCollectInputV3 {
+	return {
+		name: "reviewer_result",
+		schema: "https://gentle-ai.dev/schema/review/reviewer/v1",
+		captureOperation: "review.capture-result",
+		arguments: [
+			{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` },
+			{ name: "expected-revision", value: SHA, token: `--expected-revision=${SHA}` },
+			{ name: "target", value: SHA, token: `--target=${SHA}` },
+			{ name: "lens", value: lens, token: `--lens=${lens}` },
+			{ name: "order", value: String(order), token: `--order=${order}` },
+			{ name: "subject-hash", value: `sha256:${String(order).repeat(64)}`, token: `--subject-hash=sha256:${String(order).repeat(64)}` },
+		],
+		artifactSubject: {
+			schema: "gentle-ai.review-artifact-subject/v2",
+			subjectHash: `sha256:${String(order).repeat(64)}`,
+			lineageId,
+			authorityRevision: SHA,
+			targetIdentity: SHA,
+			baseTree: "3".repeat(40),
+			candidateTree: "4".repeat(40),
+			changedPathManifestSha256: SHA,
+			lens,
+			selectedOrder: order,
+		},
+	} as unknown as ReviewCollectInputV3;
+}
+
+interface StatusFixtureShape {
+	lineageId: string;
+	baseTree: string;
+	currentCandidateTree: string;
+	paths: readonly string[];
+	inputs?: readonly ReviewCollectInputV3[];
+	executeFinalize?: boolean;
+}
+
+function recoveredStatus(shape: StatusFixtureShape): ReviewStatusV3 {
+	return {
+		contract: "gentle-ai.review-integration/v2",
+		applicability: "current_target",
+		authority: { version: "compact-v2", lineageId: shape.lineageId, state: "reviewer_results_required", generation: 2, revision: SHA },
+		receipt: { status: "expected_missing" },
+		action: "finalize",
+		replayability: "not_replayable",
+		targetIdentity: SHA,
+		projection: {
+			schema: "gentle-ai.review-integration.projection/v1",
+			kind: "current-changes",
+			projection: "workspace",
+			baseTree: shape.baseTree,
+			initialReviewTree: shape.currentCandidateTree,
+			currentCandidateTree: shape.currentCandidateTree,
+			pathsDigest: SHA,
+			paths: [...shape.paths],
+			intendedUntracked: [],
+			intendedUntrackedProof: SHA,
+			initialSnapshotIdentity: SHA,
+			currentSnapshotIdentity: SHA,
+		},
+		candidates: [],
+		...(shape.inputs !== undefined
+			? { nextTransition: { kind: "collect", reasonCode: "reviewer_results_required", collect: { inputs: [...shape.inputs] } } }
+			: {}),
+		...(shape.executeFinalize === true
+			? { nextTransition: { kind: "execute", reasonCode: "captured_results_ready", execute: { operation: "review.finalize", arguments: [], binding: { lineageId: shape.lineageId } } } }
+			: {}),
+		raw: { schema: "gentle-ai.review-integration.status/v5", action: "finalize", lineage_id: shape.lineageId },
+	} as unknown as ReviewStatusV3;
+}
+
+function statusOnlyNative(statuses: readonly ReviewStatusV3[]): { native: NativeReviewCli; finalizeCalls: () => number; statusCalls: () => number } {
+	const queue = [...statuses];
+	let finalizeCalls = 0;
+	let statusCalls = 0;
+	const native = {
+		targetStatus: async () => {
+			statusCalls += 1;
+			// The v5 lane legitimately re-queries STATUS (workspace-root
+			// rebind); keep serving the terminal fixture once drained.
+			const next = queue.length > 1 ? queue.shift() : queue[0];
+			if (next === undefined) throw new Error("status queue exhausted");
+			return next;
+		},
+		finalize: async () => {
+			finalizeCalls += 1;
+			throw new Error("native finalize must not be invoked while reviewer results are outstanding");
+		},
+	} as unknown as NativeReviewCli;
+	return { native, finalizeCalls: () => finalizeCalls, statusCalls: () => statusCalls };
+}
+
+async function runController(
+	parameters: Record<string, unknown>,
+	cwd: string,
+	native: NativeReviewCli,
+	candidateViews: CandidateViewRegistry,
+): Promise<Record<string, unknown>> {
+	return await __testing.executeReviewControllerOperation(
+		parameters,
+		cwd,
+		new Map(),
+		native,
+		undefined,
+		undefined,
+		undefined,
+		candidateViews,
+	) as Record<string, unknown>;
+}
+
+// --- DEFECT A: STATUS discovery hydrates the dispatch binding ---
+
+test("STATUS discovery hydrates the dispatch binding for an externally recovered lineage", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "tracked.txt"), "successor candidate change\n");
+	// Derive the real frozen identity of the live workspace candidate the way
+	// native recover froze it: the descriptor in status/v5 names these trees.
+	const probe = new CandidateViewRegistry();
+	const probeView = probe.create({ contributorRoot: cwd });
+	const frozen = { baseTree: probeView.baseTree, currentCandidateTree: probeView.candidateTree, paths: probeView.paths };
+	probe.cleanup(probeView.token);
+
+	const successor = "review-recovered-successor";
+	const status = recoveredStatus({ lineageId: successor, ...frozen, inputs: [reviewerResultCollectInput(successor, "review-reliability", 0)] });
+	const { native } = statusOnlyNative([status]);
+	const registry = new CandidateViewRegistry();
+
+	// The controller does not know this lineage: dispatch refuses.
+	assert.throws(
+		() => injectReviewCandidateView({ agent: "review-reliability", task: "review", mode: "task" }, registry),
+		/no current controller-owned candidate view lineage binding/,
+	);
+
+	const envelope = await runController({ operation: "status", lineageId: successor }, cwd, native, registry);
+	assert.equal(envelope.operation, "status");
+
+	// After the controller itself decoded the successor's authoritative
+	// STATUS, the dispatch binding must be hydrated from that status.
+	assert.equal(registry.hasCurrentBinding(), true, "STATUS discovery must hydrate the controller-owned dispatch binding");
+	try {
+		const dispatch: Record<string, unknown> = { agent: "review-reliability", task: "review the recovered successor", mode: "task" };
+		assert.doesNotThrow(() => injectReviewCandidateView(dispatch, registry));
+		assert.match(String(dispatch.task), new RegExp(successor));
+		assert.equal(registry.resolveCurrentForLens("review-reliability").candidateTree, frozen.currentCandidateTree);
+	} finally {
+		registry.cleanup(registry.resolveCurrentForLens("review-reliability").token);
+	}
+});
+
+test("STATUS discovery never hydrates without pending reviewer-result collection", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "tracked.txt"), "successor candidate change\n");
+	const probe = new CandidateViewRegistry();
+	const probeView = probe.create({ contributorRoot: cwd });
+	const frozen = { baseTree: probeView.baseTree, currentCandidateTree: probeView.candidateTree, paths: probeView.paths };
+	probe.cleanup(probeView.token);
+
+	const successor = "review-recovered-successor";
+	const { native } = statusOnlyNative([recoveredStatus({ lineageId: successor, ...frozen, executeFinalize: true })]);
+	const registry = new CandidateViewRegistry();
+	await runController({ operation: "status", lineageId: successor }, cwd, native, registry);
+	assert.equal(registry.hasCurrentBinding(), false, "an execute transition offers no reviewer dispatch and must not hydrate");
+});
+
+// --- DEFECT B: finalize routes strictly from the provider transition ---
+
+test("finalize at reviewer_results_required surfaces capture-result and never enters evidence ordering", async (t) => {
+	const cwd = repository(t);
+	const lineageId = "recovered-lineage";
+	const status = () => recoveredStatus({
+		lineageId,
+		baseTree: "3".repeat(40),
+		currentCandidateTree: "4".repeat(40),
+		paths: ["tracked.txt"],
+		inputs: [reviewerResultCollectInput(lineageId, "review-reliability", 0)],
+	});
+
+	// Plain finalize with no negotiated collection answers.
+	const plainHarness = statusOnlyNative([status()]);
+	const plain = await runController({ operation: "finalize", lineageId, input: JSON.stringify({}) }, cwd, plainHarness.native, new CandidateViewRegistry());
+	assert.equal(plain.status, "blocked");
+	assert.equal(plain.outcome, "reviewer-results-required");
+	assert.match(String(plain.reason), /capture the reviewer result first/i);
+	assert.match(String(plain.reason), /review\.capture-result/);
+	assert.equal(plain.mutation_performed, false);
+	assert.equal(plain.mutation_outcome, "none");
+	assert.deepEqual(plain.pending_lenses, ["review-reliability"]);
+	assert.equal(plainHarness.finalizeCalls(), 0, "raw native finalize must never run while reviewer results are outstanding");
+	assert.doesNotMatch(JSON.stringify(plain), /evidence-first-ordering/);
+
+	// The live misroute shape: finalize carrying final evidence must not fall
+	// into the correction evidence-first-ordering lane either.
+	const evidenceHarness = statusOnlyNative([status()]);
+	const misrouted = await runController(
+		{ operation: "finalize", lineageId, input: JSON.stringify({ final_evidence: "all checks green", final_verification_passed: true }) },
+		cwd,
+		evidenceHarness.native,
+		new CandidateViewRegistry(),
+	);
+	assert.equal(misrouted.status, "blocked");
+	assert.equal(misrouted.outcome, "reviewer-results-required");
+	assert.match(String(misrouted.reason), /capture the reviewer result first/i);
+	assert.equal(misrouted.mutation_performed, false);
+	assert.equal(misrouted.mutation_outcome, "none");
+	assert.equal(evidenceHarness.finalizeCalls(), 0);
+	assert.doesNotMatch(JSON.stringify(misrouted), /evidence-first-ordering/);
+});


### PR DESCRIPTION
Two live-confirmed adapter defects around a lineage recovered EXTERNALLY through the native CLI (`gentle-ai review recover`, disposition `scope_changed`), reproduced by the maintainer on gentle-ai 2.4.0-main with the regenerated Pi package (Engram #12461/#12466). Zero mutations in every failure; candidate and authority intact.

## Defect A — recovered-lineage binding

The controller never saw the successor's START, so direct reviewer dispatch refused with `no current controller-owned candidate view lineage binding` even though the controller itself had just decoded the successor's authoritative STATUS (state `reviewer_results_required`, one lens).

**Fix:** mirror the START-time registration from STATUS discovery. When an unknown-but-live lineage still collecting reviewer results appears in a status the controller decoded, the new `CandidateViewRegistry.restoreCurrentForDispatchFromNative` restores the frozen projection from the native status/v5 descriptor, re-materializes the live candidate, verifies it matches exactly, and binds the dispatch-facing current view with the provider-named pending lenses. Hydration is best-effort: on a drifted workspace, dispatch keeps its own typed refusal.

## Defect B — finalize misrouting

`gentle_review finalize` on a lineage at `reviewer_results_required` misrouted into the correction evidence-first-ordering lane and failed (`mutation_performed: false`).

**Fix:** route strictly from the provider-returned `next_transition`. A collect naming `review.capture-result` means reviewer results are outstanding: any document-carrying finalize, and any document-free finalize on the status/v5 lane, now returns a blocked envelope with the actionable direction — "Capture the reviewer result first; the provider offers review.capture-result" — plus the pending lenses. The pinned pre-v5 raw-finalize fallback keeps its native captured-results discovery unchanged, and materialize-marked pi slots still route through the host relay.

## RED evidence

Unit (`tests/review-recovered-lineage-routing.test.ts`, written first):
- A: dispatch against a lineage present in decoded status but absent from the registry refused; STATUS did not hydrate (`hasCurrentBinding` stayed false).
- B: finalize at `reviewer_results_required` produced `native-operation-failed` instead of the actionable capture-result step.

Battery (fix files temporarily reverted): `external native recover to captured successor lens` FAILED with "controller STATUS did not hydrate the candidate-view dispatch binding for the recovered successor" (12 checks, 1 failed).

## Battery coverage (real binary, real recover)

New cross-lane checks reproduce the maintainer's scenario end-to-end: approve a low lineage, change scope with a code edit, native `review recover --disposition scope_changed` with the explicit LF-only `gentle-ai.review-recovery-authorization/v1` binding, then drive the successor through the controller from STATUS alone to one really captured lens.

- `recovered binding: STATUS hydrates controller dispatch` — PASS
- `recovered routing: finalize offers capture-result, never evidence ordering` — PASS
- `external native recover to captured successor lens` — PASS

Scope note: an ACTIVE reviewing predecessor refuses recovery natively, so the battery recovers from an APPROVED predecessor (the smallest state the binary accepts for `scope_changed`); the successor lands in the maintainer's exact `reviewer_results_required` shape.

## Verification (all foreground)

- New unit file: 3/3 pass. Affected files (`review-controller-native-routing`, `review-host-relay-routing`, `review-candidate-view`, new): 279/279.
- Full suite: 1252 tests, 1237 pass; the 14 failures are the known pre-existing dev-binary-override environment set (identical on clean origin/main).
- `pnpm test:cross-lane`: 14 checks, 0 failed.
- `check:transaction-runner`: no generated drift. `check:provider-contract`: pass. `test:harness`: exit 0.
