### PR TITLE
feat(commands): surface the background-subagents policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ pi
 /sdd-init                  Create or refresh openspec/config.yaml (openspec/both stores only).
 /gentle:models             Assign global model/effort routing to SDD/custom agents.
 /gentle:persona            Switch between gentleman and neutral persona modes.
+/gentle:background-subagents  Show or set the managed background-subagents policy, with its deciding source.
 /gentle:banner             Configure startup rose, text logo, and color preset.
 /gentle:commit-status      Inspect an unresolved durable commit transaction.
 /gentle:commit-abort       Abandon safe recovery state without changing HEAD or the index.
@@ -594,6 +595,7 @@ Legacy string entries are still accepted and treated as `model`-only config.
 | `/gentle:doctor`              | Runs read-only diagnostics for SDD assets, model/persona config, memory tools, and safety guards. |
 | `/gentle:models`                 | Opens global model + effort assignment UI. Press `x` to export and `r` to restore saved routing. |
 | `/gentle:persona`                | Switches global persona mode, with project override support.        |
+| `/gentle:background-subagents`   | Shows or sets the managed background-subagents policy (`status\|enable\|disable`), naming the source that decided it. |
 | `/gentle:banner`                 | Configures startup banner rose, text logo, and color preset.        |
 | `/gentle:toggle-rose`            | Toggles the startup rose.                                           |
 | `/gentle:toggle-text-logo`       | Toggles the startup text logo.                                      |
@@ -605,6 +607,29 @@ Legacy string entries are still accepted and treated as `model`-only config.
 | `/skill-creation`                | Creates or updates an LLM-first skill using the packaged `gentle-ai-skill-creator` contract and style guide. |
 
 Package-owned global SDD runtime assets are also refreshed automatically on session start when `gentle-pi` changes. Project-local `.pi/agents` and `.pi/chains` remain manual overrides and are never overwritten by startup refresh.
+
+### Background subagents policy
+
+Background delegation is off unless you turn it on. The policy is user-owned: only an explicit `/gentle:background-subagents enable` or `disable` writes it, and Pi automation never toggles it.
+
+```text
+/gentle:background-subagents           Report the effective policy, the deciding source, and the resolved capability.
+/gentle:background-subagents enable    Write "on" to the global file.
+/gentle:background-subagents disable   Write "off" to the global file.
+```
+
+Four sources can decide the policy, and the first hit wins:
+
+| Priority | Source                                            | Notes                                                        |
+| -------- | ------------------------------------------------- | ------------------------------------------------------------ |
+| 1        | `<cwd>/.pi/gentle-ai/background-subagents.json`   | Project file. Outranks everything, including a global write.  |
+| 2        | `<configHome>/background-subagents.json`          | Global file, written by `enable`/`disable`. `configHome` honors `GENTLE_PI_CONFIG_HOME` and defaults to `~/.pi/gentle-ai`. |
+| 3        | `GENTLE_PI_BACKGROUND_SUBAGENTS`                  | Exactly `on` or `off`. Any other value is ignored.            |
+| 4        | Built-in default                                  | `off`.                                                        |
+
+Both files use the strict shape `{"schema":"gentle-pi.background-subagents/v1","policy":"on"}`. A file that is present but malformed fails closed to `off` and is **not** skipped in favor of a lower-priority source, so a typo in the project file disables background subagents rather than silently handing the decision to the global file. The command reports that case as a warning instead of an ordinary `off`.
+
+Because the project file outranks the global one, `enable` still writes the global file but reports plainly when a project file keeps the effective policy unchanged. The resolved capability (`ready` or `absent`) reports whether `subagent_run` is actually callable in this session; a policy of `on` with capability `absent` means the subagents package is not installed.
 
 Startup banner settings are global and default to the current pink rose + text logo. Supported color presets are `pink`, `cyan`, `yellow`, and `green`.
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -249,6 +249,26 @@ interface BackgroundSubagentsRendering {
 	capability: BackgroundSubagentsCapability;
 }
 
+/** Which of the four sources decided the effective policy. */
+type BackgroundSubagentsSource =
+	| "project_file"
+	| "global_file"
+	| "environment"
+	| "default";
+
+interface BackgroundSubagentsResolution {
+	policy: BackgroundSubagentsPolicy;
+	source: BackgroundSubagentsSource;
+	/** The deciding file was present but failed the strict decode. */
+	malformed: boolean;
+	projectFile: string;
+	globalFile: string;
+	projectFileExists: boolean;
+	globalFileExists: boolean;
+	/** The raw env value, reported even when it is unrecognized and inert. */
+	envValue: string | undefined;
+}
+
 interface LoadBackgroundSubagentsOptions {
 	/** Override the config home directory (used in tests to avoid touching ~/.pi). */
 	gentlePiConfigHome?: string;
@@ -286,7 +306,7 @@ function parseBackgroundSubagentsPolicyFile(
 }
 
 /**
- * Load the background-subagents policy.
+ * Resolve the background-subagents policy AND the source that decided it.
  *
  * Resolution order (first hit wins, mirroring loadRuntimeGuardrailsConfig):
  *   1. Project file `${cwd}/.pi/gentle-ai/background-subagents.json`
@@ -296,28 +316,157 @@ function parseBackgroundSubagentsPolicyFile(
  *   4. Default "off"
  *
  * A present-but-malformed file fails closed to "off" instead of falling
- * through to a lower-priority source.
+ * through to a lower-priority source, and it stays attributed to that file:
+ * "off decided by a broken project file" and "off by default" are different
+ * situations, and only the first one is a mistake to fix.
+ *
+ * Four sources with first-hit-wins is exactly the shape that makes an edit
+ * look like it did nothing, so the deciding source is part of the result
+ * rather than something a caller has to re-derive.
+ */
+function resolveBackgroundSubagentsPolicy(
+	cwd: string,
+	options: LoadBackgroundSubagentsOptions = {},
+): BackgroundSubagentsResolution {
+	const env = options.env ?? process.env;
+	const envValue = env.GENTLE_PI_BACKGROUND_SUBAGENTS;
+	let projectFile = "";
+	let globalFile = "";
+	try {
+		const configHome = options.gentlePiConfigHome ?? gentleAiConfigHome();
+		projectFile = join(cwd, ".pi", "gentle-ai", BACKGROUND_SUBAGENTS_FILE);
+		globalFile = join(configHome, BACKGROUND_SUBAGENTS_FILE);
+		const projectFileExists = existsSync(projectFile);
+		const globalFileExists = existsSync(globalFile);
+		const locations = { projectFile, globalFile, projectFileExists, globalFileExists, envValue };
+		for (const [source, path, present] of [
+			["project_file", projectFile, projectFileExists],
+			["global_file", globalFile, globalFileExists],
+		] as const) {
+			if (!present) continue;
+			let decoded: BackgroundSubagentsPolicy | undefined;
+			try {
+				decoded = parseBackgroundSubagentsPolicyFile(readFileSync(path, "utf8"));
+			} catch {
+				// Unreadable is indistinguishable from unusable at this layer, and
+				// both must fail closed on the file that claimed the decision.
+				decoded = undefined;
+			}
+			return decoded === undefined
+				? { policy: "off", source, malformed: true, ...locations }
+				: { policy: decoded, source, malformed: false, ...locations };
+		}
+		if (envValue === "on" || envValue === "off") {
+			return { policy: envValue, source: "environment", malformed: false, ...locations };
+		}
+		return { policy: "off", source: "default", malformed: false, ...locations };
+	} catch {
+		return {
+			policy: "off",
+			source: "default",
+			malformed: false,
+			projectFile,
+			globalFile,
+			projectFileExists: false,
+			globalFileExists: false,
+			envValue,
+		};
+	}
+}
+
+/**
+ * The effective policy alone, for callers that do not report a source.
+ * It delegates so the loader and the resolver can never disagree.
  */
 function loadBackgroundSubagentsPolicy(
 	cwd: string,
 	options: LoadBackgroundSubagentsOptions = {},
 ): BackgroundSubagentsPolicy {
-	try {
-		const env = options.env ?? process.env;
-		const configHome = options.gentlePiConfigHome ?? gentleAiConfigHome();
-		for (const path of [
-			join(cwd, ".pi", "gentle-ai", BACKGROUND_SUBAGENTS_FILE),
-			join(configHome, BACKGROUND_SUBAGENTS_FILE),
-		]) {
-			if (!existsSync(path)) continue;
-			return parseBackgroundSubagentsPolicyFile(readFileSync(path, "utf8")) ?? "off";
-		}
-		const fromEnv = env.GENTLE_PI_BACKGROUND_SUBAGENTS;
-		if (fromEnv === "on" || fromEnv === "off") return fromEnv;
-		return "off";
-	} catch {
-		return "off";
+	return resolveBackgroundSubagentsPolicy(cwd, options).policy;
+}
+
+/** Write the global policy file, creating the config home when needed. */
+function writeGlobalBackgroundSubagentsPolicy(
+	policy: BackgroundSubagentsPolicy,
+	configHome: string = gentleAiConfigHome(),
+): string {
+	const path = join(configHome, BACKGROUND_SUBAGENTS_FILE);
+	mkdirSync(configHome, { recursive: true });
+	writeFileSync(
+		path,
+		`${JSON.stringify({ schema: BACKGROUND_SUBAGENTS_SCHEMA, policy }, null, 2)}\n`,
+	);
+	return path;
+}
+
+function describeBackgroundSubagentsSource(
+	resolution: BackgroundSubagentsResolution,
+): string {
+	switch (resolution.source) {
+		case "project_file":
+			return `project file ${resolution.projectFile}`;
+		case "global_file":
+			return `global file ${resolution.globalFile}`;
+		case "environment":
+			return "GENTLE_PI_BACKGROUND_SUBAGENTS";
+		default:
+			return "built-in default";
 	}
+}
+
+/**
+ * Report the effective policy, the source that decided it, and the resolved
+ * capability, plus whatever the user needs to know about the sources that did
+ * NOT decide. `wrote` names a policy this invocation just wrote to the global
+ * file; a write that a higher-priority file outranks must never be reported as
+ * if it had taken effect.
+ */
+function renderBackgroundSubagentsReport(
+	resolution: BackgroundSubagentsResolution,
+	capability: BackgroundSubagentsCapability,
+	wrote?: BackgroundSubagentsPolicy,
+): { message: string; type: "info" | "warning" } {
+	const lines = [
+		`background subagents: ${resolution.policy} (decided by ${describeBackgroundSubagentsSource(resolution)}; capability: ${capability})`,
+	];
+	if (wrote !== undefined) {
+		lines.push(`Wrote ${wrote} to the global file ${resolution.globalFile}.`);
+	}
+	if (resolution.malformed) {
+		const path =
+			resolution.source === "project_file" ? resolution.projectFile : resolution.globalFile;
+		lines.push(
+			`${path} is present but malformed, so the policy fails closed to off and no lower-priority source is consulted.`,
+		);
+	}
+	const outranksTheWrite = wrote !== undefined && resolution.source === "project_file";
+	if (outranksTheWrite) {
+		lines.push(
+			`That global write does not take effect here: the project file ${resolution.projectFile} outranks it. Edit or remove that project file to let the global setting decide.`,
+		);
+	} else if (
+		wrote === undefined &&
+		resolution.source === "project_file" &&
+		resolution.globalFileExists
+	) {
+		lines.push(
+			`The global file ${resolution.globalFile} exists but is outranked by that project file.`,
+		);
+	}
+	if (resolution.envValue !== undefined && resolution.source !== "environment") {
+		lines.push(
+			resolution.envValue === "on" || resolution.envValue === "off"
+				? `GENTLE_PI_BACKGROUND_SUBAGENTS=${resolution.envValue} is set, but both files outrank it and it outranks the built-in default; it decides only when neither file exists.`
+				: `GENTLE_PI_BACKGROUND_SUBAGENTS="${resolution.envValue}" is not a recognized value ("on" or "off"), so it is ignored.`,
+		);
+	}
+	lines.push(
+		"Resolution order (first hit wins): project file, global file, GENTLE_PI_BACKGROUND_SUBAGENTS, built-in default off.",
+	);
+	return {
+		message: lines.join("\n"),
+		type: resolution.malformed || outranksTheWrite ? "warning" : "info",
+	};
 }
 
 const SUBAGENTS_PACKAGE_NAMES = ["pi-subagents-j0k3r", "pi-subagents"] as const;
@@ -6967,6 +7116,9 @@ export const __testing = {
 	getOrchestratorPrompt,
 	renderOrchestratorPrompt,
 	loadBackgroundSubagentsPolicy,
+	resolveBackgroundSubagentsPolicy,
+	renderBackgroundSubagentsReport,
+	writeGlobalBackgroundSubagentsPolicy,
 	parseBackgroundSubagentsPolicyFile,
 	resolveBackgroundSubagentsCapability,
 	readActiveToolNames,
@@ -7600,6 +7752,31 @@ function createGentleAiExtensionForTesting(
 					ctx.ui.notify("Gentle AI review mode is not available with the currently negotiated native version.", "info");
 					return;
 				}
+				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+			}
+		},
+	});
+
+	// Mirrors gentle:review-mode: a user-owned switch, never an automated one.
+	// It matters more here than there, because this policy governs whether
+	// background subagents may be launched at all, so nothing in Pi may write
+	// it. The only writer is this handler, reached only by explicit invocation.
+	pi.registerCommand("gentle:background-subagents", {
+		description: "Show or set the managed background-subagents policy (status|enable|disable). Every sub-action is user-initiated only; Pi automation never toggles it.",
+		handler: async (args, ctx) => {
+			const subAction = args.trim().length === 0 ? "status" : args.trim();
+			if (subAction !== "status" && subAction !== "enable" && subAction !== "disable") {
+				ctx.ui.notify(`Unknown /gentle:background-subagents sub-action "${subAction}". Use status, enable, or disable.`, "warning");
+				return;
+			}
+			try {
+				const wrote: BackgroundSubagentsPolicy | undefined = subAction === "enable" ? "on" : subAction === "disable" ? "off" : undefined;
+				if (wrote !== undefined) writeGlobalBackgroundSubagentsPolicy(wrote);
+				const resolution = resolveBackgroundSubagentsPolicy(ctx.cwd);
+				const capability = resolveBackgroundSubagentsCapability(ctx.cwd, readActiveToolNames(pi));
+				const report = renderBackgroundSubagentsReport(resolution, capability, wrote);
+				ctx.ui.notify(report.message, report.type);
+			} catch (error) {
 				ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
 			}
 		},

--- a/tests/background-subagents.test.ts
+++ b/tests/background-subagents.test.ts
@@ -1,9 +1,20 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test, { after } from "node:test";
-import { __testing } from "../extensions/gentle-ai.ts";
+import test, { after, type TestContext } from "node:test";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { __testing, createGentleAiExtension } from "../extensions/gentle-ai.ts";
 
 // ---------------------------------------------------------------------------
 // Background subagents policy (issue #256).
@@ -24,6 +35,7 @@ import { __testing } from "../extensions/gentle-ai.ts";
 
 const {
 	loadBackgroundSubagentsPolicy,
+	resolveBackgroundSubagentsPolicy,
 	parseBackgroundSubagentsPolicyFile,
 	resolveBackgroundSubagentsCapability,
 	readActiveToolNames,
@@ -354,4 +366,406 @@ test("getOrchestratorPrompt renders exactly one background status line", () => {
 	const rendered = getOrchestratorPrompt();
 	const matches = rendered.match(/Background subagent policy: (?:on|off) \(capability: (?:ready|absent)\)/g) ?? [];
 	assert.equal(matches.length, 1, "the always-on core must carry exactly one status line");
+});
+
+// ---------------------------------------------------------------------------
+// Source attribution (issue #345)
+//
+// Four sources can decide the policy and the first hit wins, so a user who
+// edits the global file while a project file exists sees no effect. The
+// resolver reports WHICH source decided so the command can say so; the plain
+// loader delegates to it, which is the only way the two can never disagree.
+// ---------------------------------------------------------------------------
+
+test("the resolver attributes the project file, with its path", () => {
+	const cwd = makeScratch("gp-bg-src-project-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	writePolicyFile(join(cwd, ".pi", "gentle-ai"), "on");
+	writePolicyFile(configHome, "off");
+	const resolution = resolveBackgroundSubagentsPolicy(cwd, {
+		gentlePiConfigHome: configHome,
+		env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "off" },
+	});
+	assert.equal(resolution.policy, "on");
+	assert.equal(resolution.source, "project_file");
+	assert.equal(
+		resolution.projectFile,
+		join(cwd, ".pi", "gentle-ai", "background-subagents.json"),
+	);
+	assert.equal(resolution.globalFile, join(configHome, "background-subagents.json"));
+	assert.equal(resolution.projectFileExists, true);
+	assert.equal(resolution.globalFileExists, true, "the shadowed global file is still reported");
+	assert.equal(resolution.malformed, false);
+	assert.equal(resolution.envValue, "off");
+});
+
+test("the resolver attributes the global file when no project file exists", () => {
+	const cwd = makeScratch("gp-bg-src-global-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	writePolicyFile(configHome, "on");
+	const resolution = resolveBackgroundSubagentsPolicy(cwd, {
+		gentlePiConfigHome: configHome,
+		env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "off" },
+	});
+	assert.equal(resolution.policy, "on");
+	assert.equal(resolution.source, "global_file");
+	assert.equal(resolution.projectFileExists, false);
+	assert.equal(resolution.globalFileExists, true);
+});
+
+test("the resolver attributes the environment variable when no file exists", () => {
+	const cwd = makeScratch("gp-bg-src-env-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const resolution = resolveBackgroundSubagentsPolicy(cwd, {
+		gentlePiConfigHome: configHome,
+		env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "on" },
+	});
+	assert.equal(resolution.policy, "on");
+	assert.equal(resolution.source, "environment");
+	assert.equal(resolution.envValue, "on");
+});
+
+test("the resolver attributes the built-in default when nothing else decides", () => {
+	const cwd = makeScratch("gp-bg-src-default-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const resolution = resolveBackgroundSubagentsPolicy(cwd, {
+		gentlePiConfigHome: configHome,
+		env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "yes" },
+	});
+	assert.equal(resolution.policy, "off");
+	assert.equal(resolution.source, "default");
+	assert.equal(
+		resolution.envValue,
+		"yes",
+		"an unrecognized env value is reported verbatim so the command can call it inert",
+	);
+});
+
+test("the resolver attributes a malformed file to that file and does not fall through", () => {
+	const cwd = makeScratch("gp-bg-src-malformed-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const projectDir = join(cwd, ".pi", "gentle-ai");
+	mkdirSync(projectDir, { recursive: true });
+	writeFileSync(join(projectDir, "background-subagents.json"), "{malformed");
+	writePolicyFile(configHome, "on");
+	const resolution = resolveBackgroundSubagentsPolicy(cwd, {
+		gentlePiConfigHome: configHome,
+		env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "on" },
+	});
+	assert.equal(resolution.policy, "off", "a malformed file fails closed");
+	assert.equal(
+		resolution.source,
+		"project_file",
+		"the malformed file still decided; it did not fall through to the global file",
+	);
+	assert.equal(resolution.malformed, true);
+});
+
+test("loadBackgroundSubagentsPolicy delegates to the resolver so the two can never disagree", () => {
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	writePolicyFile(configHome, "on");
+	const scenarios: Array<{ cwd: string; env: Record<string, string | undefined> }> = [];
+	const bare = makeScratch("gp-bg-agree-bare-");
+	scenarios.push({ cwd: bare, env: {} });
+	scenarios.push({ cwd: bare, env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "on" } });
+	const projectOn = makeScratch("gp-bg-agree-project-");
+	writePolicyFile(join(projectOn, ".pi", "gentle-ai"), "off");
+	scenarios.push({ cwd: projectOn, env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "on" } });
+	const malformed = makeScratch("gp-bg-agree-malformed-");
+	mkdirSync(join(malformed, ".pi", "gentle-ai"), { recursive: true });
+	writeFileSync(
+		join(malformed, ".pi", "gentle-ai", "background-subagents.json"),
+		"{malformed",
+	);
+	scenarios.push({ cwd: malformed, env: { GENTLE_PI_BACKGROUND_SUBAGENTS: "on" } });
+	for (const scenario of scenarios) {
+		const options = { gentlePiConfigHome: configHome, env: scenario.env };
+		assert.equal(
+			loadBackgroundSubagentsPolicy(scenario.cwd, options),
+			resolveBackgroundSubagentsPolicy(scenario.cwd, options).policy,
+			`loader and resolver must agree for ${scenario.cwd}`,
+		);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// /gentle:background-subagents command (issue #345)
+//
+// The policy had no user-facing surface at all: it could only be set by
+// hand-writing JSON or exporting an env var, and the deciding source was
+// visible to nobody. The command mirrors /gentle:review-mode — status|enable|
+// disable, user-initiated only, Pi automation never toggles it.
+// ---------------------------------------------------------------------------
+
+interface CommandFixture {
+	description?: string;
+	handler: (args: string, ctx: ExtensionContext) => Promise<void>;
+}
+
+function registeredCommands(activeTools?: readonly string[]): Map<string, CommandFixture> {
+	const commands = new Map<string, CommandFixture>();
+	createGentleAiExtension({ nativeReviewCli: null })({
+		on() {},
+		registerTool() {},
+		registerCommand(name: string, definition: CommandFixture) {
+			commands.set(name, definition);
+		},
+		...(activeTools === undefined ? {} : { getActiveTools: () => activeTools }),
+	} as unknown as ExtensionAPI);
+	return commands;
+}
+
+function notifyContext(
+	cwd: string,
+	notices: Array<{ message: string; type?: string }>,
+): ExtensionContext {
+	return {
+		cwd,
+		hasUI: false,
+		ui: {
+			notify: (message: string, type?: string) => {
+				notices.push({ message, type });
+			},
+		},
+	} as unknown as ExtensionContext;
+}
+
+/** Point the command's global config home at a scratch dir, never at ~/.pi. */
+function scopedEnv(t: TestContext, values: Record<string, string | undefined>): void {
+	const previous = new Map<string, string | undefined>();
+	for (const [key, value] of Object.entries(values)) {
+		previous.set(key, process.env[key]);
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	t.after(() => {
+		for (const [key, value] of previous) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+}
+
+async function runBackgroundSubagents(
+	t: TestContext,
+	argument: string,
+	cwd: string,
+	configHome: string,
+	env: Record<string, string | undefined> = {},
+): Promise<{ message: string; type?: string }> {
+	scopedEnv(t, {
+		GENTLE_PI_CONFIG_HOME: configHome,
+		GENTLE_PI_BACKGROUND_SUBAGENTS: undefined,
+		...env,
+	});
+	const command = registeredCommands().get("gentle:background-subagents");
+	assert.ok(command, "gentle:background-subagents must be registered");
+	const notices: Array<{ message: string; type?: string }> = [];
+	await command!.handler(argument, notifyContext(cwd, notices));
+	assert.equal(notices.length, 1, "one invocation reports exactly once");
+	return notices[0]!;
+}
+
+test("gentle:background-subagents is registered and declares user-initiated sub-actions", () => {
+	const command = registeredCommands().get("gentle:background-subagents");
+	assert.ok(command, "gentle:background-subagents must be registered");
+	assert.match(command!.description ?? "", /status\|enable\|disable/);
+	assert.match(
+		command!.description ?? "",
+		/user-initiated only; Pi automation never toggles it/,
+	);
+});
+
+test("no argument reports the effective policy, the deciding default, and the capability", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-default-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const notice = await runBackgroundSubagents(t, "", cwd, configHome);
+	assert.equal(notice.type, "info");
+	assert.equal(
+		notice.message,
+		[
+			"background subagents: off (decided by built-in default; capability: absent)",
+			"Resolution order (first hit wins): project file, global file, GENTLE_PI_BACKGROUND_SUBAGENTS, built-in default off.",
+		].join("\n"),
+	);
+});
+
+test("status names the project file that decided and the global file it shadows", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-project-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	writePolicyFile(join(cwd, ".pi", "gentle-ai"), "on");
+	writePolicyFile(configHome, "off");
+	installSubagentsPackage(cwd, "pi-subagents-j0k3r");
+	const notice = await runBackgroundSubagents(t, "status", cwd, configHome);
+	assert.equal(notice.type, "info");
+	assert.equal(
+		notice.message,
+		[
+			`background subagents: on (decided by project file ${join(cwd, ".pi", "gentle-ai", "background-subagents.json")}; capability: ready)`,
+			`The global file ${join(configHome, "background-subagents.json")} exists but is outranked by that project file.`,
+			"Resolution order (first hit wins): project file, global file, GENTLE_PI_BACKGROUND_SUBAGENTS, built-in default off.",
+		].join("\n"),
+	);
+});
+
+test("status names the global file when it is the deciding source", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-global-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	writePolicyFile(configHome, "on");
+	const notice = await runBackgroundSubagents(t, "status", cwd, configHome);
+	assert.equal(
+		notice.message.split("\n")[0],
+		`background subagents: on (decided by global file ${join(configHome, "background-subagents.json")}; capability: absent)`,
+	);
+});
+
+test("status names the environment variable when it is the deciding source", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-env-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const notice = await runBackgroundSubagents(t, "status", cwd, configHome, {
+		GENTLE_PI_BACKGROUND_SUBAGENTS: "on",
+	});
+	assert.equal(notice.type, "info");
+	assert.equal(
+		notice.message.split("\n")[0],
+		"background subagents: on (decided by GENTLE_PI_BACKGROUND_SUBAGENTS; capability: absent)",
+	);
+});
+
+test("status calls an unrecognized environment value inert instead of silently ignoring it", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-env-bad-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const notice = await runBackgroundSubagents(t, "status", cwd, configHome, {
+		GENTLE_PI_BACKGROUND_SUBAGENTS: "true",
+	});
+	assert.equal(
+		notice.message.split("\n")[0],
+		"background subagents: off (decided by built-in default; capability: absent)",
+	);
+	assert.ok(
+		notice.message.includes(
+			'GENTLE_PI_BACKGROUND_SUBAGENTS="true" is not a recognized value ("on" or "off"), so it is ignored.',
+		),
+		notice.message,
+	);
+});
+
+test("status reports a malformed deciding file as fail-closed, not as a real off", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-malformed-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const projectFile = join(cwd, ".pi", "gentle-ai", "background-subagents.json");
+	mkdirSync(join(cwd, ".pi", "gentle-ai"), { recursive: true });
+	writeFileSync(projectFile, "{malformed");
+	writePolicyFile(configHome, "on");
+	const notice = await runBackgroundSubagents(t, "status", cwd, configHome);
+	assert.equal(notice.type, "warning");
+	assert.equal(
+		notice.message.split("\n")[0],
+		`background subagents: off (decided by project file ${projectFile}; capability: absent)`,
+	);
+	assert.ok(
+		notice.message.includes(
+			`${projectFile} is present but malformed, so the policy fails closed to off and no lower-priority source is consulted.`,
+		),
+		notice.message,
+	);
+});
+
+test("enable writes the global file and reports that it decides", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-enable-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const globalFile = join(configHome, "background-subagents.json");
+	const notice = await runBackgroundSubagents(t, "enable", cwd, configHome);
+	assert.deepEqual(JSON.parse(readFileSync(globalFile, "utf8")), {
+		schema: "gentle-pi.background-subagents/v1",
+		policy: "on",
+	});
+	assert.equal(notice.type, "info");
+	assert.equal(
+		notice.message,
+		[
+			`background subagents: on (decided by global file ${globalFile}; capability: absent)`,
+			`Wrote on to the global file ${globalFile}.`,
+			"Resolution order (first hit wins): project file, global file, GENTLE_PI_BACKGROUND_SUBAGENTS, built-in default off.",
+		].join("\n"),
+	);
+});
+
+test("disable writes the global file off and reports that it decides", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-disable-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const globalFile = join(configHome, "background-subagents.json");
+	writePolicyFile(configHome, "on");
+	const notice = await runBackgroundSubagents(t, "disable", cwd, configHome);
+	assert.deepEqual(JSON.parse(readFileSync(globalFile, "utf8")), {
+		schema: "gentle-pi.background-subagents/v1",
+		policy: "off",
+	});
+	assert.equal(notice.type, "info");
+	assert.equal(
+		notice.message.split("\n")[0],
+		`background subagents: off (decided by global file ${globalFile}; capability: absent)`,
+	);
+});
+
+// The defect this command exists to kill: telling a user "enabled" while a
+// project file keeps the policy off. The global write still happens — it is
+// what the user asked for — but the report must lead with the truth.
+test("enable under an outranking project file writes the global file and says it does not take effect", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-outranked-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const projectFile = join(cwd, ".pi", "gentle-ai", "background-subagents.json");
+	const globalFile = join(configHome, "background-subagents.json");
+	writePolicyFile(join(cwd, ".pi", "gentle-ai"), "off");
+	const notice = await runBackgroundSubagents(t, "enable", cwd, configHome);
+	assert.deepEqual(
+		JSON.parse(readFileSync(globalFile, "utf8")),
+		{ schema: "gentle-pi.background-subagents/v1", policy: "on" },
+		"the requested global write still happens",
+	);
+	assert.equal(notice.type, "warning");
+	assert.equal(
+		notice.message,
+		[
+			`background subagents: off (decided by project file ${projectFile}; capability: absent)`,
+			`Wrote on to the global file ${globalFile}.`,
+			`That global write does not take effect here: the project file ${projectFile} outranks it. Edit or remove that project file to let the global setting decide.`,
+			"Resolution order (first hit wins): project file, global file, GENTLE_PI_BACKGROUND_SUBAGENTS, built-in default off.",
+		].join("\n"),
+	);
+});
+
+test("enable with the environment variable set reports where that variable ranks", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-enable-env-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const globalFile = join(configHome, "background-subagents.json");
+	const notice = await runBackgroundSubagents(t, "enable", cwd, configHome, {
+		GENTLE_PI_BACKGROUND_SUBAGENTS: "off",
+	});
+	assert.equal(
+		notice.message.split("\n")[0],
+		`background subagents: on (decided by global file ${globalFile}; capability: absent)`,
+	);
+	assert.ok(
+		notice.message.includes(
+			"GENTLE_PI_BACKGROUND_SUBAGENTS=off is set, but both files outrank it and it outranks the built-in default; it decides only when neither file exists.",
+		),
+		notice.message,
+	);
+});
+
+test("an unknown sub-action warns and changes nothing", async (t) => {
+	const cwd = makeScratch("gp-bg-cmd-unknown-");
+	const configHome = join(makeScratch("gp-bg-home-"), "gentle-ai");
+	const notice = await runBackgroundSubagents(t, "toggle", cwd, configHome);
+	assert.equal(notice.type, "warning");
+	assert.equal(
+		notice.message,
+		'Unknown /gentle:background-subagents sub-action "toggle". Use status, enable, or disable.',
+	);
+	assert.equal(
+		existsSync(join(configHome, "background-subagents.json")),
+		false,
+		"an unknown sub-action must not write anything",
+	);
 });


### PR DESCRIPTION
Closes #345

## Problem

The managed background-subagents policy could be enabled and disabled, but no registered command read or wrote it. `loadBackgroundSubagentsPolicy` was called only from `getOrchestratorPrompt`, which renders `Background subagent policy: <policy> (capability: <capability>)` into the *model's* prompt. A user could only set the policy by hand-writing JSON or exporting `GENTLE_PI_BACKGROUND_SUBAGENTS`, and had no way to see which of the four sources decided it.

Verified against the code before implementing: every claim in the issue holds (single internal consumer, four-source first-hit-wins order, malformed-file fail-closed to `off` without falling through).

## What this adds

`gentle:background-subagents` with `status|enable|disable`, modelled on `gentle:review-mode` including its stated property: every sub-action is user-initiated only, and Pi automation never toggles it. The handler is the only writer of the policy file, and it is reachable only by explicit command invocation.

**Status** reports the effective policy, the deciding source, and the resolved capability, and always closes with the resolution order:

```text
background subagents: on (decided by project file /repo/.pi/gentle-ai/background-subagents.json; capability: ready)
The global file /home/u/.pi/gentle-ai/background-subagents.json exists but is outranked by that project file.
Resolution order (first hit wins): project file, global file, GENTLE_PI_BACKGROUND_SUBAGENTS, built-in default off.
```

The source is named concretely: `project file <path>`, `global file <path>`, `GENTLE_PI_BACKGROUND_SUBAGENTS`, or `built-in default`. An environment variable that is set but not deciding is reported with where it ranks; a set-but-unrecognized value is called inert rather than silently ignored.

**Enable / disable** write the global file, and lead with the effective truth rather than with the write. When a project file outranks the write, the notice is a warning and says so:

```text
background subagents: off (decided by project file /repo/.pi/gentle-ai/background-subagents.json; capability: absent)
Wrote on to the global file /home/u/.pi/gentle-ai/background-subagents.json.
That global write does not take effect here: the project file /repo/.pi/gentle-ai/background-subagents.json outranks it. Edit or remove that project file to let the global setting decide.
Resolution order (first hit wins): project file, global file, GENTLE_PI_BACKGROUND_SUBAGENTS, built-in default off.
```

The requested global write still happens (it is what the user asked for), but the user is never told "enabled" while a project file keeps it off.

**Unknown sub-action** uses the same warning shape as `gentle:review-mode` and writes nothing.

## Resolution, not duplication

`resolveBackgroundSubagentsPolicy` returns the policy plus the deciding source, the two file paths and whether they exist, whether the deciding file was malformed, and the raw env value. `loadBackgroundSubagentsPolicy` now delegates to it and returns only `.policy`, so the reported source and the effective policy cannot drift apart. A test asserts that agreement across a matrix of scenarios.

Fail-closed behaviour is preserved exactly and covered: a present-but-malformed file resolves to `off`, does **not** fall through to a lower-priority source, and stays attributed to that file, so the command can flag a broken config instead of reporting an ordinary `off`. An unreadable file is treated the same way.

## Tests

Written RED first in `tests/background-subagents.test.ts` (18 failing, 22 pre-existing green), then implemented to GREEN (40/40): source attribution for all four sources, malformed fail-closed attribution, loader/resolver agreement, command registration and description, status for each deciding source, unrecognized env value, malformed status warning, `enable`/`disable` global writes, the project-file-outranks-global-write case, the env-precedence note, and the unknown sub-action warning.

## Docs

README gains the command in Quick start and in the Commands table, plus a **Background subagents policy** section with the full precedence table, the strict file shape, and the fail-closed rule. `pi.md` lives in the `gentle-ai` repository, so that half of the docs gap is out of scope for this PR.

## Verification

All foreground, from the worktree:

- `node --experimental-strip-types --test tests/background-subagents.test.ts`: 40/40 pass.
- `pnpm test`: 1279 tests, 1264 pass, 7 fail. The 7 failures are the pre-existing dev-binary/pinned-version environment set and reproduce identically on a clean `origin/main` checkout (`gentle-ai-binary.test.ts`, `native-review-cli.test.ts`, `native-review-parity-runtime.test.ts`); none is touched by this change. CI runs with `GENTLE_PI_REQUIRE_NATIVE_BINARY=1` and a provisioned binary.
- `pnpm run check:provider-contract`: pass.
- `pnpm run check:transaction-runner`: pass (no `lib/` change, so the generated runtime `.mjs` files are unaffected).
- `pnpm test:cross-lane`: 17 checks, 0 failed.
- `node scripts/verify-package-files.mjs`: pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/gentle:background-subagents` with `status`, `enable`, and `disable` actions.
  * View the active background-subagent policy, its source, precedence details, capability availability, and warnings.
  * Enable or disable the policy through explicit command actions.
  * Invalid configuration files now fail safely with background subagents disabled.
* **Documentation**
  * Added quick-start and command reference guidance for managing background-subagent policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->