### PR TITLE
fix(review): hydrate dispatch bindings from every authoritative status decode

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5503,20 +5503,39 @@ function pendingReviewerLenses(status: ReviewStatusV3): readonly string[] {
 // from STATUS discovery: when an unknown-but-live lineage still collecting
 // reviewer results appears in a status this controller decoded, restore its
 // frozen projection from the native descriptor and bind the dispatch-facing
-// current candidate view with the provider-named pending lenses. Best-effort
-// by design: when the live candidate no longer matches the frozen descriptor,
-// dispatch keeps its own typed refusal.
-function hydrateDispatchBindingFromStatus(candidateViews: CandidateViewRegistry | null, contributorRoot: string, status: ReviewStatusV3): void {
-	if (candidateViews === null || candidateViews.hasCurrentBinding()) return;
+// current candidate view with the provider-named pending lenses.
+//
+// Field report (2026-08-16, gentle-pi 402f9f77): hydration must run from
+// EVERY lane that decodes an authoritative status, not from the STATUS
+// operation alone — the reported flow was `finalize` (blocked on
+// review.capture-result) followed by a reviewer dispatch, which never passed
+// through STATUS. It also never fails its caller: STATUS and the blocked
+// FINALIZE envelope stay read-only, and the outcome is returned so the caller
+// can report it instead of swallowing it.
+type DispatchHydrationOutcome =
+	| { hydrated: true; lineage_id: string; lenses: readonly string[] }
+	| { hydrated: false; lineage_id: string; reason: string; message: string }
+	| undefined;
+
+function hydrateDispatchBindingFromStatus(candidateViews: CandidateViewRegistry | null, contributorRoot: string, status: ReviewStatusV3): DispatchHydrationOutcome {
+	if (candidateViews === null || candidateViews.hasCurrentBinding()) return undefined;
 	const lineageId = status.authority?.lineageId;
-	if (lineageId === undefined || status.applicability !== "current_target" || candidateViews.hasProjection(lineageId)) return;
+	if (lineageId === undefined || status.applicability !== "current_target" || candidateViews.hasProjection(lineageId)) return undefined;
 	const lenses = pendingReviewerLenses(status);
-	if (lenses.length === 0) return;
+	if (lenses.length === 0) return undefined;
 	try {
 		candidateViews.restoreCurrentForDispatchFromNative(lineageId, contributorRoot, status.projection, lenses);
-	} catch {
-		// Dispatch surfaces its own typed refusal when the live candidate
-		// cannot be bound; a read-only STATUS never fails on hydration.
+		return { hydrated: true, lineage_id: lineageId, lenses };
+	} catch (error) {
+		// Never fail the caller on hydration; the registry records the typed
+		// cause so the later dispatch refusal names the attempt instead of
+		// claiming no binding was ever available.
+		return {
+			hydrated: false,
+			lineage_id: lineageId,
+			reason: error instanceof CandidateViewError ? error.reason : "candidate-view-invalid",
+			message: error instanceof Error ? error.message : String(error),
+		};
 	}
 }
 
@@ -6032,12 +6051,20 @@ async function executeReviewControllerOperation(
 				if (reviewerResultsOutstanding && (finalizeDocumentsPresent || (negotiatedStatus.raw as { schema?: unknown }).schema === "gentle-ai.review-integration.status/v5")) {
 					const outstandingReviewerLenses = pendingReviewerLenses(negotiatedStatus);
 					if (candidateView !== undefined && candidateViews && (correctionCompletion || validationAttempt)) candidateViews.cleanup(candidateView.token);
+					// Field report (2026-08-16): this lane is where the reported
+					// flow actually learns reviewer results are outstanding, and
+					// the reviewer dispatch follows it directly. Hydrate the
+					// dispatch binding from the authoritative status just decoded
+					// — against the workspace root, never a frozen view root —
+					// and report the outcome either way.
+					const dispatchBinding = hydrateDispatchBindingFromStatus(candidateViews, defaultCwd, negotiatedStatus);
 					return {
 						operation: parameters.operation,
 						status: "blocked",
 						outcome: "reviewer-results-required",
 						reason: "Capture the reviewer result first; the provider offers review.capture-result. Correction evidence and targeted validation are never admissible while reviewer results are outstanding.",
 						...(outstandingReviewerLenses.length === 0 ? {} : { pending_lenses: outstandingReviewerLenses }),
+						...(dispatchBinding === undefined ? {} : { dispatch_binding: dispatchBinding }),
 						result: negotiatedStatus.raw,
 						mutation_performed: false,
 						mutation_outcome: "none",

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -857,6 +857,11 @@ export class CandidateViewRegistry {
 	private readonly projections = new Map<string, FrozenCandidateProjection>();
 	private readonly replays = new Map<string, string>();
 	private current: { lineageId: string; token: string } | undefined;
+	// The last dispatch-binding hydration that was attempted and failed. A
+	// swallowed hydration failure is its own defect (field report 2026-08-16):
+	// without it the later dispatch refusal claims no binding was ever
+	// available instead of naming the attempt and its typed cause.
+	private lastHydrationFailure: { lineageId: string; reason: string; message: string } | undefined;
 
 	create(request: CreateCandidateViewRequest): CandidateView {
 		return this.createOrReuse(request);
@@ -1116,21 +1121,31 @@ export class CandidateViewRegistry {
 	 */
 	restoreCurrentForDispatchFromNative(lineageId: string, contributorRoot: string, descriptor: NativeCandidateProjectionDescriptor, selectedLenses: readonly string[]): void {
 		if (this.current !== undefined) throw new CandidateViewError("candidate view already has a current lineage binding", "current-binding-already-established");
-		const lenses = this.validateSelectedLenses(selectedLenses);
-		this.restoreProjectionFromNative(lineageId, contributorRoot, descriptor);
-		const projection = this.resolveProjection(lineageId, contributorRoot);
-		const record = materializeCandidateView({ contributorRoot, baseRef: projection.baseCommit, committedOnly: projection.committedOnly }, this.gitExecutor);
 		try {
-			if (record.baseTree !== projection.baseTree || record.candidateTree !== projection.candidateTree || JSON.stringify(record.scope.paths) !== JSON.stringify(projection.paths)) {
-				throw new CandidateViewError("live candidate does not match the native frozen projection");
+			const lenses = this.validateSelectedLenses(selectedLenses);
+			this.restoreProjectionFromNative(lineageId, contributorRoot, descriptor);
+			const projection = this.resolveProjection(lineageId, contributorRoot);
+			const record = materializeCandidateView({ contributorRoot, baseRef: projection.baseCommit, committedOnly: projection.committedOnly }, this.gitExecutor);
+			try {
+				if (record.baseTree !== projection.baseTree || record.candidateTree !== projection.candidateTree || JSON.stringify(record.scope.paths) !== JSON.stringify(projection.paths)) {
+					throw new CandidateViewError("live candidate does not match the native frozen projection");
+				}
+				this.records.set(record.token, record);
+				this.bindRecord(record.token, lineageId, lenses);
+				this.current = { lineageId, token: record.token };
+			} catch (error) {
+				this.projections.delete(lineageId);
+				this.records.delete(record.token);
+				this.remove(record);
+				throw error;
 			}
-			this.records.set(record.token, record);
-			this.bindRecord(record.token, lineageId, lenses);
-			this.current = { lineageId, token: record.token };
+			this.lastHydrationFailure = undefined;
 		} catch (error) {
-			this.projections.delete(lineageId);
-			this.records.delete(record.token);
-			this.remove(record);
+			this.lastHydrationFailure = {
+				lineageId,
+				reason: error instanceof CandidateViewError ? error.reason : "candidate-view-invalid",
+				message: error instanceof Error ? error.message : String(error),
+			};
 			throw error;
 		}
 	}
@@ -1152,8 +1167,22 @@ export class CandidateViewRegistry {
 	}
 
 	currentLineageId(): string {
-		if (this.current === undefined) throw new CandidateViewError("review subagent dispatch has no current controller-owned candidate view lineage binding", "current-binding-missing");
+		if (this.current === undefined) {
+			const failure = this.lastHydrationFailure;
+			if (failure !== undefined) {
+				throw new CandidateViewError(
+					`review subagent dispatch has no current controller-owned candidate view lineage binding: hydration for lineage ${failure.lineageId} was attempted from authoritative native status and failed (${failure.reason}): ${failure.message}`,
+					"current-binding-hydration-failed",
+				);
+			}
+			throw new CandidateViewError("review subagent dispatch has no current controller-owned candidate view lineage binding", "current-binding-missing");
+		}
 		return this.current.lineageId;
+	}
+
+	/** The last failed dispatch-binding hydration, for controller envelopes. */
+	lastDispatchHydrationFailure(): Readonly<{ lineageId: string; reason: string; message: string }> | undefined {
+		return this.lastHydrationFailure;
 	}
 
 	resolveCurrentForLens(lens: string): CandidateView {

--- a/tests/crosslane/cross-lane.mjs
+++ b/tests/crosslane/cross-lane.mjs
@@ -151,6 +151,17 @@ function scratchRepo(root, name) {
 	return cwd;
 }
 
+// A LINKED git worktree (not the primary checkout) of a fresh scratch repo:
+// the field shape the reported defect was hit in.
+function scratchLinkedWorktree(root, name) {
+	const primary = scratchRepo(root, `${name}-primary`);
+	const linked = join(root, `${name}-linked`);
+	git(primary, "worktree", "add", "-q", linked, "-b", `feature/${name}`);
+	git(linked, "config", "user.email", "crosslane@example.com");
+	git(linked, "config", "user.name", "Cross Lane Battery");
+	return linked;
+}
+
 function write(cwd, name, content) {
 	const path = join(cwd, name);
 	mkdirSync(dirname(path), { recursive: true });
@@ -633,6 +644,96 @@ async function recoveredSuccessorLifecycle(binary, cli, root) {
 	}
 }
 
+// externallyRecoveredSuccessor performs the shared setup both recovered-
+// lineage checks need: approve a predecessor in `cwd`, change the scope, and
+// create a successor through the EXTERNAL native `review recover` command
+// with its explicit LF-only v1 binding. Returns the successor lineage id.
+async function externallyRecoveredSuccessor(binary, cli, cwd, successor) {
+	let raw = rawStatus(binary, cwd);
+	let status = await cli.targetStatus({ cwd });
+	assertOfferedStepMatchesNative("pre-start", status, raw);
+	const start = await cli.start({ cwd, targetIdentity: status.targetIdentity, projection: "workspace" });
+	if (start.state !== "reviewing") throw new Error(`predecessor start state=${start.state}`);
+	status = await cli.targetStatus({ cwd });
+	if (status.nextTransition?.execute?.operation !== "review.finalize") {
+		throw new Error(`expected review.finalize, got ${summarizeDecoded(status.nextTransition)}`);
+	}
+	const finalize = await cli.finalizeTransition({ cwd, argumentTokens: executeTokens(status.nextTransition) });
+	if (finalize.state !== "approved") throw new Error(`predecessor finalize state=${finalize.state}`);
+	// The caller has already staged its scope change in the worktree.
+	write(cwd, "src/mul.js", "export function mul(a, b) {\n  return a * b;\n}\nexport function twice(a) {\n  return a + a;\n}\n");
+	raw = rawStatus(binary, cwd);
+	const authorization = [
+		"gentle-ai.review-recovery-authorization/v1",
+		`predecessor_lineage=${finalize.lineageId}`,
+		`predecessor_revision=${finalize.storeRevision}`,
+		`target_identity=${raw.target_identity}`,
+		"actor=cross-lane-battery",
+		"reason=scope changed after approval",
+	].join("\n");
+	rawInvoke(binary, cwd, [
+		"review", "recover", "--cwd", cwd,
+		"--predecessor-lineage", finalize.lineageId,
+		"--expected-predecessor-revision", finalize.storeRevision,
+		"--successor-lineage", successor,
+		"--disposition", "scope_changed",
+		"--actor", "cross-lane-battery",
+		"--reason", "scope changed after approval",
+		"--maintainer-authorization", authorization,
+	]);
+	return successor;
+}
+
+// recoveredSuccessorFieldFlow reproduces the FIELD-REPORTED flow (2026-08-16,
+// gentle-pi 402f9f77 + gentle-ai 2.4.0-main): the candidate lives in a LINKED
+// git worktree with UNCOMMITTED tracked modifications, the successor came
+// from an external native recover, and the session drives `finalize` FIRST
+// and dispatches the reviewer straight after — never calling the STATUS
+// controller operation. Hydration wired only into STATUS leaves that flow
+// refusing, which is exactly what the maintainer hit after #340.
+//
+// Residual gap, honestly stated: the battery cannot age a lineage by days or
+// span real OS processes; it reproduces linked-worktree placement, dirty
+// tracked files, external recovery, and a FRESH controller registry (the
+// property a new process actually contributes), not wall-clock age.
+async function recoveredSuccessorFieldFlow(binary, cli, root) {
+	const cwd = scratchLinkedWorktree(root, "pi-recovered-linked");
+	write(cwd, "docs/recover-guide.md", "# Recover guide\n\nline one\n");
+	write(cwd, "src/mul.js", "export function mul(a, b) {\n  return a * b;\n}\n");
+	commitAll(cwd, "feat: base");
+	write(cwd, "docs/recover-guide.md", "# Recover guide\n\nline one\nline two, purely passive documentation\n");
+	const successor = await externallyRecoveredSuccessor(binary, cli, cwd, "recovered-linked-successor");
+	// The tracked scope change stays UNCOMMITTED, like the reported worktree.
+	const dirty = execFileSync("git", ["status", "--porcelain"], { cwd, encoding: "utf8" });
+	if (!/^ M src\/mul\.js$/m.test(dirty)) throw new Error(`expected an uncommitted tracked modification, got ${JSON.stringify(dirty)}`);
+
+	// A brand-new registry stands in for the fresh Pi session.
+	const registry = new CandidateViewRegistry();
+	try {
+		const finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({}) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
+		if (finalizeEnvelope.outcome !== "reviewer-results-required") {
+			throw new Error(`finalize routed to ${String(finalizeEnvelope.outcome ?? finalizeEnvelope.status)} instead of the blocked reviewer-results-required step`);
+		}
+		const binding = finalizeEnvelope.dispatch_binding;
+		if (binding === undefined) throw new Error("the blocked finalize envelope does not report a dispatch-binding hydration outcome");
+		if (binding.hydrated !== true) {
+			throw new Error(`finalize reported hydration failure ${String(binding.reason)}: ${String(binding.message)}`);
+		}
+		if (!registry.hasCurrentBinding()) throw new Error("finalize did not hydrate the candidate-view dispatch binding");
+		// The reviewer dispatch the maintainer runs next must resolve.
+		const dispatch = { agent: "review-reliability", task: "review the recovered successor", mode: "task" };
+		injectReviewCandidateView(dispatch, registry);
+		if (!dispatch.task.includes(successor)) throw new Error("hydrated dispatch context is not bound to the recovered successor lineage");
+		return "linked worktree + uncommitted tracked changes + external recover: finalize-first (no STATUS call) hydrated the dispatch binding and the reviewer dispatch resolved; residual gap: the battery cannot age a lineage by days or span OS processes, only a fresh registry";
+	} finally {
+		try {
+			registry.cleanup(registry.resolveCurrentForLens("review-reliability").token);
+		} catch {
+			// No hydrated view to clean when the check failed before binding.
+		}
+	}
+}
+
 async function modelReview(binary, cli, cwd) {
 	const raw = rawStatus(binary, cwd);
 	const input = raw.next_transition?.collect?.inputs?.[0];
@@ -758,6 +859,12 @@ async function main() {
 			pass("external native recover to captured successor lens", await recoveredSuccessorLifecycle(binary, cli, root));
 		} catch (error) {
 			fail("external native recover to captured successor lens", knownRedParity(describeError(error)));
+		}
+
+		try {
+			pass("recovered field flow: linked dirty worktree, finalize-first dispatch", await recoveredSuccessorFieldFlow(binary, cli, root));
+		} catch (error) {
+			fail("recovered field flow: linked dirty worktree, finalize-first dispatch", knownRedParity(describeError(error)));
 		}
 
 		if (WITH_MODEL && mediumRepo !== undefined) {

--- a/tests/review-dispatch-hydration-gap.test.ts
+++ b/tests/review-dispatch-hydration-gap.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { __testing } from "../extensions/gentle-ai.ts";
+import type { NativeReviewCli } from "../lib/native-review-cli.ts";
+import { CandidateViewError, CandidateViewRegistry, injectReviewCandidateView } from "../lib/review-candidate-view.ts";
+import type { ReviewCollectInputV3, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+
+// Field report (2026-08-16, gentle-pi main 402f9f77 + gentle-ai
+// 2.4.0-main.20278905): after #340 the FINALIZE routing defect was fixed but
+// the Pi relay's candidate-view registration still refused for an externally
+// recovered successor. Reproduced against the live binary: hydration itself
+// works for that shape (a dirty LINKED worktree hydrates fine) — the gap is
+// that hydration was wired into the STATUS controller operation ONLY, while
+// the maintainer's flow is `finalize` (now correctly blocked with
+// review.capture-result) followed by a reviewer dispatch. The FINALIZE lane
+// decodes the same authoritative status and never hydrated from it.
+//
+// Second defect in the same area: every hydration failure was swallowed by a
+// bare catch, so the later dispatch refusal claimed no binding existed
+// without ever admitting hydration had been attempted and why it failed.
+
+const SHA = `sha256:${"1".repeat(64)}`;
+
+function git(cwd: string, ...arguments_: string[]): string {
+	return execFileSync("git", arguments_, { cwd, encoding: "utf8" }).trim();
+}
+
+/** A LINKED worktree (not the primary checkout) with dirty tracked files. */
+function linkedDirtyWorktree(t: test.TestContext): string {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-hydration-gap-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const primary = join(root, "primary");
+	const linked = join(root, "linked");
+	mkdirSync(primary, { recursive: true });
+	git(primary, "init", "-b", "main");
+	git(primary, "config", "user.name", "Hydration Test");
+	git(primary, "config", "user.email", "hydration@example.invalid");
+	mkdirSync(join(primary, "internal"), { recursive: true });
+	writeFileSync(join(primary, "internal", "parser.go"), "package internal\n\nfunc Parse(s string) string {\n\treturn s\n}\n");
+	git(primary, "add", "-A");
+	git(primary, "commit", "-m", "base");
+	git(primary, "worktree", "add", linked, "-b", "feature/fence-info");
+	// Uncommitted tracked modification, exactly the field shape.
+	writeFileSync(join(linked, "internal", "parser.go"), "package internal\n\nimport \"strings\"\n\nfunc Parse(s string) string {\n\treturn strings.TrimSpace(s)\n}\n");
+	return linked;
+}
+
+function reviewerResultCollectInput(lineageId: string, lens: string): ReviewCollectInputV3 {
+	return {
+		name: "reviewer_result",
+		schema: "https://gentle-ai.dev/schema/review/reviewer/v1",
+		captureOperation: "review.capture-result",
+		arguments: [
+			{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` },
+			{ name: "expected-revision", value: SHA, token: `--expected-revision=${SHA}` },
+			{ name: "lens", value: lens, token: `--lens=${lens}` },
+			{ name: "order", value: "0", token: "--order=0" },
+		],
+		artifactSubject: {
+			schema: "gentle-ai.review-artifact-subject/v2",
+			subjectHash: SHA,
+			lineageId,
+			authorityRevision: SHA,
+			targetIdentity: SHA,
+			baseTree: "3".repeat(40),
+			candidateTree: "4".repeat(40),
+			changedPathManifestSha256: SHA,
+			lens,
+			selectedOrder: 0,
+		},
+	} as unknown as ReviewCollectInputV3;
+}
+
+function successorStatus(lineageId: string, projection: { baseTree: string; currentCandidateTree: string; paths: readonly string[] }): ReviewStatusV3 {
+	return {
+		contract: "gentle-ai.review-integration/v2",
+		applicability: "current_target",
+		authority: { version: "compact-v2", lineageId, state: "reviewer_results_required", generation: 2, revision: SHA },
+		receipt: { status: "expected_missing" },
+		action: "finalize",
+		replayability: "not_replayable",
+		targetIdentity: SHA,
+		projection: {
+			schema: "gentle-ai.review-integration.projection/v1",
+			kind: "current-changes",
+			projection: "workspace",
+			baseTree: projection.baseTree,
+			initialReviewTree: projection.currentCandidateTree,
+			currentCandidateTree: projection.currentCandidateTree,
+			pathsDigest: SHA,
+			paths: [...projection.paths],
+			intendedUntracked: [],
+			intendedUntrackedProof: SHA,
+			initialSnapshotIdentity: SHA,
+			currentSnapshotIdentity: SHA,
+		},
+		candidates: [],
+		nextTransition: { kind: "collect", reasonCode: "reviewer_results_required", collect: { inputs: [reviewerResultCollectInput(lineageId, "review-reliability")] } },
+		raw: { schema: "gentle-ai.review-integration.status/v5", action: "finalize", lineage_id: lineageId },
+	} as unknown as ReviewStatusV3;
+}
+
+/** The live frozen identity of the dirty linked worktree candidate. */
+function liveProjection(cwd: string): { baseTree: string; currentCandidateTree: string; paths: readonly string[] } {
+	const probe = new CandidateViewRegistry();
+	const view = probe.create({ contributorRoot: cwd });
+	try {
+		return { baseTree: view.baseTree, currentCandidateTree: view.candidateTree, paths: view.paths };
+	} finally {
+		probe.cleanup(view.token);
+	}
+}
+
+function statusNative(status: ReviewStatusV3): NativeReviewCli {
+	return {
+		targetStatus: async () => status,
+		finalize: async () => { throw new Error("native finalize must not run while reviewer results are outstanding"); },
+	} as unknown as NativeReviewCli;
+}
+
+async function runController(parameters: Record<string, unknown>, cwd: string, native: NativeReviewCli, candidateViews: CandidateViewRegistry): Promise<Record<string, unknown>> {
+	return await __testing.executeReviewControllerOperation(
+		parameters, cwd, new Map(), native, undefined, undefined, undefined, candidateViews,
+	) as Record<string, unknown>;
+}
+
+test("FINALIZE hydrates the dispatch binding for an externally recovered successor in a dirty linked worktree", async (t) => {
+	const cwd = linkedDirtyWorktree(t);
+	const lineageId = "recovered-dirty-successor";
+	const registry = new CandidateViewRegistry();
+	const native = statusNative(successorStatus(lineageId, liveProjection(cwd)));
+
+	// The maintainer's flow: FINALIZE first (correctly blocked since #340),
+	// then a reviewer dispatch. FINALIZE never went through the STATUS
+	// controller operation, so nothing had hydrated the registry.
+	const finalize = await runController({ operation: "finalize", lineageId, input: JSON.stringify({}) }, cwd, native, registry);
+	assert.equal(finalize.outcome, "reviewer-results-required");
+	assert.equal(registry.hasCurrentBinding(), true, "FINALIZE must hydrate the dispatch binding from the status it decoded");
+	assert.deepEqual(finalize.dispatch_binding, { hydrated: true, lineage_id: lineageId, lenses: ["review-reliability"] });
+
+	try {
+		const dispatch: Record<string, unknown> = { agent: "review-reliability", task: "review the recovered successor", mode: "task" };
+		assert.doesNotThrow(() => injectReviewCandidateView(dispatch, registry));
+		assert.match(String(dispatch.task), new RegExp(lineageId));
+	} finally {
+		registry.cleanup(registry.resolveCurrentForLens("review-reliability").token);
+	}
+});
+
+test("a swallowed hydration failure becomes an observable typed dispatch refusal", async (t) => {
+	const cwd = linkedDirtyWorktree(t);
+	const lineageId = "drifted-successor";
+	const registry = new CandidateViewRegistry();
+	// Realistic drift: the frozen candidate names the pristine HEAD tree while
+	// the live worktree carries the uncommitted modification. Hydration
+	// legitimately fails, and that failure must stop being invisible.
+	const live = liveProjection(cwd);
+	const drifted = { ...live, currentCandidateTree: live.baseTree };
+	const finalize = await runController({ operation: "finalize", lineageId, input: JSON.stringify({}) }, cwd, statusNative(successorStatus(lineageId, drifted)), registry);
+
+	assert.equal(finalize.outcome, "reviewer-results-required");
+	assert.equal(registry.hasCurrentBinding(), false);
+	const binding = finalize.dispatch_binding as { hydrated: boolean; lineage_id: string; reason: string; message: string };
+	assert.equal(binding.hydrated, false, "a failed hydration must be reported, never swallowed");
+	assert.equal(binding.lineage_id, lineageId);
+	assert.ok(typeof binding.reason === "string" && binding.reason.length > 0, "the failure carries a typed reason");
+	assert.match(binding.message, /projection|live candidate/i);
+
+	// The dispatch refusal must now admit that hydration was attempted.
+	assert.throws(
+		() => injectReviewCandidateView({ agent: "review-reliability", task: "review", mode: "task" }, registry),
+		(error: unknown) => error instanceof CandidateViewError
+			&& error.reason === "current-binding-hydration-failed"
+			&& /hydrat/i.test(error.message)
+			&& error.message.includes(lineageId),
+	);
+});
+
+test("STATUS keeps hydrating and stays read-only when hydration fails", async (t) => {
+	const cwd = linkedDirtyWorktree(t);
+	const lineageId = "status-drifted-successor";
+	const registry = new CandidateViewRegistry();
+	const statusLive = liveProjection(cwd);
+	const drifted = { ...statusLive, currentCandidateTree: statusLive.baseTree };
+	// STATUS must never fail because hydration failed.
+	const envelope = await runController({ operation: "status", lineageId }, cwd, statusNative(successorStatus(lineageId, drifted)), registry);
+	assert.equal(envelope.operation, "status");
+	assert.equal(registry.hasCurrentBinding(), false);
+	assert.throws(
+		() => injectReviewCandidateView({ agent: "review-reliability", task: "review", mode: "task" }, registry),
+		(error: unknown) => error instanceof CandidateViewError && error.reason === "current-binding-hydration-failed",
+	);
+});


### PR DESCRIPTION
Follow-up to #340. Field report from the maintainer on gentle-pi main `402f9f77` + gentle-ai `2.4.0-main.20278905`, with the package regenerated: "la regeneración arregló el routing de FINALIZE, pero NO el registro de candidate-view del relay Pi." Defect B (finalize routing) is confirmed fixed; defect A was not, in the real scenario.

## Root cause: hydration was wired into one call site, and his flow uses another

Reported shape: lineage `review-463517b298dacbf7`, successor from an external native `review recover --disposition scope_changed`, days old, different process; candidate in a LINKED git worktree (not the primary checkout) with uncommitted tracked modifications, projection `workspace`, state `reviewer_results_required` with one pending lens.

I reproduced that shape against the live binary (primary repo + linked worktree, dirty tracked files, approved predecessor, external `review recover`, fresh registry) and measured each hypothesis:

- **Not the dirty linked worktree.** `restoreCurrentForDispatchFromNative` hydrates that shape correctly — driving the controller STATUS operation against the reproduced successor returned `hydrated: true` and the reviewer dispatch resolved.
- **Not a decode/shape mismatch.** `applicability` and `projection` are populated on the decoded status/v5 object for this path; none of the guards `hasCurrentBinding`, `applicability`, `hasProjection`, or zero-pending-lenses fired.
- **It is the call-site gap (hypothesis c).** `hydrateDispatchBindingFromStatus` had exactly one caller: the STATUS controller operation. The FINALIZE lane decodes the same authoritative status (and re-decodes it for the v5 workspace rebind) and never hydrated. The maintainer's flow is `finalize` — which since #340 correctly returns the blocked `review.capture-result` envelope — followed directly by the reviewer dispatch. That flow never passes through the STATUS operation, so the registry stayed empty and dispatch refused. My #340 battery check passed precisely because it called controller STATUS first; his session does not.

Measured side by side on the reproduced shape, before this PR:

```
PATH1 status   -> hydrated: true
PATH2 finalize -> hydrated: false
PATH2 dispatch REFUSED: review subagent dispatch has no current controller-owned candidate view lineage binding
```

## Second defect: the swallowed failure

The bare `catch {}` hid every hydration failure, so a later dispatch refusal claimed no binding was ever available instead of admitting hydration ran and why it failed. A silently-swallowed failure is its own defect even when the hydration itself is legitimately impossible (drifted candidate).

## Fix

- `hydrateDispatchBindingFromStatus` now returns a typed outcome instead of swallowing, and the FINALIZE lane calls it when it reports outstanding reviewer results — against the workspace root, never a frozen view root. The blocked envelope carries `dispatch_binding: { hydrated: true, lineage_id, lenses }` or `{ hydrated: false, lineage_id, reason, message }`.
- `CandidateViewRegistry` records the last failed hydration; `currentLineageId()` then refuses with reason `current-binding-hydration-failed` and a message naming the lineage, the typed cause, and the underlying error, instead of the bare `current-binding-missing`.
- STATUS stays read-only and never fails because hydration failed.

## RED evidence

`tests/review-dispatch-hydration-gap.test.ts` (written first, against a real linked worktree with uncommitted tracked modifications) — all three RED before the fix:
- FINALIZE hydrates the dispatch binding for an externally recovered successor: `FINALIZE must hydrate the dispatch binding from the status it decoded`.
- A swallowed hydration failure becomes an observable typed dispatch refusal.
- STATUS keeps hydrating and stays read-only when hydration fails.

Battery RED (fix files stash-reverted): `recovered field flow: linked dirty worktree, finalize-first dispatch` FAILED with "the blocked finalize envelope does not report a dispatch-binding hydration outcome" (15 checks, 1 failed).

## Battery

New check `recovered field flow: linked dirty worktree, finalize-first dispatch` drives the reported flow against the real binary: linked worktree, uncommitted tracked modification, external native recover, fresh registry, `finalize` first with no STATUS call, then the reviewer dispatch.

**Residual gap, stated in the check note rather than faked:** the battery cannot age a lineage by days or span real OS processes. It reproduces linked-worktree placement, dirty tracked files, external recovery, and a fresh controller registry — the property a new process actually contributes — not wall-clock age.

## Verification (all foreground)

- New unit file 3/3; affected files (candidate-view, controller routing, host relay, recovered routing, new) 282/282.
- Full suite: 1255 tests, 1240 pass; the 14 failures are the known pre-existing dev-binary-override environment set, name-for-name identical to prior runs.
- `pnpm test:cross-lane`: 15 checks, 0 failed. `check:transaction-runner`: no drift. `check:provider-contract`: pass. `test:harness`: exit 0.

The maintainer's lineage and worktree were never touched; the investigation was read-only reasoning plus an independent scratch reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dispatch-binding recovery during finalization, with clear success or failure details.
  - Reviewer result dispatch now validates recovered bindings before proceeding.
  - Status checks remain read-only and continue reporting even when hydration fails.
  - Missing or failed bindings now produce specific, actionable errors.

- **Tests**
  - Added coverage for recovered linked worktrees, hydration failures, finalization, status checks, and reviewer dispatch validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->