### PR TITLE
fix(review): scale the pi host relay reviewer bound and name its timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ SDD completion adds no review or Judgment Day pass.
 
 Review operations, validation, and SDD perform no push, PR creation, release, or publication. The separate durable commit runner may create exactly one local commit only after final native pre-commit validation and post-commit tree proof.
 
+The Pi host relay bounds each locked-down reviewer subprocess by materialized prompt size rather than by one fixed number: a 15-minute floor plus 15 minutes per mebibyte of prompt, clamped to a 2-hour ceiling. Set `GENTLE_PI_REVIEW_RELAY_PI_TIMEOUT_MS` to a positive decimal to replace that derived bound with your own; malformed values are ignored and the same 2-hour ceiling still applies, so no configuration turns a foreground finalize into an unbounded child process. A reviewer killed by the bound reports `pi-host-relay-timeout` with the elapsed time and the limit it was measured against, and it explicitly does not ask you to relaunch the identical slot — that would re-spend the model tokens to reach the same wall. Reviewer results admitted earlier in the same finalize stay admitted and are not re-run.
+
 Adversarial review roles (the refuter and the targeted validator) are never Pi-authored: the provider renders self-contained `review.capture-refuter` / `review.capture-validation` vectors and Go runs its own locked-down `pi` process on them. Package agent assets remain a package-managed isolated installation. Project and user overrides may shadow a package asset; `gentle-pi` preserves those definitions and does not claim their effective permissions are package-compliant.
 
 ## SDD/OpenSpec flow

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -54,6 +54,8 @@ import { canonicalJsonV1, domainHashV1 } from "../lib/review-canonical.ts";
 import { parseNativeCompactFinalizeInput, toNativeValidatorDocument } from "../lib/review-compact-contract.ts";
 import {
 	REVIEW_HOST_RELAY_FAILURE,
+	REVIEW_HOST_RELAY_PI_TIMEOUT_ENV,
+	REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS,
 	REVIEW_HOST_RELAY_SUBMISSION_MISSING_MESSAGE,
 	REVIEW_HOST_RELAY_UNAVAILABLE_MESSAGE,
 	ReviewHostRelayError,
@@ -5514,6 +5516,35 @@ function setReviewHostRelayRunnerForTesting(runner?: ReviewHostRelayRunner): voi
 const REVIEW_HOST_RELAY_RETRY_ACTION =
 	"Re-query negotiated STATUS and relaunch only if the exact same bound slot is reoffered; never rerun from transcript inference.";
 
+// gentle-pi#367: the ordinary continuation above is wrong for exactly one
+// failure class. A reviewer killed by the relay bound is deterministic — the
+// same slot, the same prompt and the same bound reach the same wall — so
+// telling the caller to relaunch it re-spends real model tokens to buy the
+// identical failure. The honest outcome stays blocked, never fabricates a
+// capture, and names the two things that can actually change the result.
+function reviewHostRelayTimeoutNextAction(error: ReviewHostRelayError, capturedCount: number): string {
+	const admitted = capturedCount === 0
+		? "No reviewer result was admitted in this run."
+		: `${capturedCount} reviewer result${capturedCount === 1 ? " is" : "s are"} already admitted in this lineage; negotiated STATUS reoffers only the outstanding slots, so those are not re-run.`;
+	const measured = error.elapsedMs === null || error.timeoutMs === null
+		? ""
+		: ` The reviewer was killed after ${error.elapsedMs}ms against a ${error.timeoutMs}ms bound.`;
+	return `Do not relaunch this slot unchanged: the same bound kills the same reviewer run again and re-spends the model tokens for nothing.${measured} ${admitted} `
+		+ `Change one of two things first: export ${REVIEW_HOST_RELAY_PI_TIMEOUT_ENV}=<milliseconds> above the reviewer's real wall time (hard ceiling ${REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS}), or reduce the candidate scope so the materialized prompt is smaller. `
+		+ "Then re-query negotiated STATUS and relaunch only the slot it reoffers.";
+}
+
+function reviewHostRelayFailureReport(error: ReviewHostRelayError): Record<string, unknown> {
+	return {
+		kind: error.kind,
+		stage: error.stage,
+		exit_code: error.exitCode,
+		timed_out: error.timedOut,
+		...(error.elapsedMs === null ? {} : { elapsed_ms: error.elapsedMs }),
+		...(error.timeoutMs === null ? {} : { timeout_ms: error.timeoutMs }),
+	};
+}
+
 async function executeReviewHostRelayCollection(
 	operation: ReviewControllerOperation,
 	lineageId: string,
@@ -5567,10 +5598,19 @@ async function executeReviewHostRelayCollection(
 					next_action: REVIEW_HOST_RELAY_RETRY_ACTION,
 				};
 			}
+			if (error.kind === REVIEW_HOST_RELAY_FAILURE.PI_TIMED_OUT) {
+				return {
+					...base,
+					outcome: "pi-host-relay-timeout",
+					failure: reviewHostRelayFailureReport(error),
+					reason: error.message,
+					next_action: reviewHostRelayTimeoutNextAction(error, captured.length),
+				};
+			}
 			return {
 				...base,
 				outcome: "pi-host-relay-transport-failure",
-				failure: { kind: error.kind, stage: error.stage, exit_code: error.exitCode, timed_out: error.timedOut },
+				failure: reviewHostRelayFailureReport(error),
 				reason: error.message,
 				next_action: REVIEW_HOST_RELAY_RETRY_ACTION,
 			};

--- a/lib/review-host-relay.ts
+++ b/lib/review-host-relay.ts
@@ -61,6 +61,11 @@ export const REVIEW_HOST_RELAY_FAILURE = {
 	EMPTY_PROMPT: "empty-prompt",
 	PI_LAUNCH_FAILED: "pi-launch-failed",
 	PI_FAILED: "pi-failed",
+	// gentle-pi#367: a reviewer killed by the relay bound is not a crash. It
+	// is the one failure class that a byte-identical relaunch cannot survive,
+	// so it carries its own kind, its own elapsed/limit evidence, and its own
+	// continuation instead of hiding inside `pi-failed`.
+	PI_TIMED_OUT: "pi-timed-out",
 	PI_EMPTY_OUTPUT: "pi-empty-output",
 	SUBMISSION_REFUSED: "submission-refused",
 } as const;
@@ -79,11 +84,17 @@ export class ReviewHostRelayError extends Error {
 	readonly exitCode: number | null;
 	readonly stderr: string;
 	readonly timedOut: boolean;
+	// Wall time the killed or failed child actually consumed, and the bound it
+	// was measured against. Both are null only when no child process ran.
+	// Without them a transport failure cannot be told apart from a crash, which
+	// is what forced the gentle-pi#367 reporter to measure the relay by hand.
+	readonly elapsedMs: number | null;
+	readonly timeoutMs: number | null;
 	// "none" until the submission invocation launches; a launched submission
 	// whose outcome could not be read is "unknown" and the caller reconciles
 	// through negotiated STATUS, never through a blind retry.
 	readonly mutationOutcome: "none" | "unknown";
-	constructor(kind: ReviewHostRelayFailureKind, stage: ReviewHostRelayStage, message: string, details?: { exitCode?: number | null; stderr?: string; timedOut?: boolean }) {
+	constructor(kind: ReviewHostRelayFailureKind, stage: ReviewHostRelayStage, message: string, details?: { exitCode?: number | null; stderr?: string; timedOut?: boolean; elapsedMs?: number; timeoutMs?: number }) {
 		super(message);
 		this.name = "ReviewHostRelayError";
 		this.kind = kind;
@@ -91,6 +102,8 @@ export class ReviewHostRelayError extends Error {
 		this.exitCode = details?.exitCode ?? null;
 		this.stderr = details?.stderr ?? "";
 		this.timedOut = details?.timedOut ?? false;
+		this.elapsedMs = details?.elapsedMs ?? null;
+		this.timeoutMs = details?.timeoutMs ?? null;
 		this.mutationOutcome = stage === "submit" ? "unknown" : "none";
 	}
 }
@@ -245,6 +258,12 @@ export interface ReviewHostRelayRequest {
 	readonly piExecutable?: string;
 	readonly environment?: NodeJS.ProcessEnv;
 	readonly gentleAiTimeoutMs?: number;
+	/**
+	 * Overrides the reviewer bound entirely. Production leaves it unset and the
+	 * relay derives the bound from the materialized prompt bytes and
+	 * {@link REVIEW_HOST_RELAY_PI_TIMEOUT_ENV}; this seam exists so tests can
+	 * exercise the timeout leg without a wall-clock wait.
+	 */
 	readonly piTimeoutMs?: number;
 	readonly signal?: AbortSignal;
 }
@@ -259,13 +278,64 @@ export interface ReviewHostRelayResult {
 export type ReviewHostRelayRunner = (request: ReviewHostRelayRequest) => Promise<ReviewHostRelayResult>;
 
 const DEFAULT_GENTLE_AI_TIMEOUT_MS = 120_000;
-const DEFAULT_PI_TIMEOUT_MS = 600_000;
+
+// ---------------------------------------------------------------------------
+// The reviewer subprocess bound (gentle-pi#367).
+//
+// The previous bound was a single hardcoded 600_000 ms reachable only through
+// the test-injectable runner. A field-measured lens legitimately needed 478s
+// against a ~1.58 MB materialized prompt: it survived by hand and was killed
+// under the relay, and the sanctioned continuation then re-spent every lens to
+// reach the same wall. One fixed number cannot serve a prompt class that
+// varies by orders of magnitude, so the bound is derived instead:
+//
+//   floor + ceil(promptBytes / MiB * perMebibyte), clamped to the ceiling
+//
+// The floor covers model latency that does not depend on prompt size; the
+// linear term covers the part that does. At the measured 1.58 MB the derived
+// bound is ~37 minutes, roughly a 4.7x margin over the 478s the reviewer
+// actually needed — deliberately generous, because the reviewer model and
+// provider are user-owned and the relay cannot know their throughput.
+//
+// GENTLE_PI_REVIEW_RELAY_PI_TIMEOUT_MS replaces the derived bound entirely for
+// callers who know their own configuration. It follows the repository's
+// established numeric-override shape (GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS,
+// GENTLE_PI_REVIEW_MAX_BUFFER_BYTES): a positive decimal, silently ignored
+// when malformed, and clamped to the same hard ceiling so no configuration can
+// turn a foreground FINALIZE into an unbounded child process.
+// ---------------------------------------------------------------------------
+
+export const REVIEW_HOST_RELAY_PI_TIMEOUT_ENV = "GENTLE_PI_REVIEW_RELAY_PI_TIMEOUT_MS";
+export const REVIEW_HOST_RELAY_PI_TIMEOUT_FLOOR_MS = 900_000;
+export const REVIEW_HOST_RELAY_PI_TIMEOUT_PER_MEBIBYTE_MS = 900_000;
+export const REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS = 7_200_000;
+const BYTES_PER_MEBIBYTE = 1024 * 1024;
+
+export function resolveReviewHostRelayPiTimeoutMs(promptByteLength: number, environment: NodeJS.ProcessEnv = process.env): number {
+	const configured = environment[REVIEW_HOST_RELAY_PI_TIMEOUT_ENV];
+	if (configured !== undefined && /^[1-9]\d*$/.test(configured)) {
+		const parsed = Number(configured);
+		if (Number.isSafeInteger(parsed)) return Math.min(parsed, REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS);
+	}
+	const bytes = Number.isSafeInteger(promptByteLength) && promptByteLength > 0 ? promptByteLength : 0;
+	const scaled = REVIEW_HOST_RELAY_PI_TIMEOUT_FLOOR_MS + Math.ceil((bytes / BYTES_PER_MEBIBYTE) * REVIEW_HOST_RELAY_PI_TIMEOUT_PER_MEBIBYTE_MS);
+	return Math.min(scaled, REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS);
+}
+
+// The reviewer ran out of time; it did not crash. The message states both
+// measurements and names the two things that can change the outcome, because
+// the one thing that cannot is relaunching the identical slot.
+export function reviewHostRelayPiTimeoutMessage(elapsedMs: number, timeoutMs: number, promptByteLength: number): string {
+	return `pi reviewer subprocess exceeded the relay bound: killed after ${elapsedMs}ms against a ${timeoutMs}ms limit for a ${promptByteLength}-byte materialized prompt. `
+		+ `Relaunching the same slot unchanged reaches the same wall. Raise ${REVIEW_HOST_RELAY_PI_TIMEOUT_ENV} above the reviewer's real wall time (ceiling ${REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS}ms) or reduce the candidate scope so the materialized prompt is smaller.`;
+}
 
 interface ProcessCapture {
 	stdout: Buffer;
 	stderr: Buffer;
 	exitCode: number | null;
 	timedOut: boolean;
+	elapsedMs: number;
 }
 
 function collectProcess(
@@ -274,6 +344,7 @@ function collectProcess(
 	options: { cwd: string; env: NodeJS.ProcessEnv; stdin?: Buffer; timeoutMs: number; signal?: AbortSignal },
 ): Promise<ProcessCapture> {
 	return new Promise((resolve, reject) => {
+		const startedAt = Date.now();
 		const child = spawn(file, [...arguments_], {
 			cwd: options.cwd,
 			env: options.env,
@@ -305,7 +376,7 @@ function collectProcess(
 			if (settled) return;
 			settled = true;
 			if (timer !== undefined) clearTimeout(timer);
-			resolve({ stdout: Buffer.concat(stdout), stderr: Buffer.concat(stderr), exitCode: code, timedOut });
+			resolve({ stdout: Buffer.concat(stdout), stderr: Buffer.concat(stderr), exitCode: code, timedOut, elapsedMs: Date.now() - startedAt });
 		});
 		if (options.stdin === undefined) {
 			child.stdin.end();
@@ -342,7 +413,6 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 	// pi subprocess environment stays exactly as the user configured it.
 	const gentleAiEnvironment = { ...baseEnvironment, [GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV]: GENTLE_PI_REVIEW_RELAY_CONTRACT };
 	const gentleAiTimeoutMs = request.gentleAiTimeoutMs ?? DEFAULT_GENTLE_AI_TIMEOUT_MS;
-	const piTimeoutMs = request.piTimeoutMs ?? DEFAULT_PI_TIMEOUT_MS;
 
 	// (a) Materialize the Go-issued opaque prompt. This invocation is also the
 	// capability detection: an old binary's unknown-flag refusal proves the
@@ -362,18 +432,25 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 	if (materialized.exitCode !== 0 || materialized.timedOut) {
 		const stderr = materialized.stderr.toString("utf8");
 		const refusal = classifyReviewHostRelayRefusal(stderr);
+		const timing = { elapsedMs: materialized.elapsedMs, timeoutMs: gentleAiTimeoutMs };
 		if (refusal === "unknown-flag") {
-			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE, "materialize", REVIEW_HOST_RELAY_UNAVAILABLE_MESSAGE, { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut });
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE, "materialize", REVIEW_HOST_RELAY_UNAVAILABLE_MESSAGE, { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut, ...timing });
 		}
 		if (refusal === "handshake") {
-			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.HANDSHAKE_REFUSED, "materialize", stderr, { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut });
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.HANDSHAKE_REFUSED, "materialize", stderr, { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut, ...timing });
 		}
-		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.MATERIALIZE_FAILED, "materialize", "gentle-ai prompt materialization failed", { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut });
+		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.MATERIALIZE_FAILED, "materialize", materialized.timedOut
+			? `gentle-ai prompt materialization exceeded its ${gentleAiTimeoutMs}ms bound after ${materialized.elapsedMs}ms`
+			: "gentle-ai prompt materialization failed", { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut, ...timing });
 	}
 	const promptBytes = materialized.stdout;
 	if (promptBytes.length === 0) {
-		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.EMPTY_PROMPT, "materialize", "gentle-ai prompt materialization produced no bytes", { exitCode: 0, stderr: materialized.stderr.toString("utf8") });
+		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.EMPTY_PROMPT, "materialize", "gentle-ai prompt materialization produced no bytes", { exitCode: 0, stderr: materialized.stderr.toString("utf8"), elapsedMs: materialized.elapsedMs, timeoutMs: gentleAiTimeoutMs });
 	}
+	// The reviewer bound is derived from the prompt the provider actually
+	// materialized, so it can only be resolved here. An explicit request
+	// timeout (the test seam) still wins over both the override and the scale.
+	const piTimeoutMs = request.piTimeoutMs ?? resolveReviewHostRelayPiTimeoutMs(promptBytes.length, baseEnvironment);
 
 	// (b)/(c) Fresh locked-down pi subprocess in an empty scratch directory.
 	const scratchDirectory = await mkdtemp(join(tmpdir(), "gentle-pi-host-relay-scratch-"));
@@ -393,12 +470,18 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 		} catch (error) {
 			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_LAUNCH_FAILED, "pi", `pi subprocess could not start: ${error instanceof Error ? error.message : String(error)}`);
 		}
-		if (piRun.exitCode !== 0 || piRun.timedOut) {
-			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_FAILED, "pi", "pi subprocess failed", { exitCode: piRun.exitCode, stderr: piRun.stderr.toString("utf8"), timedOut: piRun.timedOut });
+		const piTiming = { elapsedMs: piRun.elapsedMs, timeoutMs: piTimeoutMs };
+		// A reviewer that ran out of time is reported as exactly that, with both
+		// measurements, and never as an unexplained crash.
+		if (piRun.timedOut) {
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_TIMED_OUT, "pi", reviewHostRelayPiTimeoutMessage(piRun.elapsedMs, piTimeoutMs, promptBytes.length), { exitCode: piRun.exitCode, stderr: piRun.stderr.toString("utf8"), timedOut: true, ...piTiming });
+		}
+		if (piRun.exitCode !== 0) {
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_FAILED, "pi", "pi subprocess failed", { exitCode: piRun.exitCode, stderr: piRun.stderr.toString("utf8"), timedOut: false, ...piTiming });
 		}
 		const resultBytes = piRun.stdout;
 		if (resultBytes.length === 0) {
-			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_EMPTY_OUTPUT, "pi", "pi subprocess produced no output bytes", { exitCode: 0, stderr: piRun.stderr.toString("utf8") });
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_EMPTY_OUTPUT, "pi", "pi subprocess produced no output bytes", { exitCode: 0, stderr: piRun.stderr.toString("utf8"), ...piTiming });
 		}
 
 		// (d) Submit the raw final bytes untouched through the provider-owned
@@ -422,7 +505,7 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", `gentle-ai capture submission could not start: ${error instanceof Error ? error.message : String(error)}`);
 		}
 		if (submission.exitCode !== 0 || submission.timedOut || submission.stdout.length === 0) {
-			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", "gentle-ai refused the relayed capture submission", { exitCode: submission.exitCode, stderr: submission.stderr.toString("utf8"), timedOut: submission.timedOut });
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", "gentle-ai refused the relayed capture submission", { exitCode: submission.exitCode, stderr: submission.stderr.toString("utf8"), timedOut: submission.timedOut, elapsedMs: submission.elapsedMs, timeoutMs: gentleAiTimeoutMs });
 		}
 		return {
 			promptByteLength: promptBytes.length,

--- a/tests/review-host-relay-routing.test.ts
+++ b/tests/review-host-relay-routing.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { __testing } from "../extensions/gentle-ai.ts";
 import type { NativeReviewCli } from "../lib/native-review-cli.ts";
-import { REVIEW_HOST_RELAY_FAILURE, REVIEW_HOST_RELAY_SUBMISSION_MISSING_MESSAGE, REVIEW_HOST_RELAY_UNAVAILABLE_MESSAGE, ReviewHostRelayError, type ReviewHostRelayRequest } from "../lib/review-host-relay.ts";
+import { REVIEW_HOST_RELAY_FAILURE, REVIEW_HOST_RELAY_PI_TIMEOUT_ENV, REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS, REVIEW_HOST_RELAY_SUBMISSION_MISSING_MESSAGE, REVIEW_HOST_RELAY_UNAVAILABLE_MESSAGE, ReviewHostRelayError, type ReviewHostRelayRequest } from "../lib/review-host-relay.ts";
 import type { ReviewCaptureSubmissionV1, ReviewCollectInputV3, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 
 // Wiring contract (gentle-pi#311 P4): the compact controller FINALIZE lane
@@ -266,6 +266,78 @@ test("a transport failure mid-collection stops immediately and directs STATUS re
 	assert.match(String(result.next_action), /exact same bound slot/);
 	assert.equal(harness.finalizeCalls, 0);
 	assert.equal(harness.statusCalls.length, 1, "no automatic relaunch after transport failure");
+});
+
+// gentle-pi#367: a reviewer killed by the relay bound is deterministic, so the
+// generic "relaunch the same slot" continuation would re-spend model tokens to
+// buy the identical failure. It gets its own outcome, its own measurements, and
+// a continuation that names what must change — while staying blocked.
+test("a relay timeout reports elapsed and limit and refuses to encourage an unchanged relaunch", async (t) => {
+	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
+	const cwd = repository(t);
+	const lineageId = "relay-lineage";
+	const inputs = [
+		relayCollectInput(lineageId, "review-risk", 0),
+		relayCollectInput(lineageId, "review-reliability", 1),
+	];
+	const harness = nativeHarness([finalizeStatus(lineageId, inputs)]);
+	let calls = 0;
+	__testing.setReviewHostRelayRunnerForTesting(async () => {
+		calls += 1;
+		if (calls === 1) return { promptByteLength: 8, resultByteLength: 8, submission: '{"admission_decision":"completed"}' };
+		throw new ReviewHostRelayError(
+			REVIEW_HOST_RELAY_FAILURE.PI_TIMED_OUT,
+			"pi",
+			"pi reviewer subprocess exceeded the relay bound",
+			{ exitCode: null, timedOut: true, elapsedMs: 2_256_004, timeoutMs: 2_256_000 },
+		);
+	});
+
+	const result = await runFinalize(cwd, harness, lineageId);
+
+	assert.equal(result.status, "blocked", "a timeout is never reported as a completed capture");
+	assert.equal(result.outcome, "pi-host-relay-timeout");
+	assert.deepEqual(result.failure, {
+		kind: "pi-timed-out",
+		stage: "pi",
+		exit_code: null,
+		timed_out: true,
+		elapsed_ms: 2_256_004,
+		timeout_ms: 2_256_000,
+	});
+	// The lens that did complete stays admitted; only the outstanding one is
+	// outstanding.
+	assert.equal((result.captured_slots as unknown[]).length, 1);
+	assert.equal(result.mutation_performed, true);
+	assert.equal(result.mutation_outcome, "committed");
+
+	const nextAction = String(result.next_action);
+	assert.match(nextAction, /Do not relaunch this slot unchanged/);
+	assert.match(nextAction, /2256004ms against a 2256000ms bound/);
+	assert.match(nextAction, new RegExp(`${REVIEW_HOST_RELAY_PI_TIMEOUT_ENV}=<milliseconds>`));
+	assert.match(nextAction, new RegExp(String(REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS)));
+	assert.match(nextAction, /reduce the candidate scope/);
+	assert.equal(/relaunch only if the exact same bound slot is reoffered/.test(nextAction), false,
+		"the unconditional retry continuation must not be offered for a deterministic timeout");
+
+	assert.equal(harness.finalizeCalls, 0);
+	assert.equal(harness.statusCalls.length, 1, "no automatic relaunch after a relay timeout");
+});
+
+test("a non-timeout transport failure keeps its generic continuation and now carries its measurements", async (t) => {
+	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
+	const cwd = repository(t);
+	const lineageId = "relay-lineage";
+	const harness = nativeHarness([finalizeStatus(lineageId, [relayCollectInput(lineageId, "review-reliability", 0)])]);
+	__testing.setReviewHostRelayRunnerForTesting(async () => {
+		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_FAILED, "pi", "pi subprocess failed", { exitCode: 4, elapsedMs: 1_200, timeoutMs: 900_000 });
+	});
+
+	const result = await runFinalize(cwd, harness, lineageId);
+
+	assert.equal(result.outcome, "pi-host-relay-transport-failure");
+	assert.deepEqual(result.failure, { kind: "pi-failed", stage: "pi", exit_code: 4, timed_out: false, elapsed_ms: 1_200, timeout_ms: 900_000 });
+	assert.match(String(result.next_action), /Re-query negotiated STATUS/);
 });
 
 test("materialize tokens without a provider submission fail closed as a typed contract mismatch", async (t) => {

--- a/tests/review-host-relay.test.ts
+++ b/tests/review-host-relay.test.ts
@@ -7,10 +7,15 @@ import { createNodeExecFileAdapter } from "../lib/native-review-cli.ts";
 import {
 	REVIEW_HOST_RELAY_FAILURE,
 	REVIEW_HOST_RELAY_PI_ARGV,
+	REVIEW_HOST_RELAY_PI_TIMEOUT_ENV,
+	REVIEW_HOST_RELAY_PI_TIMEOUT_FLOOR_MS,
+	REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS,
+	REVIEW_HOST_RELAY_PI_TIMEOUT_PER_MEBIBYTE_MS,
 	REVIEW_HOST_RELAY_SUBMISSION_MISSING_MESSAGE,
 	REVIEW_HOST_RELAY_UNAVAILABLE_MESSAGE,
 	ReviewHostRelayError,
 	classifyReviewHostRelayRefusal,
+	resolveReviewHostRelayPiTimeoutMs,
 	resolveReviewHostRelaySubmission,
 	reviewHostRelaySlots,
 	runReviewHostRelaySlot,
@@ -305,10 +310,84 @@ test("empty pi stdout fails closed with a typed error and no submission", async 
 
 test("pi timeout fails closed with a typed error and no submission", async (t) => {
 	const fixture = harness(t, { RELAY_FAKE_PI_MODE: "hang" });
-	const error = await rejectsWithRelayError(runReviewHostRelaySlot(relayRequest(fixture, { piTimeoutMs: 300 })), REVIEW_HOST_RELAY_FAILURE.PI_FAILED, "pi");
+	const error = await rejectsWithRelayError(runReviewHostRelaySlot(relayRequest(fixture, { piTimeoutMs: 300 })), REVIEW_HOST_RELAY_FAILURE.PI_TIMED_OUT, "pi");
 	assert.equal(error.timedOut, true);
 	assert.equal(readLog(fixture.logPath).length, 1);
 	assert.equal(existsSync(fixture.submitCapturePath), false);
+});
+
+// ---------------------------------------------------------------------------
+// gentle-pi#367 — the reviewer bound is reachable from production, and a
+// reviewer killed by it says so with both measurements.
+// ---------------------------------------------------------------------------
+
+test("the reviewer bound scales with materialized prompt bytes instead of one fixed number", () => {
+	const empty: NodeJS.ProcessEnv = {};
+	// A tiny prompt still gets the model-latency floor.
+	assert.equal(resolveReviewHostRelayPiTimeoutMs(0, empty), REVIEW_HOST_RELAY_PI_TIMEOUT_FLOOR_MS);
+	assert.equal(resolveReviewHostRelayPiTimeoutMs(1, empty), REVIEW_HOST_RELAY_PI_TIMEOUT_FLOOR_MS + 1);
+	// One mebibyte of prompt buys exactly one linear allowance.
+	assert.equal(
+		resolveReviewHostRelayPiTimeoutMs(1024 * 1024, empty),
+		REVIEW_HOST_RELAY_PI_TIMEOUT_FLOOR_MS + REVIEW_HOST_RELAY_PI_TIMEOUT_PER_MEBIBYTE_MS,
+	);
+	// The reported field candidate: ~1.58 MB of prompt, whose reviewer needed
+	// 478s and was killed by the old fixed 600s bound. The derived bound must
+	// clear that measurement with real margin.
+	const reported = resolveReviewHostRelayPiTimeoutMs(1_580_000, empty);
+	assert.ok(reported > 600_000, `derived bound ${reported} must exceed the old fixed 600000ms bound`);
+	assert.ok(reported > 478_000 * 3, `derived bound ${reported} must keep real margin over the measured 478000ms reviewer run`);
+	// Never unbounded, however large the prompt gets.
+	assert.equal(resolveReviewHostRelayPiTimeoutMs(Number.MAX_SAFE_INTEGER, empty), REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS);
+});
+
+test("the reviewer bound honours the environment override and ignores malformed values", () => {
+	const bytes = 4 * 1024 * 1024;
+	assert.equal(resolveReviewHostRelayPiTimeoutMs(bytes, { [REVIEW_HOST_RELAY_PI_TIMEOUT_ENV]: "1234" }), 1234);
+	// The override is clamped by the same hard ceiling as the derived bound.
+	assert.equal(resolveReviewHostRelayPiTimeoutMs(bytes, { [REVIEW_HOST_RELAY_PI_TIMEOUT_ENV]: "999999999" }), REVIEW_HOST_RELAY_PI_TIMEOUT_MAX_MS);
+	const derived = resolveReviewHostRelayPiTimeoutMs(bytes, {});
+	for (const malformed of ["", "0", "-1", "12.5", "abc", " 600000", "1e6"]) {
+		assert.equal(resolveReviewHostRelayPiTimeoutMs(bytes, { [REVIEW_HOST_RELAY_PI_TIMEOUT_ENV]: malformed }), derived, `malformed ${JSON.stringify(malformed)} must fall back to the derived bound`);
+	}
+});
+
+test("the production relay path resolves the reviewer bound from the environment, with no injected timeout", async (t) => {
+	// The regression: piTimeoutMs was reachable only through the test seam, so
+	// production always ran against the fixed 600s bound. This request injects
+	// no timeout at all — the override must reach the real spawn.
+	const fixture = harness(t, { RELAY_FAKE_PI_MODE: "hang", [REVIEW_HOST_RELAY_PI_TIMEOUT_ENV]: "300" });
+	const error = await rejectsWithRelayError(
+		runReviewHostRelaySlot(relayRequest(fixture, { piTimeoutMs: undefined })),
+		REVIEW_HOST_RELAY_FAILURE.PI_TIMED_OUT,
+		"pi",
+	);
+	assert.equal(error.timeoutMs, 300);
+	assert.equal(error.timedOut, true);
+	assert.equal(readLog(fixture.logPath).length, 1, "no submission after a reviewer timeout");
+	assert.equal(existsSync(fixture.submitCapturePath), false);
+});
+
+test("a killed reviewer reports elapsed, limit, and what to change instead of an opaque transport failure", async (t) => {
+	const fixture = harness(t, { RELAY_FAKE_PI_MODE: "hang" });
+	const error = await rejectsWithRelayError(runReviewHostRelaySlot(relayRequest(fixture, { piTimeoutMs: 300 })), REVIEW_HOST_RELAY_FAILURE.PI_TIMED_OUT, "pi");
+	assert.equal(error.timeoutMs, 300);
+	assert.ok(error.elapsedMs !== null && error.elapsedMs >= 250, `elapsed ${error.elapsedMs} must record the real wall time`);
+	assert.ok(error.elapsedMs! < 10_000, "the reviewer was killed at the bound, not left to finish");
+	assert.match(error.message, /exceeded the relay bound/);
+	assert.match(error.message, new RegExp(String(error.elapsedMs)));
+	assert.match(error.message, /limit for a \d+-byte materialized prompt/);
+	assert.match(error.message, new RegExp(REVIEW_HOST_RELAY_PI_TIMEOUT_ENV));
+	assert.equal(error.mutationOutcome, "none");
+});
+
+test("a crashed reviewer stays distinguishable from a killed one and still carries its measurements", async (t) => {
+	const fixture = harness(t, { RELAY_FAKE_PI_MODE: "fail" });
+	const error = await rejectsWithRelayError(runReviewHostRelaySlot(relayRequest(fixture, { piTimeoutMs: 30_000 })), REVIEW_HOST_RELAY_FAILURE.PI_FAILED, "pi");
+	assert.equal(error.timedOut, false);
+	assert.equal(error.exitCode, 4);
+	assert.equal(error.timeoutMs, 30_000);
+	assert.ok(error.elapsedMs !== null && error.elapsedMs >= 0);
 });
 
 test("submission refusal is a typed error whose outcome is unknown pending STATUS", async (t) => {


### PR DESCRIPTION
Closes #367.

Defect A only. B and C are filed upstream as gentle-ai#3440 and gentle-ai#3441 and nothing here touches the gentle-ai side.

## What was wrong

`lib/review-host-relay.ts` pinned `DEFAULT_PI_TIMEOUT_MS = 600_000` and read `request.piTimeoutMs ?? DEFAULT_PI_TIMEOUT_MS`. `piTimeoutMs` was reachable only through the test-injectable runner, so production always ran against the fixed bound. The reporter measured a lens that needed 478s against a ~1.58 MB materialized prompt: it succeeded when hand-executed and was killed under the relay. FINALIZE then returned `pi-host-relay-transport-failure` with no way to tell a timeout from a crash, and its sanctioned continuation was to relaunch the identical slot.

## 1. The bound is reachable, and it scales

The bound is now derived from the prompt the provider actually materialized, resolved after materialization because that is the first point the size is known:

```
floor + ceil(promptBytes / MiB * perMebibyte), clamped to the ceiling
```

- floor `900_000` ms — model latency that does not depend on prompt size
- per mebibyte `900_000` ms — the part that does
- ceiling `7_200_000` ms — hard, so no configuration turns a foreground finalize into an unbounded child process

`GENTLE_PI_REVIEW_RELAY_PI_TIMEOUT_MS` replaces the derived bound entirely, following the shape already used by `GENTLE_PI_CANDIDATE_GIT_TIMEOUT_MS` and `GENTLE_PI_REVIEW_MAX_BUFFER_BYTES`: positive decimal, malformed values silently ignored, clamped by the same ceiling.

**On raising the default.** Yes, and the old one was not close. At the reported 1.58 MB the derived bound is ~37 minutes, about 4.7x the measured 478s. Even a zero-byte prompt now gets 15 minutes rather than 10. 600s left a reviewer that needed 478s with 20% headroom, which is not headroom at all once the model or provider changes, and both are user-owned. The margin is deliberately generous because the cost of being wrong is asymmetric: too high wastes wall time on a run that was going to fail anyway, too low destroys four completed reviewer runs and charges for them.

## 2. It says why it died

`ReviewHostRelayError` carries `elapsedMs` and `timeoutMs` on every leg that ran a child process, and a reviewer killed by the bound gets its own kind, `pi-timed-out`, instead of sharing `pi-failed` with a crash. Both measurements reach the controller envelope as `failure.elapsed_ms` and `failure.timeout_ms`. Nobody has to measure the relay by hand again.

## 3. It stops encouraging the loop

The generic continuation ("relaunch only if the exact same bound slot is reoffered") is right for a transient failure and wrong for this one: the same slot with the same prompt and the same bound reaches the same wall, so following it re-spends real model tokens to buy the identical failure. A timeout now projects as its own outcome, `pi-host-relay-timeout`, still `status: blocked`, still admitting nothing that was not captured, with a continuation that says plainly not to relaunch unchanged and names the two things that can change the result: raise the bound above the reviewer's real wall time, or reduce the candidate scope.

## 4. Per-slot admission is already in place

Worth stating because it changes what the remaining exposure is. `executeReviewHostRelayCollection` iterates slots and each slot's relay completes materialize → pi → submit on its own, so a reviewer result is admitted natively the moment its lens finishes. A late-lens timeout does not force re-running the earlier ones: they are already in the lineage, they appear in `captured_slots`, `mutation_outcome` is `committed`, and negotiated STATUS reoffers only the outstanding slots. The timeout continuation now says this explicitly so the human is not left guessing what was lost.

This is also why suggestion 4 would not have rescued the reported run: their **first** lens timed out, so there was nothing admitted to protect. The re-spend they saw came from the bound, not from batched admission. No follow-up is proposed, because the change is already there.

## Tests

`tests/review-host-relay.test.ts` and `tests/review-host-relay-routing.test.ts`. No wall-clock waits: the timeout legs use the existing injectable-runner seam and a 300 ms bound against the fake hanging `pi`, so the slowest new test is ~340 ms.

Each production hunk was reverted individually and the suite re-run:

| Reverted hunk | Tests that go red |
| --- | --- |
| bound resolved from prompt bytes + env (back to fixed `600_000`) | production relay path resolves the reviewer bound from the environment (fails after burning the full 10s fake hang, which is the regression signature exactly) |
| the scaling formula (back to a constant) | the reviewer bound scales with materialized prompt bytes |
| distinct `pi-timed-out` kind (back to `exitCode !== 0 \|\| timedOut`) | 3 tests |
| `elapsedMs` / `timeoutMs` on the error (back to `null`) | 5 tests |
| controller `pi-host-relay-timeout` branch | a relay timeout refuses to encourage an unchanged relaunch |
| `elapsed_ms` / `timeout_ms` in the envelope | 2 tests |

## Verification

`runtime/*.mjs` was regenerated; `review-host-relay.ts` is not in the generator's source list, so there is no generated drift, and `check:transaction-runner` confirms it. Every CI step run locally in the foreground, all exit 0:

```
pnpm test                                                  0   1294 pass, 1 skip
node scripts/verify-package-files.mjs                      0   163 files, 65 exact v2.4.0 contract artifacts
pnpm run check:provider-contract                           0   contract 1.1.0, 8 bundle entries
pnpm run check:transaction-runner                          0   5 modules match TypeScript sources
GENTLE_PI_REQUIRE_NATIVE_BINARY=1 pnpm run test:packed-runner   0   gentle-pi 2.2.0, Gentle AI 2.4.0, 13 states
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded execution timeouts for Pi host reviews, based on prompt size with configurable limits and overrides.
  * Timeout errors now include elapsed time, configured limits, and guidance for adjusting settings or reducing scope.
* **Bug Fixes**
  * Timed-out reviews are clearly distinguished from other failures.
  * Completed review results remain valid, and timed-out slots are not automatically retried unchanged.
* **Documentation**
  * Updated README documentation to explain timeout behavior and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->