### PR TITLE
fix(review): rebind FINALIZE to the corrected candidate the provider authorized

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -6204,6 +6204,25 @@ async function executeReviewControllerOperation(
 				// belongs to a different worktree than the requested workspace (#169).
 				if (candidateViews && parameters.lineageId && candidateViews.hasProjection(parameters.lineageId)) candidateViews.resolveProjection(parameters.lineageId, defaultCwd);
 				candidateView ??= candidateViews && parameters.lineageId && !ordinaryFinalVerification ? (correctionCompletion || validationAttempt) ? candidateViews.createCorrected(parameters.lineageId, defaultCwd, replayKey) : candidateViews.resolveForFinalize(parameters.lineageId) : undefined;
+				// Field defect (Engram #12547): a FINALIZE that merely follows the
+				// provider's own execute transition carries no documents, so
+				// neither correctionCompletion nor validationAttempt holds and the
+				// START-time reviewer view is resolved. After an admitted bounded
+				// correction the candidate identity has legitimately moved, so
+				// that view is compared against the corrected target the provider
+				// itself authorized and every finalize fails as drift — no receipt
+				// is ever minted, while a fresh process finalizes the same lineage
+				// fine because it restores from the native descriptor. Re-derive
+				// the binding from that same descriptor here instead of reading a
+				// retired reviewer view as drift. It is not a relaxation: the
+				// replacement is materialized from Git, must match the provider
+				// descriptor exactly, and is asserted immediately below.
+				if (
+					candidateView !== undefined && candidateViews && parameters.lineageId && !ordinaryFinalVerification &&
+					candidateView.candidateTree !== negotiatedStatus.projection.currentCandidateTree
+				) {
+					candidateView = candidateViews.rebindForFinalizeFromNative(parameters.lineageId, defaultCwd, negotiatedStatus.projection);
+				}
 				if (candidateView !== undefined) assertNativeFinalizeCandidateBinding(candidateView, negotiatedStatus);
 				if (ordinaryFinalVerification && parameters.lineageId) {
 					// A projection held by this process routes the top-of-try path

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -1092,6 +1092,37 @@ export class CandidateViewRegistry {
 		});
 	}
 
+	/**
+	 * Re-derives this lineage's FINALIZE binding from the provider's own
+	 * projection, replacing a binding this session is still holding.
+	 *
+	 * Field defect (Engram #12547): once a bounded correction is admitted, the
+	 * candidate identity legitimately moves, and the provider issues its
+	 * finalize transition for that corrected target. A session that started the
+	 * review still holds the START-time immutable reviewer view, so comparing
+	 * it against the corrected projection reads as drift and no receipt is ever
+	 * minted — while a fresh process, which restores from the native descriptor,
+	 * finalizes the very same lineage successfully. This makes the in-session
+	 * path behave like that already-correct fresh-process path.
+	 *
+	 * This is a re-derivation, not a relaxation: the replacement is
+	 * materialized from Git and must match the provider descriptor exactly
+	 * (base tree, projection kind, changed-path manifest), and the caller still
+	 * asserts the binding afterwards. The immutable reviewer view is retired
+	 * here on purpose — the lenses that consumed it finished before the
+	 * correction.
+	 */
+	rebindForFinalizeFromNative(lineageId: string, contributorRoot: string, descriptor: NativeCandidateProjectionDescriptor): CandidateView {
+		const staleToken = this.lineages.get(lineageId);
+		const stale = staleToken === undefined ? undefined : this.records.get(staleToken);
+		this.projections.delete(lineageId);
+		if (stale !== undefined) {
+			this.remove(stale);
+			this.forget(stale);
+		}
+		return this.restoreForFinalizeFromNative(lineageId, contributorRoot, descriptor);
+	}
+
 	restoreForFinalizeFromNative(lineageId: string, contributorRoot: string, descriptor: NativeCandidateProjectionDescriptor): CandidateView {
 		this.restoreProjectionFromNative(lineageId, contributorRoot, descriptor);
 		const projection = this.resolveProjection(lineageId, contributorRoot);

--- a/tests/crosslane/cross-lane.mjs
+++ b/tests/crosslane/cross-lane.mjs
@@ -22,7 +22,7 @@
 // tests/*.test.ts only.
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -776,6 +776,147 @@ async function recoveredSuccessorFieldFlow(binary, cli, root) {
 // check drives everything up to and including the REAL materialize leg
 // against the real binary (the provider-issued tokens must actually produce
 // prompt bytes), and stubs only the pi-subprocess hop.
+// correctedLifecycleThroughAdapter drives the shape three field defects in a
+// row escaped through: a MEDIUM candidate taken all the way through detection,
+// bounded correction, evidence and targeted validation to an approved receipt
+// THROUGH THE ADAPTER — not the clean-approval path, and not raw CLI.
+//
+// Field defect it locks down (Engram #12547): after an admitted correction the
+// candidate identity legitimately moves, and a FINALIZE that merely follows the
+// provider's own execute transition carries no documents. That made the
+// adapter resolve the START-time reviewer view and report
+// `candidate-target-projection-drift`, so no corrected lineage could ever reach
+// a receipt through Pi.
+//
+// The controller-driven client is built from lib/*.ts on purpose: the battery's
+// shared `cli` comes from runtime/*.mjs, and mixing that module instance with
+// the extension's lib/*.ts instance breaks `instanceof` across the boundary,
+// which silently turns the consent path into a generic failure.
+async function correctedLifecycleThroughAdapter(binary, root) {
+	const { createNativeReviewCli } = await import("../../lib/native-review-cli.ts");
+	const cli = createNativeReviewCli(undefined, binary);
+	const cwd = scratchRepo(root, "pi-corrected");
+	const base = "export function parsePath(input) {\n  return input.split(\"/\");\n}\n";
+	write(cwd, "src/parse.js", base);
+	commitAll(cwd, "feat: parse");
+	// The intentional reliability defect: the last component is omitted.
+	write(cwd, "src/parse.js", `${base}export function lastComponent(input) {\n  const parts = input.split("/");\n  return parts[parts.length - 2];\n}\n`);
+
+	const registry = new CandidateViewRegistry();
+	const context = { cwd, hasUI: false, ui: { confirm: async () => true, notify: () => {} } };
+	// The real tool is used, not the bare entry point: the pending-consent map
+	// lives for the tool's lifetime, so START and ANSWER-CONSENT share it.
+	const { createGentleAiExtension } = await import("../../extensions/gentle-ai.ts");
+	const tools = new Map();
+	createGentleAiExtension({ nativeReviewCli: cli, candidateViews: registry })({
+		on() {}, registerTool(definition) { tools.set(definition.name, definition); }, registerCommand() {},
+	});
+	const tool = tools.get("gentle_review");
+	let call = 0;
+	const controller = async (parameters) => (await tool.execute(`corrected-${call++}`, parameters, undefined, undefined, context)).details;
+	let boundLineageId;
+	try {
+		// START through the controller so this session holds the START-time
+		// immutable reviewer view — the state the defect needs.
+		let envelope = await controller({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) });
+		if (envelope.consent_binding === undefined) throw new Error(`medium START did not surface consent: ${String(envelope.outcome ?? envelope.status)}`);
+		envelope = await controller({ operation: "answer-consent", input: JSON.stringify({ consentBinding: envelope.consent_binding, answer: "granted" }) });
+		const lineageId = envelope.result?.lineage_id;
+		boundLineageId = lineageId;
+		if (envelope.result?.state !== "reviewing" || lineageId === undefined) throw new Error(`granted START state=${String(envelope.result?.state)}`);
+		if (!registry.hasCurrentBinding()) throw new Error("START did not bind the immutable reviewer view for this session");
+		const startTree = rawStatus(binary, cwd).projection.current_candidate_tree;
+
+		// Reviewer slot: one deterministic candidate-caused BLOCKER.
+		let raw = rawStatus(binary, cwd);
+		let slot = raw.next_transition?.collect?.inputs?.[0];
+		if (slot?.capture_operation !== "review.capture-result") throw new Error(`expected review.capture-result, got ${summarizeRaw(raw.next_transition)}`);
+		let args = rawArgumentValues(slot);
+		const reviewerFile = join(root, "pi-corrected-reviewer.json");
+		writeFileSync(reviewerFile, JSON.stringify({
+			subject_hash: args["subject-hash"],
+			inspection: { status: "completed", paths: ["src/parse.js"] },
+			evidence: ["lastComponent indexes parts.length - 2 and omits the last component; introduced by the candidate hunk"],
+			findings: [{
+				claim: "lastComponent returns the second-to-last path component instead of the last",
+				severity: "BLOCKER",
+				evidence_class: "deterministic",
+				causal_disposition: "introduced",
+				lens: args.lens,
+				location: "src/parse.js:6",
+				proof_refs: ["src/parse.js:4-7 indexes parts.length - 2 in the candidate tree"],
+			}],
+		}));
+		rawInvoke(binary, cwd, ["review", "capture-result", "--lineage", args.lineage, "--expected-revision", args["expected-revision"],
+			"--target", args.target, "--repository-context", args["repository-context"], "--lens", args.lens,
+			"--order", args.order, "--subject-hash", args["subject-hash"], "--input", reviewerFile]);
+
+		envelope = await controller({ operation: "finalize", lineageId, input: JSON.stringify({}) });
+		if (envelope.result?.state !== "correction_required") throw new Error(`finalize after capture state=${String(envelope.result?.state ?? envelope.outcome)}`);
+
+		// Bounded correction: forecast BEFORE editing, then the edit.
+		raw = rawStatus(binary, cwd);
+		const planInput = raw.next_transition?.collect?.inputs?.[0];
+		if (planInput?.capture_operation !== "external.plan_correction") throw new Error(`expected external.plan_correction, got ${summarizeRaw(raw.next_transition)}`);
+		const bounds = planInput.submission?.values?.[0] ?? {};
+		envelope = await controller({ operation: "finalize", lineageId, input: JSON.stringify({ correction_line_forecast: bounds.minimum ?? 1 }) });
+		if (envelope.result?.state !== "correction_required") throw new Error(`correction forecast rejected: ${JSON.stringify(envelope.diagnostics ?? envelope.outcome)}`);
+		write(cwd, "src/parse.js", `${base}export function lastComponent(input) {\n  const parts = input.split("/");\n  return parts[parts.length - 1];\n}\n`);
+		const correctedTree = rawStatus(binary, cwd).projection.current_candidate_tree;
+		if (correctedTree === startTree) throw new Error("the correction did not move the candidate identity");
+
+		// THE REGRESSION PROBE: a FINALIZE that just follows the provider
+		// transition carries no documents. Whatever the provider answers is
+		// fine; what must never come back is adapter-side reviewer-view drift.
+		envelope = await controller({ operation: "finalize", lineageId, input: JSON.stringify({}) });
+		if (envelope.diagnostics?.code === "candidate-target-projection-drift") {
+			throw new Error("document-free FINALIZE on the corrected candidate still reports candidate-target-projection-drift");
+		}
+
+		// Correction evidence, then targeted validation, to the receipt.
+		envelope = await controller({ operation: "finalize", lineageId, input: JSON.stringify({ final_evidence: "node --check src/parse.js passed; lastComponent now returns the final component", final_verification_passed: true }) });
+		if (envelope.diagnostics?.code === "candidate-target-projection-drift") throw new Error("evidence FINALIZE reported candidate-target-projection-drift");
+		raw = rawStatus(binary, cwd);
+		const validationInput = raw.next_transition?.collect?.inputs?.[0];
+		if (validationInput?.capture_operation !== "external.run_targeted_validation") {
+			return `corrected lineage reached ${String(raw.authority?.state)} through the adapter with no candidate-target-projection-drift at any step; residual gap: this provider renders targeted validation as the Go-owned ${String(validationInput?.capture_operation)} vector, which costs a model run, so the battery stops before the receipt`;
+		}
+		// The evidence-only FINALIZE above already advanced the provider to
+		// targeted validation, so the receipt is completed through the exact
+		// provider-rendered submission (the same way the sequencing check does).
+		// Re-calling FINALIZE with final_evidence AND validation re-enters
+		// evidence capture on this provider; that lane question is pre-existing
+		// and out of scope for this defect, and is noted rather than papered over.
+		const request = raw.validation_request ?? validationInput.validation_request;
+		const validatorFile = join(root, "pi-corrected-validator.json");
+		writeFileSync(validatorFile, JSON.stringify({
+			targeted_validation_request_hash: request.request_hash,
+			correction_target_identity: request.correction_target_identity,
+			original_criteria: { passed: true, evidence: ["frozen correction tree returns parts[parts.length - 1]"] },
+			correction_regression: { passed: true, evidence: ["parsePath is untouched by the correction diff"] },
+			follow_ups: [],
+		}));
+		const submitted = rawInvoke(binary, root, ["review", validationInput.submission.operation_token,
+			...substitute(validationInput.submission.argument_tokens, { value: validatorFile })]);
+		const finalState = submitted?.result?.state ?? submitted?.state ?? rawStatus(binary, cwd).authority?.state;
+		if (finalState !== "approved") throw new Error(`corrected lineage ended at ${String(finalState)} instead of approved`);
+		// The receipt must be the adapter-validatable one for the corrected tree.
+		const gate = await controller({ operation: "status", lineageId });
+		if (gate.result?.authority?.state !== "approved") throw new Error(`adapter status does not see the approved corrected lineage: ${String(gate.result?.authority?.state)}`);
+		return "medium candidate driven through the adapter: BLOCKER detected -> bounded correction -> document-free provider-transition FINALIZE with no candidate-target-projection-drift -> correction evidence -> targeted validation -> approved receipt the adapter can see. Residual gap: the final targeted-validation document is submitted through the exact provider-rendered vector, because a combined evidence+validation FINALIZE re-enters evidence capture on this provider (pre-existing lane question, not this defect)";
+	} finally {
+		// Candidate views are materialized read-only; leaving one behind makes
+		// the battery's own root cleanup fail with EACCES.
+		const resolvers = [
+			() => registry.resolveCurrentForLens("review-reliability"),
+			...(boundLineageId === undefined ? [] : [() => registry.resolveForFinalize(boundLineageId)]),
+		];
+		for (const resolve of resolvers) {
+			try { registry.cleanup(resolve().token); } catch { /* nothing bound to clean */ }
+		}
+	}
+}
+
 async function relayMaterializeSlotLifecycle(binary, cli, root) {
 	const cwd = scratchLinkedWorktree(root, "pi-relay-slot");
 	write(cwd, "docs/relay-guide.md", "# Relay guide\n\nline one\n");
@@ -908,6 +1049,28 @@ function decoderFreshness(binary) {
 	}
 }
 
+// Candidate views are materialized read-only, so a leaked one makes a plain
+// rmSync fail with EACCES — and losing the battery's results table to a scratch
+// permission is worse than leaving bytes in /tmp. Make everything writable
+// first, then remove, and never let cleanup mask the run's outcome.
+function removeScratchRoot(root) {
+	const makeWritable = (path) => {
+		let entry;
+		try { entry = statSync(path); } catch { return; }
+		try { chmodSync(path, entry.isDirectory() ? 0o700 : 0o600); } catch { /* best effort */ }
+		if (!entry.isDirectory()) return;
+		let children = [];
+		try { children = readdirSync(path); } catch { return; }
+		for (const child of children) makeWritable(join(path, child));
+	};
+	makeWritable(root);
+	try {
+		rmSync(root, { recursive: true, force: true });
+	} catch (error) {
+		console.log(`note: scratch root ${root} could not be fully removed (${error.code ?? "unknown"}); results below are unaffected`);
+	}
+}
+
 // --- driver ---
 
 async function main() {
@@ -969,6 +1132,12 @@ async function main() {
 			fail("relay materialize slot on an externally recovered lineage", knownRedParity(describeError(error)));
 		}
 
+		try {
+			pass("corrected lifecycle through the adapter to an approved receipt", await correctedLifecycleThroughAdapter(binary, root));
+		} catch (error) {
+			fail("corrected lifecycle through the adapter to an approved receipt", knownRedParity(describeError(error)));
+		}
+
 		if (WITH_MODEL && mediumRepo !== undefined) {
 			try {
 				pass("medium reviewer model run (pi)", await modelReview(binary, cli, mediumRepo));
@@ -981,7 +1150,7 @@ async function main() {
 
 		decoderFreshness(binary);
 	} finally {
-		rmSync(root, { recursive: true, force: true });
+		removeScratchRoot(root);
 	}
 
 	const nameWidth = Math.max(...checks.map((check) => check.name.length), "check".length);

--- a/tests/review-corrected-finalize-binding.test.ts
+++ b/tests/review-corrected-finalize-binding.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { __testing } from "../extensions/gentle-ai.ts";
+import type { NativeReviewCli } from "../lib/native-review-cli.ts";
+import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
+import type { ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+
+// Field defect (Engram #12547, lineage review-43762fca1bba0bf3): a MEDIUM
+// lineage detected a reliability defect, corrected it inside budget, captured
+// evidence and the native targeted validator. Negotiated STATUS then returned
+// `captured_provider_targeted_validation_ready` with an execute
+// `review.finalize` transition, and running that exact transition failed twice
+// with `candidate-target-projection-drift`, mutation none, so no receipt was
+// ever minted.
+//
+// Measured on a faithful live reproduction (medium candidate, real binary,
+// START through the controller so the registry holds the START-time view):
+//
+//   START candidate tree:     4c24487f850050af0a0944d37d4dbb15287ab3da
+//   corrected candidate tree: 777f48fdc4e6ed9abd325d6b4c49e6d06036c906
+//   FINALIZE (no documents) -> candidate-target-projection-drift, mutation none
+//   registry branch taken:    ["resolveForFinalize"]
+//
+// Root cause: the corrected tree is tolerated only while
+// `correctionCompletion` (validation AND final_evidence) or `validationAttempt`
+// (final_evidence without a forecast) hold. A FINALIZE that merely follows the
+// provider's own execute transition carries no documents, so both are false,
+// the START-time view is resolved, and it is compared against the corrected
+// candidate the provider itself authorized.
+
+const SHA = `sha256:${"1".repeat(64)}`;
+const DEFECT = "export function lastComponent(input) {\n  const parts = input.split(\"/\");\n  return parts[parts.length - 2];\n}\n";
+const CORRECTED = "export function lastComponent(input) {\n  const parts = input.split(\"/\");\n  return parts[parts.length - 1];\n}\n";
+
+function git(cwd: string, ...arguments_: string[]): string {
+	return execFileSync("git", arguments_, { cwd, encoding: "utf8" }).trim();
+}
+
+function repository(t: test.TestContext): string {
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-corrected-finalize-"));
+	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	git(cwd, "init", "-b", "main");
+	git(cwd, "config", "user.name", "Corrected Test");
+	git(cwd, "config", "user.email", "corrected@example.invalid");
+	mkdirSync(join(cwd, "src"), { recursive: true });
+	writeFileSync(join(cwd, "src", "parse.js"), "export function parsePath(input) {\n  return input.split(\"/\");\n}\n");
+	git(cwd, "add", "-A");
+	git(cwd, "commit", "-m", "base");
+	writeFileSync(join(cwd, "src", "parse.js"), DEFECT);
+	return cwd;
+}
+
+/** The live frozen identity of the current workspace candidate. */
+function liveIdentity(cwd: string): { baseTree: string; candidateTree: string; paths: readonly string[] } {
+	const probe = new CandidateViewRegistry();
+	const view = probe.create({ contributorRoot: cwd });
+	try {
+		return { baseTree: view.baseTree, candidateTree: view.candidateTree, paths: view.paths };
+	} finally {
+		probe.cleanup(view.token);
+	}
+}
+
+function correctedStatus(lineageId: string, identity: { baseTree: string; candidateTree: string; paths: readonly string[] }): ReviewStatusV3 {
+	return {
+		contract: "gentle-ai.review-integration/v2",
+		applicability: "current_target",
+		authority: { version: "compact-v2", lineageId, state: "correction_required", generation: 1, revision: SHA },
+		receipt: { status: "expected_missing" },
+		action: "finalize",
+		replayability: "not_replayable",
+		frozen: { tier: "medium", originalChangedLines: 4, correctionBudget: 2 },
+		targetIdentity: SHA,
+		projection: {
+			schema: "gentle-ai.review-integration.projection/v1",
+			kind: "current-changes",
+			projection: "workspace",
+			baseTree: identity.baseTree,
+			initialReviewTree: identity.candidateTree,
+			currentCandidateTree: identity.candidateTree,
+			pathsDigest: SHA,
+			paths: [...identity.paths],
+			intendedUntracked: [],
+			intendedUntrackedProof: SHA,
+			initialSnapshotIdentity: SHA,
+			currentSnapshotIdentity: SHA,
+		},
+		candidates: [],
+		// The provider's own answer after it admitted the captured validator.
+		nextTransition: {
+			kind: "execute",
+			reasonCode: "captured_provider_targeted_validation_ready",
+			execute: {
+				operation: "review.finalize",
+				arguments: [
+					{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` },
+					{ name: "captured-evidence", value: "true", token: "--captured-evidence=true" },
+				],
+				binding: { lineageId },
+			},
+		},
+		raw: { schema: "gentle-ai.review-integration.status/v5", action: "finalize", lineage_id: lineageId },
+	} as unknown as ReviewStatusV3;
+}
+
+function approvingNative(status: ReviewStatusV3): { native: NativeReviewCli; transitions: number } {
+	const state = { transitions: 0 };
+	const native = {
+		targetStatus: async () => status,
+		finalizeTransition: async () => {
+			state.transitions += 1;
+			return { lineageId: status.authority!.lineageId, state: "approved", action: "approved", storeRevision: "r2" };
+		},
+		finalize: async () => { throw new Error("the provider transition must be executed, not raw finalize"); },
+	} as unknown as NativeReviewCli;
+	return { native, get transitions() { return state.transitions; } } as never;
+}
+
+/** Binds the START-time immutable reviewer view, as a live session does. */
+function sessionWithStartBinding(cwd: string, lineageId: string): { registry: CandidateViewRegistry; startTree: string } {
+	const registry = new CandidateViewRegistry();
+	const view = registry.createOrReuse({ contributorRoot: cwd });
+	registry.bindCurrent({ token: view.token, lineageId, selectedLenses: ["review-reliability"] });
+	return { registry, startTree: view.candidateTree };
+}
+
+test("FINALIZE follows the provider transition after a correction instead of drifting on the START view", async (t) => {
+	const cwd = repository(t);
+	const lineageId = "review-corrected-lineage";
+	const { registry, startTree } = sessionWithStartBinding(cwd, lineageId);
+	t.after(() => { try { registry.cleanup(registry.resolveForFinalize(lineageId).token); } catch { /* already cleaned */ } });
+
+	// The bounded correction lands: the candidate identity legitimately moves.
+	writeFileSync(join(cwd, "src", "parse.js"), CORRECTED);
+	const corrected = liveIdentity(cwd);
+	assert.notEqual(corrected.candidateTree, startTree, "the correction must move the candidate tree");
+
+	const harness = approvingNative(correctedStatus(lineageId, corrected));
+	const result = await __testing.executeReviewControllerOperation(
+		// Exactly the reporter's call: follow the provider transition, no documents.
+		{ operation: "finalize", lineageId, input: JSON.stringify({}) },
+		cwd, new Map(), harness.native, undefined, undefined, undefined, registry,
+	) as Record<string, unknown>;
+
+	assert.notEqual(
+		(result.diagnostics as { code?: string } | undefined)?.code,
+		"candidate-target-projection-drift",
+		"a corrected candidate the provider authorized must not read as reviewer-view drift",
+	);
+	assert.equal(harness.transitions, 1, "the provider's own finalize transition must run");
+	assert.equal((result.result as { state?: string } | undefined)?.state, "approved");
+});
+
+test("FINALIZE still fails closed when the live candidate does not match the provider projection", async (t) => {
+	const cwd = repository(t);
+	const lineageId = "review-drifted-lineage";
+	const { registry } = sessionWithStartBinding(cwd, lineageId);
+	t.after(() => { try { registry.cleanup(registry.resolveForFinalize(lineageId).token); } catch { /* already cleaned */ } });
+
+	// The provider describes a candidate this workspace cannot reproduce.
+	const identity = liveIdentity(cwd);
+	const harness = approvingNative(correctedStatus(lineageId, { ...identity, candidateTree: identity.baseTree }));
+	const result = await __testing.executeReviewControllerOperation(
+		{ operation: "finalize", lineageId, input: JSON.stringify({}) },
+		cwd, new Map(), harness.native, undefined, undefined, undefined, registry,
+	) as Record<string, unknown>;
+
+	assert.equal(result.status, "blocked", "an unverifiable candidate must never mint a receipt");
+	assert.equal(result.mutation_outcome, "none");
+	assert.equal(harness.transitions, 0, "no provider transition may run for an unverifiable candidate");
+});


### PR DESCRIPTION
Blocking field defect (Engram #12547, lineage `review-43762fca1bba0bf3`, finding R3-last-component-omitted), reproduced in a clean dedicated clone: a MEDIUM lineage detected a reliability defect, corrected it inside budget, captured evidence and the native targeted validator. Negotiated STATUS returned `captured_provider_targeted_validation_ready`, and running that exact FINALIZE transition failed twice with `candidate-target-projection-drift`, mutation none. No receipt, so the commit and push gates could never be exercised. This blocks the Pi path for any lineage that goes through a correction.

## Root cause, measured

The lead was right and the measurement confirms it. On a faithful live reproduction (medium candidate, real binary, START through the controller so the session holds the START-time view):

```
START candidate tree:     4c24487f850050af0a0944d37d4dbb15287ab3da
corrected candidate tree: 777f48fdc4e6ed9abd325d6b4c49e6d06036c906   (differs: true)
FINALIZE (no documents) -> diagnostics: { code: "candidate-target-projection-drift" }, mutation_outcome: none
registry branch taken:    ["resolveForFinalize"]
```

`correctionCompletion = validation !== undefined && final_evidence !== undefined` and `validationAttempt = correction_line_forecast === undefined && final_evidence !== undefined` **both require documents**. A FINALIZE that merely follows the provider's own execute transition carries none, so both are false, `resolveForFinalize` returns the START-time immutable reviewer view, and `assertNativeFinalizeCandidateBinding` compares it against the corrected candidate the provider itself authorized. Guaranteed drift, every time.

The decisive asymmetry: a **fresh process** finalizes the very same lineage successfully, because with no held projection it goes through `restoreForFinalizeFromNative` and re-derives the binding from the native descriptor. Only the session that started the review fails. The adapter was contradicting the provider.

## Fix

`CandidateViewRegistry.rebindForFinalizeFromNative` re-derives the lineage's FINALIZE binding from the provider's own projection, replacing a stale in-session binding; the FINALIZE lane calls it when the held view's candidate tree no longer matches the provider's `currentCandidateTree`.

This is a re-derivation, not a relaxation: the replacement is materialized from Git, must match the provider descriptor exactly (base tree, projection kind, changed-path manifest), and is still asserted immediately afterwards. A second test proves an unverifiable candidate still fails closed with no provider transition and no receipt. The immutable reviewer view is retired at that point on purpose — the lenses that consumed it finished before the correction.

## Mirror case (`assertNativeStartCandidateBinding`) — checked, no equivalent drift

Measured rather than reasoned. Fresh candidate, and again after the candidate moves:

```
pre-START:              baseTree/initialReviewTree/currentCandidateTree/paths all match the live view
resume shape:           authority reviewing, all three tree fields match
after candidate moves:  applicability "unrelated", authority null, both tree fields match the live view
```

When the candidate moves the target identity changes, so the status detaches to `unrelated` with no authority and START evaluates a pre-authority target describing the live candidate, where `initialReviewTree === currentCandidateTree`. No post-correction START path drifts. No change made there.

## RED evidence

`tests/review-corrected-finalize-binding.test.ts` (written first) failed with `actual: 'candidate-target-projection-drift'` on the reporter's exact shape: session holding the START view, provider offering an execute `review.finalize` for `captured_provider_targeted_validation_ready`.

Battery RED (fix reverted): `corrected lifecycle through the adapter to an approved receipt` FAILED with *"document-free FINALIZE on the corrected candidate still reports candidate-target-projection-drift"*.

## Battery — the corrected path, not the clean-approval path

Three field defects in a row escaped because the checks never drove the real shape. The new check drives a MEDIUM candidate through the **adapter**: START (consent granted) → deterministic BLOCKER lens capture → `correction_required` → bounded correction forecast → the fix → **document-free provider-transition FINALIZE (the regression probe)** → correction evidence → targeted validation → approved receipt the adapter can see.

```
corrected lifecycle through the adapter to an approved receipt  PASS  medium candidate driven through the adapter: BLOCKER detected -> bounded correction -> document-free provider-transition FINALIZE with no candidate-target-projection-drift -> correction evidence -> targeted validation -> approved receipt the adapter can see. Residual gap: the final targeted-validation document is submitted through the exact provider-rendered vector, because a combined evidence+validation FINALIZE re-enters evidence capture on this provider (pre-existing lane question, not this defect)
```

Two incidental battery findings, both fixed here rather than left as traps:
- The battery imports the CLI from `runtime/*.mjs` and the extension from `lib/*.ts`. Those are different module instances, so `instanceof NativeReviewConsentRequiredError` fails across the boundary and the consent path silently degrades into a generic failure. The new check builds its controller-driven client from `lib/*.ts`; the hazard is documented at the call site.
- A leaked read-only candidate worktree made the battery's own root cleanup throw `EACCES` **before** the results table printed, losing every result. Cleanup now makes the tree writable first and never masks the run's outcome.

## Verification (all foreground)

- New unit file 2/2. Full suite: 1261 tests, 1246 pass; the 14 failures are the known pre-existing dev-binary-override environment set, name-for-name identical to prior runs.
- `pnpm test:cross-lane`: 17 checks, 0 failed. `check:transaction-runner`: no drift. `check:provider-contract`: pass. `test:harness`: exit 0.

The reporter's worktree and lineage were never touched; everything above was measured on an independent scratch reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected candidate finalization now follows the provider’s latest authorized candidate state when the candidate changes during review.
  - Prevented valid document-free execution transitions from being incorrectly blocked by projection-drift errors.
  - Unverifiable provider projections remain safely blocked without applying changes.

- **Tests**
  - Added coverage for corrected-candidate finalization, approval receipts, evidence validation, and end-to-end review lifecycles.
  - Added validation for cleanup of read-only candidate views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->