### PR TITLE
fix(review): negotiate status for the pi reviewer transport so the host relay runs

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -6086,6 +6086,38 @@ async function executeReviewControllerOperation(
 					? reviewHostRelaySlots(negotiatedStatus.nextTransition.collect?.inputs ?? [])
 					: [];
 				if (hostRelaySlots.length > 0 && input.final_evidence === undefined && input.correction_line_forecast === undefined) {
+					// One cost/side-effect forecast BEFORE launch, once per
+					// FINALIZE and never per lens: each host-relay slot runs a
+					// real locked-down `pi` reviewer subprocess against the
+					// user's own model, so an unacknowledged finalize would spend
+					// tokens as a silent side effect of what reads like
+					// bookkeeping. Same acknowledgement shape the adapter already
+					// uses for consequential inputs (committedOnly): the caller
+					// states the cost it accepts, which keeps headless callers
+					// working without an interactive prompt.
+					if (input.reviewer_run_acknowledged !== true) {
+						const forecastLenses = hostRelaySlots.map((slot, index) => slot.lens ?? `slot-${index}`);
+						return {
+							operation: parameters.operation,
+							status: "blocked",
+							outcome: "reviewer-model-run-forecast",
+							reason: `Finalize is about to run ${hostRelaySlots.length} real reviewer model run${hostRelaySlots.length === 1 ? "" : "s"} through the pi host relay (${forecastLenses.join(", ")}), one locked-down pi subprocess per outstanding lens, in the foreground. This spends model tokens on your configured model and provider.`,
+							cost_forecast: {
+								transport: "pi_host_relay",
+								model_runs: hostRelaySlots.length,
+								lenses: forecastLenses,
+								side_effects: [
+									"one locked-down pi subprocess per lens, in an empty scratch directory with every discovery surface disabled",
+									"each captured reviewer result is admitted natively into this lineage's authority",
+									"no candidate file, index, or commit is modified",
+								],
+								model_selection: "user-owned: the relay never sets --model, --provider, or --profile",
+							},
+							mutation_performed: false,
+							mutation_outcome: "none",
+							next_action: "Re-run finalize with {\"reviewer_run_acknowledged\": true} to authorize exactly this reviewer work.",
+						};
+					}
 					// The relay itself needs no candidate view (it consumes only
 					// provider-issued tokens), but a session that dispatches a
 					// reviewer by hand on this same lineage does. Hydrate here too
@@ -7037,7 +7069,7 @@ function createGentleAiExtensionForTesting(
 			'Call {"operation":"inspect"} before START. New native ordinary START uses a JSON string such as "{\\"mode\\":\\"ordinary\\"}"; an explicit baseRef must be paired with committedOnly: true to request a committed range, while policyPath remains repository-local. policyHash is legacy compact-only. The controller derives lineage, Git/untracked scope, tier, lenses, authored lines, and budget.',
 			"Use RECONCILE_AUTHORITY only to quarantine one invalid native recovery successor. Supply exact predecessorLineage, expectedPredecessorRevision, successorLineage, expectedSuccessorRevision, actor, and reason values; Pi derives and displays the seven-line native authorization binding for fresh UI approval. The predecessor stays untouched, native returns the durable audit record, and Pi never falls back to RESET or RECOVER.",
 			"Use ABANDON or QUARANTINE_LEGACY only after an explicit user decision and with exact native inputs. ABANDON needs lineage, expectedRevision, snapshotIdentity, capturedLensResults, findingsPresent, evidenceRecordsPresent, actor, and reason; QUARANTINE_LEGACY accepts only the published malformed freeze-findings diagnostic/disposition. A dual reconciliation may supply only anomalies `unchanged_target,malformed_recovery_authorization` in that exact order. Use REPAIR_LEGACY_ALIAS only with lineage, actor, and reason: Pi freshly reads native inventory and derives repository, revision, diagnostic, disposition, and the exact eight-line binding before interactive approval. `review dispose-result` is unsupported pending design.",
-			"Lens, refuter, and validator verdicts are admitted natively, never Pi-authored: FINALIZE routes provider --materialize lens slots through the host relay, executes provider-rendered self-contained role vectors verbatim, and runs the provider's own review.finalize transition (captured-results discovery). Call FINALIZE with a JSON string carrying only the negotiated collection answers: correction_line_forecast for the pre-edit forecast, validation for the targeted validation document the exact collection input requests, and final_evidence paired with exactly one of final_verification_passed or final_verification_outcome (passed, verification_failed, procedural_tooling_failed). Correction evidence is captured natively before STATUS can expose targeted validation. Use ADVANCE only for explicit graph-v1 Judgment Day.",
+			"Lens, refuter, and validator verdicts are admitted natively, never Pi-authored: FINALIZE routes provider --materialize lens slots through the host relay, executes provider-rendered self-contained role vectors verbatim, and runs the provider's own review.finalize transition (captured-results discovery). Call FINALIZE with a JSON string carrying only the negotiated collection answers: correction_line_forecast for the pre-edit forecast, validation for the targeted validation document the exact collection input requests, and final_evidence paired with exactly one of final_verification_passed or final_verification_outcome (passed, verification_failed, procedural_tooling_failed). Correction evidence is captured natively before STATUS can expose targeted validation. When the provider offers host-relay lens slots, FINALIZE first returns a `reviewer-model-run-forecast` naming the lenses and the real model runs it would spend; re-run it with `reviewer_run_acknowledged: true` to authorize exactly that reviewer work. Use ADVANCE only for explicit graph-v1 Judgment Day.",
 			"For blocked-legacy or blocked-mixed, do not call START repeatedly. Explain invalidation, request explicit user authorization for the exact reset_request challenge, then call RESET or RECOVER only after authorization. RESET and RECOVER_LOCK route to audited native `gentle-ai review reclaim` and RECOVER routes to native `gentle-ai review recover`; negotiated target status supplies the sole accepted recovery disposition, and a caller-supplied substitute is rejected. Treat a native-input-required envelope as a request for exact values, never as permission to invent them. After a committed native recovery record, INSPECT before any fresh ordinary START.",
 			"A consent-required START returns the complete provider envelope and an opaque consent_binding, then stops. The parent presents and localizes that envelope without changing machine tokens, commands, target IDs, or invocations. After one explicit human answer, call answer-consent exactly once with a JSON string containing only consentBinding and answer (`granted` or `declined`). A reported lineage_created false or pre-authority validation error proves no lineage was created. After ambiguous START, answer-consent, or FINALIZE output, the controller calls target-scoped native status first and returns only its declared action. Never infer or prescribe replay unless native explicitly reports exact_replay_safe for the same canonical request and required lineage.",
 			"Use gentle_review for bounded review transaction operations and exact lifecycle validation; never fabricate bash tool metadata or a separate gate target.",

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -126,6 +126,7 @@ import {
 	NativeReviewCliError,
 	NativeReviewConsentBindingError,
 	NativeReviewConsentRequiredError,
+	NativeReviewIntegrationError,
 	NATIVE_REVIEW_ERROR_CODE,
 	NATIVE_REVIEW_OPERATION,
 	NATIVE_REVIEW_LEGACY_QUARANTINE,
@@ -135,6 +136,7 @@ import {
 	NATIVE_REVIEW_RECONCILE_ANOMALIES,
 	sanitizeForeignNativeReviewDiagnostics,
 	type NativeReviewCli,
+	type NativeTargetStatusRequest,
 	type NativeFinalizeResult,
 	type NativeReviewVerificationEvidenceV2,
 	type NativeReviewModeOperation,
@@ -5512,6 +5514,60 @@ function pendingReviewerLenses(status: ReviewStatusV3): readonly string[] {
 // through STATUS. It also never fails its caller: STATUS and the blocked
 // FINALIZE envelope stay read-only, and the outcome is returned so the caller
 // can report it instead of swallowing it.
+// Field defect (2026-08-16, third report): the Pi host relay never ran for a
+// real lineage. Measured against the live 2.4.0-main provider on a faithful
+// reproduction — an agent-less `review status` returns a bare capture-result
+// collect input (lineage, expected-revision, target, repository-context, lens,
+// order, subject-hash), while the SAME status with `--agent pi` additionally
+// carries agent=pi, materialize=true and the provider submission. The adapter
+// never named its agent, so reviewHostRelaySlots() saw zero materialize slots,
+// the relay was unreachable, and no lens was ever launched.
+//
+// The agent is PROBED, never assumed: the pinned 2.2.3 provider refuses the
+// flag outright. A typed refusal is remembered per provider instance and the
+// exact provider cause is reported to the user rather than degraded into a
+// generic candidate-view message.
+const REVIEW_HOST_AGENT = "pi" as const;
+const REVIEW_TRANSPORT_REFUSAL_CODES = new Set([
+	"immutable_review_transport_unsupported",
+	"unsupported_agent",
+	"unknown_flag",
+]);
+interface ReviewTransportRefusal { supported: false; code: string; message: string; }
+const reviewTransportRefusalByProvider = new WeakMap<object, ReviewTransportRefusal>();
+
+function clearReviewTransportProbeForTesting(nativeReviewCli: NativeReviewCli | null): void {
+	if (nativeReviewCli !== null) reviewTransportRefusalByProvider.delete(nativeReviewCli as unknown as object);
+}
+
+/**
+ * Queries negotiated STATUS for the pi reviewer transport so the provider
+ * offers its materialize-marked relay slot, probing the agent exactly once per
+ * provider and falling back to the agent-less status on a typed refusal. The
+ * refusal is returned, never swallowed.
+ */
+async function negotiatedStatusForHostTransport(
+	nativeReviewCli: NativeReviewCli,
+	request: NativeTargetStatusRequest,
+): Promise<{ status: ReviewStatusV3; transport?: ReviewTransportRefusal }> {
+	const provider = nativeReviewCli as unknown as object;
+	const remembered = reviewTransportRefusalByProvider.get(provider);
+	if (remembered !== undefined) {
+		return { status: await nativeReviewCli.targetStatus!(request), transport: remembered };
+	}
+	try {
+		return { status: await nativeReviewCli.targetStatus!({ ...request, agent: REVIEW_HOST_AGENT }) };
+	} catch (error) {
+		const code = error instanceof NativeReviewIntegrationError ? error.failureEnvelope.code : undefined;
+		// Only a transport-shaped refusal falls back; every other failure is
+		// the caller's to handle exactly as before.
+		if (code === undefined || !REVIEW_TRANSPORT_REFUSAL_CODES.has(code)) throw error;
+		const refusal: ReviewTransportRefusal = { supported: false, code, message: error.message };
+		reviewTransportRefusalByProvider.set(provider, refusal);
+		return { status: await nativeReviewCli.targetStatus!(request), transport: refusal };
+	}
+}
+
 type DispatchHydrationOutcome =
 	| { hydrated: true; lineage_id: string; lenses: readonly string[] }
 	| { hydrated: false; lineage_id: string; reason: string; message: string }
@@ -5969,6 +6025,7 @@ async function executeReviewControllerOperation(
 			let provisionalCandidateView: ReturnType<CandidateViewRegistry["create"]> | undefined;
 			let nativeResult: NativeFinalizeResult | undefined;
 			let correctionStep: CorrectionStep | undefined;
+			let transportRefusal: ReviewTransportRefusal | undefined;
 			try {
 				if (parameters.lineageId === undefined) throw new CandidateViewError("Native FINALIZE requires an explicit lineage");
 				correctionCompletion = input.validation !== undefined && input.final_evidence !== undefined;
@@ -5985,7 +6042,13 @@ async function executeReviewControllerOperation(
 				}
 				candidateView?.verify();
 				const statusCandidateRoot = candidateView?.root ?? defaultCwd;
-				negotiatedStatus = await nativeReviewCli.targetStatus({ cwd: statusCandidateRoot, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
+				// Name the host's reviewer transport so the provider offers its
+				// materialize-marked relay slot; a provider without that
+				// transport answers the agent-less status and its typed refusal
+				// travels with the result.
+				const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, { cwd: statusCandidateRoot, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
+				negotiatedStatus = negotiated.status;
+				transportRefusal = negotiated.transport;
 				if (negotiatedStatus.applicability !== "current_target" || negotiatedStatus.authority?.lineageId !== parameters.lineageId || (negotiatedStatus.action !== "finalize" && negotiatedStatus.action !== "reconcile_finalize")) {
 					if (provisionalCandidateView && candidateViews) {
 						candidateViews.cleanup(provisionalCandidateView.token);
@@ -6008,7 +6071,9 @@ async function executeReviewControllerOperation(
 				// the workspace root before executing any rendered payload.
 				// Pinned pre-v5 emitters keep the frozen-view status untouched.
 				if (statusCandidateRoot !== defaultCwd && (negotiatedStatus.raw as { schema?: unknown }).schema === "gentle-ai.review-integration.status/v5") {
-					const workspaceStatus = await nativeReviewCli.targetStatus({ cwd: defaultCwd, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
+					const rebound = await negotiatedStatusForHostTransport(nativeReviewCli, { cwd: defaultCwd, lineageId: parameters.lineageId, ...(signal === undefined ? {} : { signal }) });
+					const workspaceStatus = rebound.status;
+					transportRefusal = rebound.transport;
 					if (workspaceStatus.authority?.lineageId !== parameters.lineageId || workspaceStatus.authority.revision !== negotiatedStatus.authority.revision) {
 						throw new CandidateViewError("workspace-root status no longer matches the negotiated lifecycle authority", "workspace-status-rebind-drift");
 					}
@@ -6021,7 +6086,14 @@ async function executeReviewControllerOperation(
 					? reviewHostRelaySlots(negotiatedStatus.nextTransition.collect?.inputs ?? [])
 					: [];
 				if (hostRelaySlots.length > 0 && input.final_evidence === undefined && input.correction_line_forecast === undefined) {
-					return await executeReviewHostRelayCollection(parameters.operation, parameters.lineageId, hostRelaySlots, nativeReviewCli, defaultCwd, signal);
+					// The relay itself needs no candidate view (it consumes only
+					// provider-issued tokens), but a session that dispatches a
+					// reviewer by hand on this same lineage does. Hydrate here too
+					// so both routes work; it is best-effort and never fails the
+					// relay.
+					const relayDispatchBinding = hydrateDispatchBindingFromStatus(candidateViews, defaultCwd, negotiatedStatus);
+					const relayResult = await executeReviewHostRelayCollection(parameters.operation, parameters.lineageId, hostRelaySlots, nativeReviewCli, defaultCwd, signal);
+					return relayDispatchBinding === undefined ? relayResult : { ...relayResult, dispatch_binding: relayDispatchBinding };
 				}
 				// gentle-pi#311 P4-roles: the provider renders the non-lens
 				// adversarial roles as self-contained --execute vectors; each is
@@ -6062,9 +6134,12 @@ async function executeReviewControllerOperation(
 						operation: parameters.operation,
 						status: "blocked",
 						outcome: "reviewer-results-required",
-						reason: "Capture the reviewer result first; the provider offers review.capture-result. Correction evidence and targeted validation are never admissible while reviewer results are outstanding.",
+						reason: transportRefusal === undefined
+							? "Capture the reviewer result first; the provider offers review.capture-result. Correction evidence and targeted validation are never admissible while reviewer results are outstanding."
+							: `Capture the reviewer result first; the provider offers review.capture-result. This provider does not admit the pi reviewer transport (${transportRefusal.code}), so it offers no host-relay slot: ${transportRefusal.message}`,
 						...(outstandingReviewerLenses.length === 0 ? {} : { pending_lenses: outstandingReviewerLenses }),
 						...(dispatchBinding === undefined ? {} : { dispatch_binding: dispatchBinding }),
+						...(transportRefusal === undefined ? {} : { relay_transport: transportRefusal }),
 						result: negotiatedStatus.raw,
 						mutation_performed: false,
 						mutation_outcome: "none",
@@ -6835,6 +6910,7 @@ export const __testing = {
 	nativeStatusUnsupported,
 	executeReviewControllerOperation,
 	setReviewHostRelayRunnerForTesting,
+	clearReviewTransportProbeForTesting,
 	enforceReviewGateAndCommandSafety,
 	renderSddModelPanel: renderSddModelPanelForTesting,
 	getOrchestratorPrompt,

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -540,7 +540,22 @@ export interface NativeBindSddRequest { cwd: string; change: string; lineage: st
 export interface NativeSddStatusRequest { cwd: string; change: string; signal?: AbortSignal; }
 export interface NativeReviewStatusRequest { cwd: string; signal?: AbortSignal; }
 export interface NativeCapabilitiesRequest { cwd?: string; signal?: AbortSignal; }
-export interface NativeTargetStatusRequest { cwd: string; lineageId?: string; baseRef?: string; projection?: "workspace" | "staged"; signal?: AbortSignal; }
+export interface NativeTargetStatusRequest {
+	cwd: string;
+	lineageId?: string;
+	baseRef?: string;
+	projection?: "workspace" | "staged";
+	/**
+	 * The immutable reviewer runtime this host provides. Measured against the
+	 * live 2.4.0-main provider: the materialize-marked relay slot (agent=pi,
+	 * materialize=true, plus the provider submission) is offered ONLY when the
+	 * caller names its agent; an agent-less status returns a bare
+	 * capture-result input the host relay cannot consume. Older providers
+	 * (pinned 2.2.3) refuse the flag, so callers probe and fall back.
+	 */
+	agent?: "pi";
+	signal?: AbortSignal;
+}
 export interface NativeGateContext { lineageId: string; storeRevision: string; raw: Record<string, unknown>; }
 
 export const NATIVE_REVIEW_AUTHORITY_STATUS = {
@@ -2429,6 +2444,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			"--projection", request.projection ?? "workspace",
 			...(request.baseRef === undefined ? [] : ["--base-ref", request.baseRef]),
 			...(request.lineageId === undefined ? [] : ["--lineage", request.lineageId]),
+			...(request.agent === undefined ? [] : ["--agent", request.agent]),
 			"--next-transition",
 		], false, request.signal);
 		assertSupportedNextTransitionOperation(execution.body);

--- a/lib/review-compact-contract.ts
+++ b/lib/review-compact-contract.ts
@@ -60,6 +60,14 @@ export interface CompactFinalizeContractInput {
 	final_evidence?: string;
 	final_verification_passed?: boolean;
 	final_verification_outcome?: CorrectionOutcome;
+	/**
+	 * Explicit acknowledgement that this FINALIZE may spend real model tokens:
+	 * a provider host-relay slot runs one locked-down `pi` reviewer subprocess
+	 * per outstanding lens. Absent, FINALIZE forecasts the run and spends
+	 * nothing. Same shape as the existing `committedOnly` acknowledgement — the
+	 * caller states the consequence it accepts.
+	 */
+	reviewer_run_acknowledged?: boolean;
 }
 
 function fail(area: string, code: string, message: string): never {
@@ -122,7 +130,8 @@ function parseValidation(value: unknown, area: string): CompactTargetedValidatio
 }
 
 function parseCompactFinalizeInputValue(value: unknown): CompactFinalizeContractInput {
-	const input = exact(value, "review/finalize", ["cwd"], ["lineageId", "correction_line_forecast", "validation", "final_evidence", "final_verification_passed", "final_verification_outcome"]);
+	const input = exact(value, "review/finalize", ["cwd"], ["lineageId", "correction_line_forecast", "validation", "final_evidence", "final_verification_passed", "final_verification_outcome", "reviewer_run_acknowledged"]);
+	if (input.reviewer_run_acknowledged !== undefined && typeof input.reviewer_run_acknowledged !== "boolean") fail("review/finalize.reviewer_run_acknowledged", "type", "must be boolean");
 	const outcomeFields = Number(input.final_verification_passed !== undefined) + Number(input.final_verification_outcome !== undefined);
 	if ((input.final_evidence === undefined && outcomeFields !== 0) || (input.final_evidence !== undefined && outcomeFields !== 1)) fail("review/finalize", "field-pair", "final evidence requires exactly one verification result or outcome");
 	let correction_line_forecast: number | undefined;
@@ -145,7 +154,7 @@ function parseCompactFinalizeInputValue(value: unknown): CompactFinalizeContract
 		if (typeof input.final_evidence !== "string" || input.final_evidence.length === 0) fail("review/finalize.final_evidence", "empty", "must contain at least one byte");
 		final_evidence = input.final_evidence;
 	}
-	return { cwd: string(input.cwd, "review/finalize.cwd"), ...(optionalLineage(input.lineageId, "review/finalize.lineageId") === undefined ? {} : { lineageId: optionalLineage(input.lineageId, "review/finalize.lineageId")! }), ...(correction_line_forecast === undefined ? {} : { correction_line_forecast }), ...(input.validation === undefined ? {} : { validation: parseValidation(input.validation, "review/finalize.validation") }), ...(final_evidence === undefined ? {} : { final_evidence }), ...(input.final_verification_passed === undefined ? {} : { final_verification_passed: input.final_verification_passed }), ...(final_verification_outcome === undefined ? {} : { final_verification_outcome }) };
+	return { cwd: string(input.cwd, "review/finalize.cwd"), ...(optionalLineage(input.lineageId, "review/finalize.lineageId") === undefined ? {} : { lineageId: optionalLineage(input.lineageId, "review/finalize.lineageId")! }), ...(correction_line_forecast === undefined ? {} : { correction_line_forecast }), ...(input.validation === undefined ? {} : { validation: parseValidation(input.validation, "review/finalize.validation") }), ...(final_evidence === undefined ? {} : { final_evidence }), ...(input.final_verification_passed === undefined ? {} : { final_verification_passed: input.final_verification_passed }), ...(final_verification_outcome === undefined ? {} : { final_verification_outcome }), ...(input.reviewer_run_acknowledged === undefined ? {} : { reviewer_run_acknowledged: input.reviewer_run_acknowledged as boolean }) };
 }
 
 export function parseNativeCompactFinalizeInput(value: unknown): CompactFinalizeContractInput {

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -544,6 +544,21 @@ export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "dec
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 export const NATIVE_REVIEW_AUTHORITY_STATUS = {
 	CLEAN: "clean",
 	ACTIVE: "active",
@@ -2430,6 +2445,7 @@ export class NativeReviewCliV216                            {
 			"--projection", request.projection ?? "workspace",
 			...(request.baseRef === undefined ? [] : ["--base-ref", request.baseRef]),
 			...(request.lineageId === undefined ? [] : ["--lineage", request.lineageId]),
+			...(request.agent === undefined ? [] : ["--agent", request.agent]),
 			"--next-transition",
 		], false, request.signal);
 		assertSupportedNextTransitionOperation(execution.body);

--- a/tests/crosslane/cross-lane.mjs
+++ b/tests/crosslane/cross-lane.mjs
@@ -593,20 +593,36 @@ async function recoveredSuccessorLifecycle(binary, cli, root) {
 			"external scope_changed successor driven from STATUS alone: pre-STATUS dispatch refused, post-STATUS dispatch injected the successor candidate context (a controller without STATUS hydration fails here)",
 		);
 
-		// Defect B: document-free finalize at reviewer_results_required.
-		const finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({}) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
-		if (finalizeEnvelope.status !== "blocked" || finalizeEnvelope.outcome !== "reviewer-results-required" || finalizeEnvelope.mutation_performed !== false) {
-			throw new Error(`finalize routed to ${String(finalizeEnvelope.outcome ?? finalizeEnvelope.status)} instead of the blocked reviewer-results-required step`);
+		// Defect B: finalize must follow the provider transition for reviewer
+		// results and never the correction evidence-first-ordering lane. On a
+		// provider that admits the pi transport the correct route is the host
+		// relay; the pi-subprocess hop is stubbed to keep this check free.
+		let relaySlots = 0;
+		__testing.setReviewHostRelayRunnerForTesting(async (request) => {
+			relaySlots += 1;
+			return { promptByteLength: request.captureArgumentTokens.length, resultByteLength: 0, submission: "{}" };
+		});
+		let finalizeEnvelope;
+		try {
+			finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({}) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
+		} finally {
+			__testing.setReviewHostRelayRunnerForTesting();
 		}
-		if (!/capture the reviewer result first/i.test(String(finalizeEnvelope.reason)) || !String(finalizeEnvelope.reason).includes("review.capture-result")) {
-			throw new Error("finalize block is missing the actionable review.capture-result direction");
+		const routedToRelay = relaySlots > 0 && finalizeEnvelope.host_relay?.transport === "pi_host_relay";
+		const routedToBlockedCapture = finalizeEnvelope.outcome === "reviewer-results-required"
+			&& /capture the reviewer result first/i.test(String(finalizeEnvelope.reason))
+			&& finalizeEnvelope.mutation_performed === false;
+		if (!routedToRelay && !routedToBlockedCapture) {
+			throw new Error(`finalize routed to ${String(finalizeEnvelope.outcome ?? finalizeEnvelope.status)} instead of the provider reviewer-result step`);
 		}
 		if (JSON.stringify(finalizeEnvelope).includes("evidence-first-ordering")) {
 			throw new Error("finalize still leaked the correction evidence-first-ordering lane");
 		}
 		pass(
 			"recovered routing: finalize offers capture-result, never evidence ordering",
-			"document-free finalize at reviewer_results_required returned the actionable review.capture-result block with zero mutations (a finalize that misroutes into evidence ordering fails here)",
+			routedToRelay
+				? "finalize followed the provider transition into the pi host relay for the outstanding reviewer result (a finalize that misroutes into evidence ordering fails here)"
+				: "document-free finalize at reviewer_results_required returned the actionable review.capture-result block with zero mutations (a finalize that misroutes into evidence ordering fails here)",
 		);
 
 		// Complete the drive to one really captured lens through the exact
@@ -710,9 +726,19 @@ async function recoveredSuccessorFieldFlow(binary, cli, root) {
 	// A brand-new registry stands in for the fresh Pi session.
 	const registry = new CandidateViewRegistry();
 	try {
-		const finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({}) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
-		if (finalizeEnvelope.outcome !== "reviewer-results-required") {
-			throw new Error(`finalize routed to ${String(finalizeEnvelope.outcome ?? finalizeEnvelope.status)} instead of the blocked reviewer-results-required step`);
+		// The pi-subprocess hop is stubbed: this check is about the dispatch
+		// binding the finalize-first flow leaves behind, on whichever route the
+		// provider offers (host relay when it admits the pi transport).
+		__testing.setReviewHostRelayRunnerForTesting(async (request) => ({ promptByteLength: request.captureArgumentTokens.length, resultByteLength: 0, submission: "{}" }));
+		let finalizeEnvelope;
+		try {
+			finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({}) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
+		} finally {
+			__testing.setReviewHostRelayRunnerForTesting();
+		}
+		const routed = finalizeEnvelope.outcome === "reviewer-results-required" || finalizeEnvelope.host_relay?.transport === "pi_host_relay";
+		if (!routed) {
+			throw new Error(`finalize routed to ${String(finalizeEnvelope.outcome ?? finalizeEnvelope.status)} instead of the provider reviewer-result step`);
 		}
 		const binding = finalizeEnvelope.dispatch_binding;
 		if (binding === undefined) throw new Error("the blocked finalize envelope does not report a dispatch-binding hydration outcome");
@@ -730,6 +756,73 @@ async function recoveredSuccessorFieldFlow(binary, cli, root) {
 			registry.cleanup(registry.resolveCurrentForLens("review-reliability").token);
 		} catch {
 			// No hydrated view to clean when the check failed before binding.
+		}
+	}
+}
+
+// relayMaterializeSlotLifecycle covers the shape every earlier check missed:
+// the provider's MATERIALIZE-marked host-relay slot (agent=pi,
+// materialize=true, provider submission) on an externally recovered lineage.
+// Measured root cause (third field report): the adapter's negotiated STATUS
+// never named its agent, so the provider only ever returned a bare
+// capture-result input, reviewHostRelaySlots() saw zero slots, and the relay
+// never ran. This check fails on any build that drops `--agent pi`.
+//
+// Residual gap, stated honestly: the locked-down pi subprocess and the final
+// provider submit leg are NOT executed here — those cost model spend. The
+// check drives everything up to and including the REAL materialize leg
+// against the real binary (the provider-issued tokens must actually produce
+// prompt bytes), and stubs only the pi-subprocess hop.
+async function relayMaterializeSlotLifecycle(binary, cli, root) {
+	const cwd = scratchLinkedWorktree(root, "pi-relay-slot");
+	write(cwd, "docs/relay-guide.md", "# Relay guide\n\nline one\n");
+	write(cwd, "src/mul.js", "export function mul(a, b) {\n  return a * b;\n}\n");
+	commitAll(cwd, "feat: base");
+	write(cwd, "docs/relay-guide.md", "# Relay guide\n\nline one\nline two, purely passive documentation\n");
+	const successor = await externallyRecoveredSuccessor(binary, cli, cwd, "relay-materialize-successor");
+
+	const relayed = [];
+	let materializedBytes = 0;
+	const registry = new CandidateViewRegistry();
+	__testing.setReviewHostRelayRunnerForTesting(async (request) => {
+		relayed.push(request);
+		// The REAL materialize leg: the provider-issued tokens must produce a
+		// non-empty opaque prompt from the real binary. No model spend.
+		const prompt = execFileSync(binary, ["review", "capture-result", ...request.captureArgumentTokens], {
+			cwd,
+			env: gentleAiProcessEnvironment(),
+			maxBuffer: 64 * 1024 * 1024,
+		});
+		materializedBytes = prompt.length;
+		if (materializedBytes === 0) throw new Error("provider materialize produced no prompt bytes");
+		return { promptByteLength: materializedBytes, resultByteLength: 0, submission: "{}" };
+	});
+	try {
+		const envelope = await __testing.executeReviewControllerOperation(
+			{ operation: "finalize", lineageId: successor, input: JSON.stringify({}) },
+			cwd, new Map(), cli, undefined, undefined, undefined, registry,
+		);
+		if (relayed.length !== 1) {
+			throw new Error(`the provider materialize slot never reached the host relay (relayed ${relayed.length}); outcome=${String(envelope.outcome ?? envelope.status)}`);
+		}
+		const tokens = relayed[0].captureArgumentTokens;
+		if (!tokens.includes("--agent=pi") || !tokens.includes("--materialize=true")) {
+			throw new Error(`relay slot is missing the provider transport tokens: ${tokens.join(" ")}`);
+		}
+		if (relayed[0].submission?.operationToken !== "capture-result") {
+			throw new Error("relay slot carries no provider submission completing form");
+		}
+		const hostRelay = envelope.host_relay;
+		if (hostRelay?.transport !== "pi_host_relay" || hostRelay.captured_slots?.length !== 1) {
+			throw new Error(`controller envelope did not report one relayed slot: ${JSON.stringify(hostRelay)}`);
+		}
+		return `provider offered the materialize slot to the adapter and it reached the relay verbatim (agent=pi, materialize=true, submission=capture-result); the real materialize leg returned ${materializedBytes} prompt bytes. Residual gap: the locked-down pi subprocess and the provider submit leg are not executed here (model spend)`;
+	} finally {
+		__testing.setReviewHostRelayRunnerForTesting();
+		try {
+			registry.cleanup(registry.resolveCurrentForLens("review-reliability").token);
+		} catch {
+			// No hydrated view to clean when the relay lane bound nothing.
 		}
 	}
 }
@@ -865,6 +958,12 @@ async function main() {
 			pass("recovered field flow: linked dirty worktree, finalize-first dispatch", await recoveredSuccessorFieldFlow(binary, cli, root));
 		} catch (error) {
 			fail("recovered field flow: linked dirty worktree, finalize-first dispatch", knownRedParity(describeError(error)));
+		}
+
+		try {
+			pass("relay materialize slot on an externally recovered lineage", await relayMaterializeSlotLifecycle(binary, cli, root));
+		} catch (error) {
+			fail("relay materialize slot on an externally recovered lineage", knownRedParity(describeError(error)));
 		}
 
 		if (WITH_MODEL && mediumRepo !== undefined) {

--- a/tests/crosslane/cross-lane.mjs
+++ b/tests/crosslane/cross-lane.mjs
@@ -604,7 +604,7 @@ async function recoveredSuccessorLifecycle(binary, cli, root) {
 		});
 		let finalizeEnvelope;
 		try {
-			finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({}) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
+			finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({ reviewer_run_acknowledged: true }) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
 		} finally {
 			__testing.setReviewHostRelayRunnerForTesting();
 		}
@@ -621,8 +621,8 @@ async function recoveredSuccessorLifecycle(binary, cli, root) {
 		pass(
 			"recovered routing: finalize offers capture-result, never evidence ordering",
 			routedToRelay
-				? "finalize followed the provider transition into the pi host relay for the outstanding reviewer result (a finalize that misroutes into evidence ordering fails here)"
-				: "document-free finalize at reviewer_results_required returned the actionable review.capture-result block with zero mutations (a finalize that misroutes into evidence ordering fails here)",
+				? "finalize followed the provider transition into the pi host relay for the outstanding reviewer result. Accepting either provider-correct route (relay when the provider admits the pi transport, blocked capture-result otherwise) is NOT a relaxation of the evidence-ordering guard: this check still fails on any evidence-first-ordering leak in the envelope, and on any route that is neither of the two"
+				: "document-free finalize at reviewer_results_required returned the actionable review.capture-result block with zero mutations. Accepting either provider-correct route (relay when the provider admits the pi transport, blocked capture-result otherwise) is NOT a relaxation of the evidence-ordering guard: this check still fails on any evidence-first-ordering leak in the envelope, and on any route that is neither of the two",
 		);
 
 		// Complete the drive to one really captured lens through the exact
@@ -732,13 +732,16 @@ async function recoveredSuccessorFieldFlow(binary, cli, root) {
 		__testing.setReviewHostRelayRunnerForTesting(async (request) => ({ promptByteLength: request.captureArgumentTokens.length, resultByteLength: 0, submission: "{}" }));
 		let finalizeEnvelope;
 		try {
-			finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({}) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
+			finalizeEnvelope = await __testing.executeReviewControllerOperation({ operation: "finalize", lineageId: successor, input: JSON.stringify({ reviewer_run_acknowledged: true }) }, cwd, new Map(), cli, undefined, undefined, undefined, registry);
 		} finally {
 			__testing.setReviewHostRelayRunnerForTesting();
 		}
 		const routed = finalizeEnvelope.outcome === "reviewer-results-required" || finalizeEnvelope.host_relay?.transport === "pi_host_relay";
 		if (!routed) {
 			throw new Error(`finalize routed to ${String(finalizeEnvelope.outcome ?? finalizeEnvelope.status)} instead of the provider reviewer-result step`);
+		}
+		if (JSON.stringify(finalizeEnvelope).includes("evidence-first-ordering")) {
+			throw new Error("finalize leaked the correction evidence-first-ordering lane");
 		}
 		const binding = finalizeEnvelope.dispatch_binding;
 		if (binding === undefined) throw new Error("the blocked finalize envelope does not report a dispatch-binding hydration outcome");
@@ -750,7 +753,7 @@ async function recoveredSuccessorFieldFlow(binary, cli, root) {
 		const dispatch = { agent: "review-reliability", task: "review the recovered successor", mode: "task" };
 		injectReviewCandidateView(dispatch, registry);
 		if (!dispatch.task.includes(successor)) throw new Error("hydrated dispatch context is not bound to the recovered successor lineage");
-		return "linked worktree + uncommitted tracked changes + external recover: finalize-first (no STATUS call) hydrated the dispatch binding and the reviewer dispatch resolved; residual gap: the battery cannot age a lineage by days or span OS processes, only a fresh registry";
+		return "linked worktree + uncommitted tracked changes + external recover: finalize-first (no STATUS call) hydrated the dispatch binding and the reviewer dispatch resolved, on whichever provider-correct route was offered, and the envelope still carries no evidence-first-ordering leak; residual gap: the battery cannot age a lineage by days or span OS processes, only a fresh registry";
 	} finally {
 		try {
 			registry.cleanup(registry.resolveCurrentForLens("review-reliability").token);
@@ -799,7 +802,7 @@ async function relayMaterializeSlotLifecycle(binary, cli, root) {
 	});
 	try {
 		const envelope = await __testing.executeReviewControllerOperation(
-			{ operation: "finalize", lineageId: successor, input: JSON.stringify({}) },
+			{ operation: "finalize", lineageId: successor, input: JSON.stringify({ reviewer_run_acknowledged: true }) },
 			cwd, new Map(), cli, undefined, undefined, undefined, registry,
 		);
 		if (relayed.length !== 1) {

--- a/tests/review-host-relay-routing.test.ts
+++ b/tests/review-host-relay-routing.test.ts
@@ -131,7 +131,12 @@ function finalizeParameters(lineageId: string, input: Record<string, unknown> = 
 	return { operation: "finalize", lineageId, input: JSON.stringify(input) };
 }
 
-async function runFinalize(cwd: string, harness: RoutingHarness, lineageId: string, input: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+// Relay ROUTING is the subject here, not spend authorization: a host-relay
+// finalize now forecasts its reviewer model runs and spends nothing until the
+// caller acknowledges them (see review-relay-transport-agent.test.ts), so these
+// routing cases authorize the run up front and keep asserting where the slots
+// go. A case that must observe the forecast passes the acknowledgement off.
+async function runFinalize(cwd: string, harness: RoutingHarness, lineageId: string, input: Record<string, unknown> = { reviewer_run_acknowledged: true }): Promise<Record<string, unknown>> {
 	return await __testing.executeReviewControllerOperation(
 		finalizeParameters(lineageId, input),
 		cwd,

--- a/tests/review-relay-transport-agent.test.ts
+++ b/tests/review-relay-transport-agent.test.ts
@@ -146,9 +146,9 @@ function transportAwareNative(options: { refusePiAgent?: boolean } = {}): { nati
 	return { native, agents };
 }
 
-async function runFinalize(cwd: string, native: NativeReviewCli, lineageId: string): Promise<Record<string, unknown>> {
+async function runFinalize(cwd: string, native: NativeReviewCli, lineageId: string, input: Record<string, unknown> = { reviewer_run_acknowledged: true }): Promise<Record<string, unknown>> {
 	return await __testing.executeReviewControllerOperation(
-		{ operation: "finalize", lineageId, input: JSON.stringify({}) },
+		{ operation: "finalize", lineageId, input: JSON.stringify(input) },
 		cwd, new Map(), native, undefined, undefined, undefined, new CandidateViewRegistry(),
 	) as Record<string, unknown>;
 }
@@ -174,6 +174,38 @@ test("the negotiated status asks for the pi agent so the provider offers its mat
 	assert.ok(hostRelay !== undefined, "the envelope reports the relay capture");
 	assert.equal(hostRelay.transport, "pi_host_relay");
 	assert.equal(hostRelay.captured_slots.length, 1);
+});
+
+test("finalize forecasts the reviewer model run once and spends nothing until it is acknowledged", async (t) => {
+	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
+	const cwd = repository(t);
+	const lineageId = "forecast-lineage";
+	const { native } = transportAwareNative();
+	let launches = 0;
+	__testing.setReviewHostRelayRunnerForTesting(async () => {
+		launches += 1;
+		return { promptByteLength: 128, resultByteLength: 64, submission: '{"admission_decision":"completed"}' };
+	});
+
+	// An unacknowledged finalize must forecast, never spend.
+	const forecast = await runFinalize(cwd, native, lineageId, {});
+	assert.equal(launches, 0, "no reviewer model run may start before the forecast is acknowledged");
+	assert.equal(forecast.status, "blocked");
+	assert.equal(forecast.outcome, "reviewer-model-run-forecast");
+	assert.equal(forecast.mutation_performed, false);
+	assert.equal(forecast.mutation_outcome, "none");
+	const cost = forecast.cost_forecast as { transport: string; model_runs: number; lenses: readonly string[]; side_effects: readonly string[] };
+	assert.equal(cost.transport, "pi_host_relay");
+	assert.equal(cost.model_runs, 1, "one model run per outstanding lens, forecast once before launch");
+	assert.deepEqual(cost.lenses, ["review-reliability"]);
+	assert.ok(cost.side_effects.length > 0);
+	assert.match(String(forecast.reason), /model run/i);
+	assert.match(String(forecast.next_action), /reviewer_run_acknowledged/);
+
+	// The acknowledged finalize runs exactly the forecast work.
+	const acknowledged = await runFinalize(cwd, native, lineageId, { reviewer_run_acknowledged: true });
+	assert.equal(launches, 1, "the acknowledged finalize runs the forecast model run");
+	assert.equal((acknowledged.host_relay as { captured_slots: readonly unknown[] }).captured_slots.length, 1);
 });
 
 test("a provider that refuses the pi transport surfaces the typed cause and still returns status", async (t) => {

--- a/tests/review-relay-transport-agent.test.ts
+++ b/tests/review-relay-transport-agent.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { __testing } from "../extensions/gentle-ai.ts";
+import { NativeReviewIntegrationError, type NativeReviewCli } from "../lib/native-review-cli.ts";
+import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
+import type { ReviewCollectInputV3, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+import type { ReviewHostRelayRequest } from "../lib/review-host-relay.ts";
+
+// Third field failure on the recovered-lineage defect (2026-08-16, gentle-pi
+// main 402f9f77 + gentle-ai 2.4.0-main.20278905): STATUS recognises the
+// lineage, the Pi RELAY never runs, no lens is launched, zero mutations.
+//
+// Measured against the live binary on a faithful reproduction (linked
+// worktree, uncommitted tracked files, externally recovered successor):
+//
+//   agent-less STATUS  -> collect input arguments:
+//       lineage, expected-revision, target, repository-context, lens, order,
+//       subject-hash                      (no agent, no materialize, no submission)
+//   `--agent pi` STATUS -> the same input PLUS agent=pi, materialize=true and
+//       the provider submission (operation_token=capture-result)
+//
+// The adapter's negotiated targetStatus never sent `--agent pi`, so the
+// provider never offered the materialize-marked relay slot,
+// reviewHostRelaySlots() returned 0 for every real lineage, and the host relay
+// was unreachable. The prior fixes all exercised dispatch-shaped slots.
+//
+// The pinned 2.2.3 binary refuses `--agent pi` outright, so the agent is
+// probed and the typed refusal must reach the user instead of being swallowed.
+
+const SHA = `sha256:${"1".repeat(64)}`;
+const TRANSPORT_REFUSAL_CODE = "immutable_review_transport_unsupported";
+
+function repository(t: test.TestContext): string {
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-relay-transport-"));
+	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	execFileSync("git", ["init", "-b", "main"], { cwd });
+	writeFileSync(join(cwd, "app.ts"), "export const value = 1;\n");
+	execFileSync("git", ["add", "."], { cwd });
+	execFileSync("git", ["-c", "user.name=Relay", "-c", "user.email=relay@example.invalid", "commit", "-m", "base"], { cwd });
+	return cwd;
+}
+
+function collectInput(lineageId: string, materialize: boolean): ReviewCollectInputV3 {
+	const binding = [
+		{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` },
+		{ name: "expected-revision", value: SHA, token: `--expected-revision=${SHA}` },
+		{ name: "target", value: SHA, token: `--target=${SHA}` },
+		{ name: "repository-context", value: `rctx1_${"e".repeat(64)}`, token: `--repository-context=rctx1_${"e".repeat(64)}` },
+		{ name: "lens", value: "review-reliability", token: "--lens=review-reliability" },
+		{ name: "order", value: "0", token: "--order=0" },
+		{ name: "subject-hash", value: SHA, token: `--subject-hash=${SHA}` },
+	];
+	return {
+		name: "reviewer_result",
+		schema: "https://gentle-ai.dev/schema/review/reviewer/v1",
+		captureOperation: "review.capture-result",
+		arguments: materialize
+			? [...binding, { name: "agent", value: "pi", token: "--agent=pi" }, { name: "materialize", value: "true", token: "--materialize=true" }]
+			: binding,
+		artifactSubject: {
+			schema: "gentle-ai.review-artifact-subject/v2",
+			subjectHash: SHA,
+			lineageId,
+			authorityRevision: SHA,
+			targetIdentity: SHA,
+			baseTree: "3".repeat(40),
+			candidateTree: "4".repeat(40),
+			changedPathManifestSha256: SHA,
+			lens: "review-reliability",
+			selectedOrder: 0,
+		},
+		...(materialize
+			? {
+				submission: {
+					operationToken: "capture-result",
+					argumentTokens: [...binding.map((argument) => argument.token), "--input={{value}}"],
+					values: [{ slot: "reviewer_result", domain: "artifact_path_or_stdin", substitutionLocation: binding.length }],
+				},
+			}
+			: {}),
+	} as unknown as ReviewCollectInputV3;
+}
+
+function recoveredStatus(lineageId: string, materialize: boolean): ReviewStatusV3 {
+	return {
+		contract: "gentle-ai.review-integration/v2",
+		applicability: "current_target",
+		authority: { version: "compact-v2", lineageId, state: "reviewer_results_required", generation: 2, revision: SHA },
+		receipt: { status: "expected_missing" },
+		action: "finalize",
+		replayability: "not_replayable",
+		targetIdentity: SHA,
+		projection: {
+			schema: "gentle-ai.review-integration.projection/v1",
+			kind: "current-changes",
+			projection: "workspace",
+			baseTree: "3".repeat(40),
+			initialReviewTree: "4".repeat(40),
+			currentCandidateTree: "4".repeat(40),
+			pathsDigest: SHA,
+			paths: ["app.ts"],
+			intendedUntracked: [],
+			intendedUntrackedProof: SHA,
+			initialSnapshotIdentity: SHA,
+			currentSnapshotIdentity: SHA,
+		},
+		candidates: [],
+		nextTransition: { kind: "collect", reasonCode: "reviewer_results_required", collect: { inputs: [collectInput(lineageId, materialize)] } },
+		raw: { schema: "gentle-ai.review-integration.status/v5", action: "finalize", lineage_id: lineageId },
+	} as unknown as ReviewStatusV3;
+}
+
+/**
+ * Mirrors the MEASURED live provider: the materialize-marked relay slot is
+ * offered only when the caller asks for the pi agent.
+ */
+function transportAwareNative(options: { refusePiAgent?: boolean } = {}): { native: NativeReviewCli; agents: Array<string | undefined> } {
+	const agents: Array<string | undefined> = [];
+	const native = {
+		targetStatus: async (request: { lineageId?: string; agent?: string }) => {
+			agents.push(request.agent);
+			if (request.agent === "pi" && options.refusePiAgent === true) {
+				throw new NativeReviewIntegrationError({
+					schema: "gentle-ai.review-integration.failure/v2",
+					contract: "gentle-ai.review-integration/v2",
+					operation: "review.status",
+					phase: "pre_native",
+					code: TRANSPORT_REFUSAL_CODE,
+					message: "supported immutable review runtimes: claude-code, opencode, codex",
+					mutationOutcome: "none",
+					authorityApplicability: "current_target",
+					retrySafe: true,
+					replayability: "not_replayable",
+					nextAction: "stop",
+					raw: {},
+				} as never);
+			}
+			return recoveredStatus(request.lineageId ?? "relay-lineage", request.agent === "pi");
+		},
+		finalize: async () => { throw new Error("native finalize must not run while reviewer results are outstanding"); },
+	} as unknown as NativeReviewCli;
+	return { native, agents };
+}
+
+async function runFinalize(cwd: string, native: NativeReviewCli, lineageId: string): Promise<Record<string, unknown>> {
+	return await __testing.executeReviewControllerOperation(
+		{ operation: "finalize", lineageId, input: JSON.stringify({}) },
+		cwd, new Map(), native, undefined, undefined, undefined, new CandidateViewRegistry(),
+	) as Record<string, unknown>;
+}
+
+test("the negotiated status asks for the pi agent so the provider offers its materialize relay slot", async (t) => {
+	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
+	const cwd = repository(t);
+	const lineageId = "relay-recovered-successor";
+	const { native, agents } = transportAwareNative();
+	const relayed: ReviewHostRelayRequest[] = [];
+	__testing.setReviewHostRelayRunnerForTesting(async (request: ReviewHostRelayRequest) => {
+		relayed.push(request);
+		return { promptByteLength: 128, resultByteLength: 64, submission: '{"admission_decision":"completed"}' };
+	});
+
+	const result = await runFinalize(cwd, native, lineageId);
+
+	assert.ok(agents.includes("pi"), "the controller must negotiate STATUS for the pi reviewer transport");
+	assert.equal(relayed.length, 1, "the materialize-marked slot must reach the host relay");
+	assert.ok(relayed[0]!.captureArgumentTokens.includes("--materialize=true"));
+	assert.ok(relayed[0]!.submission !== undefined, "the provider submission drives the completing form");
+	const hostRelay = result.host_relay as { transport: string; captured_slots: readonly unknown[] } | undefined;
+	assert.ok(hostRelay !== undefined, "the envelope reports the relay capture");
+	assert.equal(hostRelay.transport, "pi_host_relay");
+	assert.equal(hostRelay.captured_slots.length, 1);
+});
+
+test("a provider that refuses the pi transport surfaces the typed cause and still returns status", async (t) => {
+	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
+	const cwd = repository(t);
+	const lineageId = "legacy-transport-lineage";
+	const { native, agents } = transportAwareNative({ refusePiAgent: true });
+	let relayCalls = 0;
+	__testing.setReviewHostRelayRunnerForTesting(async () => {
+		relayCalls += 1;
+		return { promptByteLength: 1, resultByteLength: 1, submission: "{}" };
+	});
+
+	const result = await runFinalize(cwd, native, lineageId);
+
+	assert.ok(agents.includes("pi"), "the transport is probed once");
+	assert.ok(agents.includes(undefined), "a refusal falls back to the agent-less status instead of failing the operation");
+	assert.equal(relayCalls, 0, "no relay slot exists on a provider without the pi transport");
+	// Deliverable: the user sees the real typed cause, never a generic
+	// candidate-view message.
+	const transport = result.relay_transport as { supported: boolean; code: string; message: string } | undefined;
+	assert.ok(transport !== undefined, "the envelope must report the transport refusal");
+	assert.equal(transport.supported, false);
+	assert.equal(transport.code, TRANSPORT_REFUSAL_CODE);
+	assert.match(transport.message, /immutable review runtimes/i);
+	assert.doesNotMatch(JSON.stringify(result), /no current controller-owned candidate view/);
+	// The lifecycle still routes: reviewer results remain outstanding.
+	assert.equal(result.outcome, "reviewer-results-required");
+});
+
+test("the pi transport is probed once per provider and the refusal is remembered", async (t) => {
+	const cwd = repository(t);
+	const { native, agents } = transportAwareNative({ refusePiAgent: true });
+	await runFinalize(cwd, native, "probe-lineage");
+	const afterFirst = agents.filter((agent) => agent === "pi").length;
+	await runFinalize(cwd, native, "probe-lineage");
+	const afterSecond = agents.filter((agent) => agent === "pi").length;
+	assert.equal(afterFirst, 1, "the first flow probes the pi transport exactly once");
+	assert.equal(afterSecond, 1, "a remembered refusal is never re-probed for the same provider");
+});


### PR DESCRIPTION
Third field failure on the recovered-lineage defect, after #340 and #341 shipped and the package was regenerated: STATUS recognises the lineage, the Pi relay never runs, no lens is launched, zero mutations.

## Root cause (measured, not inferred): the adapter never named its agent

The provider only emits the materialize-marked host-relay slot when the caller identifies its immutable reviewer runtime. `NativeReviewCliV216.targetStatus` never sent `--agent pi`.

Measured on a faithful reproduction against the live binary — linked git worktree (not the primary checkout), uncommitted tracked modifications, successor from an external `review recover --disposition scope_changed`:

```
agent-less STATUS   -> collect input arguments:
  lineage, expected-revision, target, repository-context, lens, order, subject-hash
  artifact_subject: present     submission: ABSENT

--agent pi STATUS   -> the same input PLUS:
  agent=pi, materialize=true    submission: operation_token=capture-result
```

Through the adapter, before this PR:

```
adapter STATUS decoded -> reasonCode: reviewer_results_required
  arg names: lineage,expected-revision,target,repository-context,lens,order,subject-hash
  reviewHostRelaySlots(inputs).length = 0     <-- the relay gets nothing
```

So `reviewHostRelaySlots()` returned zero for every real lineage, the relay branch in FINALIZE never executed, and no lens was ever launched. Every earlier fix exercised dispatch-shaped slots, which is why all of them passed while the field kept failing.

**The other two hypotheses were measured and ruled out:**
- *Handshake env*: not the cause. `gentleAiProcessEnvironment()` already stamps `GENTLE_PI_REVIEW_RELAY_CONTRACT` on **every** adapter invocation, and the relay stamps it again for its own gentle-ai calls. The refusal the maintainer saw bare-handed does not occur through the adapter.
- *Relay needing a candidate view*: false. `lib/review-host-relay.ts` has zero candidate-view coupling — it consumes provider tokens only. Its materialize leg was also verified to work from any cwd (opaque `repository-context` binds the repository): identical 9890-byte prompt from the candidate worktree and from an unrelated directory.

## Fix

- `NativeTargetStatusRequest` gains `agent?: "pi"`, and `targetStatus` renders `--agent pi` when asked.
- The FINALIZE lane negotiates status for the host transport. The agent is **probed, never assumed**: the pinned 2.2.3 provider refuses the flag (verified: `failure/v2`, `operation_failed`), so a typed transport refusal is remembered per provider instance and the lane falls back to the agent-less status. Nothing regresses for providers without the pi transport.
- The relay lane also hydrates the dispatch binding (best-effort) so a hand-dispatched reviewer on the same lineage still resolves; the relay itself does not need it.

## Deliverable 4 — the typed refusal is surfaced, not swallowed

When a provider refuses the pi transport, the envelope carries `relay_transport: { supported: false, code, message }` and the blocked reason names the code and the provider's own words ("supported immutable review runtimes: ..."). It is never degraded into a generic candidate-view message; a regression test asserts the candidate-view string is absent from that envelope.

## RED evidence

`tests/review-relay-transport-agent.test.ts` — fake provider mirrors the measured live behaviour (materialize slot only when the pi agent is named). All three RED before the fix:
- "the controller must negotiate STATUS for the pi reviewer transport"
- "the transport is probed once" (typed refusal + fallback + surfaced cause)
- probe-once memoization

Battery RED (fix files stash-reverted): `relay materialize slot on an externally recovered lineage` FAILED with "the provider materialize slot never reached the host relay (relayed 0); outcome=reviewer-results-required".

## Battery

New check `relay materialize slot on an externally recovered lineage`:

```
relay materialize slot on an externally recovered lineage  PASS  provider offered the materialize slot to the adapter and it reached the relay verbatim (agent=pi, materialize=true, submission=capture-result); the real materialize leg returned 9092 prompt bytes. Residual gap: the locked-down pi subprocess and the provider submit leg are not executed here (model spend)
```

It drives a linked worktree + external recover through the controller, asserts the provider-issued transport tokens and submission reach the relay verbatim, and runs the **real** materialize leg against the real binary. Residual gap declared in the note rather than faked: the pi subprocess and the submit leg cost model spend and are not executed.

Two existing checks were updated, not weakened: with the transport enabled the correct route for a relay-capable provider is the host relay rather than the blocked capture-result step, so they now accept either provider-correct route and still fail on any leak into evidence ordering.

## Verification (all foreground)

- New unit file 3/3; adjacent suites (host-relay routing, controller routing, hydration gap, recovered routing, parity) 262/262.
- Full suite: 1258 tests, 1243 pass; the 14 failures are the known pre-existing dev-binary-override environment set, name-for-name identical to prior runs.
- `pnpm test:cross-lane`: 16 checks, 0 failed. `check:transaction-runner`: no drift. `check:provider-contract`: pass. `test:harness`: exit 0.

The maintainer's lineage and worktree were never touched; everything above was measured on an independent scratch reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for negotiating review-result transport with providers.
  * Review workflows can now fall back automatically when a provider declines the preferred transport.
  * Transport refusal details are surfaced when reviewer results are required.
  * Host-relay execution now supports recovered review workflows and materialized prompts.

* **Bug Fixes**
  * Improved finalization and workspace rebind handling for provider-specific transport differences.
  * Prevented relay attempts when the provider does not support the requested transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->