### PR TITLE
fix(review): detect a linked worktree missing its project-local .pi config

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -151,6 +151,11 @@ import {
 import type { ReviewCollectInputV3, ReviewConsentEnvelope, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 import { assertDistinctCorrectionEvidence, resolveCorrectionStep, type CorrectionEvidence, type CorrectionOutcome, type CorrectionStep } from "../lib/review-correction-lifecycle.ts";
 import { recordReviewConsentLatch } from "../lib/review-consent-latch.ts";
+import {
+	inspectWorktreeWorkspaceConfig,
+	renderWorktreeWorkspaceConfigStatusLine,
+	renderWorktreeWorkspaceConfigWarning,
+} from "../lib/worktree-workspace-config.ts";
 
 const GRAPH_V1_ORDINARY_READ_ONLY = "Graph-v1 ordinary review authority is read-only; use native compact-v2 review operations";
 import {
@@ -7415,6 +7420,21 @@ function createGentleAiExtensionForTesting(
 		} catch (error) {
 			if (ctx.hasUI) ctx.ui.notify(`Gentle AI dev binary override check failed: ${error instanceof Error ? error.message : String(error)}`, "warning");
 		}
+		// gentle-pi#370: a linked worktree starts without the ignored
+		// project-local `.pi` configuration. Say so here, at the boundary that
+		// created the gap, instead of letting it resurface much later as a
+		// gentle-ai refusal that names `pi` as an unsupported runtime.
+		try {
+			const worktreeConfig = renderWorktreeWorkspaceConfigWarning(inspectWorktreeWorkspaceConfig(ctx.cwd));
+			if (ctx.hasUI && worktreeConfig !== undefined) ctx.ui.notify(worktreeConfig, "warning");
+		} catch (error) {
+			if (ctx.hasUI) {
+				ctx.ui.notify(
+					`Gentle AI could not check this worktree's project-local .pi configuration: ${error instanceof Error ? error.message : String(error)}`,
+					"warning",
+				);
+			}
+		}
 		try {
 			const transactionRecovery = reconcileCommitTransaction(ctx.cwd);
 			if (ctx.hasUI && transactionRecovery.status !== "clean") {
@@ -7922,10 +7942,20 @@ function createGentleAiExtensionForTesting(
 			const localSddAgentOverrides = sddLocalAgentOverrideCount(ctx.cwd);
 			const modelConfig = await readModelConfigAsync(ctx.cwd);
 			const devBinary = await describeDevBinaryOverride();
+			// gentle-pi#370: whoever is already investigating "pi is not a
+			// supported runtime" reaches for this command, so the worktree
+			// configuration gap has to be visible from here too.
+			let worktreeConfigLine: string | undefined;
+			try {
+				worktreeConfigLine = renderWorktreeWorkspaceConfigStatusLine(inspectWorktreeWorkspaceConfig(ctx.cwd));
+			} catch {
+				worktreeConfigLine = undefined;
+			}
 			ctx.ui.notify(
 				[
 					"el Gentleman package is active.",
 					...(devBinary.state === "inactive" ? [] : [devBinary.line]),
+					...(worktreeConfigLine === undefined ? [] : [worktreeConfigLine]),
 					`Persona: ${readPersonaMode(ctx.cwd)}`,
 					`Global SDD agents: ${agentsInstalled ? "installed" : "not installed"}`,
 					`Global SDD chains: ${chainsInstalled ? "installed" : "not installed"}`,
@@ -7943,7 +7973,7 @@ function createGentleAiExtensionForTesting(
 					`Global model config: ${existsSync(modelConfigPath(ctx.cwd)) ? "present" : "missing"}`,
 					...describeModelConfig(ctx.cwd, modelConfig),
 				].join("\n"),
-				staleSddAssets > 0 || localSddAgentOverrides > 0 || devBinary.state !== "inactive" ? "warning" : "info",
+				staleSddAssets > 0 || localSddAgentOverrides > 0 || devBinary.state !== "inactive" || worktreeConfigLine !== undefined ? "warning" : "info",
 			);
 		},
 	});

--- a/lib/worktree-workspace-config.ts
+++ b/lib/worktree-workspace-config.ts
@@ -1,0 +1,230 @@
+// gentle-pi#370. Detects the one configuration boundary that made a setup gap
+// look like a runtime-support verdict.
+//
+// Git never copies ignored files into a linked worktree, and `.pi/` is ignored
+// in every project that keeps it out of version control. So a worktree created
+// from a fully configured workspace starts with no project-local `.pi`
+// configuration at all. Nothing announces that. What the user eventually sees
+// is a gentle-ai refusal listing claude-code, opencode and codex as the
+// supported immutable-review runtimes, with `pi` absent -- because without the
+// project-local configuration the extension is not the caller, gentle-ai gets
+// driven from a plain shell, and nothing exports the relay handshake that makes
+// `pi` eligible. Four independent reporters on published 2.4.0 read that
+// refusal as a statement about runtime support.
+//
+// This module reports the gap where it is created. It never writes into a
+// worktree: provisioning means copying whatever a parent workspace happens to
+// contain, which can silently duplicate stale configuration, and that decision
+// belongs to the user rather than to a startup hook.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+
+/**
+ * The handshake gentle-ai requires before `pi` is an eligible immutable-review
+ * runtime. Named here only so the diagnostic can say which variable and value
+ * are involved; nothing in this module sets, forges, or bypasses it.
+ */
+export const REVIEW_RELAY_HANDSHAKE = "GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1";
+
+export interface ProjectPiConfigEntry {
+	/** Repository-relative path, rendered with the host separator. */
+	readonly relativePath: string;
+	/** What stops working when this path is absent. */
+	readonly capability: string;
+}
+
+/**
+ * The project-local `.pi` paths the extension actually reads. Directories are
+ * probed as a whole rather than file by file: a worktree either received the
+ * directory or it did not, and enumerating every file inside it would report
+ * differences that are ordinary workspace drift rather than the worktree gap.
+ */
+export const PROJECT_PI_CONFIG_ENTRIES: readonly ProjectPiConfigEntry[] = [
+	{
+		relativePath: join(".pi", "npm", "node_modules"),
+		capability:
+			"project-local Pi package installs. When gentle-pi is installed here rather than globally, the extension does not load in this worktree at all",
+	},
+	{
+		relativePath: join(".pi", "settings.json"),
+		capability: "project Pi settings",
+	},
+	{
+		relativePath: join(".pi", "gentle-ai"),
+		capability:
+			"project Gentle AI config: runtime guardrails, background-subagents policy, persona, SDD preflight",
+	},
+	{
+		relativePath: join(".pi", "agents"),
+		capability: "project subagent definitions",
+	},
+	{
+		relativePath: join(".pi", "subagents"),
+		capability: "project subagent definitions",
+	},
+	{
+		relativePath: join(".pi", "subagents.json"),
+		capability: "project subagent model routing profiles",
+	},
+	{
+		relativePath: join(".pi", "skills"),
+		capability: "project skills",
+	},
+];
+
+export interface MissingProjectPiConfig extends ProjectPiConfigEntry {
+	/** Where it would live in this worktree. */
+	readonly worktreePath: string;
+	/** Where it exists in the parent workspace. */
+	readonly parentPath: string;
+}
+
+export type WorktreeWorkspaceConfigReport =
+	/** The session cwd is the repository's own main worktree; nothing to carry across. */
+	| { readonly status: "not-a-linked-worktree" }
+	/** Git identity, the main worktree, or both could not be resolved. Never guessed. */
+	| { readonly status: "undetermined"; readonly reason: string }
+	/** A linked worktree that lacks nothing the parent workspace has. */
+	| {
+			readonly status: "provisioned";
+			readonly worktreeRoot: string;
+			readonly parentWorkspaceRoot: string;
+	  }
+	/** A linked worktree missing project-local configuration the parent workspace has. */
+	| {
+			readonly status: "missing";
+			readonly worktreeRoot: string;
+			readonly parentWorkspaceRoot: string;
+			readonly missing: readonly MissingProjectPiConfig[];
+	  };
+
+function git(cwd: string, args: readonly string[]): string {
+	return execFileSync("git", args, {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	}).trim();
+}
+
+function canonical(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return path;
+	}
+}
+
+/**
+ * The repository's main worktree, which is the workspace a linked worktree was
+ * branched from and therefore the only honest comparison point.
+ *
+ * `git worktree list --porcelain` always emits the main worktree first. A bare
+ * repository has no main worktree, so there is nothing to compare against and
+ * the caller must stay quiet rather than invent a parent.
+ */
+function resolveParentWorkspaceRoot(cwd: string): { readonly root: string } | { readonly reason: string } {
+	let porcelain: string;
+	try {
+		porcelain = git(cwd, ["worktree", "list", "--porcelain"]);
+	} catch {
+		return { reason: "git worktree list did not answer" };
+	}
+	const record = porcelain.split(/\r?\n\r?\n/)[0] ?? "";
+	const lines = record.split(/\r?\n/).map((line) => line.trimEnd());
+	if (lines.includes("bare")) return { reason: "the repository has no main worktree (it is bare)" };
+	const declaration = lines.find((line) => line.startsWith("worktree "));
+	if (declaration === undefined) return { reason: "git worktree list reported no main worktree" };
+	const root = declaration.slice("worktree ".length).trim();
+	if (root.length === 0 || !isAbsolute(root)) return { reason: "git worktree list reported no absolute main worktree path" };
+	if (!existsSync(root)) return { reason: `the main worktree ${root} no longer exists` };
+	return { root: canonical(root) };
+}
+
+/**
+ * Classifies the session cwd and, when it is a linked worktree, reports which
+ * project-local `.pi` paths the parent workspace has and this worktree lacks.
+ *
+ * Every failure to resolve is `undetermined`. A detector that guesses is worse
+ * than no detector: it would put a second wrong explanation in front of the
+ * same user this exists to unblock.
+ */
+export function inspectWorktreeWorkspaceConfig(cwd: string): WorktreeWorkspaceConfigReport {
+	let toplevel: string;
+	let commonDir: string;
+	try {
+		toplevel = canonical(git(cwd, ["rev-parse", "--show-toplevel"]));
+		commonDir = canonical(resolve(cwd, git(cwd, ["rev-parse", "--git-common-dir"])));
+	} catch {
+		return { status: "undetermined", reason: `${cwd} does not resolve a Git worktree identity` };
+	}
+	// A main worktree keeps its repository directory at `<toplevel>/.git`. A
+	// linked worktree keeps a `.git` *file* there and shares the common dir
+	// with the main worktree, so the two paths differ.
+	if (canonical(join(toplevel, ".git")) === commonDir) return { status: "not-a-linked-worktree" };
+
+	const parent = resolveParentWorkspaceRoot(cwd);
+	if (!("root" in parent)) return { status: "undetermined", reason: parent.reason };
+	// `--separate-git-dir` also moves the common dir off `<toplevel>/.git`
+	// without creating a linked worktree. It is still the main worktree.
+	if (parent.root === toplevel) return { status: "not-a-linked-worktree" };
+
+	const missing = PROJECT_PI_CONFIG_ENTRIES.flatMap((entry) => {
+		const parentPath = join(parent.root, entry.relativePath);
+		const worktreePath = join(toplevel, entry.relativePath);
+		if (!existsSync(parentPath) || existsSync(worktreePath)) return [];
+		return [{ ...entry, worktreePath, parentPath }];
+	});
+	if (missing.length === 0) {
+		return { status: "provisioned", worktreeRoot: toplevel, parentWorkspaceRoot: parent.root };
+	}
+	return { status: "missing", worktreeRoot: toplevel, parentWorkspaceRoot: parent.root, missing };
+}
+
+/**
+ * The full diagnostic, or undefined when there is nothing to report.
+ *
+ * It names three things deliberately: the exact paths that are missing, the
+ * parent workspace that has them, and the failure the user would otherwise
+ * meet later without any way to connect it back here.
+ */
+export function renderWorktreeWorkspaceConfigWarning(
+	report: WorktreeWorkspaceConfigReport,
+): string | undefined {
+	if (report.status !== "missing") return undefined;
+	const lines = [
+		"Gentle AI: this linked Git worktree does not carry the project-local .pi configuration your parent workspace has.",
+		"Git never copies ignored files into a worktree, so nothing here is broken or corrupted. It was simply never brought across.",
+		"",
+		`Worktree:         ${report.worktreeRoot}`,
+		`Parent workspace: ${report.parentWorkspaceRoot}`,
+		"",
+		"Missing here, present in the parent workspace:",
+	];
+	for (const entry of report.missing) {
+		lines.push(`  ${entry.worktreePath}`);
+		lines.push(`    present at ${entry.parentPath}`);
+		lines.push(`    ${entry.capability}`);
+	}
+	lines.push(
+		"",
+		"Until this is resolved, this worktree runs without that configuration.",
+		"In particular, if gentle-pi is installed project-locally, its extension does not load here, so gentle-ai ends up being driven from a plain shell.",
+		`A plain shell exports no ${REVIEW_RELAY_HANDSHAKE}, and without that handshake gentle-ai refuses the \`pi\` runtime and lists claude-code, opencode and codex instead.`,
+		"That refusal is correct: it names the runtime, but the cause is the missing configuration named above, not a missing runtime.",
+		"",
+		"Resolve it by copying the listed paths from the parent workspace into this worktree, or by running Pi from the parent workspace.",
+		"gentle-pi will not write into your worktree on its own.",
+	);
+	return lines.join("\n");
+}
+
+/** One compact line for `/gentle:status`, or undefined when there is nothing to report. */
+export function renderWorktreeWorkspaceConfigStatusLine(
+	report: WorktreeWorkspaceConfigReport,
+): string | undefined {
+	if (report.status !== "missing") return undefined;
+	const paths = report.missing.map((entry) => entry.relativePath).join(", ");
+	return `Linked worktree config: ${report.missing.length} project-local path(s) missing that ${report.parentWorkspaceRoot} has (${paths}) - copy them across or run Pi from the parent workspace; until then the \`pi\` review runtime is refused for want of ${REVIEW_RELAY_HANDSHAKE}`;
+}

--- a/tests/worktree-workspace-config.test.ts
+++ b/tests/worktree-workspace-config.test.ts
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import {
+	inspectWorktreeWorkspaceConfig,
+	renderWorktreeWorkspaceConfigStatusLine,
+	renderWorktreeWorkspaceConfigWarning,
+	REVIEW_RELAY_HANDSHAKE,
+} from "../lib/worktree-workspace-config.ts";
+
+// gentle-pi#370. A linked Git worktree never receives the project-local `.pi`
+// configuration, because Git does not copy ignored files into a worktree.
+// Four reporters on published 2.4.0 then read the downstream symptom -- a
+// gentle-ai refusal naming `pi` as an unsupported runtime -- as a statement
+// about runtime support. These tests pin the opposite: the configuration gap
+// is detected and named at the boundary where it is created, so it can never
+// again present itself as a runtime-support question.
+
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+/** A committed repository whose main worktree is the parent workspace. */
+function parentWorkspace(t: test.TestContext): string {
+	const root = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-worktree-config-parent-")));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	git(root, "init", "-b", "main");
+	writeFileSync(join(root, "app.ts"), "export const value = 1;\n");
+	writeFileSync(join(root, ".gitignore"), ".pi/\n");
+	git(root, "add", ".");
+	git(root, "-c", "user.name=Worktree Test", "-c", "user.email=worktree@example.invalid", "commit", "-m", "initial");
+	return root;
+}
+
+function addLinkedWorktree(t: test.TestContext, parent: string, branch: string): string {
+	const holder = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-worktree-config-linked-")));
+	const worktree = join(holder, branch);
+	git(parent, "worktree", "add", "-b", branch, worktree);
+	t.after(() => {
+		try {
+			git(parent, "worktree", "remove", "--force", worktree);
+		} catch {
+			// The parent may already be gone; the holder removal below is enough.
+		}
+		rmSync(holder, { recursive: true, force: true });
+	});
+	return realpathSync(worktree);
+}
+
+/** The project-local `.pi` configuration a real workspace accumulates. */
+function provisionProjectPiConfig(root: string): void {
+	mkdirSync(join(root, ".pi", "npm", "node_modules", "gentle-pi"), { recursive: true });
+	writeFileSync(join(root, ".pi", "npm", "node_modules", "gentle-pi", "package.json"), '{"name":"gentle-pi"}\n');
+	mkdirSync(join(root, ".pi", "gentle-ai"), { recursive: true });
+	writeFileSync(join(root, ".pi", "gentle-ai", "runtime-guardrails.json"), '{"autonomousMode":false}\n');
+	writeFileSync(join(root, ".pi", "settings.json"), "{}\n");
+}
+
+test("the main worktree is never reported as a linked worktree, even with project config present", (t) => {
+	const parent = parentWorkspace(t);
+	provisionProjectPiConfig(parent);
+	assert.equal(inspectWorktreeWorkspaceConfig(parent).status, "not-a-linked-worktree");
+});
+
+test("a linked worktree missing the parent's project-local .pi configuration is detected", (t) => {
+	const parent = parentWorkspace(t);
+	provisionProjectPiConfig(parent);
+	const worktree = addLinkedWorktree(t, parent, "feature");
+
+	const report = inspectWorktreeWorkspaceConfig(worktree);
+	assert.equal(report.status, "missing");
+	assert.equal(report.status === "missing" && report.worktreeRoot, worktree);
+	assert.equal(report.status === "missing" && report.parentWorkspaceRoot, parent);
+	assert.ok(report.status === "missing");
+	const relative = report.missing.map((entry) => entry.relativePath);
+	assert.deepEqual(
+		relative,
+		[join(".pi", "npm", "node_modules"), join(".pi", "settings.json"), join(".pi", "gentle-ai")],
+		JSON.stringify(relative),
+	);
+	for (const entry of report.missing) {
+		assert.equal(entry.worktreePath, join(worktree, entry.relativePath));
+		assert.equal(entry.parentPath, join(parent, entry.relativePath));
+		assert.ok(entry.capability.length > 0);
+	}
+});
+
+test("the report names the missing path, the parent that has it, and what stays broken", (t) => {
+	const parent = parentWorkspace(t);
+	provisionProjectPiConfig(parent);
+	const worktree = addLinkedWorktree(t, parent, "feature");
+
+	const warning = renderWorktreeWorkspaceConfigWarning(inspectWorktreeWorkspaceConfig(worktree));
+	assert.ok(warning, "a missing project-local configuration must render a warning");
+	// Names the missing path and the parent that has it.
+	assert.ok(warning.includes(join(worktree, ".pi", "npm", "node_modules")), warning);
+	assert.ok(warning.includes(join(parent, ".pi", "npm", "node_modules")), warning);
+	assert.ok(warning.includes(worktree), warning);
+	assert.ok(warning.includes(parent), warning);
+	// Names what will not work, and names it as a configuration gap rather
+	// than as a statement about which runtimes gentle-ai supports.
+	assert.ok(warning.includes(REVIEW_RELAY_HANDSHAKE), warning);
+	assert.match(warning, /unsupported runtime|not a supported runtime|refuses the `pi` runtime/i);
+	assert.match(warning, /worktree/i);
+	// Never instructs anyone to work around the handshake, disable review, or
+	// pick a different runtime: the refusal itself is correct behavior.
+	assert.doesNotMatch(warning, /review mode disable|--agent[= ](?:claude-code|opencode|codex)/i);
+});
+
+test("a linked worktree carrying the same project-local configuration reports nothing", (t) => {
+	const parent = parentWorkspace(t);
+	provisionProjectPiConfig(parent);
+	const worktree = addLinkedWorktree(t, parent, "feature");
+	provisionProjectPiConfig(worktree);
+
+	const report = inspectWorktreeWorkspaceConfig(worktree);
+	assert.equal(report.status, "provisioned");
+	assert.equal(renderWorktreeWorkspaceConfigWarning(report), undefined);
+	assert.equal(renderWorktreeWorkspaceConfigStatusLine(report), undefined);
+});
+
+test("a parent workspace with no project-local configuration leaves nothing to report", (t) => {
+	const parent = parentWorkspace(t);
+	const worktree = addLinkedWorktree(t, parent, "feature");
+
+	const report = inspectWorktreeWorkspaceConfig(worktree);
+	assert.equal(report.status, "provisioned");
+	assert.equal(renderWorktreeWorkspaceConfigWarning(report), undefined);
+});
+
+test("only the paths the worktree actually lacks are reported", (t) => {
+	const parent = parentWorkspace(t);
+	provisionProjectPiConfig(parent);
+	const worktree = addLinkedWorktree(t, parent, "feature");
+	mkdirSync(join(worktree, ".pi", "npm", "node_modules"), { recursive: true });
+	writeFileSync(join(worktree, ".pi", "settings.json"), "{}\n");
+
+	const report = inspectWorktreeWorkspaceConfig(worktree);
+	assert.ok(report.status === "missing");
+	assert.deepEqual(report.missing.map((entry) => entry.relativePath), [join(".pi", "gentle-ai")]);
+});
+
+test("a path that is not a Git worktree is undetermined, never a false alarm", async (t) => {
+	const outside = realpathSync(await mkdtemp(join(tmpdir(), "gentle-pi-worktree-config-outside-")));
+	t.after(() => rmSync(outside, { recursive: true, force: true }));
+	const report = inspectWorktreeWorkspaceConfig(outside);
+	assert.equal(report.status, "undetermined");
+	assert.equal(renderWorktreeWorkspaceConfigWarning(report), undefined);
+});
+
+test("session start reports the missing worktree configuration instead of leaving it to surface as a runtime refusal", async (t) => {
+	const parent = parentWorkspace(t);
+	provisionProjectPiConfig(parent);
+	const worktree = addLinkedWorktree(t, parent, "feature");
+
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const previousConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
+	process.env.GENTLE_PI_AGENT_HOME = await mkdtemp(join(tmpdir(), "gentle-pi-worktree-config-agent-home-"));
+	process.env.GENTLE_PI_CONFIG_HOME = await mkdtemp(join(tmpdir(), "gentle-pi-worktree-config-config-home-"));
+	t.after(() => {
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		if (previousConfigHome === undefined) delete process.env.GENTLE_PI_CONFIG_HOME;
+		else process.env.GENTLE_PI_CONFIG_HOME = previousConfigHome;
+	});
+
+	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void>>();
+	const pi = {
+		on(name: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void>) {
+			handlers.set(name, handler);
+		},
+		registerCommand() {},
+		registerTool() {},
+	} as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli: null })(pi);
+	const sessionStart = handlers.get("session_start");
+	assert.equal(typeof sessionStart, "function");
+
+	const notifications: Array<{ message: string; severity: string }> = [];
+	const ctx = {
+		cwd: worktree,
+		hasUI: true,
+		ui: {
+			notify(message: string, severity: string) {
+				notifications.push({ message, severity });
+			},
+		},
+	} as unknown as ExtensionContext;
+	await sessionStart!({}, ctx);
+
+	const announcement = notifications.find((entry) => entry.message.includes(join(worktree, ".pi", "npm", "node_modules")));
+	assert.ok(announcement, JSON.stringify(notifications));
+	assert.equal(announcement.severity, "warning");
+	assert.ok(announcement.message.includes(parent), announcement.message);
+	assert.ok(announcement.message.includes(REVIEW_RELAY_HANDSHAKE), announcement.message);
+});
+
+test("session start stays silent in a worktree that carries the configuration", async (t) => {
+	const parent = parentWorkspace(t);
+	provisionProjectPiConfig(parent);
+	const worktree = addLinkedWorktree(t, parent, "feature");
+	provisionProjectPiConfig(worktree);
+
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const previousConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
+	process.env.GENTLE_PI_AGENT_HOME = await mkdtemp(join(tmpdir(), "gentle-pi-worktree-config-agent-home-"));
+	process.env.GENTLE_PI_CONFIG_HOME = await mkdtemp(join(tmpdir(), "gentle-pi-worktree-config-config-home-"));
+	t.after(() => {
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		if (previousConfigHome === undefined) delete process.env.GENTLE_PI_CONFIG_HOME;
+		else process.env.GENTLE_PI_CONFIG_HOME = previousConfigHome;
+	});
+
+	const handlers = new Map<string, (event: unknown, ctx: ExtensionContext) => Promise<void>>();
+	const pi = {
+		on(name: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void>) {
+			handlers.set(name, handler);
+		},
+		registerCommand() {},
+		registerTool() {},
+	} as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli: null })(pi);
+	const notifications: Array<{ message: string; severity: string }> = [];
+	await handlers.get("session_start")!({}, {
+		cwd: worktree,
+		hasUI: true,
+		ui: {
+			notify(message: string, severity: string) {
+				notifications.push({ message, severity });
+			},
+		},
+	} as unknown as ExtensionContext);
+
+	assert.equal(
+		notifications.filter((entry) => /linked Git worktree/i.test(entry.message)).length,
+		0,
+		JSON.stringify(notifications),
+	);
+});
+
+test("gentle:status names the gap for anyone already investigating the refusal", async (t) => {
+	const parent = parentWorkspace(t);
+	provisionProjectPiConfig(parent);
+	const worktree = addLinkedWorktree(t, parent, "feature");
+
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const previousConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
+	process.env.GENTLE_PI_AGENT_HOME = await mkdtemp(join(tmpdir(), "gentle-pi-worktree-config-agent-home-"));
+	process.env.GENTLE_PI_CONFIG_HOME = await mkdtemp(join(tmpdir(), "gentle-pi-worktree-config-config-home-"));
+	t.after(() => {
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		if (previousConfigHome === undefined) delete process.env.GENTLE_PI_CONFIG_HOME;
+		else process.env.GENTLE_PI_CONFIG_HOME = previousConfigHome;
+	});
+
+	const commands = new Map<string, { handler: (args: string, ctx: ExtensionContext) => Promise<void> }>();
+	createGentleAiExtension({ nativeReviewCli: null })({
+		on() {},
+		registerCommand(name: string, registration: { handler: (args: string, ctx: ExtensionContext) => Promise<void> }) {
+			commands.set(name, registration);
+		},
+		registerTool() {},
+	} as unknown as ExtensionAPI);
+
+	const notifications: Array<{ message: string; severity: string }> = [];
+	await commands.get("gentle:status")!.handler("", {
+		cwd: worktree,
+		hasUI: true,
+		ui: {
+			notify(message: string, severity: string) {
+				notifications.push({ message, severity });
+			},
+		},
+	} as unknown as ExtensionContext);
+
+	assert.equal(notifications.length, 1, JSON.stringify(notifications));
+	assert.match(notifications[0]!.message, /Linked worktree config:/);
+	assert.ok(notifications[0]!.message.includes(parent), notifications[0]!.message);
+	assert.equal(notifications[0]!.severity, "warning");
+});


### PR DESCRIPTION
Closes #370.

A linked Git worktree never receives the project-local `.pi` configuration, because Git does not copy ignored files into a worktree. Without it the extension is not the caller, gentle-ai gets driven from a plain shell, nothing exports `GENTLE_PI_REVIEW_RELAY_CONTRACT`, and gentle-ai correctly refuses `pi` while listing the three runtimes that need no handshake. Four independent reporters on published 2.4.0 read that refusal as a statement about runtime support.

This detects the gap at the boundary that creates it, and names it.

## Scope: detection, not provisioning

@EloyEMC proposed either provisioning the configuration into the worktree or detecting its absence and reporting it. This does the second.

Provisioning means writing into a user's worktree, copying whatever their parent workspace happens to contain, and deciding what is safe to copy. It can silently duplicate stale configuration, and it is a much larger surface. Detection is small, honest, and cannot damage anything. Nothing here writes into a worktree.

## Detection condition

`inspectWorktreeWorkspaceConfig(cwd)` in `lib/worktree-workspace-config.ts`:

1. Resolve `git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`, both canonicalised.
2. If `realpath(<toplevel>/.git) === commonDir`, this is the main worktree. Stop.
3. Resolve the parent workspace from the first `git worktree list --porcelain` record. A `bare` first record has no main worktree, so there is nothing to compare against and nothing is reported.
4. If that main worktree is this toplevel, this is `--separate-git-dir`, not a linked worktree. Stop.
5. Report every probed `.pi` path that exists in the parent workspace and not here.

The probed set is the project-local paths the extension actually reads: `.pi/npm/node_modules`, `.pi/settings.json`, `.pi/gentle-ai`, `.pi/agents`, `.pi/subagents`, `.pi/subagents.json`, `.pi/skills`.

Every failure to resolve is `undetermined` and reports nothing. A detector that guesses would put a second wrong explanation in front of the same user this exists to unblock.

## What a user sees

At session start, and only when something is actually missing:

```
Gentle AI: this linked Git worktree does not carry the project-local .pi configuration your parent workspace has.
Git never copies ignored files into a worktree, so nothing here is broken or corrupted. It was simply never brought across.

Worktree:         /home/you/repo-worktrees/feature
Parent workspace: /home/you/repo

Missing here, present in the parent workspace:
  /home/you/repo-worktrees/feature/.pi/npm/node_modules
    present at /home/you/repo/.pi/npm/node_modules
    project-local Pi package installs. When gentle-pi is installed here rather than globally, the extension does not load in this worktree at all
  /home/you/repo-worktrees/feature/.pi/settings.json
    present at /home/you/repo/.pi/settings.json
    project Pi settings
  /home/you/repo-worktrees/feature/.pi/gentle-ai
    present at /home/you/repo/.pi/gentle-ai
    project Gentle AI config: runtime guardrails, background-subagents policy, persona, SDD preflight

Until this is resolved, this worktree runs without that configuration.
In particular, if gentle-pi is installed project-locally, its extension does not load here, so gentle-ai ends up being driven from a plain shell.
A plain shell exports no GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1, and without that handshake gentle-ai refuses the `pi` runtime and lists claude-code, opencode and codex instead.
That refusal is correct: it names the runtime, but the cause is the missing configuration named above, not a missing runtime.

Resolve it by copying the listed paths from the parent workspace into this worktree, or by running Pi from the parent workspace.
gentle-pi will not write into your worktree on its own.
```

`/gentle:status` carries the same finding as one line, because that is the command someone already investigating "pi is not a supported runtime" reaches for:

```
Linked worktree config: 3 project-local path(s) missing that /home/you/repo has (.pi/npm/node_modules, .pi/settings.json, .pi/gentle-ai) - copy them across or run Pi from the parent workspace; until then the `pi` review runtime is refused for want of GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1
```

## What this does not touch

- The handshake requirement is unchanged. gentle-ai refusing an unhandshaken `pi` is correct, and the message says so.
- `gentleAiProcessEnvironment` is unchanged; the extension's own invocations were never the problem.
- One test asserts the message never suggests `review mode disable` or switching to another `--agent`.
- No `runtime/*.mjs` regeneration: the new module is not one of the five sources `scripts/build-git-commit-transaction-runner.mjs` generates from, and `pnpm run check:transaction-runner` confirms no drift.

## Tests

`tests/worktree-workspace-config.test.ts`, 10 tests. They create real linked worktrees rather than constructed state, including the one the reporter asked for: a linked worktree, driven through the extension's real `session_start`, asserting the missing configuration is reported there instead of surfacing later as a runtime refusal.

Revert-proof. With the linked-worktree branch in `inspectWorktreeWorkspaceConfig` reverted, 7 of the 10 go red, including the session-start and `/gentle:status` end-to-end ones. Restored, all 10 pass.

## Verification

Every CI step, foreground, all green:

- `pnpm test` — 1305 tests, 1304 pass, 0 fail, 1 skipped
- `node scripts/verify-package-files.mjs` — 163 files, 65 byte-identical v2.4.0 contract artifacts
- `pnpm run check:provider-contract` — contract 1.1.0, 8 bundle entries, 2 baselines
- `pnpm run check:transaction-runner` — 5 modules match their TypeScript sources
- `GENTLE_PI_REQUIRE_NATIVE_BINARY=1 pnpm run test:packed-runner` — gentle-pi 2.2.0, Gentle AI 2.4.0, 13 states

## Still open after this

Per @Alan-TheGentleman's routing on #367, the confirming run provisioned `.pi` and ensured the handshake export together, so which was load-bearing is not isolated. This closes the invisible half: the configuration gap now announces itself instead of arriving as a runtime-support mystery. `gentle-ai#3440` and `gentle-ai#3443` remain the threads for the refusal message itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection of project-local `.pi` configuration for linked Git worktrees.
  - Session startup now warns when required configuration is missing or cannot be inspected.
  - `/gentle:status` now displays configuration status and highlights issues with warning severity.
  - Warnings identify affected capabilities and note the required review relay handshake.

- **Bug Fixes**
  - Improved visibility into incomplete worktree setup and configuration-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->