### PR TITLE
fix(review): separate native RECOVER authorization from the RESET challenge

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -122,6 +122,7 @@ import {
 	nativeReviewLegacyAliasRepairAuthorization,
 	nativeReviewLegacyQuarantineAuthorization,
 	nativeReviewReconcileAuthorization,
+	nativeReviewRecoverAuthorization,
 	normalizeNativeReviewCwd,
 	NativeReviewCliError,
 	NativeReviewConsentBindingError,
@@ -2919,7 +2920,17 @@ async function authorizeDestructiveReviewOperation(
 	ctx: ExtensionContext,
 ): Promise<void> {
 	const parameters = parseReviewControllerParameters(parametersValue);
-	const isReset = parameters.operation === REVIEW_CONTROLLER_OPERATION.RESET || parameters.operation === REVIEW_CONTROLLER_OPERATION.RECOVER;
+	// RESET alone carries the legacy repository-wide challenge. Native compact-v2
+	// RECOVER has its own six-field contract and its own derived
+	// `gentle-ai.review-recovery-authorization/v1` binding, neither of which the
+	// legacy `repositoryId`/`commonDirHash`/`inventoryHash`/`confirmation` quartet
+	// can express. Native INSPECT never publishes that quartet either, so
+	// demanding it here made the only supported recovery flow unreachable
+	// (issue #212).
+	// RECOVER authorizes itself in `executeReviewControllerOperation`, the way
+	// REPAIR_LEGACY_ALIAS does, because its binding can only be derived from a
+	// fresh native target-status read.
+	const isReset = parameters.operation === REVIEW_CONTROLLER_OPERATION.RESET;
 	const maintenance = nativeMaintenanceOperation(parameters.operation);
 	if (!isReset && maintenance === undefined) return;
 	const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);
@@ -5811,6 +5822,20 @@ async function executeReviewControllerOperation(
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.RECOVER) {
 		const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);
+		// The authorization binding is Pi-derived, never caller-carried. It is
+		// recorded verbatim as a maintainer attestation, so accepting one the
+		// caller composed would let an unapproved actor sign the recovery edge.
+		if (input.maintainerAuthorization !== undefined) {
+			return {
+				operation: parameters.operation,
+				status: "blocked",
+				outcome: "native-recovery-caller-authorization-rejected",
+				native_operation: "review recover",
+				mutation_performed: false,
+				mutation_outcome: "none",
+				next_action: "resubmit-without-maintainer-authorization",
+			};
+		}
 		const missing = NATIVE_RECOVERY_INPUT.recover.filter((key) =>
 			key === "disposition"
 				? !["scope_changed", "invalidated", "escalated"].includes(input[key] as string)
@@ -5818,27 +5843,76 @@ async function executeReviewControllerOperation(
 		);
 		if (missing.length > 0) return await executeNativeRecoveryRoute(parameters.operation, "recover", input, defaultCwd, nativeReviewCli, pendingAuthorizations, signal);
 		if (nativeReviewCli?.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
+		const frozenTarget = candidateViews?.hasProjection(String(input.predecessorLineage))
+			? candidateViews.resolveProjection(String(input.predecessorLineage), defaultCwd)
+			: undefined;
+		const statusRequest = {
+			cwd: defaultCwd,
+			lineageId: String(input.predecessorLineage),
+			...(frozenTarget?.committedOnly === true ? { baseRef: frozenTarget.baseCommit } : {}),
+			...(signal === undefined ? {} : { signal }),
+		};
 		let status: ReviewStatusV3;
 		try {
-			const frozenTarget = candidateViews?.hasProjection(String(input.predecessorLineage))
-				? candidateViews.resolveProjection(String(input.predecessorLineage), defaultCwd)
-				: undefined;
-			status = await nativeReviewCli.targetStatus({
-				cwd: defaultCwd,
-				lineageId: String(input.predecessorLineage),
-				...(frozenTarget?.committedOnly === true ? { baseRef: frozenTarget.baseCommit } : {}),
-				...(signal === undefined ? {} : { signal }),
-			});
+			status = await nativeReviewCli.targetStatus(statusRequest);
 		} catch (error) {
 			return nativeStatusFailed(parameters.operation, error);
 		}
-		if (status.action !== "recover" || status.actionDisposition === undefined || status.authority?.lineageId !== input.predecessorLineage || status.authority.revision !== input.expectedPredecessorRevision) {
+		const pinnedRecoveryStatus = (candidate: ReviewStatusV3): boolean =>
+			candidate.action === "recover"
+			&& candidate.actionDisposition === status.actionDisposition
+			&& candidate.authority?.lineageId === input.predecessorLineage
+			&& candidate.authority?.revision === input.expectedPredecessorRevision
+			&& candidate.targetIdentity === status.targetIdentity;
+		if (status.action !== "recover" || status.actionDisposition === undefined || status.authority?.lineageId !== input.predecessorLineage || status.authority.revision !== input.expectedPredecessorRevision || !isCanonicalProcessString(status.targetIdentity)) {
 			return { operation: parameters.operation, status: "blocked", outcome: "native-recovery-status-mismatch", mutation_performed: false, mutation_outcome: "none", result: status.raw, next_action: "follow-provider-target-status" };
 		}
 		if (input.disposition !== status.actionDisposition) {
 			return { operation: parameters.operation, status: "blocked", outcome: "native-recovery-disposition-mismatch", mutation_performed: false, mutation_outcome: "none", provider_disposition: status.actionDisposition, next_action: "resubmit-with-provider-disposition" };
 		}
-		return await executeNativeRecoveryRoute(parameters.operation, "recover", { ...input, disposition: status.actionDisposition }, defaultCwd, nativeReviewCli, pendingAuthorizations, signal);
+		const recoverAuthorization = nativeReviewRecoverAuthorization({
+			predecessorLineage: String(input.predecessorLineage),
+			expectedPredecessorRevision: String(input.expectedPredecessorRevision),
+			targetIdentity: status.targetIdentity,
+			actor: String(input.actor),
+			reason: String(input.reason),
+		});
+		if (context?.hasUI !== true) throw new Error("Review controller RECOVER requires fresh explicit authorization through the interactive Pi UI; headless execution fails closed");
+		const approved = await context.ui.confirm(
+			"Authorize destructive review authority RECOVER?",
+			[
+				"Operation: RECOVER",
+				`Provider-selected disposition: ${status.actionDisposition}`,
+				"Exact published authorization binding:",
+				recoverAuthorization,
+				`The native command creates one auditable successor authority (${String(input.successorLineage)}) for this exact predecessor and target identity; the predecessor stays untouched.`,
+			].join("\n"),
+		);
+		if (!approved) throw new Error("Review controller RECOVER was not explicitly authorized");
+		// Time-of-check to time-of-use: the human deliberates for an unbounded
+		// interval, and the authority can advance, be recovered by someone else, or
+		// stop being recovery-eligible while they do. The approval and the derived
+		// binding are pinned to the pre-approval read, so the authority is read once
+		// more and must still match it exactly before anything mutates.
+		let confirmedStatus: ReviewStatusV3;
+		try {
+			confirmedStatus = await nativeReviewCli.targetStatus(statusRequest);
+		} catch (error) {
+			return nativeStatusFailed(parameters.operation, error);
+		}
+		if (!pinnedRecoveryStatus(confirmedStatus)) {
+			return {
+				operation: parameters.operation,
+				status: "blocked",
+				outcome: "native-recovery-authority-changed",
+				native_operation: "review recover",
+				mutation_performed: false,
+				mutation_outcome: "none",
+				result: confirmedStatus.raw,
+				next_action: "reinspect-and-reauthorize-recovery",
+			};
+		}
+		return await executeNativeRecoveryRoute(parameters.operation, "recover", { ...input, disposition: status.actionDisposition, maintainerAuthorization: recoverAuthorization }, defaultCwd, nativeReviewCli, pendingAuthorizations, signal);
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.RESET) {
 		const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);
@@ -7241,7 +7315,7 @@ function createGentleAiExtensionForTesting(
 			"Use RECONCILE_AUTHORITY only to quarantine one invalid native recovery successor. Supply exact predecessorLineage, expectedPredecessorRevision, successorLineage, expectedSuccessorRevision, actor, and reason values; Pi derives and displays the seven-line native authorization binding for fresh UI approval. The predecessor stays untouched, native returns the durable audit record, and Pi never falls back to RESET or RECOVER.",
 			"Use ABANDON or QUARANTINE_LEGACY only after an explicit user decision and with exact native inputs. ABANDON needs lineage, expectedRevision, snapshotIdentity, capturedLensResults, findingsPresent, evidenceRecordsPresent, actor, and reason; QUARANTINE_LEGACY accepts only the published malformed freeze-findings diagnostic/disposition. A dual reconciliation may supply only anomalies `unchanged_target,malformed_recovery_authorization` in that exact order. Use REPAIR_LEGACY_ALIAS only with lineage, actor, and reason: Pi freshly reads native inventory and derives repository, revision, diagnostic, disposition, and the exact eight-line binding before interactive approval. `review dispose-result` is unsupported pending design.",
 			"Lens, refuter, and validator verdicts are admitted natively, never Pi-authored: FINALIZE routes provider --materialize lens slots through the host relay, executes provider-rendered self-contained role vectors verbatim, and runs the provider's own review.finalize transition (captured-results discovery). Call FINALIZE with a JSON string carrying only the negotiated collection answers: correction_line_forecast for the pre-edit forecast, validation for the targeted validation document the exact collection input requests, and final_evidence paired with exactly one of final_verification_passed or final_verification_outcome (passed, verification_failed, procedural_tooling_failed). Correction evidence is captured natively before STATUS can expose targeted validation. When the provider offers host-relay lens slots, FINALIZE first returns a `reviewer-model-run-forecast` naming the lenses and the real model runs it would spend; re-run it with `reviewer_run_acknowledged: true` to authorize exactly that reviewer work. Use ADVANCE only for explicit graph-v1 Judgment Day.",
-			"For blocked-legacy or blocked-mixed, do not call START repeatedly. Explain invalidation, request explicit user authorization for the exact reset_request challenge, then call RESET or RECOVER only after authorization. RESET and RECOVER_LOCK route to audited native `gentle-ai review reclaim` and RECOVER routes to native `gentle-ai review recover`; negotiated target status supplies the sole accepted recovery disposition, and a caller-supplied substitute is rejected. Treat a native-input-required envelope as a request for exact values, never as permission to invent them. After a committed native recovery record, INSPECT before any fresh ordinary START.",
+			"For blocked-legacy or blocked-mixed, do not call START repeatedly. Explain invalidation, request explicit user authorization, then call RESET or RECOVER only after authorization. RESET and RECOVER_LOCK route to audited native `gentle-ai review reclaim`; only RESET carries the legacy repositoryId, commonDirHash, inventoryHash, and confirmation challenge. RECOVER routes to native `gentle-ai review recover` with exactly six inputs: predecessorLineage, expectedPredecessorRevision, successorLineage, disposition, actor, and reason. Never send RECOVER the reset challenge and never send it a maintainerAuthorization: Pi reads fresh native target status, pins the predecessor lineage, revision, provider-selected disposition, and target identity, derives the exact six-line native authorization binding, displays it for fresh UI approval, and re-reads status before mutating. Negotiated target status supplies the sole accepted recovery disposition, and a caller-supplied substitute is rejected. Treat a native-input-required envelope as a request for exact values, never as permission to invent them. After a committed native recovery record, INSPECT before any fresh ordinary START.",
 			"A consent-required START returns the complete provider envelope and an opaque consent_binding, then stops. The parent presents and localizes that envelope without changing machine tokens, commands, target IDs, or invocations. After one explicit human answer, call answer-consent exactly once with a JSON string containing only consentBinding and answer (`granted` or `declined`). A reported lineage_created false or pre-authority validation error proves no lineage was created. After ambiguous START, answer-consent, or FINALIZE output, the controller calls target-scoped native status first and returns only its declared action. Never infer or prescribe replay unless native explicitly reports exact_replay_safe for the same canonical request and required lineage.",
 			"Use gentle_review for bounded review transaction operations and exact lifecycle validation; never fabricate bash tool metadata or a separate gate target.",
 		],

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -1829,6 +1829,32 @@ export function nativeReviewLegacyQuarantineAuthorization(request: Pick<NativeRe
 	].join("\n");
 }
 
+/**
+ * The exact native `gentle-ai.review-recovery-authorization/v1` binding for one
+ * recovery edge.
+ *
+ * Native `review recover` accepts a caller-supplied authorization only when it
+ * reproduces this binding byte for byte, because it is copied verbatim into the
+ * recovery provenance and read afterwards as a maintainer attestation. Pi
+ * therefore derives it from freshly read native target status and never
+ * forwards a caller-supplied one: a wrong binding is worse than an absent one,
+ * since an absent field cannot lie about who approved what.
+ *
+ * `targetIdentity` is the live target identity the provider itself publishes in
+ * the `review.recover` eligibility binding (`status.target_identity`), which is
+ * the identity the successor's initial snapshot takes.
+ */
+export function nativeReviewRecoverAuthorization(request: Pick<NativeReviewRecoverRequest, "predecessorLineage" | "expectedPredecessorRevision" | "actor" | "reason"> & { targetIdentity: string }): string {
+	return [
+		"gentle-ai.review-recovery-authorization/v1",
+		`predecessor_lineage=${request.predecessorLineage}`,
+		`predecessor_revision=${request.expectedPredecessorRevision}`,
+		`target_identity=${request.targetIdentity}`,
+		`actor=${request.actor.trim()}`,
+		`reason=${request.reason.trim()}`,
+	].join("\n");
+}
+
 export function nativeReviewReconcileAuthorization(request: Pick<NativeReviewReconcileAuthorityRequest, "predecessorLineage" | "expectedPredecessorRevision" | "successorLineage" | "expectedSuccessorRevision" | "actor" | "reason" | "anomalies">): string {
 	return [
 		"gentle-ai.review-reconcile-authorization/v1",

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -1830,6 +1830,32 @@ export function nativeReviewLegacyQuarantineAuthorization(request               
 	].join("\n");
 }
 
+/**
+ * The exact native `gentle-ai.review-recovery-authorization/v1` binding for one
+ * recovery edge.
+ *
+ * Native `review recover` accepts a caller-supplied authorization only when it
+ * reproduces this binding byte for byte, because it is copied verbatim into the
+ * recovery provenance and read afterwards as a maintainer attestation. Pi
+ * therefore derives it from freshly read native target status and never
+ * forwards a caller-supplied one: a wrong binding is worse than an absent one,
+ * since an absent field cannot lie about who approved what.
+ *
+ * `targetIdentity` is the live target identity the provider itself publishes in
+ * the `review.recover` eligibility binding (`status.target_identity`), which is
+ * the identity the successor's initial snapshot takes.
+ */
+export function nativeReviewRecoverAuthorization(request                                                                                                                                          )         {
+	return [
+		"gentle-ai.review-recovery-authorization/v1",
+		`predecessor_lineage=${request.predecessorLineage}`,
+		`predecessor_revision=${request.expectedPredecessorRevision}`,
+		`target_identity=${request.targetIdentity}`,
+		`actor=${request.actor.trim()}`,
+		`reason=${request.reason.trim()}`,
+	].join("\n");
+}
+
 export function nativeReviewReconcileAuthorization(request                                                                                                                                                                                         )         {
 	return [
 		"gentle-ai.review-reconcile-authorization/v1",

--- a/tests/review-controller-native-recovery.test.ts
+++ b/tests/review-controller-native-recovery.test.ts
@@ -124,6 +124,26 @@ const RECONCILE_AUTHORIZATION = [
 	"reason=invalid recovery edge",
 ].join("\n");
 const COMBINED_RECONCILE_AUTHORIZATION = `${RECONCILE_AUTHORIZATION}\nanomalies=${COMBINED_RECONCILE_ANOMALIES}`;
+const RECOVER_TARGET_IDENTITY = `sha256:${"e".repeat(64)}`;
+// The six canonical native recovery inputs, and nothing else. INSPECT never
+// publishes the legacy RESET quartet for a compact-v2 recovery, so this is the
+// complete request a maintainer can actually assemble (issue #212).
+const RECOVER_INPUT = {
+	predecessorLineage: "broken",
+	expectedPredecessorRevision: "rev-1",
+	successorLineage: "successor",
+	disposition: "invalidated",
+	actor: "maintainer",
+	reason: "invalid authority",
+} as const;
+const RECOVER_AUTHORIZATION = [
+	"gentle-ai.review-recovery-authorization/v1",
+	"predecessor_lineage=broken",
+	"predecessor_revision=rev-1",
+	`target_identity=${RECOVER_TARGET_IDENTITY}`,
+	"actor=maintainer",
+	"reason=invalid authority",
+].join("\n");
 
 function scratchDir(prefix: string): string {
 	const dir = mkdtempSync(join(tmpdir(), prefix));
@@ -133,8 +153,9 @@ function scratchDir(prefix: string): string {
 
 interface RecordedNativeCall { operation: "reclaim" | "recover" | "reconcileAuthority" | "abandon" | "quarantineLegacy"; request: Record<string, unknown>; }
 
-function fakeRecoveryNative(record: Record<string, unknown>): { native: NativeReviewCli; calls: RecordedNativeCall[] } {
+function fakeRecoveryNative(record: Record<string, unknown>): { native: NativeReviewCli; calls: RecordedNativeCall[]; statusReads: Array<string | undefined> } {
 	const calls: RecordedNativeCall[] = [];
+	const statusReads: Array<string | undefined> = [];
 	const native = {
 		async reclaim(request: Record<string, unknown>) {
 			calls.push({ operation: "reclaim", request });
@@ -157,14 +178,23 @@ function fakeRecoveryNative(record: Record<string, unknown>): { native: NativeRe
 			return { record };
 		},
 		async targetStatus(request: { lineageId?: string }) {
-			return {
-				action: "recover",
-				actionDisposition: "invalidated",
-				authority: { lineageId: request.lineageId ?? "broken", revision: "rev-1" },
-			} as unknown;
+			statusReads.push(request.lineageId);
+			return recoveryTargetStatus(request.lineageId ?? "broken");
 		},
 	} as unknown as NativeReviewCli;
-	return { native, calls };
+	return { native, calls, statusReads };
+}
+
+/** One recovery-eligible native target status, shaped as the provider publishes it. */
+function recoveryTargetStatus(lineageId: string, overrides: Record<string, unknown> = {}): unknown {
+	return {
+		action: "recover",
+		actionDisposition: "invalidated",
+		authority: { lineageId, revision: "rev-1" },
+		targetIdentity: RECOVER_TARGET_IDENTITY,
+		raw: { action: "recover", target_identity: RECOVER_TARGET_IDENTITY },
+		...overrides,
+	};
 }
 
 async function runControllerOperation(
@@ -182,6 +212,39 @@ async function runControllerOperation(
 		signal,
 	);
 }
+
+/**
+ * The registered `gentle_review` tool, driven exactly as Pi drives it. RECOVER
+ * regressions hide from `executeReviewControllerOperation` alone, because the
+ * defect in issue #212 lived in the authorization preflight the tool runs first.
+ */
+function recoveryController(native: NativeReviewCli, prefix: string): (id: string, parameters: Record<string, unknown>, context: ExtensionContext) => Promise<Record<string, unknown>> {
+	const tools = new Map<string, { execute: (id: string, params: unknown, signal: undefined, onUpdate: undefined, ctx: ExtensionContext) => Promise<unknown> }>();
+	const pi = { on() {}, registerTool(definition: { name: string; execute: never }) { tools.set(definition.name, definition as never); }, registerCommand() {} } as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli: native })(pi);
+	const controller = tools.get("gentle_review");
+	assert.ok(controller);
+	const cwd = scratchDir(prefix);
+	return async (id, parameters, context) => {
+		const result = await controller.execute(id, parameters, undefined, undefined, { ...context, cwd } as unknown as ExtensionContext) as { details: Record<string, unknown> };
+		return result.details;
+	};
+}
+
+/** An interactive Pi context that records every prompt it is shown. */
+function interactiveContext(prompts: string[], approve = true): ExtensionContext {
+	return {
+		hasUI: true,
+		ui: {
+			async confirm(_title: string, message: string) {
+				prompts.push(message);
+				return approve;
+			},
+		},
+	} as unknown as ExtensionContext;
+}
+
+const HEADLESS_CONTEXT = { hasUI: false, ui: { confirm: async () => true } } as unknown as ExtensionContext;
 
 test("native reclaim wrapper issues the exact review reclaim command and returns the audit record", async () => {
 	const { adapter, calls } = queuedAdapter([VERSION_219, { stdout: JSON.stringify(RECLAIM_RECORD) }]);
@@ -619,24 +682,23 @@ test("RESET without a native client fails closed as unavailable", async () => {
 	assert.equal(details.mutation_performed, false);
 });
 
-test("RECOVER maps to native review recover with the successor authority binding", async () => {
-	const { native, calls } = fakeRecoveryNative(RECOVER_RECORD);
-	const details = await runControllerOperation({
-		operation: "recover",
-		input: JSON.stringify({
-			repositoryId: "repo-id",
-			commonDirHash: "c".repeat(64),
-			inventoryHash: "d".repeat(64),
-			confirmation: "DESTROY REVIEW AUTHORITY repo-id",
-			predecessorLineage: "broken",
-			expectedPredecessorRevision: "rev-1",
-			successorLineage: "successor",
-			disposition: "invalidated",
-			actor: "maintainer",
-			reason: "invalid authority",
-			maintainerAuthorization: "binding",
-		}),
-	}, native);
+// Issue #212: `authorizeDestructiveReviewOperation` classified native RECOVER as
+// a legacy repository-wide RESET, so a correct six-field native recovery was
+// refused with "Review controller recover requires an exact string repositoryId"
+// before it ever reached the native router. INSPECT does not publish that
+// quartet for compact-v2 recovery, which left the only supported flow
+// unreachable. Reported by @PwnLabsmx, independently reproduced on macOS by
+// @e-Evolution and again by the maintainer.
+//
+// Every RECOVER test below drives the registered tool rather than
+// `executeReviewControllerOperation`, because the defect lived in the
+// authorization preflight the tool runs before that function.
+test("RECOVER accepts the six canonical native inputs without the legacy RESET challenge", async () => {
+	const { native, calls, statusReads } = fakeRecoveryNative(RECOVER_RECORD);
+	const run = recoveryController(native, "gentle-pi-recover-six-field-");
+	const prompts: string[] = [];
+	const details = await run("recover", { operation: "recover", input: JSON.stringify(RECOVER_INPUT) }, interactiveContext(prompts));
+	assert.equal(details.status, undefined, "the native six-field recovery contract is complete on its own");
 	assert.equal(details.native_operation, "review recover");
 	assert.equal(details.mutation_performed, true);
 	assert.deepEqual(details.result, RECOVER_RECORD);
@@ -646,26 +708,144 @@ test("RECOVER maps to native review recover with the successor authority binding
 	assert.equal(calls[0]?.request.expectedPredecessorRevision, "rev-1");
 	assert.equal(calls[0]?.request.successorLineage, "successor");
 	assert.equal(calls[0]?.request.disposition, "invalidated");
-	assert.equal(calls[0]?.request.maintainerAuthorization, "binding");
+	// Pi derives the binding; it is never the caller's to supply.
+	assert.equal(calls[0]?.request.maintainerAuthorization, RECOVER_AUTHORIZATION);
+	assert.equal(prompts.length, 1);
+	assert.match(prompts[0]!, /gentle-ai\.review-recovery-authorization\/v1/);
+	assert.match(prompts[0]!, new RegExp(`target_identity=${RECOVER_TARGET_IDENTITY}`));
+	assert.match(prompts[0]!, /Provider-selected disposition: invalidated/);
+	assert.equal(prompts[0]!.includes("repositoryId"), false, "the legacy reset challenge has no place in native recovery");
+	// Status is read before approval and read again before mutation.
+	assert.deepEqual(statusReads, ["broken", "broken"]);
+});
+
+test("RECOVER rejects a caller-supplied maintainerAuthorization before reading or prompting", async () => {
+	const { native, calls, statusReads } = fakeRecoveryNative(RECOVER_RECORD);
+	const run = recoveryController(native, "gentle-pi-recover-caller-authorization-");
+	const prompts: string[] = [];
+	const details = await run(
+		"recover",
+		{ operation: "recover", input: JSON.stringify({ ...RECOVER_INPUT, maintainerAuthorization: RECOVER_AUTHORIZATION }) },
+		interactiveContext(prompts),
+	);
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-recovery-caller-authorization-rejected");
+	assert.equal(details.mutation_performed, false);
+	assert.equal(details.mutation_outcome, "none");
+	assert.equal(details.next_action, "resubmit-without-maintainer-authorization");
+	assert.equal(calls.length, 0);
+	assert.deepEqual(statusReads, []);
+	assert.deepEqual(prompts, []);
+});
+
+test("RECOVER fails closed without an interactive Pi UI", async () => {
+	const { native, calls, statusReads } = fakeRecoveryNative(RECOVER_RECORD);
+	const run = recoveryController(native, "gentle-pi-recover-headless-");
+	await assert.rejects(
+		run("recover", { operation: "recover", input: JSON.stringify(RECOVER_INPUT) }, HEADLESS_CONTEXT),
+		/Review controller RECOVER requires fresh explicit authorization through the interactive Pi UI; headless execution fails closed/,
+	);
+	assert.equal(calls.length, 0);
+	// Fresh native evidence is read, but nothing mutates without a human.
+	assert.deepEqual(statusReads, ["broken"]);
+});
+
+test("RECOVER refuses to mutate when the human declines the derived binding", async () => {
+	const { native, calls } = fakeRecoveryNative(RECOVER_RECORD);
+	const run = recoveryController(native, "gentle-pi-recover-declined-");
+	const prompts: string[] = [];
+	await assert.rejects(
+		run("recover", { operation: "recover", input: JSON.stringify(RECOVER_INPUT) }, interactiveContext(prompts, false)),
+		/Review controller RECOVER was not explicitly authorized/,
+	);
+	assert.equal(prompts.length, 1);
+	assert.equal(calls.length, 0);
+});
+
+test("RECOVER refuses a foreign, stale, or no-longer-recoverable authority before prompting", async () => {
+	for (const [label, status] of [
+		["foreign", recoveryTargetStatus("someone-elses-lineage")],
+		["stale", recoveryTargetStatus("broken", { authority: { lineageId: "broken", revision: "rev-2" } })],
+		["not recovery-eligible", recoveryTargetStatus("broken", { action: "start", actionDisposition: undefined })],
+	] as const) {
+		const calls: Record<string, unknown>[] = [];
+		const native = {
+			async recover(request: Record<string, unknown>) { calls.push(request); return { record: RECOVER_RECORD }; },
+			async targetStatus() { return status; },
+		} as unknown as NativeReviewCli;
+		const run = recoveryController(native, `gentle-pi-recover-${label.replace(/[^a-z]+/g, "-")}-`);
+		const prompts: string[] = [];
+		const details = await run("recover", { operation: "recover", input: JSON.stringify(RECOVER_INPUT) }, interactiveContext(prompts));
+		assert.equal(details.status, "blocked", label);
+		assert.equal(details.outcome, "native-recovery-status-mismatch", label);
+		assert.equal(details.mutation_performed, false, label);
+		assert.equal(calls.length, 0, label);
+		assert.deepEqual(prompts, [], label);
+	}
+});
+
+test("RECOVER refuses a disposition the provider did not select", async () => {
+	const { native, calls } = fakeRecoveryNative(RECOVER_RECORD);
+	const run = recoveryController(native, "gentle-pi-recover-disposition-");
+	const prompts: string[] = [];
+	const details = await run("recover", { operation: "recover", input: JSON.stringify({ ...RECOVER_INPUT, disposition: "escalated" }) }, interactiveContext(prompts));
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-recovery-disposition-mismatch");
+	assert.equal(details.provider_disposition, "invalidated");
+	assert.equal(details.mutation_performed, false);
+	assert.equal(calls.length, 0);
+	assert.deepEqual(prompts, []);
+});
+
+// The human deliberates for an unbounded interval. An authority that advanced
+// while they were deciding was never the one they approved, so the approval and
+// its derived binding are pinned and re-checked against a fresh read.
+test("RECOVER refuses to mutate when the authority changes between approval and mutation", async () => {
+	for (const [label, drifted] of [
+		["revision advanced", recoveryTargetStatus("broken", { authority: { lineageId: "broken", revision: "rev-2" } })],
+		["target identity moved", recoveryTargetStatus("broken", { targetIdentity: `sha256:${"f".repeat(64)}` })],
+		["disposition changed", recoveryTargetStatus("broken", { actionDisposition: "escalated" })],
+		["no longer recoverable", recoveryTargetStatus("broken", { action: "start", actionDisposition: undefined })],
+	] as const) {
+		const calls: Record<string, unknown>[] = [];
+		let reads = 0;
+		const native = {
+			async recover(request: Record<string, unknown>) { calls.push(request); return { record: RECOVER_RECORD }; },
+			async targetStatus() {
+				reads += 1;
+				return reads === 1 ? recoveryTargetStatus("broken") : drifted;
+			},
+		} as unknown as NativeReviewCli;
+		const run = recoveryController(native, `gentle-pi-recover-toctou-${label.replace(/[^a-z]+/g, "-")}-`);
+		const prompts: string[] = [];
+		const details = await run("recover", { operation: "recover", input: JSON.stringify(RECOVER_INPUT) }, interactiveContext(prompts));
+		assert.equal(prompts.length, 1, label);
+		assert.equal(reads, 2, label);
+		assert.equal(details.status, "blocked", label);
+		assert.equal(details.outcome, "native-recovery-authority-changed", label);
+		assert.equal(details.mutation_performed, false, label);
+		assert.equal(details.mutation_outcome, "none", label);
+		assert.equal(details.next_action, "reinspect-and-reauthorize-recovery", label);
+		assert.equal(calls.length, 0, label);
+	}
 });
 
 test("RECOVER surfaces every missing successor input including an unsupported disposition", async () => {
-	const { native, calls } = fakeRecoveryNative(RECOVER_RECORD);
-	const details = await runControllerOperation({
-		operation: "recover",
-		input: JSON.stringify({
-			repositoryId: "repo-id",
-			commonDirHash: "c".repeat(64),
-			inventoryHash: "d".repeat(64),
-			confirmation: "DESTROY REVIEW AUTHORITY repo-id",
-			predecessorLineage: "broken",
-			disposition: "not-a-disposition",
-		}),
-	}, native);
+	const { native, calls, statusReads } = fakeRecoveryNative(RECOVER_RECORD);
+	const run = recoveryController(native, "gentle-pi-recover-missing-input-");
+	const prompts: string[] = [];
+	const details = await run(
+		"recover",
+		{ operation: "recover", input: JSON.stringify({ predecessorLineage: "broken", disposition: "not-a-disposition" }) },
+		interactiveContext(prompts),
+	);
 	assert.equal(details.outcome, "native-input-required");
 	assert.equal(details.native_operation, "review recover");
+	// The missing inputs are the native six, never the legacy reset quartet.
 	assert.deepEqual(details.missing_input, ["expectedPredecessorRevision", "successorLineage", "disposition", "actor", "reason"]);
 	assert.equal(calls.length, 0);
+	assert.deepEqual(statusReads, []);
+	assert.deepEqual(prompts, []);
 });
 
 test("RECONCILE_AUTHORITY routes one exact native mutation and returns its audit record", async () => {
@@ -813,6 +993,48 @@ test("destructive RESET still fails closed without fresh interactive authorizati
 		/interactive Pi UI.*fails closed/i,
 	);
 	assert.equal(calls.length, 0);
+});
+
+// Regression guard for issue #212: separating RECOVER out must leave the legacy
+// repository-wide RESET challenge exactly as it was.
+test("RESET still demands the complete legacy repository challenge and its own fresh approval", async () => {
+	const tools = new Map<string, { execute: (id: string, params: unknown, signal: undefined, onUpdate: undefined, ctx: ExtensionContext) => Promise<unknown> }>();
+	const pi = { on() {}, registerTool(definition: { name: string; execute: never }) { tools.set(definition.name, definition as never); }, registerCommand() {} } as unknown as ExtensionAPI;
+	const { native, calls } = fakeRecoveryNative(RECLAIM_RECORD);
+	createGentleAiExtension({ nativeReviewCli: native })(pi);
+	const controller = tools.get("gentle_review");
+	assert.ok(controller);
+	const cwd = scratchDir("gentle-pi-native-reset-challenge-");
+	const challenge = {
+		repositoryId: "repo-id",
+		commonDirHash: "c".repeat(64),
+		inventoryHash: "d".repeat(64),
+		confirmation: "DESTROY REVIEW AUTHORITY repo-id",
+	};
+	const reclaim = { lineage: "stuck", actor: "maintainer", reason: "incomplete" };
+	for (const key of ["repositoryId", "commonDirHash", "inventoryHash", "confirmation"] as const) {
+		const incomplete: Record<string, unknown> = { ...challenge, ...reclaim };
+		delete incomplete[key];
+		await assert.rejects(
+			controller.execute(`reset-missing-${key}`, { operation: "reset", input: JSON.stringify(incomplete) }, undefined, undefined, {
+				cwd, hasUI: true, ui: { confirm: async () => true },
+			} as unknown as ExtensionContext),
+			new RegExp(`Review controller reset requires an exact string ${key}`),
+		);
+	}
+	assert.equal(calls.length, 0);
+	let prompt = "";
+	const approved = await controller.execute("approved-reset", { operation: "reset", input: JSON.stringify({ ...challenge, ...reclaim }) }, undefined, undefined, {
+		cwd,
+		hasUI: true,
+		ui: { confirm: async (_title: string, message: string) => { prompt = message; return true; } },
+	} as unknown as ExtensionContext) as { details: Record<string, unknown> };
+	assert.match(prompt, /Repository: repo-id/);
+	assert.match(prompt, /Exact challenge: DESTROY REVIEW AUTHORITY repo-id/);
+	assert.match(prompt, /This invalidates all prior review authority for this repository\./);
+	assert.equal(approved.details.mutation_performed, true);
+	assert.equal(calls.length, 1);
+	assert.equal(calls[0]?.operation, "reclaim");
 });
 
 test("RECONCILE_AUTHORITY requires fresh Pi approval for the exact seven-line binding", async () => {


### PR DESCRIPTION
Closes #212.

## The defect

`authorizeDestructiveReviewOperation` in `extensions/gentle-ai.ts` grouped native `RECOVER` with legacy `RESET`:

```ts
const isReset = parameters.operation === REVIEW_CONTROLLER_OPERATION.RESET
             || parameters.operation === REVIEW_CONTROLLER_OPERATION.RECOVER;
```

`nativeMaintenanceOperation` maps only `ABANDON`, `QUARANTINE_LEGACY`, and `RECONCILE_AUTHORITY`, so `RECOVER` took neither early return and fell into the `if (isReset)` branch. That branch demands `repositoryId`, `commonDirHash`, `inventoryHash`, and `confirmation`. Native compact-v2 recovery uses its own six-field contract, and `INSPECT` never publishes the legacy reset quartet, so the supported flow was unreachable:

```text
Review controller recover requires an exact string repositoryId
```

The refusal happened in the authorization preflight, before the native router ever ran.

## The fix

`RESET` keeps the legacy repository challenge, prompt text, and routing byte for byte. `RECOVER` now authorizes itself inside `executeReviewControllerOperation`, the way `REPAIR_LEGACY_ALIAS` already does, because its binding can only be derived from fresh native evidence:

1. Validate the six canonical caller fields from `NATIVE_RECOVERY_INPUT.recover` and nothing else: `predecessorLineage`, `expectedPredecessorRevision`, `successorLineage`, `disposition`, `actor`, `reason`.
2. Read native target status and pin the predecessor lineage, expected revision, the provider-selected disposition, and the target identity against it. A caller-supplied disposition that disagrees with the provider-selected one is rejected.
3. Reject any caller-supplied `maintainerAuthorization`. Pi derives the exact `gentle-ai.review-recovery-authorization/v1` binding itself. The binding is copied verbatim into the recovery provenance and read afterwards as a maintainer attestation, so a caller-composed one would let an unapproved actor sign the recovery edge.
4. Require fresh interactive approval displaying that derived binding. Headless (`!ctx.hasUI`) still fails closed.
5. Re-read status after approval and before mutation. The human deliberates for an unbounded interval; an authority that advanced, was recovered by someone else, or stopped being recovery-eligible while they were deciding was never the one they approved, so it is refused rather than acted on.

The derived binding format matches what `internal/reviewtransaction/compact_store.go` validates upstream and what the cross-lane battery already drives against the real binary, including `target_identity` taken from `status.target_identity`, which is the value the provider publishes in the `review.recover` eligibility binding.

New typed envelopes, both fail-closed and non-mutating: `native-recovery-caller-authorization-rejected` and `native-recovery-authority-changed`.

## Tests

`tests/review-controller-native-recovery.test.ts`, extended in place. Every RECOVER test drives the registered `gentle_review` tool rather than `executeReviewControllerOperation` directly, because the defect lived in the authorization preflight the tool runs first. Reverting the production hunk and re-running:

| Test | Before | After |
| --- | --- | --- |
| RECOVER accepts the six canonical native inputs without the legacy RESET challenge | FAIL | PASS |
| RECOVER rejects a caller-supplied maintainerAuthorization before reading or prompting | FAIL | PASS |
| RECOVER fails closed without an interactive Pi UI | FAIL | PASS |
| RECOVER refuses to mutate when the human declines the derived binding | FAIL | PASS |
| RECOVER refuses a foreign, stale, or no-longer-recoverable authority before prompting | FAIL | PASS |
| RECOVER refuses a disposition the provider did not select | FAIL | PASS |
| RECOVER refuses to mutate when the authority changes between approval and mutation | FAIL | PASS |
| RECOVER surfaces every missing successor input including an unsupported disposition | FAIL | PASS |
| RESET still demands the complete legacy repository challenge and its own fresh approval | PASS | PASS |

The RESET row is a regression guard, so it passes on both sides by design: that is the evidence RESET is untouched.

The first failing test reproduces the report verbatim on the pre-fix tree:

```text
✖ RECOVER accepts the six canonical native inputs without the legacy RESET challenge
  Error: Review controller recover requires an exact string repositoryId
      at authorizeDestructiveReviewOperation (extensions/gentle-ai.ts:2929:73)
      at Object.execute (extensions/gentle-ai.ts:7252:10)
```

File results: 41 pass / 8 fail before, 49 pass / 0 fail after.

## Verification

Run in the foreground on Linux, node v24.18.0, pnpm 11.1.1.

`node --experimental-strip-types --test tests/*.test.ts`

```text
ℹ tests 1286
ℹ pass 1271
ℹ fail 14
```

Baseline on clean `origin/main` (`d703565a`) in the same worktree:

```text
ℹ tests 1279
ℹ pass 1264
ℹ fail 14
```

The 14 failures are identical on both sides, name for name. They are all package-local binary integrity and pinned-runtime checks unrelated to this change (`runtime rejects a binary-only tamper...`, `production native client never invokes a global gentle-ai executable`, and so on). This branch adds 7 net tests and 7 net passes and changes the failure count by zero.

`pnpm run check:provider-contract`

```text
gentle-pi provider contract mirror check passed (contract 1.1.0, 8 bundle entries, 2 generated baselines, acquisition field-test-local).
```

exit 0

`pnpm run test:harness`

```text
(no output)
```

exit 0

The repository has no `lint` or `typecheck` script and no `tsconfig.json`. As an extra check, `tsc --strict --skipLibCheck` over the touched files reports 44 pre-existing errors on `origin/main` and 44 on this branch: no new type errors.

`pnpm run test:cross-lane` and `pnpm run test:maintainer` were not run; they are opt-in scripts outside `pnpm test` that drive a real installed binary.

## Credit

Two contributors diagnosed this and prepared patches before this one.

- **@PwnLabsmx** reported it on 2026-07-21 with a focused regression suite.
- **@e-Evolution** independently reproduced it on macOS on 2026-07-22 and verified a fail-closed patch covering RESET compatibility, headless rejection, foreign and stale authority, wrong disposition, caller-supplied authorization, and post-approval TOCTOU.

This PR implements the design they established. They have not reviewed this code.
