### PR TITLE
fix(assets): make the parent supply the worker's allowed edit surface

### DIFF
--- a/assets/agents/gentle-ai-worker.md
+++ b/assets/agents/gentle-ai-worker.md
@@ -20,10 +20,10 @@ Use this agent only for scoped implementation work that is too large for the par
 Before repository work:
 
 1. Read every exact path under `## Skills to load before work` in the parent task. Do not rediscover the skill registry.
-2. Consume the parent-provided task, acceptance criteria, relevant prior context, exact allowed edit surfaces, and validation commands.
+2. Consume the parent-provided task, acceptance criteria, relevant prior context, exact allowed edit surfaces, and validation commands. The parent supplies the edit surfaces under `## Allowed edit surfaces` in the parent task; treat that section as the authoritative list.
 3. Inspect the working tree and preserve pre-existing changes. Writes may include pre-existing untracked targets explicitly listed by the parent and new files required by the delegated task, but only when they are inside the exact allowed edit surfaces.
 4. Preserve every unrelated tracked or untracked file. Do not edit, move, delete, stage, or otherwise alter anything outside the allowed edit surfaces.
-5. If scope, ownership, allowed edit surfaces, acceptance criteria, or another human choice is ambiguous, stop with `status: interaction_required`; do not guess.
+5. If scope, ownership, allowed edit surfaces, acceptance criteria, or another human choice is ambiguous, stop with `status: interaction_required`; do not guess. Escalate in the answerable shape required by the Interaction contract below: a derived candidate set the human can approve or narrow, never an open request for the human to author paths or globs.
 
 Do not read persistent memory for context. The parent selects and forwards relevant observations.
 
@@ -67,6 +67,10 @@ Run focused tests first. Broad suites, builds, formatters, or linters may run on
 
 When any human input is required, stop editing and return the full schema in the Return contract with `status: interaction_required` and the nested `interaction_required` payload completed. Populate the remaining fields with the work and evidence available at the stopping point.
 
+Every interaction must be answerable from the payload alone. State the concrete choices in `options` as a closed set the human can approve, decline, or select from, and never ask the human to author paths, globs, identifiers, or commands as free text.
+
+When the missing input is the allowed edit surface, derive the candidate set before stopping: put the exact repository-relative paths the delegated task would touch in `options`, and ask the human to approve that list or name which entries to drop. Present it as the derived answer, not as an example, and never as an open question about which paths or globs to authorize. If the delegated task gives no basis for even a candidate list, say that plainly in `reason` and name the missing evidence in `unblock_response`.
+
 Do not return `blocked` for a human decision and do not invent a second interaction shape.
 
 ## Return contract
@@ -92,7 +96,7 @@ skill_resolution: paths-injected | paths-invalid | none
 interaction_required: <include only when status is interaction_required>
   question: <same deterministic interaction question>
   reason: <same deterministic blocking reason>
-  options: <same meaningful choices and tradeoffs, when applicable>
+  options: <same closed set of concrete choices; for a missing edit surface, the derived candidate paths>
   unblock_response: <same exact context needed to continue>
 ```
 

--- a/assets/orchestrator-delegation.md
+++ b/assets/orchestrator-delegation.md
@@ -275,6 +275,21 @@ For generic non-SDD technical verification that executes or delegates commands, 
 
 Use `sdd-explore` and `sdd-verify` only inside SDD. Use review lenses only inside explicit review transactions.
 
+#### Allowed edit surfaces (MANDATORY)
+
+The bounded writer refuses to write outside the exact allowed edit surfaces and stops with `status: interaction_required` when they are missing. The parent owns that input. Deriving it is part of planning the delegation, not something the writer or the human can be left to supply.
+
+Before launching a bounded writer (`gentle-ai-worker`, a user-configured `worker`, or the native `Agent` fallback), derive the allowed edit surface from the task being delegated — the files the planned change must touch, plus the directories where the task authorizes new files — and pass it in the delegated prompt under an `## Allowed edit surfaces` heading, in the same exact-path form as `## Skills to load before work`:
+
+- exact repository-relative paths or narrow globs, one per line; never `.` and never a bare repository root;
+- pre-existing untracked targets the writer may write, listed explicitly;
+- the directories where new files are authorized, when the task requires new files;
+- nothing beyond the delegated task — a surface wider than the task is the same defect as no surface at all.
+
+If the surface genuinely cannot be derived, do not launch the writer, and do not ask the human to author paths. Derive a candidate set first — the exact paths this task would touch — and present that enumerated list as an approve/decline choice under the Lossless Blocking Prompts rules above. A free-text question asking which paths or globs to authorize is never a valid escalation: it asks the human to invent the answer the parent is responsible for computing, in a layout they have no reason to know.
+
+Relay a writer's `interaction_required` payload about edit surfaces the same way: present its derived candidate paths as the choice, and add or drop paths only on the human's explicit instruction.
+
 #### Key Learnings closing block
 
 When delegating to a generic Explore/general worker (`gentle-ai-explore`, `gentle-ai-worker`, `gentle-ai-verify`) or their native `Agent` fallback, include the same `## Key Learnings` closing instruction in the delegated prompt: after the worker returns its normal result envelope or handoff, it closes its final response text with a `## Key Learnings` block of 1–5 numbered items, each a standalone factual sentence of at least 20 characters and at least 4 words, omitting the block when there is genuinely no reusable learning. The block layers on after the structured Return contract and does not alter its fields. This applies to final response text only — not intermediate tool output. The Engram memory provider automatically extracts and persists these items as passive capture; the worker does not parse the block or invoke passive-capture tools itself. This is separate from explicit `mem_save` artifact/decision persistence. Agents that must return strict JSON (review lenses, `review-refuter`, `review-validator`, Judgment Day judges and fix agent) never receive this closing instruction; their strict output shape is unchanged.


### PR DESCRIPTION
Closes #352.

## What was broken

Two contracts disagreed, and the gap deadlocked every delegated write.

`assets/agents/gentle-ai-worker.md` requires the parent to supply the edit surface (rule 2) and obliges the worker to stop without it (rule 5):

> Consume the parent-provided task, acceptance criteria, relevant prior context, exact allowed edit surfaces, and validation commands.

> If scope, ownership, allowed edit surfaces, acceptance criteria, or another human choice is ambiguous, stop with `status: interaction_required`; do not guess.

`assets/orchestrator-delegation.md`, the parent's own contract, had **zero** matches for "allowed edit" anywhere in its 58 KB. The parent was never told to derive or pass the surface, so the worker's stop rule fired on every launch and the human got an unanswerable free-text prompt asking which paths or globs to authorize.

## What changed

**1. The parent now derives and passes the surface.** New `#### Allowed edit surfaces (MANDATORY)` subsection under `### 2. Simple Delegation` in `assets/orchestrator-delegation.md`, next to the existing bounded-writer precedence and Key Learnings subsections. It reuses the envelope shape the parent contract already established for `## Skills to load before work` (a named `##` heading in the delegated prompt carrying exact paths), rather than inventing a new format. The heading is `## Allowed edit surfaces`.

**2. The escalation is now answerable.** Worker rule 5 is preserved verbatim in intent: stopping rather than guessing stays a hard invariant. What changed is the shape. A missing edit surface must escalate as a derived candidate set of exact repository-relative paths the human approves or narrows, never as an open request to author paths or globs. Specified on both sides: the worker's `## Interaction contract` and its `interaction_required.options` field, and the parent's relay obligation in the new subsection.

**3. Containment untouched.** Worker rules 3 and 4 and the "never write outside the exact allowed edit surfaces" rule in `## Tool safety` are unchanged. Only the supply side was broken.

## Placement note

The fix lands in the Pi Runtime Overlays, after `<!-- canon:end -->`. The block above that marker is byte-mirrored from gentle-ai's `internal/assets/generic/sdd-orchestrator.md`, and `gentle-ai-worker` is a Pi-local role that gentle-ai does not ship, so the obligation belongs on the Pi-owned side.

## Pins and mirrors

No mirror or hash needed updating.

- `scripts/verify-package-files.mjs` pins bytes only for `contracts/**` and `docs/review-integration.md`; `assets/**` is presence-checked, not hashed.
- `assets/migrations/managed-assets-*.json` are historical fingerprints of v0.10.7 / v0.13.0 / v0.14.0 shipped assets, consumed by `lib/sdd-preflight.ts` to recognize unmodified older installs. They must not track current asset bytes.
- No `lib/` file was touched, so `runtime/*.mjs` needs no regeneration. `check:transaction-runner` confirms it.

## Verification (foreground)

```
$ pnpm run check:provider-contract
gentle-pi provider contract mirror check passed (contract 1.1.0, 8 bundle entries, 2 generated baselines, acquisition field-test-local).
EXIT=0

$ node scripts/verify-package-files.mjs
gentle-pi package resource check passed (162 files; 64 exact byte-identical v2.2.3 contract artifacts).
EXIT=0

$ pnpm run check:transaction-runner
commit transaction runtime matches TypeScript sources (5 modules)
EXIT=0

$ pnpm run test:harness
EXIT=0
```

`pnpm test`, before and after the change, on the same machine:

```
ℹ tests 1286
ℹ suites 0
ℹ pass 1271
ℹ fail 14
ℹ cancelled 0
ℹ skipped 1
ℹ todo 0
```

The 14 failures are identical in both runs (`diff` of the sorted failure sets is empty) and are pre-existing environment noise, not a regression: a global `gentle-ai` binary at `/home/gentleman/.cargo/bin/gentle-ai` is on `PATH`, so the `tests/gentle-ai-binary.test.ts` and `tests/native-review-cli.test.ts` cases that assert the runtime fails closed without a package-local binary resolve it anyway, plus one pinned-runtime digest mismatch in `tests/native-review-parity-runtime.test.ts`. CI runs without that binary.

The asset-contract tests that actually cover these two files all pass: `tests/package-manifest.test.ts` (worker Return-contract field list, single `text` fence, Interaction-contract shape, bounded-writer routing in both policy sections), `tests/delegated-key-learnings-contract.test.ts`, `tests/orchestrator-budget.test.ts`, `tests/sdd-agent-tools.test.ts`, `tests/persona-single-channel.test.ts`.

## Follow-up worth filing

`assets/agents/sdd-apply.md:57`, `sdd-archive.md:54`, `sdd-sync.md:56` and `sdd-verify.md:53` speak of "allowed edit **roots**". That is a real native concept: `allowedEditRoots` is an `actionContext` field defined in `assets/support/sdd-status-contract.md:82`, supplied by native SDD status, and backed by an envelope carrying `missing_roots` and a formed `gentle-ai sdd-attempt grant` invocation. The worker's "allowed edit **surfaces**" is a Pi-local prompt convention with no native supplier.

Two near-identical phrases, one backed by a typed envelope and one by prose, in sibling files under `assets/agents/`, is genuinely confusing and is plausibly what led an agent to improvise a grant-style prompt for a non-SDD delegation. Not unified here, deliberately: they are different mechanisms and merging them is a design change, not a defect fix.