### PR TITLE
chore(release): gentle-pi 2.2.0 carrying gentle-ai v2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gentle-pi",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Turn Pi into el Gentleman: a senior-architect development harness with SDD/OpenSpec, subagents, strict TDD evidence, review guardrails, and skill discovery.",
   "license": "MIT",
   "type": "module",

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1160,9 +1160,9 @@ test("pi-pretty wrapper uses real package path resolution for pnpm symlink insta
 	assert.match(wrapper, /quietToolsEnabled/);
 });
 
-test("v2.1.2 release package and runtime stop before publication", () => {
+test("v2.2.0 release package and runtime stop before publication", () => {
 	const packageJson = readPackageJson();
-	assert.equal(packageJson.version, "2.1.2", "the release manifest must remain explicitly pinned to v2.1.2");
+	assert.equal(packageJson.version, "2.2.0", "the release manifest must remain explicitly pinned to v2.2.0");
 	assert.equal(
 		packageJson.scripts?.test,
 		"node --experimental-strip-types --test tests/*.test.ts && pnpm run check:provider-contract && pnpm run test:harness",


### PR DESCRIPTION
Closes #358.

`package.json` `2.1.2` → `2.2.0`, plus the manifest test that pins it explicitly. Two files.

The pin landed in #357; without this bump nothing installs it.

## Why minor

The pinned binary jumps three gentle-ai stables (`v2.2.3` → `v2.3.0` → `v2.4.0`) and changes user-visible behavior: receipt-driven development is opt-in, so an installation that never enabled it resolves to off. gentle-pi's own `reviewModeContinuation` changed to match, because under the new default the `default` source is the most common refusal rather than an unreachable one.

## Verification

Every CI step reproduced locally with the dev-binary override parked, then restored byte-identical.

| check | result |
| --- | --- |
| `pnpm test` | 1288 tests, 1287 pass, 0 fail, exit 0 |
| `node scripts/verify-package-files.mjs` | 163 files; **65 exact byte-identical v2.4.0 contract artifacts**; exit 0 |
| `pnpm run check:provider-contract` | contract 1.1.0, 8 bundle entries, 2 generated baselines; exit 0 |
| `pnpm run check:transaction-runner` | matches TypeScript sources (5 modules); exit 0 |
| `GENTLE_PI_REQUIRE_NATIVE_BINARY=1 pnpm run test:packed-runner` | **packed runner E2E passed (gentle-pi 2.2.0; Gentle AI 2.4.0; 13 states)**; exit 0 |

`test:packed-runner` runs only in CI and `prepublishOnly`, so it is reproduced here deliberately rather than assumed from `pnpm test`.

End-to-end proof the pin resolves: `pnpm install` in a clean worktree reported `postinstall: Gentle AI v2.4.0 installed`.
