### PR TITLE
fix(review): preserve Pi identity through RDD consent

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3282,6 +3282,8 @@ interface PendingReviewConsent {
 	cleanupCandidate: () => void;
 	untrackedSelection?: RetainedNativeUntrackedSelection;
 	consent: ReviewConsentEnvelope;
+	/** The transport selected for the START that issued this consent. */
+	startAgent: "pi" | undefined;
 	consentDigest: string;
 	expiresAt: number;
 	expiry?: ReturnType<typeof setTimeout>;
@@ -4478,6 +4480,7 @@ async function executeReviewControllerOperation(
 				cwd: pending.authorityCwd,
 				consent: pending.consent,
 				answer: input.answer,
+				startAgent: pending.startAgent,
 				...(signal === undefined ? {} : { signal }),
 			});
 			if (answered.kind === "declined") {
@@ -4499,7 +4502,7 @@ async function executeReviewControllerOperation(
 					cwd: pending.authorityCwd,
 					...(pending.candidateView.committedOnly ? { baseRef: pending.candidateView.baseCommit } : {}),
 					projection: "workspace",
-					...(pending.consent.schema === "gentle-ai.review-integration.consent/v3" && pending.consent.agent === REVIEW_HOST_AGENT ? { agent: REVIEW_HOST_AGENT } : {}),
+					...(pending.startAgent === undefined ? {} : { agent: pending.startAgent }),
 				});
 		}
 		if (input.answer === "granted") {
@@ -4601,7 +4604,8 @@ async function executeReviewControllerOperation(
 					if (!(error instanceof NativeReviewConsentRequiredError)) throw error;
 					try {
 						if (error.consent.schema === "gentle-ai.review-integration.consent/v3") {
-							decodeReviewConsentV3(error.consent.raw, REVIEW_HOST_AGENT);
+							const decodedConsent = decodeReviewConsentV3(error.consent.raw, startAgent);
+							if (decodedConsent.agent !== REVIEW_HOST_AGENT) throw new TypeError("consent.agent does not match the Pi host binding");
 						}
 					} catch (cause) {
 						// A provider response that cannot prove the Pi binding is not a
@@ -4620,7 +4624,7 @@ async function executeReviewControllerOperation(
 					const repositoryCwd = realpathSync(defaultCwd);
 					const consentDigest = reviewConsentDigest(error.consent);
 					const pendingReviewConsents = pendingReviewConsentRegistry.get(pendingReviewConsentSession);
-					const existing = [...(pendingReviewConsents?.values() ?? [])].find((pending) => pending.repositoryCwd === repositoryCwd && pending.candidateView.token === consentCandidateView.token && pending.consentDigest === consentDigest && pending.expiresAt > reviewConsentNow());
+					const existing = [...(pendingReviewConsents?.values() ?? [])].find((pending) => pending.repositoryCwd === repositoryCwd && pending.candidateView.token === consentCandidateView.token && pending.consentDigest === consentDigest && pending.startAgent === startAgent && pending.expiresAt > reviewConsentNow());
 					if (existing === undefined) {
 						for (const pending of [...(pendingReviewConsents?.values() ?? [])]) {
 							if (pending.candidateView.token === consentCandidateView.token) {
@@ -4645,6 +4649,7 @@ async function executeReviewControllerOperation(
 							},
 							...(retainedUntrackedSelection === undefined ? {} : { untrackedSelection: retainedUntrackedSelection }),
 							consent: error.consent,
+							startAgent,
 							consentDigest,
 							expiresAt: reviewConsentNow() + PENDING_REVIEW_CONSENT_TTL_MS,
 						};

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3509,7 +3509,7 @@ async function reconcileNativeMutationFailure(
 	error: unknown,
 	nativeReviewCli: NativeReviewCli,
 	target: Parameters<NonNullable<NativeReviewCli["targetStatus"]>>[0],
-	preOperationRevision?: string,
+	preOperationRevision?:
 	canonicalRetentionRoot = target.cwd,
 ): Promise<Record<string, unknown>> {
 	const failure = nativeOperationFailure(operation, error);
@@ -4157,6 +4157,24 @@ async function negotiatedStatusForHostTransport(
 	}
 }
 
+/**
+ * START first requests Pi's provider-issued transport. Unlike the immutable
+ * review relay, a typed unsupported-agent refusal may safely use the provider's
+ * agentless START route; the selected transport is retained for reconciliation.
+ */
+async function negotiatedStartStatus(
+	nativeReviewCli: NativeReviewCli,
+	request: NativeTargetStatusRequest,
+): Promise<{ status: ReviewStatusV3; agent: "pi" | undefined }> {
+	try {
+		return { status: await nativeReviewCli.targetStatus!({ ...request, agent: REVIEW_HOST_AGENT }), agent: REVIEW_HOST_AGENT };
+	} catch (error) {
+		const code = error instanceof NativeReviewIntegrationError ? error.failureEnvelope.code : undefined;
+		if (code === undefined || !REVIEW_TRANSPORT_REFUSAL_CODES.has(code)) throw error;
+		return { status: await nativeReviewCli.targetStatus!(request), agent: undefined };
+	}
+}
+
 type DispatchHydrationOutcome =
 	| { hydrated: true; lineage_id: string; lenses: readonly string[] }
 	| { hydrated: false; lineage_id: string; reason: string; message: string }
@@ -4478,10 +4496,11 @@ async function executeReviewControllerOperation(
 			const value = error as { mutationOutcome?: unknown };
 			if (value.mutationOutcome === "none") pending.cleanupCandidate();
 			return await reconcileNativeMutationFailure(parameters.operation, error, nativeReviewCli, {
-				cwd: pending.authorityCwd,
-				...(pending.candidateView.committedOnly ? { baseRef: pending.candidateView.baseCommit } : {}),
-				projection: "workspace",
-			});
+					cwd: pending.authorityCwd,
+					...(pending.candidateView.committedOnly ? { baseRef: pending.candidateView.baseCommit } : {}),
+					projection: "workspace",
+					...(pending.consent.schema === "gentle-ai.review-integration.consent/v3" && pending.consent.agent === REVIEW_HOST_AGENT ? { agent: REVIEW_HOST_AGENT } : {}),
+				});
 		}
 		if (input.answer === "granted") {
 			try {
@@ -4534,14 +4553,17 @@ async function executeReviewControllerOperation(
 			}
 			if (nativeReviewCli?.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
 			let target: ReviewStatusV3;
+			let startAgent: "pi" | undefined;
 			try {
-				target = await nativeReviewCli.targetStatus({
+				const negotiated = await negotiatedStartStatus(nativeReviewCli, {
 					cwd: defaultCwd,
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 					...(canonicalBaseRef === undefined ? {} : { baseRef: canonicalBaseRef }),
 					...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
 					...(signal === undefined ? {} : { signal }),
 				});
+				target = negotiated.status;
+				startAgent = negotiated.agent;
 				if (target.nextTransition?.kind === "collect" || target.applicability !== "unrelated" || target.action !== "start") return mapNativeTargetStatus(parameters.operation, target, parameters.lineageId);
 			} catch (error) {
 				return nativeOperationFailure(parameters.operation, error);
@@ -4569,6 +4591,7 @@ async function executeReviewControllerOperation(
 						targetIdentity: target.targetIdentity,
 						projection: target.projection.projection,
 						...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
+						agent: startAgent,
 						...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 						...(policy.policyPath === undefined ? {} : { policyPath: policy.policyPath }),
 						...(focus === undefined ? {} : { focus }),
@@ -4648,6 +4671,7 @@ async function executeReviewControllerOperation(
 					...(canonicalBaseRef === undefined ? {} : { baseRef: candidateView?.baseCommit ?? canonicalBaseRef }),
 					...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
 					projection: "workspace",
+					agent: startAgent,
 				});
 			}
 		}

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -108,6 +108,7 @@ import {
 import {
 	createNativeReviewCli,
 	createNodeExecFileAdapter,
+	validateNativeReviewConsentAgentBinding,
 	isCanonicalProcessString,
 	nativeReviewAbandonAuthorization,
 	nativeReviewLegacyAliasRepairAuthorization,
@@ -4605,6 +4606,7 @@ async function executeReviewControllerOperation(
 					try {
 						if (error.consent.schema === "gentle-ai.review-integration.consent/v3") {
 							const decodedConsent = decodeReviewConsentV3(error.consent.raw, startAgent);
+							validateNativeReviewConsentAgentBinding(decodedConsent, startAgent);
 							if (decodedConsent.agent !== REVIEW_HOST_AGENT) throw new TypeError("consent.agent does not match the Pi host binding");
 						}
 					} catch (cause) {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -136,7 +136,7 @@ import {
 	type NativeReviewProcessDiagnostics,
 	type NativeStartResult,
 } from "../lib/native-review-cli.ts";
-import type { ReviewCollectInputV3, ReviewConsentEnvelope, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+import { decodeReviewConsentV3, type ReviewCollectInputV3, type ReviewConsentEnvelope, type ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 import { assertDistinctCorrectionEvidence, resolveCorrectionStep, type CorrectionEvidence, type CorrectionOutcome, type CorrectionStep } from "../lib/review-correction-lifecycle.ts";
 import { recordReviewConsentLatch } from "../lib/review-consent-latch.ts";
 
@@ -4599,6 +4599,22 @@ async function executeReviewControllerOperation(
 					});
 				} catch (error) {
 					if (!(error instanceof NativeReviewConsentRequiredError)) throw error;
+					try {
+						if (error.consent.schema === "gentle-ai.review-integration.consent/v3") {
+							decodeReviewConsentV3(error.consent.raw, REVIEW_HOST_AGENT);
+						}
+					} catch (cause) {
+						// A provider response that cannot prove the Pi binding is not a
+						// candidate-scoped question Pi may expose or answer. Its prior
+						// mutation claim is untrusted too, so reconcile through STATUS.
+						throw new NativeReviewCliError(
+							NATIVE_REVIEW_ERROR_CODE.IMMUTABLE_REVIEW_TRANSPORT_UNSUPPORTED,
+							NATIVE_REVIEW_OPERATION.START,
+							true,
+							true,
+							`native Pi consent binding is invalid: ${cause instanceof Error ? cause.message : String(cause)}`,
+						);
+					}
 					if (candidateView === undefined) throw new CandidateViewError("native consent requires a frozen candidate view");
 					const consentCandidateView = candidateView;
 					const repositoryCwd = realpathSync(defaultCwd);

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3509,7 +3509,7 @@ async function reconcileNativeMutationFailure(
 	error: unknown,
 	nativeReviewCli: NativeReviewCli,
 	target: Parameters<NonNullable<NativeReviewCli["targetStatus"]>>[0],
-	preOperationRevision?:
+	preOperationRevision?: string,
 	canonicalRetentionRoot = target.cwd,
 ): Promise<Record<string, unknown>> {
 	const failure = nativeOperationFailure(operation, error);

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4671,7 +4671,7 @@ async function executeReviewControllerOperation(
 					...(canonicalBaseRef === undefined ? {} : { baseRef: candidateView?.baseCommit ?? canonicalBaseRef }),
 					...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
 					projection: "workspace",
-					agent: startAgent,
+					...(startAgent === undefined ? {} : { agent: startAgent }),
 				});
 			}
 		}

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -515,6 +515,8 @@ export interface NativeStartRequest extends NativeUntrackedSelectionRequest {
 	focus?: string;
 	targetIdentity?: string;
 	projection?: "workspace" | "staged";
+	/** Omit to use Pi; explicitly pass undefined for a typed agentless fallback. */
+	agent?: "pi";
 	signal?: AbortSignal;
 }
 export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "declined" } as const;
@@ -2130,6 +2132,9 @@ function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): 
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
 	const lineageId = optionalConsentLineageOption(arguments_);
+	if (request.consent.schema === "gentle-ai.review-integration.consent/v3" && request.consent.agent === "pi" && exactConsentOption(arguments_, "--agent") !== "pi") {
+		throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
+	}
 	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");
 	return { arguments_, ...(lineageId === undefined ? {} : { lineageId }) };
 }
@@ -2369,6 +2374,8 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		if (request.baseRef !== undefined && request.committedOnly !== true) throw new TypeError("Native START baseRef requires explicit committedOnly acknowledgement");
 		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native START committedOnly requires an explicit baseRef");
 		if (request.targetIdentity !== undefined && !/^sha256:[0-9a-f]{64}$/.test(request.targetIdentity)) throw new TypeError("Native START targetIdentity must be a canonical sha256 identity");
+		const agent = Object.prototype.hasOwnProperty.call(request, "agent") ? request.agent : "pi";
+		if (agent !== undefined && agent !== "pi") throw new TypeError("Native START agent is unsupported");
 		// STATUS owns the candidate binding and renders the only executable START
 		// vector. Callers may supply a previously observed identity only to detect
 		// drift; Pi never rebuilds that vector from request fields.
@@ -2380,7 +2387,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			...(request.baseRef === undefined ? {} : { baseRef: request.baseRef }),
 			...(request.lineageId === undefined ? {} : { lineageId: request.lineageId }),
 			...selection,
-			agent: "pi",
+			...(agent === undefined ? {} : { agent }),
 			...(request.signal === undefined ? {} : { signal: request.signal }),
 		});
 		const transition = status.nextTransition?.kind === "execute" && status.nextTransition.execute?.operation === "review.start"
@@ -2409,7 +2416,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => (
 				execution.body.schema === "gentle-ai.review-integration.consent/v2"
 					? decodeReviewConsentV2(execution.body)
-					: decodeReviewConsentV3(execution.body, "pi")
+					: decodeReviewConsentV3(execution.body, agent)
 			));
 			if (consent.targetIdentity !== targetIdentity || consent.projection !== projection) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent target binding mismatch");
 			throw new NativeReviewConsentRequiredError(consent);

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -2064,6 +2064,34 @@ function exactConsentOption(arguments_: readonly string[], name: string): string
 	}
 }
 
+function consentInvocationAgentOptions(arguments_: readonly string[]): readonly string[] {
+	const values: string[] = [];
+	for (let index = 0; index < arguments_.length; index += 1) {
+		const token = arguments_[index]!;
+		if (token === "--agent") {
+			const value = arguments_[index + 1];
+			if (value === undefined || value.length === 0 || value.startsWith("--")) throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native consent invocation agent binding changed");
+			values.push(value);
+			index += 1;
+		} else if (token.startsWith("--agent=")) values.push(token.slice("--agent=".length));
+	}
+	return values;
+}
+
+/** Validates every v3 provider choice against the negotiated START transport. */
+export function validateNativeReviewConsentAgentBinding(consent: ReviewConsentEnvelope, startAgent: "pi" | undefined): void {
+	if (consent.schema !== "gentle-ai.review-integration.consent/v3") return;
+	if (consent.agent !== "pi") throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent envelope agent binding changed");
+	for (const choice of consent.choices) {
+		const agentOptions = consentInvocationAgentOptions(splitNativeConsentInvocation(choice.invocation));
+		if (startAgent === "pi") {
+			if (agentOptions.length !== 1 || agentOptions[0] !== "pi") throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
+		} else if (agentOptions.length !== 0) {
+			throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native agentless consent invocation must not bind an agent");
+		}
+	}
+}
+
 function optionalConsentLineageOption(arguments_: readonly string[]): string | undefined {
 	const values: string[] = [];
 	for (let index = 0; index < arguments_.length; index += 1) {
@@ -2089,6 +2117,7 @@ interface ConsentInvocation {
 
 function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): ConsentInvocation {
 	if (request.startAgent !== undefined && request.startAgent !== "pi") throw new TypeError("Native consent START transport is unsupported");
+	validateNativeReviewConsentAgentBinding(request.consent, request.startAgent);
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
 	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
@@ -2099,9 +2128,6 @@ function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): 
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
 	const lineageId = optionalConsentLineageOption(arguments_);
-	if (request.consent.schema === "gentle-ai.review-integration.consent/v3" && request.startAgent === "pi" && exactConsentOption(arguments_, "--agent") !== "pi") {
-		throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
-	}
 	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");
 	return { arguments_, ...(lineageId === undefined ? {} : { lineageId }) };
 }

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -524,7 +524,14 @@ export interface NativeStartRequest extends NativeUntrackedSelectionRequest {
 }
 export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "declined" } as const;
 export type NativeReviewConsentAnswer = (typeof NATIVE_REVIEW_CONSENT_ANSWER)[keyof typeof NATIVE_REVIEW_CONSENT_ANSWER];
-export interface NativeReviewConsentAnswerRequest { cwd: string; consent: ReviewConsentEnvelope; answer: NativeReviewConsentAnswer; signal?: AbortSignal; }
+export interface NativeReviewConsentAnswerRequest {
+	cwd: string;
+	consent: ReviewConsentEnvelope;
+	answer: NativeReviewConsentAnswer;
+	/** The selected START transport; undefined is the typed agentless fallback. */
+	startAgent: "pi" | undefined;
+	signal?: AbortSignal;
+}
 export interface NativeReviewConsentDeclinedResult {
 	kind: "declined";
 	targetIdentity: string;
@@ -2081,6 +2088,7 @@ interface ConsentInvocation {
 }
 
 function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): ConsentInvocation {
+	if (request.startAgent !== undefined && request.startAgent !== "pi") throw new TypeError("Native consent START transport is unsupported");
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
 	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
@@ -2091,7 +2099,7 @@ function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): 
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
 	const lineageId = optionalConsentLineageOption(arguments_);
-	if (request.consent.schema === "gentle-ai.review-integration.consent/v3" && request.consent.agent === "pi" && exactConsentOption(arguments_, "--agent") !== "pi") {
+	if (request.consent.schema === "gentle-ai.review-integration.consent/v3" && request.startAgent === "pi" && exactConsentOption(arguments_, "--agent") !== "pi") {
 		throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
 	}
 	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -14,6 +14,8 @@ import {
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
 	decodeReviewAdvisoryFindingsV1,
+	exactReviewConsentOption,
+	splitReviewConsentInvocation,
 	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewRepairV2,
@@ -86,6 +88,7 @@ export const NATIVE_REVIEW_ERROR_CODE = {
 	CANCELLED: "cancelled",
 	PACKAGE_BINARY_MISSING: "package-local-binary-missing",
 	UNSUPPORTED_TRANSITION_OPERATION: "unsupported-transition-operation",
+	IMMUTABLE_REVIEW_TRANSPORT_UNSUPPORTED: "immutable_review_transport_unsupported",
 } as const;
 export type NativeReviewErrorCode = (typeof NATIVE_REVIEW_ERROR_CODE)[keyof typeof NATIVE_REVIEW_ERROR_CODE];
 
@@ -2039,63 +2042,19 @@ export class NativeReviewConsentBindingError extends Error {
 }
 
 function splitNativeConsentInvocation(invocation: string): readonly string[] {
-	const words: string[] = [];
-	let current = "";
-	let quote: "'" | '"' | undefined;
-	let escaping = false;
-	let started = false;
-	for (const character of invocation.trim()) {
-		if (escaping) {
-			current += character;
-			escaping = false;
-			started = true;
-			continue;
-		}
-		if (character === "\\" && quote !== "'") {
-			escaping = true;
-			started = true;
-			continue;
-		}
-		if (quote !== undefined) {
-			if (character === quote) quote = undefined;
-			else current += character;
-			started = true;
-			continue;
-		}
-		if (character === "'" || character === '"') {
-			quote = character;
-			started = true;
-			continue;
-		}
-		if (/\s/.test(character)) {
-			if (started) {
-				words.push(current);
-				current = "";
-				started = false;
-			}
-			continue;
-		}
-		current += character;
-		started = true;
+	try {
+		return splitReviewConsentInvocation(invocation);
+	} catch (cause) {
+		throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", cause instanceof Error ? cause.message : "Native consent invocation has invalid quoting");
 	}
-	if (quote !== undefined || escaping) throw new TypeError("Native consent invocation has invalid quoting");
-	if (started) words.push(current);
-	return words;
 }
 
 function exactConsentOption(arguments_: readonly string[], name: string): string {
-	const values: string[] = [];
-	for (let index = 0; index < arguments_.length; index += 1) {
-		const token = arguments_[index]!;
-		if (token === name) {
-			const value = arguments_[index + 1];
-			if (value === undefined) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", `Native consent invocation ${name} is missing its value`);
-			values.push(value);
-			index += 1;
-		} else if (token.startsWith(`${name}=`)) values.push(token.slice(name.length + 1));
+	try {
+		return exactReviewConsentOption(arguments_, name);
+	} catch (cause) {
+		throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", cause instanceof Error ? cause.message : `Native consent invocation requires exactly one ${name}`);
 	}
-	if (values.length !== 1) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", `Native consent invocation requires exactly one ${name}`);
-	return values[0]!;
 }
 
 function optionalConsentLineageOption(arguments_: readonly string[]): string | undefined {

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1901,7 +1901,7 @@ export function decodeReviewConsentV3(value: unknown, expectedAgent?: ReviewCons
 	const agent = enumeration(body.agent, Object.values(REVIEW_CONSENT_AGENT_V3), "consent.agent") as ReviewConsentAgentV3;
 	if (expectedAgent !== undefined && agent !== expectedAgent) throw new TypeError("consent.agent does not match the expected runtime binding");
 	const semantics = decodeConsentSemantics(body);
-	if (agent === "pi" && semantics.choices.some((choice) => !choice.invocation.includes(" --agent pi "))) {
+	if (expectedAgent === "pi" && semantics.choices.some((choice) => !choice.invocation.includes(" --agent pi "))) {
 		throw new TypeError("consent Pi invocation must bind agent");
 	}
 	return {

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1889,6 +1889,77 @@ export function decodeReviewConsentV2(value: unknown): ReviewConsentV2 {
 	};
 }
 
+// Tokenize the provider-owned shell-like invocation without executing it. This
+// parser is shared with the native CLI so consent/v3 decode and follow-up use
+// the same exact option-boundary and duplicate semantics.
+export function splitReviewConsentInvocation(invocation: string): readonly string[] {
+	const words: string[] = [];
+	let current = "";
+	let quote: "'" | '"' | undefined;
+	let escaping = false;
+	let started = false;
+	for (const character of invocation.trim()) {
+		if (escaping) {
+			current += character;
+			escaping = false;
+			started = true;
+			continue;
+		}
+		if (character === "\\" && quote !== "'") {
+			escaping = true;
+			started = true;
+			continue;
+		}
+		if (quote !== undefined) {
+			if (character === quote) quote = undefined;
+			else current += character;
+			started = true;
+			continue;
+		}
+		if (character === "'" || character === '"') {
+			quote = character;
+			started = true;
+			continue;
+		}
+		if (/\s/.test(character)) {
+			if (started) {
+				words.push(current);
+				current = "";
+				started = false;
+			}
+			continue;
+		}
+		current += character;
+		started = true;
+	}
+	if (quote !== undefined || escaping) throw new TypeError("Review consent invocation has invalid quoting");
+	if (started) words.push(current);
+	return words;
+}
+
+export function exactReviewConsentOption(arguments_: readonly string[], name: string): string {
+	const values: string[] = [];
+	for (let index = 0; index < arguments_.length; index += 1) {
+		const token = arguments_[index]!;
+		if (token === name) {
+			const value = arguments_[index + 1];
+			if (value === undefined) throw new TypeError(`Review consent invocation ${name} is missing its value`);
+			values.push(value);
+			index += 1;
+		} else if (token.startsWith(`${name}=`)) values.push(token.slice(name.length + 1));
+	}
+	if (values.length !== 1) throw new TypeError(`Review consent invocation requires exactly one ${name}`);
+	return values[0]!;
+}
+
+function hasExactReviewConsentOption(invocation: string, name: string, expected: string): boolean {
+	try {
+		return exactReviewConsentOption(splitReviewConsentInvocation(invocation).slice(1), name) === expected;
+	} catch {
+		return false;
+	}
+}
+
 // consent/v3 (gentle-ai >= 2.3.0): the v2 surface plus the required, fixed
 // `agent` runtime binding. Ground truth is the captured envelope from a
 // 2.4.0-main binary (tests/fixtures/devbinary/consent-v3.captured.json) plus
@@ -1901,7 +1972,7 @@ export function decodeReviewConsentV3(value: unknown, expectedAgent?: ReviewCons
 	const agent = enumeration(body.agent, Object.values(REVIEW_CONSENT_AGENT_V3), "consent.agent") as ReviewConsentAgentV3;
 	if (expectedAgent !== undefined && agent !== expectedAgent) throw new TypeError("consent.agent does not match the expected runtime binding");
 	const semantics = decodeConsentSemantics(body);
-	if (expectedAgent === "pi" && semantics.choices.some((choice) => !choice.invocation.includes(" --agent pi "))) {
+	if (expectedAgent === "pi" && semantics.choices.some((choice) => !hasExactReviewConsentOption(choice.invocation, "--agent", "pi"))) {
 		throw new TypeError("consent Pi invocation must bind agent");
 	}
 	return {

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1893,19 +1893,21 @@ export function decodeReviewConsentV2(value: unknown): ReviewConsentV2 {
 // `agent` runtime binding. Ground truth is the captured envelope from a
 // 2.4.0-main binary (tests/fixtures/devbinary/consent-v3.captured.json) plus
 // gentle-ai main contracts/review-integration/v2/schemas/consent-v3.schema.json.
-// The choice-invocation shape deliberately stays the shared v2 pattern: the
-// published v3 schema demands an `--agent claude-code` token that the live
-// emitter omits when the caller declared no --agent, so the capture is
-// authoritative and Pi replays whichever provider-owned invocation arrived.
+// Agentless fallbacks retain the provider-owned invocation, while Pi-bound
+// envelopes must carry the provider-issued Pi binding exactly.
 export function decodeReviewConsentV3(value: unknown, expectedAgent?: ReviewConsentAgentV3): ReviewConsentV3 {
 	const body = exactRecord(value, "consent", [...CONSENT_KEYS_V2, "agent"]);
 	requireIdentity(body, "gentle-ai.review-integration.consent/v3", "review.start");
 	const agent = enumeration(body.agent, Object.values(REVIEW_CONSENT_AGENT_V3), "consent.agent") as ReviewConsentAgentV3;
 	if (expectedAgent !== undefined && agent !== expectedAgent) throw new TypeError("consent.agent does not match the expected runtime binding");
+	const semantics = decodeConsentSemantics(body);
+	if (agent === "pi" && semantics.choices.some((choice) => !choice.invocation.includes(" --agent pi "))) {
+		throw new TypeError("consent Pi invocation must bind agent");
+	}
 	return {
 		schema: "gentle-ai.review-integration.consent/v3",
 		agent,
-		...decodeConsentSemantics(body),
+		...semantics,
 		raw: body,
 	};
 }

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -2131,6 +2131,9 @@ function consentInvocationArguments(request                                  )  
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
 	const lineageId = optionalConsentLineageOption(arguments_);
+	if (request.consent.schema === "gentle-ai.review-integration.consent/v3" && request.consent.agent === "pi" && exactConsentOption(arguments_, "--agent") !== "pi") {
+		throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
+	}
 	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");
 	return { arguments_, ...(lineageId === undefined ? {} : { lineageId }) };
 }
@@ -2370,6 +2373,8 @@ export class NativeReviewCliV216                            {
 		if (request.baseRef !== undefined && request.committedOnly !== true) throw new TypeError("Native START baseRef requires explicit committedOnly acknowledgement");
 		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native START committedOnly requires an explicit baseRef");
 		if (request.targetIdentity !== undefined && !/^sha256:[0-9a-f]{64}$/.test(request.targetIdentity)) throw new TypeError("Native START targetIdentity must be a canonical sha256 identity");
+		const agent = Object.prototype.hasOwnProperty.call(request, "agent") ? request.agent : "pi";
+		if (agent !== undefined && agent !== "pi") throw new TypeError("Native START agent is unsupported");
 		// STATUS owns the candidate binding and renders the only executable START
 		// vector. Callers may supply a previously observed identity only to detect
 		// drift; Pi never rebuilds that vector from request fields.
@@ -2381,7 +2386,7 @@ export class NativeReviewCliV216                            {
 			...(request.baseRef === undefined ? {} : { baseRef: request.baseRef }),
 			...(request.lineageId === undefined ? {} : { lineageId: request.lineageId }),
 			...selection,
-			agent: "pi",
+			...(agent === undefined ? {} : { agent }),
 			...(request.signal === undefined ? {} : { signal: request.signal }),
 		});
 		const transition = status.nextTransition?.kind === "execute" && status.nextTransition.execute?.operation === "review.start"
@@ -2410,7 +2415,7 @@ export class NativeReviewCliV216                            {
 			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => (
 				execution.body.schema === "gentle-ai.review-integration.consent/v2"
 					? decodeReviewConsentV2(execution.body)
-					: decodeReviewConsentV3(execution.body, "pi")
+					: decodeReviewConsentV3(execution.body, agent)
 			));
 			if (consent.targetIdentity !== targetIdentity || consent.projection !== projection) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent target binding mismatch");
 			throw new NativeReviewConsentRequiredError(consent);

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -518,6 +518,8 @@ export const NATIVE_UNTRACKED_SCOPE = {
 
 
 
+
+
 export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "declined" }         ;
 
 

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -15,6 +15,8 @@ import {
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
 	decodeReviewAdvisoryFindingsV1,
+	exactReviewConsentOption,
+	splitReviewConsentInvocation,
 	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewRepairV2,
@@ -87,6 +89,7 @@ export const NATIVE_REVIEW_ERROR_CODE = {
 	CANCELLED: "cancelled",
 	PACKAGE_BINARY_MISSING: "package-local-binary-missing",
 	UNSUPPORTED_TRANSITION_OPERATION: "unsupported-transition-operation",
+	IMMUTABLE_REVIEW_TRANSPORT_UNSUPPORTED: "immutable_review_transport_unsupported",
 }         ;
 
 
@@ -2040,63 +2043,19 @@ export class NativeReviewConsentBindingError extends Error {
 }
 
 function splitNativeConsentInvocation(invocation        )                    {
-	const words           = [];
-	let current = "";
-	let quote                       ;
-	let escaping = false;
-	let started = false;
-	for (const character of invocation.trim()) {
-		if (escaping) {
-			current += character;
-			escaping = false;
-			started = true;
-			continue;
-		}
-		if (character === "\\" && quote !== "'") {
-			escaping = true;
-			started = true;
-			continue;
-		}
-		if (quote !== undefined) {
-			if (character === quote) quote = undefined;
-			else current += character;
-			started = true;
-			continue;
-		}
-		if (character === "'" || character === '"') {
-			quote = character;
-			started = true;
-			continue;
-		}
-		if (/\s/.test(character)) {
-			if (started) {
-				words.push(current);
-				current = "";
-				started = false;
-			}
-			continue;
-		}
-		current += character;
-		started = true;
+	try {
+		return splitReviewConsentInvocation(invocation);
+	} catch (cause) {
+		throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", cause instanceof Error ? cause.message : "Native consent invocation has invalid quoting");
 	}
-	if (quote !== undefined || escaping) throw new TypeError("Native consent invocation has invalid quoting");
-	if (started) words.push(current);
-	return words;
 }
 
 function exactConsentOption(arguments_                   , name        )         {
-	const values           = [];
-	for (let index = 0; index < arguments_.length; index += 1) {
-		const token = arguments_[index] ;
-		if (token === name) {
-			const value = arguments_[index + 1];
-			if (value === undefined) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", `Native consent invocation ${name} is missing its value`);
-			values.push(value);
-			index += 1;
-		} else if (token.startsWith(`${name}=`)) values.push(token.slice(name.length + 1));
+	try {
+		return exactReviewConsentOption(arguments_, name);
+	} catch (cause) {
+		throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", cause instanceof Error ? cause.message : `Native consent invocation requires exactly one ${name}`);
 	}
-	if (values.length !== 1) throw new NativeReviewConsentBindingError("consent-invocation-option-invalid", `Native consent invocation requires exactly one ${name}`);
-	return values[0] ;
 }
 
 function optionalConsentLineageOption(arguments_                   )                     {

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -2065,6 +2065,34 @@ function exactConsentOption(arguments_                   , name        )        
 	}
 }
 
+function consentInvocationAgentOptions(arguments_                   )                    {
+	const values           = [];
+	for (let index = 0; index < arguments_.length; index += 1) {
+		const token = arguments_[index] ;
+		if (token === "--agent") {
+			const value = arguments_[index + 1];
+			if (value === undefined || value.length === 0 || value.startsWith("--")) throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native consent invocation agent binding changed");
+			values.push(value);
+			index += 1;
+		} else if (token.startsWith("--agent=")) values.push(token.slice("--agent=".length));
+	}
+	return values;
+}
+
+/** Validates every v3 provider choice against the negotiated START transport. */
+export function validateNativeReviewConsentAgentBinding(consent                       , startAgent                  )       {
+	if (consent.schema !== "gentle-ai.review-integration.consent/v3") return;
+	if (consent.agent !== "pi") throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent envelope agent binding changed");
+	for (const choice of consent.choices) {
+		const agentOptions = consentInvocationAgentOptions(splitNativeConsentInvocation(choice.invocation));
+		if (startAgent === "pi") {
+			if (agentOptions.length !== 1 || agentOptions[0] !== "pi") throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
+		} else if (agentOptions.length !== 0) {
+			throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native agentless consent invocation must not bind an agent");
+		}
+	}
+}
+
 function optionalConsentLineageOption(arguments_                   )                     {
 	const values           = [];
 	for (let index = 0; index < arguments_.length; index += 1) {
@@ -2090,6 +2118,7 @@ function optionalConsentLineageOption(arguments_                   )            
 
 function consentInvocationArguments(request                                  )                    {
 	if (request.startAgent !== undefined && request.startAgent !== "pi") throw new TypeError("Native consent START transport is unsupported");
+	validateNativeReviewConsentAgentBinding(request.consent, request.startAgent);
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
 	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
@@ -2100,9 +2129,6 @@ function consentInvocationArguments(request                                  )  
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
 	const lineageId = optionalConsentLineageOption(arguments_);
-	if (request.consent.schema === "gentle-ai.review-integration.consent/v3" && request.startAgent === "pi" && exactConsentOption(arguments_, "--agent") !== "pi") {
-		throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
-	}
 	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");
 	return { arguments_, ...(lineageId === undefined ? {} : { lineageId }) };
 }

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -554,6 +554,13 @@ export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "dec
 
 
 
+
+
+
+
+
+
+
 // gentle-pi#311 P5: the provider-driven FINALIZE. `argumentTokens` are the
 // exact rendered tokens of one provider-returned `review.finalize` execute
 // transition (e.g. `--lineage=<id> --captured-results=true`), passed through
@@ -2082,6 +2089,7 @@ function optionalConsentLineageOption(arguments_                   )            
 
 
 function consentInvocationArguments(request                                  )                    {
+	if (request.startAgent !== undefined && request.startAgent !== "pi") throw new TypeError("Native consent START transport is unsupported");
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
 	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
@@ -2092,7 +2100,7 @@ function consentInvocationArguments(request                                  )  
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
 	const lineageId = optionalConsentLineageOption(arguments_);
-	if (request.consent.schema === "gentle-ai.review-integration.consent/v3" && request.consent.agent === "pi" && exactConsentOption(arguments_, "--agent") !== "pi") {
+	if (request.consent.schema === "gentle-ai.review-integration.consent/v3" && request.startAgent === "pi" && exactConsentOption(arguments_, "--agent") !== "pi") {
 		throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
 	}
 	if (exactConsentOption(arguments_, "--consent") !== request.answer || arguments_.at(-1) !== request.answer) throw new NativeReviewConsentBindingError("consent-invocation-answer-changed", "Native consent invocation answer binding changed");

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1902,7 +1902,7 @@ export function decodeReviewConsentV3(value         , expectedAgent             
 	const agent = enumeration(body.agent, Object.values(REVIEW_CONSENT_AGENT_V3), "consent.agent")                        ;
 	if (expectedAgent !== undefined && agent !== expectedAgent) throw new TypeError("consent.agent does not match the expected runtime binding");
 	const semantics = decodeConsentSemantics(body);
-	if (agent === "pi" && semantics.choices.some((choice) => !choice.invocation.includes(" --agent pi "))) {
+	if (expectedAgent === "pi" && semantics.choices.some((choice) => !choice.invocation.includes(" --agent pi "))) {
 		throw new TypeError("consent Pi invocation must bind agent");
 	}
 	return {

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1890,6 +1890,77 @@ export function decodeReviewConsentV2(value         )                  {
 	};
 }
 
+// Tokenize the provider-owned shell-like invocation without executing it. This
+// parser is shared with the native CLI so consent/v3 decode and follow-up use
+// the same exact option-boundary and duplicate semantics.
+export function splitReviewConsentInvocation(invocation        )                    {
+	const words           = [];
+	let current = "";
+	let quote                       ;
+	let escaping = false;
+	let started = false;
+	for (const character of invocation.trim()) {
+		if (escaping) {
+			current += character;
+			escaping = false;
+			started = true;
+			continue;
+		}
+		if (character === "\\" && quote !== "'") {
+			escaping = true;
+			started = true;
+			continue;
+		}
+		if (quote !== undefined) {
+			if (character === quote) quote = undefined;
+			else current += character;
+			started = true;
+			continue;
+		}
+		if (character === "'" || character === '"') {
+			quote = character;
+			started = true;
+			continue;
+		}
+		if (/\s/.test(character)) {
+			if (started) {
+				words.push(current);
+				current = "";
+				started = false;
+			}
+			continue;
+		}
+		current += character;
+		started = true;
+	}
+	if (quote !== undefined || escaping) throw new TypeError("Review consent invocation has invalid quoting");
+	if (started) words.push(current);
+	return words;
+}
+
+export function exactReviewConsentOption(arguments_                   , name        )         {
+	const values           = [];
+	for (let index = 0; index < arguments_.length; index += 1) {
+		const token = arguments_[index] ;
+		if (token === name) {
+			const value = arguments_[index + 1];
+			if (value === undefined) throw new TypeError(`Review consent invocation ${name} is missing its value`);
+			values.push(value);
+			index += 1;
+		} else if (token.startsWith(`${name}=`)) values.push(token.slice(name.length + 1));
+	}
+	if (values.length !== 1) throw new TypeError(`Review consent invocation requires exactly one ${name}`);
+	return values[0] ;
+}
+
+function hasExactReviewConsentOption(invocation        , name        , expected        )          {
+	try {
+		return exactReviewConsentOption(splitReviewConsentInvocation(invocation).slice(1), name) === expected;
+	} catch {
+		return false;
+	}
+}
+
 // consent/v3 (gentle-ai >= 2.3.0): the v2 surface plus the required, fixed
 // `agent` runtime binding. Ground truth is the captured envelope from a
 // 2.4.0-main binary (tests/fixtures/devbinary/consent-v3.captured.json) plus
@@ -1902,7 +1973,7 @@ export function decodeReviewConsentV3(value         , expectedAgent             
 	const agent = enumeration(body.agent, Object.values(REVIEW_CONSENT_AGENT_V3), "consent.agent")                        ;
 	if (expectedAgent !== undefined && agent !== expectedAgent) throw new TypeError("consent.agent does not match the expected runtime binding");
 	const semantics = decodeConsentSemantics(body);
-	if (expectedAgent === "pi" && semantics.choices.some((choice) => !choice.invocation.includes(" --agent pi "))) {
+	if (expectedAgent === "pi" && semantics.choices.some((choice) => !hasExactReviewConsentOption(choice.invocation, "--agent", "pi"))) {
 		throw new TypeError("consent Pi invocation must bind agent");
 	}
 	return {

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1894,19 +1894,21 @@ export function decodeReviewConsentV2(value         )                  {
 // `agent` runtime binding. Ground truth is the captured envelope from a
 // 2.4.0-main binary (tests/fixtures/devbinary/consent-v3.captured.json) plus
 // gentle-ai main contracts/review-integration/v2/schemas/consent-v3.schema.json.
-// The choice-invocation shape deliberately stays the shared v2 pattern: the
-// published v3 schema demands an `--agent claude-code` token that the live
-// emitter omits when the caller declared no --agent, so the capture is
-// authoritative and Pi replays whichever provider-owned invocation arrived.
+// Agentless fallbacks retain the provider-owned invocation, while Pi-bound
+// envelopes must carry the provider-issued Pi binding exactly.
 export function decodeReviewConsentV3(value         , expectedAgent                       )                  {
 	const body = exactRecord(value, "consent", [...CONSENT_KEYS_V2, "agent"]);
 	requireIdentity(body, "gentle-ai.review-integration.consent/v3", "review.start");
 	const agent = enumeration(body.agent, Object.values(REVIEW_CONSENT_AGENT_V3), "consent.agent")                        ;
 	if (expectedAgent !== undefined && agent !== expectedAgent) throw new TypeError("consent.agent does not match the expected runtime binding");
+	const semantics = decodeConsentSemantics(body);
+	if (agent === "pi" && semantics.choices.some((choice) => !choice.invocation.includes(" --agent pi "))) {
+		throw new TypeError("consent Pi invocation must bind agent");
+	}
 	return {
 		schema: "gentle-ai.review-integration.consent/v3",
 		agent,
-		...decodeConsentSemantics(body),
+		...semantics,
 		raw: body,
 	};
 }

--- a/tests/fixtures/review-host-relay-restart-worker.mjs
+++ b/tests/fixtures/review-host-relay-restart-worker.mjs
@@ -29,7 +29,7 @@
 //                  statusCalls, finalizeCalls } as JSON for the parent.
 
 import { join } from "node:path";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, realpath, writeFile } from "node:fs/promises";
 
 const cwd = process.argv[2];
 const statusFile = process.argv[3];
@@ -40,6 +40,7 @@ if (!cwd || !statusFile || !mode || !outFile) {
 }
 
 const { __testing } = await import(join(import.meta.dirname, "..", "..", "extensions", "gentle-ai.ts"));
+const { CandidateViewRegistry } = await import(join(import.meta.dirname, "..", "..", "lib", "review-candidate-view.ts"));
 const { ReviewHostRelayError, REVIEW_HOST_RELAY_FAILURE } = await import(join(import.meta.dirname, "..", "..", "lib", "review-host-relay.ts"));
 
 const statusQueue = JSON.parse(await readFile(statusFile, "utf8"));
@@ -95,7 +96,7 @@ const parameters = mode === "inspect"
 let result;
 let error;
 try {
-	result = await __testing.executeReviewControllerOperation(parameters, cwd, new Map(), nativeReviewCli);
+	result = await __testing.executeReviewControllerOperation(parameters, await realpath(cwd), nativeReviewCli, undefined, new CandidateViewRegistry());
 } catch (caught) {
 	error = caught instanceof Error ? { name: caught.name, message: caught.message } : String(caught);
 }

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -347,6 +347,30 @@ function piConsent(): Record<string, unknown> {
 	return consent;
 }
 
+test("decodeReviewConsentV3 accepts exact Pi agent tokens and rejects missing, embedded, duplicate, or conflicting bindings", async () => {
+	const { decodeReviewConsentV3 } = await import("../lib/review-integration-v2.ts");
+	const mutateInvocations = (replace: (invocation: string) => string): Record<string, unknown> => {
+		const consent = piConsent();
+		for (const choice of consent.choices as Array<Record<string, unknown>>) choice.invocation = replace(String(choice.invocation));
+		return consent;
+	};
+
+	assert.doesNotThrow(() => decodeReviewConsentV3(piConsent(), "pi"), "the separate --agent pi form is Pi-bound");
+	assert.doesNotThrow(
+		() => decodeReviewConsentV3(mutateInvocations((invocation) => invocation.replace("--agent pi", "--agent=pi")), "pi"),
+		"the --agent=pi form is Pi-bound",
+	);
+	for (const [label, consent] of [
+		["quoted text", mutateInvocations((invocation) => invocation.replace("--agent pi", "--note \"--agent pi\""))],
+		["another argument value", mutateInvocations((invocation) => invocation.replace("--agent pi", "--note=--agent\\ pi"))],
+		["missing", mutateInvocations((invocation) => invocation.replace(" --agent pi", ""))],
+		["duplicate", mutateInvocations((invocation) => invocation.replace("--agent pi", "--agent pi --agent pi"))],
+		["conflicting", mutateInvocations((invocation) => invocation.replace("--agent pi", "--agent pi --agent claude"))],
+	] as const) {
+		assert.throws(() => decodeReviewConsentV3(consent, "pi"), /Pi invocation must bind agent/, `${label} --agent text must not satisfy the Pi binding`);
+	}
+});
+
 test("Pi START rejects a foreign consent/v3 envelope and only relays a Pi-bound clone", async () => {
 	const consent = devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json");
 	const target = String(consent.target_identity);

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -449,7 +449,7 @@ test("Pi START rejects a foreign consent/v3 envelope and only relays a Pi-bound 
 });
 
 test("a granted consent/v3 answer decodes the captured start/v3 result with its event binding", async () => {
-	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json"));
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(agentlessPiConsent());
 	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
 	const started = devbinaryFixture<Record<string, unknown>>("start-v3-consent-granted.captured.json");
 	const queue = queuedAdapter([capabilities(), started]);
@@ -468,7 +468,7 @@ test("a granted consent/v3 answer decodes the captured start/v3 result with its 
 });
 
 test("a declined consent/v3 answer accepts the captured declined result and creates no authority", async () => {
-	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json"));
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(agentlessPiConsent());
 	const cwd = decoded.choices[1].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
 	const declined = devbinaryFixture<Record<string, unknown>>("start-v3-consent-declined.captured.json");
 	const queue = queuedAdapter([capabilities(), declined]);
@@ -477,6 +477,68 @@ test("a declined consent/v3 answer accepts the captured declined result and crea
 	assert.ok(result.kind === "declined");
 	assert.equal(result.consent, "declined_this_candidate");
 	assert.equal(result.targetIdentity, decoded.targetIdentity);
+});
+
+test("agentless v3 consent rejects every tokenized agent option before provider launch", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(agentlessPiConsent()) as ReviewConsentV3;
+	const drifted = (replace: (invocation: string) => string): ReviewConsentV3 => {
+		const consent = structuredClone(decoded);
+		for (const choice of consent.choices) choice.invocation = replace(choice.invocation);
+		return consent;
+	};
+	const cases = [
+		["separate Pi", drifted((invocation) => invocation.replace(" --consent ", " --agent pi --consent "))],
+		["equals Pi", drifted((invocation) => invocation.replace(" --consent ", " --agent=pi --consent "))],
+		["foreign", drifted((invocation) => invocation.replace(" --consent ", " --agent claude-code --consent "))],
+		["duplicate", drifted((invocation) => invocation.replace(" --consent ", " --agent pi --agent pi --consent "))],
+		["conflicting", drifted((invocation) => invocation.replace(" --consent ", " --agent pi --agent=claude-code --consent "))],
+	] as const;
+	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
+	for (const [label, consent] of cases) {
+		for (const createClient of [client, runtimeClient]) {
+			const queue = queuedAdapter([]);
+			await assert.rejects(
+				() => createClient(queue.adapter).answerConsent({ cwd, consent, answer: "granted", startAgent: undefined }),
+				(error: unknown) => {
+					assert.equal((error as { name?: string }).name, "NativeReviewConsentBindingError", `${label} must be rejected locally`);
+					assert.equal((error as { reason?: string }).reason, "consent-invocation-agent-changed");
+					assert.equal((error as { launchAttempted?: boolean }).launchAttempted, false);
+					assert.equal((error as { mutationOutcome?: string }).mutationOutcome, "none");
+					return true;
+				},
+			);
+			assert.deepEqual(queue.calls, [], `${label} must not launch the provider`);
+		}
+	}
+});
+
+test("Pi v3 consent validates every choice before provider launch", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(piConsent(), "pi") as ReviewConsentV3;
+	const declined = decoded.choices.find((choice) => choice.answer === "declined")!;
+	declined.invocation = declined.invocation.replace("--agent pi", "--agent pi --agent pi");
+	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
+	const queue = queuedAdapter([]);
+	await assert.rejects(
+		() => client(queue.adapter).answerConsent({ cwd, consent: decoded, answer: "granted", startAgent: "pi" }),
+		(error: unknown) => (error as { reason?: string }).reason === "consent-invocation-agent-changed",
+	);
+	assert.deepEqual(queue.calls, [], "an invalid unselected choice must still prevent provider launch");
+});
+
+test("agentless v3 consent ignores quoted or embedded --agent text", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(agentlessPiConsent()) as ReviewConsentV3;
+	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
+	for (const replace of [
+		(invocation: string) => invocation.replace(" --consent ", " --note \"--agent pi\" --consent "),
+		(invocation: string) => invocation.replace(" --consent ", " --note=--agent\\ pi --consent "),
+	]) {
+		const consent = structuredClone(decoded);
+		for (const choice of consent.choices) choice.invocation = replace(choice.invocation);
+		const queue = queuedAdapter([capabilities(), devbinaryFixture<Record<string, unknown>>("start-v3-consent-granted.captured.json")]);
+		const result = await client(queue.adapter).answerConsent({ cwd, consent, answer: "granted", startAgent: undefined });
+		assert.equal(result.kind, "started");
+		assert.equal(queue.calls.filter((arguments_) => arguments_[0] === "review" && arguments_[1] === "start").length, 1);
+	}
 });
 
 test("agentless v3 Pi consent replays its exact provider invocation when the START transport fell back", async () => {

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -148,7 +148,7 @@ test("consent follow-up executes the provider-named invocation exactly once and 
 	started.artifact_subjects = [];
 	const queue = queuedAdapter([capabilities(), started]);
 	const native = client(queue.adapter);
-	const result = await native.answerConsent!({ cwd: "/repo", consent: decodedConsent, answer: "granted" });
+	const result = await native.answerConsent!({ cwd: "/repo", consent: decodedConsent, answer: "granted", startAgent: undefined });
 	assert.equal(result.kind, "started");
 	assert.ok(result.kind === "started");
 	assert.equal(result.start.lineageId, preboundLineage);
@@ -156,7 +156,7 @@ test("consent follow-up executes the provider-named invocation exactly once and 
 	assert.equal(queue.calls.filter((arguments_) => arguments_.includes("granted")).length, 1);
 
 	const runtimeQueue = queuedAdapter([capabilities(), structuredClone(started)]);
-	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd: "/repo", consent: decodedConsent, answer: "granted" });
+	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd: "/repo", consent: decodedConsent, answer: "granted", startAgent: undefined });
 	assert.equal(runtimeResult.kind, "started");
 	assert.ok(runtimeResult.kind === "started");
 	assert.equal(runtimeResult.start.lineageId, preboundLineage);
@@ -165,7 +165,7 @@ test("consent follow-up executes the provider-named invocation exactly once and 
 	const changedLineage = JSON.parse(JSON.stringify(started).replaceAll(preboundLineage, "different-lineage")) as Record<string, unknown>;
 	const lineageQueue = queuedAdapter([capabilities(), changedLineage]);
 	await assert.rejects(
-		() => client(lineageQueue.adapter).answerConsent!({ cwd: "/repo", consent: decodedConsent, answer: "granted" }),
+		() => client(lineageQueue.adapter).answerConsent!({ cwd: "/repo", consent: decodedConsent, answer: "granted", startAgent: undefined }),
 		/lineage mismatch/,
 	);
 	assert.equal(lineageQueue.calls.filter((arguments_) => arguments_[0] === "review" && arguments_[1] === "start").length, 1);
@@ -173,9 +173,45 @@ test("consent follow-up executes the provider-named invocation exactly once and 
 	const changed = structuredClone(decodedConsent);
 	changed.targetIdentity = `sha256:${"b".repeat(64)}`;
 	await assert.rejects(
-		() => native.answerConsent!({ cwd: "/repo", consent: changed, answer: "declined" }),
+		() => native.answerConsent!({ cwd: "/repo", consent: changed, answer: "declined", startAgent: undefined }),
 		/target|binding/,
 	);
+});
+
+test("consent/v2 replays agentless provider invocations when negotiated START used Pi", async () => {
+const consent = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+const lineageId = "Review.Lineage_42";
+for (const choice of consent.choices) choice.invocation = choice.invocation.replace("review-consent-fixture", lineageId);
+const started = fixture<Record<string, unknown>>("start.fixture.json");
+started.lineage_id = lineageId;
+started.artifact_subjects = [];
+const declined = {
+operation: "review/start",
+action: "declined",
+lenses_required: false,
+lineage_id: "",
+state: "",
+risk_level: consent.riskLevel,
+selected_lenses: [],
+lens_bindings: [],
+projection: consent.projection,
+target_identity: consent.targetIdentity,
+changed_files: 1,
+changed_lines: 1,
+correction_budget: 0,
+risk_evidence: [],
+consent: "declined_this_candidate",
+};
+for (const [answer, outcome] of [["granted", started], ["declined", declined]] as const) {
+for (const createClient of [client, runtimeClient]) {
+const queue = queuedAdapter([capabilities(), structuredClone(outcome)]);
+const result = await createClient(queue.adapter).answerConsent({ cwd: "/repo", consent, answer, startAgent: "pi" });
+assert.equal(result.kind, answer === "granted" ? "started" : "declined");
+assert.deepEqual(queue.calls.at(-1), consent.choices.find((choice) => choice.answer === answer)!.invocation.split(" ").slice(1));
+assert.equal(queue.calls.at(-1)?.some((token) => token === "--agent" || token.startsWith("--agent=")), false, "v2 provider invocations stay agentless");
+assert.equal(queue.calls.filter((arguments_) => arguments_.at(-1) === answer).length, 1, "the provider-owned invocation replays exactly once");
+}
+}
 });
 
 // A binding mismatch is decided entirely inside Pi, before the provider is
@@ -184,7 +220,7 @@ test("a consent invocation binding mismatch is a typed pre-native error that nev
 	const consent = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
 	const queue = queuedAdapter([]);
 	await assert.rejects(
-		() => client(queue.adapter).answerConsent!({ cwd: "/repo/.git/gentle-ai/candidate-views/a1c7fdae", consent, answer: "granted" }),
+		() => client(queue.adapter).answerConsent!({ cwd: "/repo/.git/gentle-ai/candidate-views/a1c7fdae", consent, answer: "granted", startAgent: undefined }),
 		(error: unknown) => {
 			assert.ok(error instanceof NativeReviewConsentBindingError);
 			assert.equal(error.name, "NativeReviewConsentBindingError");
@@ -227,7 +263,7 @@ test("every consent invocation binding guard reports its own reason without laun
 	for (const scenario of cases) {
 		const queue = queuedAdapter([]);
 		await assert.rejects(
-			() => client(queue.adapter).answerConsent!({ cwd: "/repo", consent: scenario.consent, answer: "granted" }),
+			() => client(queue.adapter).answerConsent!({ cwd: "/repo", consent: scenario.consent, answer: "granted", startAgent: undefined }),
 			(error: unknown) => {
 				assert.ok(error instanceof NativeReviewConsentBindingError, `${scenario.reason} must be a typed binding error`);
 				assert.equal(error.reason, scenario.reason);
@@ -247,7 +283,7 @@ test("fresh consent START accepts the strictly decoded provider-created lineage 
 	const freshStart = JSON.parse(JSON.stringify(fixture<Record<string, unknown>>("start.fixture.json"))
 		.replaceAll("review-start-fixture", "provider-created-lineage")) as Record<string, unknown>;
 	const queue = queuedAdapter([capabilities(), freshStart]);
-	const result = await client(queue.adapter).answerConsent!({ cwd: "/repo", consent: freshConsent, answer: "granted" });
+	const result = await client(queue.adapter).answerConsent!({ cwd: "/repo", consent: freshConsent, answer: "granted", startAgent: undefined });
 	assert.equal(result.kind, "started");
 	assert.ok(result.kind === "started");
 	assert.equal(result.start.lineageId, "provider-created-lineage");
@@ -255,7 +291,7 @@ test("fresh consent START accepts the strictly decoded provider-created lineage 
 	assert.equal(queue.calls.at(-1)?.includes("--lineage"), false);
 
 	const runtimeQueue = queuedAdapter([capabilities(), structuredClone(freshStart)]);
-	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd: "/repo", consent: freshConsent, answer: "granted" });
+	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd: "/repo", consent: freshConsent, answer: "granted", startAgent: undefined });
 	assert.equal(runtimeResult.kind, "started");
 	assert.ok(runtimeResult.kind === "started");
 	assert.equal(runtimeResult.start.lineageId, "provider-created-lineage");
@@ -266,7 +302,7 @@ test("fresh consent START accepts the strictly decoded provider-created lineage 
 	((mismatchedTarget.repository_context as Record<string, unknown>).target_identity as string) = `sha256:${"b".repeat(64)}`;
 	const mismatchQueue = queuedAdapter([capabilities(), mismatchedTarget]);
 	await assert.rejects(
-		() => client(mismatchQueue.adapter).answerConsent!({ cwd: "/repo", consent: freshConsent, answer: "granted" }),
+		() => client(mismatchQueue.adapter).answerConsent!({ cwd: "/repo", consent: freshConsent, answer: "granted", startAgent: undefined }),
 		/target mismatch/,
 	);
 	assert.equal(mismatchQueue.calls.filter((arguments_) => arguments_[0] === "review" && arguments_[1] === "start").length, 1);
@@ -289,7 +325,7 @@ test("duplicate, empty, missing, and malformed consent lineages fail before prov
 	for (const scenario of cases) {
 		const queue = queuedAdapter([]);
 		await assert.rejects(
-			() => client(queue.adapter).answerConsent!({ cwd: "/repo", consent: scenario.consent, answer: "granted" }),
+			() => client(queue.adapter).answerConsent!({ cwd: "/repo", consent: scenario.consent, answer: "granted", startAgent: undefined }),
 			(error: unknown) => {
 				assert.ok(error instanceof NativeReviewConsentBindingError, `${scenario.label} lineage must be a typed binding error`);
 				assert.equal(error.reason, "consent-invocation-option-invalid");
@@ -321,7 +357,7 @@ test("declined consent decodes the provider's explicit empty authority fields wi
 		consent: "declined_this_candidate",
 	};
 	const queue = queuedAdapter([capabilities(), declined]);
-	const result = await client(queue.adapter).answerConsent!({ cwd: "/repo", consent, answer: "declined" });
+	const result = await client(queue.adapter).answerConsent!({ cwd: "/repo", consent, answer: "declined", startAgent: undefined });
 	assert.equal(result.kind, "declined");
 	assert.equal("lineageId" in result, false);
 	assert.deepEqual(queue.calls.at(-1), consent.choices[1].invocation.split(" ").slice(1));
@@ -343,6 +379,14 @@ function piConsent(): Record<string, unknown> {
 	consent.agent = "pi";
 	for (const choice of consent.choices as Array<Record<string, unknown>>) {
 		choice.invocation = String(choice.invocation).replace(" --consent ", " --agent pi --consent ");
+	}
+	return consent;
+}
+
+function agentlessPiConsent(): Record<string, unknown> {
+	const consent = piConsent();
+	for (const choice of consent.choices as Array<Record<string, unknown>>) {
+		choice.invocation = String(choice.invocation).replace(" --agent pi", "");
 	}
 	return consent;
 }
@@ -409,7 +453,7 @@ test("a granted consent/v3 answer decodes the captured start/v3 result with its 
 	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
 	const started = devbinaryFixture<Record<string, unknown>>("start-v3-consent-granted.captured.json");
 	const queue = queuedAdapter([capabilities(), started]);
-	const result = await client(queue.adapter).answerConsent!({ cwd, consent: decoded, answer: "granted" });
+	const result = await client(queue.adapter).answerConsent!({ cwd, consent: decoded, answer: "granted", startAgent: undefined });
 	assert.equal(result.kind, "started");
 	assert.ok(result.kind === "started");
 	assert.equal(result.start.lineageId, "review-377c60e10b852cfc");
@@ -419,7 +463,7 @@ test("a granted consent/v3 answer decodes the captured start/v3 result with its 
 	assert.equal(queue.calls.filter((arguments_) => arguments_.includes("granted")).length, 1);
 
 	const runtimeQueue = queuedAdapter([capabilities(), structuredClone(started)]);
-	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd, consent: decoded, answer: "granted" });
+	const runtimeResult = await runtimeClient(runtimeQueue.adapter).answerConsent({ cwd, consent: decoded, answer: "granted", startAgent: undefined });
 	assert.equal(runtimeResult.kind, "started");
 });
 
@@ -428,11 +472,30 @@ test("a declined consent/v3 answer accepts the captured declined result and crea
 	const cwd = decoded.choices[1].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
 	const declined = devbinaryFixture<Record<string, unknown>>("start-v3-consent-declined.captured.json");
 	const queue = queuedAdapter([capabilities(), declined]);
-	const result = await client(queue.adapter).answerConsent!({ cwd, consent: decoded, answer: "declined" });
+	const result = await client(queue.adapter).answerConsent!({ cwd, consent: decoded, answer: "declined", startAgent: undefined });
 	assert.equal(result.kind, "declined");
 	assert.ok(result.kind === "declined");
 	assert.equal(result.consent, "declined_this_candidate");
 	assert.equal(result.targetIdentity, decoded.targetIdentity);
+});
+
+test("agentless v3 Pi consent replays its exact provider invocation when the START transport fell back", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(agentlessPiConsent()) as ReviewConsentV3;
+	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
+	const outcomes = {
+		granted: devbinaryFixture<Record<string, unknown>>("start-v3-consent-granted.captured.json"),
+		declined: devbinaryFixture<Record<string, unknown>>("start-v3-consent-declined.captured.json"),
+	} as const;
+	for (const [answer, outcome] of Object.entries(outcomes) as Array<["granted" | "declined", Record<string, unknown>]>) {
+		for (const createClient of [client, runtimeClient]) {
+			const queue = queuedAdapter([capabilities(), structuredClone(outcome)]);
+			const result = await createClient(queue.adapter).answerConsent({ cwd, consent: decoded, answer, startAgent: undefined });
+			assert.equal(result.kind, answer === "granted" ? "started" : "declined");
+			assert.deepEqual(queue.calls.at(-1), decoded.choices.find((choice) => choice.answer === answer)!.invocation.split(" ").slice(1));
+			assert.equal(queue.calls.at(-1)?.some((token) => token === "--agent" || token.startsWith("--agent=")), false, "agentless fallback must not synthesize --agent");
+			assert.equal(queue.calls.filter((arguments_) => arguments_.at(-1) === answer).length, 1, "provider-issued invocation replays exactly once");
+		}
+	}
 });
 
 test("Pi granted and declined consent replay the provider-issued agent invocation once", async () => {
@@ -440,14 +503,14 @@ test("Pi granted and declined consent replay the provider-issued agent invocatio
 	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
 	const started = devbinaryFixture<Record<string, unknown>>("start-v3-consent-granted.captured.json");
 	const grantedQueue = queuedAdapter([capabilities(), started]);
-	const granted = await client(grantedQueue.adapter).answerConsent!({ cwd, consent: decoded, answer: "granted" });
+	const granted = await client(grantedQueue.adapter).answerConsent!({ cwd, consent: decoded, answer: "granted", startAgent: "pi" });
 	assert.equal(granted.kind, "started");
 	assert.deepEqual(grantedQueue.calls.at(-1), decoded.choices[0].invocation.split(" ").slice(1));
 	assert.equal(grantedQueue.calls.filter((arguments_) => arguments_.includes("--agent") && arguments_.includes("pi")).length, 1);
 
 	const declined = devbinaryFixture<Record<string, unknown>>("start-v3-consent-declined.captured.json");
 	const declinedQueue = queuedAdapter([capabilities(), declined]);
-	const declinedResult = await client(declinedQueue.adapter).answerConsent!({ cwd, consent: decoded, answer: "declined" });
+	const declinedResult = await client(declinedQueue.adapter).answerConsent!({ cwd, consent: decoded, answer: "declined", startAgent: "pi" });
 	assert.equal(declinedResult.kind, "declined");
 	assert.deepEqual(declinedQueue.calls.at(-1), decoded.choices[1].invocation.split(" ").slice(1));
 	assert.equal(declinedQueue.calls.filter((arguments_) => arguments_.includes("--agent") && arguments_.includes("pi")).length, 1);

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -14,7 +14,7 @@ import {
 	NativeReviewCliV216 as RuntimeNativeReviewCliV216,
 	clearNativeReviewCapabilitiesCacheForTesting as clearRuntimeNativeReviewCapabilitiesCacheForTesting,
 } from "../runtime/native-review-cli.mjs";
-import type { ReviewConsentV2 } from "../lib/review-integration-v2.ts";
+import type { ReviewConsentV2, ReviewConsentV3 } from "../lib/review-integration-v2.ts";
 
 const fixtureRoot = join(process.cwd(), "contracts", "review-integration", "v2", "fixtures");
 const fixture = <T = Record<string, unknown>>(name: string): T => JSON.parse(readFileSync(join(fixtureRoot, name), "utf8")) as T;
@@ -338,6 +338,15 @@ test("declined consent decodes the provider's explicit empty authority fields wi
 const devbinaryFixtureRoot = join(process.cwd(), "tests", "fixtures", "devbinary");
 const devbinaryFixture = <T = Record<string, unknown>>(name: string): T => JSON.parse(readFileSync(join(devbinaryFixtureRoot, name), "utf8")) as T;
 
+function piConsent(): Record<string, unknown> {
+	const consent = devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json");
+	consent.agent = "pi";
+	for (const choice of consent.choices as Array<Record<string, unknown>>) {
+		choice.invocation = String(choice.invocation).replace(" --consent ", " --agent pi --consent ");
+	}
+	return consent;
+}
+
 test("Pi START rejects a foreign consent/v3 envelope and only relays a Pi-bound clone", async () => {
 	const consent = devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json");
 	const target = String(consent.target_identity);
@@ -353,14 +362,14 @@ test("Pi START rejects a foreign consent/v3 envelope and only relays a Pi-bound 
 			},
 		);
 		assert.deepEqual(foreignQueue.calls.at(-1), ["review", "start", ...tokens]);
-		const piConsent = { ...structuredClone(consent), agent: "pi" };
-		const piQueue = queuedAdapter([capabilities(), executableStartStatus(target), piConsent]);
+		const piBoundConsent = piConsent();
+		const piQueue = queuedAdapter([capabilities(), executableStartStatus(target), piBoundConsent]);
 		await assert.rejects(
 			() => createClient(piQueue.adapter).start({ cwd: "/repo" }),
 			(error: unknown) => {
 				assert.equal((error as { name?: string }).name, "NativeReviewConsentRequiredError");
 				const required = error as { consent: { raw: Record<string, unknown>; schema: string; targetIdentity: string; agent?: string } };
-				assert.deepEqual(required.consent.raw, piConsent);
+				assert.deepEqual(required.consent.raw, piBoundConsent);
 				assert.equal(required.consent.schema, "gentle-ai.review-integration.consent/v3");
 				assert.equal(required.consent.targetIdentity, target);
 				assert.equal(required.consent.agent, "pi");
@@ -400,4 +409,22 @@ test("a declined consent/v3 answer accepts the captured declined result and crea
 	assert.ok(result.kind === "declined");
 	assert.equal(result.consent, "declined_this_candidate");
 	assert.equal(result.targetIdentity, decoded.targetIdentity);
+});
+
+test("Pi granted and declined consent replay the provider-issued agent invocation once", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(piConsent()) as ReviewConsentV3;
+	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
+	const started = devbinaryFixture<Record<string, unknown>>("start-v3-consent-granted.captured.json");
+	const grantedQueue = queuedAdapter([capabilities(), started]);
+	const granted = await client(grantedQueue.adapter).answerConsent!({ cwd, consent: decoded, answer: "granted" });
+	assert.equal(granted.kind, "started");
+	assert.deepEqual(grantedQueue.calls.at(-1), decoded.choices[0].invocation.split(" ").slice(1));
+	assert.equal(grantedQueue.calls.filter((arguments_) => arguments_.includes("--agent") && arguments_.includes("pi")).length, 1);
+
+	const declined = devbinaryFixture<Record<string, unknown>>("start-v3-consent-declined.captured.json");
+	const declinedQueue = queuedAdapter([capabilities(), declined]);
+	const declinedResult = await client(declinedQueue.adapter).answerConsent!({ cwd, consent: decoded, answer: "declined" });
+	assert.equal(declinedResult.kind, "declined");
+	assert.deepEqual(declinedQueue.calls.at(-1), decoded.choices[1].invocation.split(" ").slice(1));
+	assert.equal(declinedQueue.calls.filter((arguments_) => arguments_.includes("--agent") && arguments_.includes("pi")).length, 1);
 });

--- a/tests/native-review-parity-runtime.test.ts
+++ b/tests/native-review-parity-runtime.test.ts
@@ -457,7 +457,7 @@ test("official pinned package runtime keeps frozen candidate lineages and receip
 	t.diagnostic("pre-push, pre-pr, and release require remote/publication evidence; their network-aware gate contracts remain covered by dedicated gate integration tests rather than this hermetic binary E2E.");
 });
 
-test("registered gentle_review surfaces the package-pinned Pi transport refusal before native START for a safe internal symlink candidate", async (t) => {
+test("registered gentle_review rejects a foreign consent envelope and reconciles before it can reach Pi", async (t) => {
 	await reviewEnabledHome(t);
 	const workspace = await mkdtemp(join(tmpdir(), "gentle-pi-v215-symlink-candidate-"));
 	const repository = join(workspace, "repository");
@@ -516,12 +516,12 @@ test("registered gentle_review surfaces the package-pinned Pi transport refusal 
 	t.diagnostic(JSON.stringify({ returned: returned?.details, error, nativeStartReached }));
 	assert.equal(thrown, undefined, "the Pi transport refusal must be returned, not thrown");
 	const result = returned?.details as Record<string, unknown> | undefined;
-	const nativeFailure = result?.native_failure as Record<string, unknown> | undefined;
+	const diagnostics = result?.diagnostics as Record<string, unknown> | undefined;
 	assert.equal(result?.status, "blocked");
 	assert.equal(result?.outcome, "native-mutation-status-reconciled");
-	assert.equal(nativeFailure?.code, "immutable_review_transport_unsupported");
-	assert.equal(result?.mutation_performed, false);
-	assert.equal(result?.mutation_outcome, "none");
-	if (result !== undefined && "lineage_created" in result) assert.equal(result.lineage_created, false);
-	assert.equal(nativeStartReached, false, "negotiated Pi transport refusal must preclude native START and any agent-less fallback");
+	assert.equal(diagnostics?.error_code, "immutable_review_transport_unsupported");
+	assert.equal("consent" in (result ?? {}), false, "a foreign consent envelope must never reach the Pi relay");
+	assert.equal(result?.mutation_performed, undefined);
+	assert.equal(result?.mutation_outcome, "unknown");
+	assert.equal(nativeStartReached, true, "the foreign provider response is reconciled after the attempted Pi-bound START rather than relayed");
 });

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -754,7 +754,7 @@ test("typed Pi transport refusal relays agentless v3 consent and keeps granted a
 	}
 });
 
-test("pending consent bindings do not dedupe across Pi and agentless START transports", async (t) => {
+test("agentless fallback rejects an agent-bound v3 route before pending-consent creation", async (t) => {
 	const cwd = repository(t);
 	const consent = foreignOrUnboundV3Consent(cwd, "unbound");
 	for (const choice of consent.choices) choice.invocation = choice.invocation.replace(" --consent ", " --agent pi --consent ");
@@ -763,9 +763,8 @@ test("pending consent bindings do not dedupe across Pi and agentless START trans
 	const targetStatus = native.targetStatus!;
 	const startRequests: NativeStartRequest[] = [];
 	const answerRequests: NativeReviewConsentAnswerRequest[] = [];
-	let piStatusCalls = 0;
 	native.targetStatus = async (request) => {
-		if (request.agent === "pi" && piStatusCalls++ > 0) {
+		if (request.agent === "pi") {
 			throw new NativeReviewIntegrationError({
 				schema: "gentle-ai.review-integration.failure/v2",
 				contract: "gentle-ai.review-integration/v2",
@@ -789,27 +788,16 @@ test("pending consent bindings do not dedupe across Pi and agentless START trans
 	};
 	native.answerConsent = async (request) => {
 		answerRequests.push(request);
-		return {
-			kind: "declined",
-			targetIdentity: consent.targetIdentity,
-			projection: consent.projection,
-			riskLevel: consent.riskLevel,
-			changedFiles: 1,
-			changedLines: 1,
-			consent: "declined_this_candidate",
-			raw: { operation: "review/start", action: "declined", consent: "declined_this_candidate" },
-		};
+		throw new Error("agent-bound fallback consent must never reach the answer provider");
 	};
 
-	const controller = runtime(native).controller;
-	const context = headlessContext(cwd);
-	const piBinding = await blockedConsent(controller, "pending-pi", context);
-	const agentlessBinding = await blockedConsent(controller, "pending-agentless", context);
-	assert.notEqual(piBinding.consent_binding, agentlessBinding.consent_binding, "a fallback route must replace, not reuse, the Pi-bound pending consent");
-	assert.deepEqual(startRequests.map((request) => request.agent), ["pi", undefined]);
-	await assert.rejects(() => answerConsent(controller, piBinding.consent_binding, "granted", context), /unknown, expired, or already consumed/);
-	await answerConsent(controller, agentlessBinding.consent_binding, "declined", context);
-	assert.equal(answerRequests[0]?.startAgent, undefined, "the surviving binding retains the fallback transport");
+	const result = await execStart(runtime(native).controller, "agent-bound-fallback", headlessContext(cwd));
+	assert.equal(result.status, "blocked");
+	assert.equal(result.outcome, "native-mutation-status-reconciled");
+	assert.equal("consent" in result, false, "an invalid fallback route must not be exposed");
+	assert.equal("consent_binding" in result, false, "an invalid fallback route must not create pending consent");
+	assert.deepEqual(startRequests.map((request) => request.agent), [undefined]);
+	assert.deepEqual(answerRequests, []);
 });
 
 test("consent relay returns the identical complete parent-visible envelope with or without UI and never answers internally", async (t) => {

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -23,7 +23,7 @@ import {
 } from "../lib/native-review-cli.ts";
 import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
 import { readReviewConsentLatch, recordReviewConsentLatch } from "../lib/review-consent-latch.ts";
-import type { AuthorityRepairAssessmentV1, ReviewConsentV2, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+import type { AuthorityRepairAssessmentV1, ReviewConsentV2, ReviewConsentV3, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 
 // Queued-adapter clients never execute a real process; default to a fixed
 // absolute package-local path so these tests do not depend on an installed
@@ -620,6 +620,29 @@ function candidateConsent(cwd: string): ReviewConsentV2 {
 	return { schema: "gentle-ai.review-integration.consent/v2", contract: "gentle-ai.review-integration/v2", operation: "review.start", action: "consent_required", blocking: true, targetIdentity, projection: "workspace", riskLevel: "high", changedFiles: 1, changedLines: 1, headline: "Review this candidate", reason: "It changes a process boundary.", value: "Review catches regressions.", riskEvidence: ["shell process"], choices, offPath: { note: "Disable reviews separately.", command: "gentle-ai review mode disable" }, raw };
 }
 
+function foreignOrUnboundV3Consent(cwd: string, agent: "claude-code" | "unbound"): ReviewConsentV3 {
+	const v2 = candidateConsent(cwd);
+	const choices = v2.choices.map((choice) => ({
+		...choice,
+		invocation: agent === "claude-code"
+			? choice.invocation.replace(" --consent ", " --agent claude-code --consent ")
+			: choice.invocation,
+	})) as [ReviewConsentV2["choices"][0], ReviewConsentV2["choices"][1]];
+	const raw = {
+		...v2.raw,
+		schema: "gentle-ai.review-integration.consent/v3",
+		agent: agent === "claude-code" ? "claude-code" : "pi",
+		choices: choices.map((choice) => ({ ...choice })),
+	};
+	return {
+		...v2,
+		schema: "gentle-ai.review-integration.consent/v3",
+		agent: agent === "claude-code" ? "claude-code" : "pi",
+		choices,
+		raw,
+	};
+}
+
 function relayedConsentNative(cwd: string): { native: NativeReviewCli; consent: ReviewConsentV2; answers: NativeReviewConsentAnswer[]; startRequests: NativeStartRequest[]; answerRequests: NativeReviewConsentAnswerRequest[] } {
 	const { native } = fakeOrganicNative();
 	const consent = candidateConsent(cwd);
@@ -651,6 +674,32 @@ async function blockedConsent(controller: RegisteredTool, id: string, ctx: Exten
 	assert.equal(typeof result.consent_binding, "string");
 	return result;
 }
+
+test("Pi reconciles Claude-bound or agentless v3 consent without exposing a foreign question or invocation", async (t) => {
+	for (const agent of ["claude-code", "unbound"] as const) {
+		const cwd = repository(t);
+		const { native } = fakeOrganicNative();
+		const consent = foreignOrUnboundV3Consent(cwd, agent);
+		const answers: NativeReviewConsentAnswer[] = [];
+		let starts = 0;
+		native.start = async () => {
+			starts += 1;
+			throw new NativeReviewConsentRequiredError(consent);
+		};
+		native.answerConsent = async (request) => {
+			answers.push(request.answer);
+			throw new Error("foreign consent answer must never be invoked");
+		};
+
+		const result = await execStart(runtime(native).controller, `foreign-${agent}`, headlessContext(cwd));
+		assert.equal(result.status, "blocked");
+		assert.equal(result.outcome, "native-mutation-status-reconciled");
+		assert.equal("consent" in result, false, `${agent} v3 consent must not reach the user`);
+		assert.equal("consent_binding" in result, false, `${agent} v3 consent must not create a Pi answer binding`);
+		assert.equal(starts, 1, `${agent} v3 response follows the one negotiated Pi START attempt`);
+		assert.deepEqual(answers, [], `${agent} v3 invocation must never be answered by Pi`);
+	}
+});
 
 test("consent relay returns the identical complete parent-visible envelope with or without UI and never answers internally", async (t) => {
 	const cwd = repository(t);

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -12,6 +12,7 @@ import {
 	NativeReviewCliError,
 	NativeReviewConsentBindingError,
 	NativeReviewConsentRequiredError,
+	NativeReviewIntegrationError,
 	NativeReviewCliV213 as NativeReviewCliV213Production,
 	normalizeNativeReviewCwd,
 	setNativeCliContractForTesting,
@@ -675,8 +676,8 @@ async function blockedConsent(controller: RegisteredTool, id: string, ctx: Exten
 	return result;
 }
 
-test("Pi reconciles Claude-bound or agentless v3 consent without exposing a foreign question or invocation", async (t) => {
-	for (const agent of ["claude-code", "unbound"] as const) {
+test("Pi reconciles a foreign v3 consent without exposing its question or invocation", async (t) => {
+	for (const agent of ["claude-code"] as const) {
 		const cwd = repository(t);
 		const { native } = fakeOrganicNative();
 		const consent = foreignOrUnboundV3Consent(cwd, agent);
@@ -699,6 +700,116 @@ test("Pi reconciles Claude-bound or agentless v3 consent without exposing a fore
 		assert.equal(starts, 1, `${agent} v3 response follows the one negotiated Pi START attempt`);
 		assert.deepEqual(answers, [], `${agent} v3 invocation must never be answered by Pi`);
 	}
+});
+
+test("typed Pi transport refusal relays agentless v3 consent and keeps granted and declined reconciliation agentless", async (t) => {
+	for (const answer of ["granted", "declined"] as const) {
+		const cwd = repository(t);
+		const consent = foreignOrUnboundV3Consent(cwd, "unbound");
+		const { native } = fakeOrganicNative();
+		const targetStatus = native.targetStatus!;
+		const statusAgents: Array<string | undefined> = [];
+		const startRequests: NativeStartRequest[] = [];
+		const answerRequests: NativeReviewConsentAnswerRequest[] = [];
+		native.targetStatus = async (request) => {
+			statusAgents.push(request.agent);
+			if (request.agent === "pi") {
+				throw new NativeReviewIntegrationError({
+					schema: "gentle-ai.review-integration.failure/v2",
+					contract: "gentle-ai.review-integration/v2",
+					operation: "review.status",
+					phase: "pre_native",
+					code: "unsupported_agent",
+					message: "Pi transport is unsupported",
+					mutationOutcome: "none",
+					authorityApplicability: "current_target",
+					retrySafe: true,
+					replayability: "not_replayable",
+					nextAction: "stop",
+					raw: {},
+				} as never);
+			}
+			return targetStatus(request);
+		};
+		native.start = async (request) => {
+			startRequests.push(request);
+			throw new NativeReviewConsentRequiredError(consent);
+		};
+		native.answerConsent = async (request) => {
+			answerRequests.push(request);
+			throw Object.assign(new Error("ambiguous consent answer"), { mutationOutcome: "unknown", nextAction: "review.status" });
+		};
+
+		const controller = runtime(native).controller;
+		const blocked = await blockedConsent(controller, `agentless-${answer}`, headlessContext(cwd));
+		assert.deepEqual(blocked.consent, consent.raw, "the complete agentless Pi envelope must reach the relay");
+		assert.deepEqual(statusAgents, ["pi", undefined], "typed Pi refusal retries only the START STATUS agentless");
+		await answerConsent(controller, blocked.consent_binding, answer, headlessContext(cwd));
+		assert.equal(startRequests[0]?.agent, undefined, "the fallback START stays agentless");
+		assert.equal(answerRequests.length, 1, "the exact provider answer is submitted once");
+		assert.equal(answerRequests[0]?.startAgent, undefined, "answer validation receives the selected agentless transport");
+		assert.deepEqual(answerRequests[0]?.consent.choices, consent.choices, "Pi replays the provider-owned choices without rewriting them");
+		assert.equal(answerRequests[0]?.consent.choices.some((choice) => /(?:^| )--agent(?:=| )/.test(choice.invocation)), false, "Pi must not synthesize --agent into agentless choices");
+		assert.deepEqual(statusAgents, ["pi", undefined, undefined], "ambiguous reconciliation must retain the agentless fallback transport");
+	}
+});
+
+test("pending consent bindings do not dedupe across Pi and agentless START transports", async (t) => {
+	const cwd = repository(t);
+	const consent = foreignOrUnboundV3Consent(cwd, "unbound");
+	for (const choice of consent.choices) choice.invocation = choice.invocation.replace(" --consent ", " --agent pi --consent ");
+	(consent.raw as { choices: unknown }).choices = consent.choices.map((choice) => ({ ...choice }));
+	const { native } = fakeOrganicNative();
+	const targetStatus = native.targetStatus!;
+	const startRequests: NativeStartRequest[] = [];
+	const answerRequests: NativeReviewConsentAnswerRequest[] = [];
+	let piStatusCalls = 0;
+	native.targetStatus = async (request) => {
+		if (request.agent === "pi" && piStatusCalls++ > 0) {
+			throw new NativeReviewIntegrationError({
+				schema: "gentle-ai.review-integration.failure/v2",
+				contract: "gentle-ai.review-integration/v2",
+				operation: "review.status",
+				phase: "pre_native",
+				code: "unsupported_agent",
+				message: "Pi transport is unsupported",
+				mutationOutcome: "none",
+				authorityApplicability: "current_target",
+				retrySafe: true,
+				replayability: "not_replayable",
+				nextAction: "stop",
+				raw: {},
+			} as never);
+		}
+		return targetStatus(request);
+	};
+	native.start = async (request) => {
+		startRequests.push(request);
+		throw new NativeReviewConsentRequiredError(consent);
+	};
+	native.answerConsent = async (request) => {
+		answerRequests.push(request);
+		return {
+			kind: "declined",
+			targetIdentity: consent.targetIdentity,
+			projection: consent.projection,
+			riskLevel: consent.riskLevel,
+			changedFiles: 1,
+			changedLines: 1,
+			consent: "declined_this_candidate",
+			raw: { operation: "review/start", action: "declined", consent: "declined_this_candidate" },
+		};
+	};
+
+	const controller = runtime(native).controller;
+	const context = headlessContext(cwd);
+	const piBinding = await blockedConsent(controller, "pending-pi", context);
+	const agentlessBinding = await blockedConsent(controller, "pending-agentless", context);
+	assert.notEqual(piBinding.consent_binding, agentlessBinding.consent_binding, "a fallback route must replace, not reuse, the Pi-bound pending consent");
+	assert.deepEqual(startRequests.map((request) => request.agent), ["pi", undefined]);
+	await assert.rejects(() => answerConsent(controller, piBinding.consent_binding, "granted", context), /unknown, expired, or already consumed/);
+	await answerConsent(controller, agentlessBinding.consent_binding, "declined", context);
+	assert.equal(answerRequests[0]?.startAgent, undefined, "the surviving binding retains the fallback transport");
 });
 
 test("consent relay returns the identical complete parent-visible envelope with or without UI and never answers internally", async (t) => {

--- a/tests/review-controller-lock-status.test.ts
+++ b/tests/review-controller-lock-status.test.ts
@@ -143,7 +143,7 @@ test("START precondition ignores released lock residue and still blocks on live 
 	const proceeded = await runtime(fakeNative(nativeStatus(cwd, "clean", [RELEASED_LOCK]), (request) => { startRequests.push(request); }))
 		.execute("start-released", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
 	const proceededDetails = proceeded.details as Record<string, unknown>;
-	assert.deepEqual(startRequests, [{ cwd, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
+	assert.deepEqual(startRequests, [{ cwd, agent: "pi", targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
 	assert.equal((proceededDetails.result as Record<string, unknown>).lineage_id, "native-lineage");
 	assert.notEqual(proceededDetails.outcome, "native-authority-lock-present");
 

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -2272,8 +2272,8 @@ test("native START uses the default policy or a canonical safe policy path, and 
 	await controller.execute("default-policy", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
 	await controller.execute("custom-policy", { operation: "start", input: JSON.stringify({ mode: "ordinary", policyPath: ".gentle-ai/policies/team policy.json" }) }, undefined, undefined, context(cwd));
 	assert.deepEqual(requests, [
-		{ cwd, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" },
-		{ cwd, policyPath, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" },
+		{ cwd, agent: "pi", targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" },
+		{ cwd, agent: "pi", policyPath, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" },
 	]);
 	for (const [input, outcome, reason] of [
 		[{ mode: "ordinary", policyHash: "legacy" }, "native-start-legacy-policy-hash-unsupported", "legacy-policy-hash-unsupported"],
@@ -2312,8 +2312,8 @@ test("native ordinary START forwards every allowed focus and leaves the native d
 	}
 	await controller.execute("default-focus", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, context(cwd));
 	assert.deepEqual(requests, [
-		...(["risk", "resilience", "readability", "reliability"] as const).map((focus) => ({ cwd, focus, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" as const })),
-		{ cwd, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" },
+		...(["risk", "resilience", "readability", "reliability"] as const).map((focus) => ({ cwd, agent: "pi", focus, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" as const })),
+		{ cwd, agent: "pi", targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" },
 	]);
 });
 
@@ -2472,7 +2472,7 @@ test("native START preserves the default dirty-inclusive candidate without base 
 	try {
 		assert.deepEqual(view.paths, ["app.ts", "untracked.ts"]);
 		assert.equal(view.committedOnly, false);
-		assert.deepEqual(requests, [{ cwd, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
+		assert.deepEqual(requests, [{ cwd, agent: "pi", targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
 		const actorBinding = (started.details as { actor_binding: { workspace_root: string; candidate_root: string; candidate_tree: string; candidate_paths: readonly string[] } }).actor_binding;
 		assert.equal(actorBinding.workspace_root, cwd);
 		assert.equal(actorBinding.candidate_root, view.root);
@@ -2504,7 +2504,7 @@ test("native START binds an acknowledged committed range and native identity to 
 		assert.deepEqual(view.paths, ["committed-after-base.ts"]);
 		assert.equal(view.committedOnly, true);
 		assert.equal(view.baseCommit, baseCommit);
-		assert.deepEqual(requests, [{ cwd, baseRef: view.baseCommit, committedOnly: true, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
+		assert.deepEqual(requests, [{ cwd, agent: "pi", baseRef: view.baseCommit, committedOnly: true, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
 	} finally {
 		view.cleanup();
 	}
@@ -2541,7 +2541,7 @@ test("native START binds a default dirty-inclusive candidate on an unborn reposi
 		assert.deepEqual(view.paths, ["staged.txt", "untracked.ts"]);
 		// No baseRef is sent to native START: the unborn default uses the
 		// workspace projection only, exactly as the provider expects.
-		assert.deepEqual(requests, [{ cwd, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
+		assert.deepEqual(requests, [{ cwd, agent: "pi", targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
 		const actorBinding = (started.details as { actor_binding: { workspace_root: string; candidate_root: string; candidate_tree: string; candidate_paths: readonly string[] } }).actor_binding;
 		assert.equal(actorBinding.workspace_root, cwd);
 		assert.equal(actorBinding.candidate_tree, view.candidateTree);
@@ -2719,7 +2719,7 @@ test("native START forwards an acknowledged base ref and rejects invalid values 
 		},
 	}));
 	await controller.execute("committed-base", { operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef: "refs/heads/main", committedOnly: true }) }, undefined, undefined, context(cwd));
-	assert.deepEqual(requests, [{ cwd, baseRef: git(cwd, "rev-parse", "refs/heads/main"), committedOnly: true, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
+	assert.deepEqual(requests, [{ cwd, agent: "pi", baseRef: git(cwd, "rev-parse", "refs/heads/main"), committedOnly: true, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
 	for (const baseRef of ["", "   ", " origin/main", "origin/main ", "origin\0main", "origin\nmain", "origin\rmain", "origin\tmain", "origin\u007fmain", 42, [], {}]) {
 		const rejected = await controller.execute("invalid-base", { operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef }) }, undefined, undefined, context(cwd));
 		assert.deepEqual(rejected.details, {

--- a/tests/review-controller-workspace-root.test.ts
+++ b/tests/review-controller-workspace-root.test.ts
@@ -305,7 +305,7 @@ test("START freezes the candidate from the explicit workspace root and returns t
 	const view = candidateViews.resolveForLens("worktree-lineage", "review-reliability");
 	assert.equal(details.actor_binding.candidate_root, view.root);
 	assert.equal(details.actor_binding.candidate_tree, view.candidateTree);
-	assert.deepEqual(startRequests, [{ cwd: root, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
+	assert.deepEqual(startRequests, [{ cwd: root, agent: "pi", targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
 	assert.notEqual(startRequests[0]?.cwd, view.root);
 	assert.equal(readFileSync(join(view.root, "app.ts"), "utf8"), "export const value = 2; // worktree candidate\n");
 	assert.equal(view.paths.includes("unrelated.ts"), false);
@@ -343,7 +343,7 @@ test("an omitted workspaceRoot canonicalizes a nested same-worktree session befo
 	assert.equal(details.actor_binding.workspace_root, root);
 	assert.equal((status.details as { workspace_root: string }).workspace_root, root);
 	assert.deepEqual(details.actor_binding.candidate_paths, ["app.ts"]);
-	assert.deepEqual(startRequests, [{ cwd: root, targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
+	assert.deepEqual(startRequests, [{ cwd: root, agent: "pi", targetIdentity: `sha256:${"a".repeat(64)}`, projection: "workspace" }]);
 	const view = candidateViews.resolveForLens("session-lineage", "review-reliability");
 	assert.equal(details.actor_binding.candidate_root, view.root);
 	const finalized = await controller.execute("finalize-session", { operation: "finalize", lineageId: "session-lineage", input: JSON.stringify({}) }, undefined, undefined, ctx);

--- a/tests/review-host-relay-restart-parity.test.ts
+++ b/tests/review-host-relay-restart-parity.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -188,7 +188,7 @@ test("INSPECT after a transport failure reoffers the exact pending binding; FINA
 	assert.equal(failure.relayRequests.length, 1, "Process A observed exactly one pending slot");
 	assert.equal(failure.statusCalls.length, 1, "no automatic STATUS re-query after transport failure");
 	assert.equal(failure.statusCalls[0].lineageId, LINEAGE, "Process A STATUS carried the relay lineage selector");
-	assert.match(failure.statusCalls[0].cwd, new RegExp(`^${escapeRegex(cwd)}/\\.git/gentle-ai/candidate-views/`), "Process A STATUS targeted the candidate-views root under cwd");
+	assert.match(failure.statusCalls[0].cwd, new RegExp(`^${escapeRegex(realpathSync(cwd))}/\\.git/gentle-ai/candidate-views/`), "Process A STATUS targeted the candidate-views root under cwd");
 	assert.equal(failure.finalizeCalls, 0, "transport failure never invokes native finalize");
 	const failedResult = failure.result;
 	assert.equal(failedResult.status, "blocked");
@@ -225,8 +225,8 @@ test("INSPECT after a transport failure reoffers the exact pending binding; FINA
 	assert.equal(relaunch.relayRequests.length, 1, "Process C launched the relay exactly once from the fresh reoffer");
 	assert.equal(relaunch.statusCalls.length, 2, "Process C re-queried STATUS after the capture");
 	assert.equal(relaunch.statusCalls[0].lineageId, LINEAGE, "Process C first STATUS carried the relay lineage selector");
-	assert.match(relaunch.statusCalls[0].cwd, new RegExp(`^${escapeRegex(cwd)}/\\.git/gentle-ai/candidate-views/`), "Process C first STATUS targeted the candidate-views root under cwd");
-	assert.deepEqual(relaunch.statusCalls[1], { cwd, lineageId: LINEAGE });
+	assert.match(relaunch.statusCalls[0].cwd, new RegExp(`^${escapeRegex(realpathSync(cwd))}/\\.git/gentle-ai/candidate-views/`), "Process C first STATUS targeted the candidate-views root under cwd");
+	assert.deepEqual(relaunch.statusCalls[1], { cwd: realpathSync(cwd), lineageId: LINEAGE });
 	// The relaunch came from the fresh reoffered binding, byte-for-byte /
 	// deep-equal to the binding the failed process observed.
 	assert.deepEqual(relaunch.relayRequests[0], observedBinding);

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -442,7 +442,12 @@ test("the generic consent/v3 decoder accepts every runtime while a Pi-bound deco
 		}
 		assert.equal(consent.offPath.command, "gentle-ai review mode disable");
 	}
-	assert.equal(decodeReviewConsentV3({ ...clone(source), agent: "pi" }, "pi").agent, "pi");
+	const piConsent = clone(source);
+	piConsent.agent = "pi";
+	for (const choice of piConsent.choices as JsonObject[]) {
+		choice.invocation = String(choice.invocation).replace(" --consent ", " --agent pi --consent ");
+	}
+	assert.equal(decodeReviewConsentV3(piConsent, "pi").agent, "pi");
 	for (const agent of ["claude-code", "opencode", "codex"] as const) {
 		assert.throws(() => decodeReviewConsentV3({ ...clone(source), agent }, "pi"), /consent\.agent/);
 	}
@@ -454,7 +459,7 @@ test("Pi consent/v3 requires provider-issued Pi invocation bindings", () => {
 	for (const choice of piConsent.choices as JsonObject[]) {
 		choice.invocation = String(choice.invocation).replace(" --consent ", " --agent pi --consent ");
 	}
-	const decoded = decodeReviewConsentV3(piConsent);
+	const decoded = decodeReviewConsentV3(piConsent, "pi");
 	assert.equal(decoded.agent, "pi");
 	assert.ok(decoded.choices.every((choice) => choice.invocation.includes(" --agent pi ")));
 
@@ -462,7 +467,7 @@ test("Pi consent/v3 requires provider-issued Pi invocation bindings", () => {
 	for (const choice of missingInvocationBinding.choices as JsonObject[]) {
 		choice.invocation = String(choice.invocation).replace(" --agent pi", "");
 	}
-	assert.throws(() => decodeReviewConsentV3(missingInvocationBinding), /agent/);
+	assert.throws(() => decodeReviewConsentV3(missingInvocationBinding, "pi"), /agent/);
 });
 
 test("consent identities never cross-decode", () => {

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -448,6 +448,23 @@ test("the generic consent/v3 decoder accepts every runtime while a Pi-bound deco
 	}
 });
 
+test("Pi consent/v3 requires provider-issued Pi invocation bindings", () => {
+	const piConsent = clone(fixture<JsonObject>("consent-v3.captured.json"));
+	piConsent.agent = "pi";
+	for (const choice of piConsent.choices as JsonObject[]) {
+		choice.invocation = String(choice.invocation).replace(" --consent ", " --agent pi --consent ");
+	}
+	const decoded = decodeReviewConsentV3(piConsent);
+	assert.equal(decoded.agent, "pi");
+	assert.ok(decoded.choices.every((choice) => choice.invocation.includes(" --agent pi ")));
+
+	const missingInvocationBinding = clone(piConsent);
+	for (const choice of missingInvocationBinding.choices as JsonObject[]) {
+		choice.invocation = String(choice.invocation).replace(" --agent pi", "");
+	}
+	assert.throws(() => decodeReviewConsentV3(missingInvocationBinding), /agent/);
+});
+
 test("consent identities never cross-decode", () => {
 	const v3 = fixture<JsonObject>("consent-v3.captured.json");
 	const v2 = v2Fixture<JsonObject>("consent.fixture.json");

--- a/tests/review-relay-transport-agent.test.ts
+++ b/tests/review-relay-transport-agent.test.ts
@@ -306,3 +306,15 @@ test("ordinary non-lifecycle STATUS inspection remains agent-less", async (t) =>
 	assert.deepEqual(agents, [undefined], "ordinary STATUS must retain its public agent-less route");
 	assert.equal(result.operation, "status");
 });
+
+test("a fresh controller provider instance probes the Pi transport again", async (t) => {
+	const cwd = repository(t);
+	const first = transportAwareNative({ refusePiAgent: true });
+	await runFinalize(cwd, first.native, "fresh-probe-lineage");
+	assert.equal(first.agents.filter((agent) => agent === "pi").length, 1);
+
+	const fresh = transportAwareNative({ refusePiAgent: true });
+	await runFinalize(cwd, fresh.native, "fresh-probe-lineage");
+	assert.equal(fresh.agents.filter((agent) => agent === "pi").length, 1,
+		"transport refusal caching must not leak across fresh controller provider instances");
+});

--- a/tests/review-relay-transport-agent.test.ts
+++ b/tests/review-relay-transport-agent.test.ts
@@ -169,6 +169,81 @@ async function runStatus(cwd: string, native: NativeReviewCli, lineageId: string
 	) as Record<string, unknown>;
 }
 
+function startStatus(lineageId: string): ReviewStatusV3 {
+	return {
+		...recoveredStatus(lineageId, false),
+		applicability: "unrelated",
+		action: "start",
+	} as ReviewStatusV3;
+}
+
+function ambiguousStartFailureNative(options: { refusePiAgent?: boolean } = {}): { native: NativeReviewCli; calls: Array<{ operation: "start" | "status"; agent: string | undefined }> } {
+	const calls: Array<{ operation: "start" | "status"; agent: string | undefined }> = [];
+	const native = {
+		targetStatus: async (request: { lineageId?: string; agent?: string }) => {
+			calls.push({ operation: "status", agent: request.agent });
+			if (request.agent === "pi" && options.refusePiAgent === true) {
+				throw new NativeReviewIntegrationError({
+					schema: "gentle-ai.review-integration.failure/v2",
+					contract: "gentle-ai.review-integration/v2",
+					operation: "review.status",
+					phase: "pre_native",
+					code: TRANSPORT_REFUSAL_CODE,
+					message: "supported immutable review runtimes: claude-code, opencode, codex",
+					mutationOutcome: "none",
+					authorityApplicability: "current_target",
+					retrySafe: true,
+					replayability: "not_replayable",
+					nextAction: "stop",
+					raw: {},
+				} as never);
+			}
+			return startStatus(request.lineageId ?? "start-lineage");
+		},
+		start: async (request: { agent?: string }) => {
+			calls.push({ operation: "start", agent: request.agent });
+			throw new Error("ambiguous native START failure");
+		},
+	} as unknown as NativeReviewCli;
+	return { native, calls };
+}
+
+async function runAmbiguousStart(cwd: string, native: NativeReviewCli, lineageId: string): Promise<Record<string, unknown>> {
+	return await __testing.executeReviewControllerOperation(
+		{ operation: "start", input: JSON.stringify({ mode: "ordinary" }), lineageId },
+		cwd, new Map(), native, undefined, undefined, undefined, null,
+	) as Record<string, unknown>;
+}
+
+test("START reconciliation preserves the negotiated pi transport after an ambiguous failure", async (t) => {
+	const cwd = repository(t);
+	const { native, calls } = ambiguousStartFailureNative();
+
+	const result = await runAmbiguousStart(cwd, native, "start-pi-lineage");
+
+	assert.deepEqual(calls, [
+		{ operation: "status", agent: "pi" },
+		{ operation: "start", agent: "pi" },
+		{ operation: "status", agent: "pi" },
+	]);
+	assert.equal(result.outcome, "native-mutation-status-reconciled");
+});
+
+test("START reconciliation remains agent-less after a typed pi transport refusal", async (t) => {
+	const cwd = repository(t);
+	const { native, calls } = ambiguousStartFailureNative({ refusePiAgent: true });
+
+	const result = await runAmbiguousStart(cwd, native, "start-legacy-lineage");
+
+	assert.deepEqual(calls, [
+		{ operation: "status", agent: "pi" },
+		{ operation: "status", agent: undefined },
+		{ operation: "start", agent: undefined },
+		{ operation: "status", agent: undefined },
+	]);
+	assert.equal(result.outcome, "native-mutation-status-reconciled");
+});
+
 test("the negotiated status asks for the pi agent so the provider offers its materialize relay slot", async (t) => {
 	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
 	const cwd = repository(t);

--- a/tests/review-relay-transport-agent.test.ts
+++ b/tests/review-relay-transport-agent.test.ts
@@ -174,6 +174,7 @@ function startStatus(lineageId: string): ReviewStatusV3 {
 		...recoveredStatus(lineageId, false),
 		applicability: "unrelated",
 		action: "start",
+		nextTransition: undefined,
 	} as ReviewStatusV3;
 }
 
@@ -211,7 +212,7 @@ function ambiguousStartFailureNative(options: { refusePiAgent?: boolean } = {}):
 async function runAmbiguousStart(cwd: string, native: NativeReviewCli, lineageId: string): Promise<Record<string, unknown>> {
 	return await __testing.executeReviewControllerOperation(
 		{ operation: "start", input: JSON.stringify({ mode: "ordinary" }), lineageId },
-		cwd, new Map(), native, undefined, undefined, undefined, null,
+		cwd, native, undefined, null,
 	) as Record<string, unknown>;
 }
 
@@ -384,11 +385,11 @@ test("ordinary non-lifecycle STATUS inspection remains agent-less", async (t) =>
 
 test("a fresh controller provider instance probes the Pi transport again", async (t) => {
 	const cwd = repository(t);
-	const first = transportAwareNative({ refusePiAgent: true });
+	const first = transportAwareNative({ refusalCode: TRANSPORT_REFUSAL_CODE });
 	await runFinalize(cwd, first.native, "fresh-probe-lineage");
 	assert.equal(first.agents.filter((agent) => agent === "pi").length, 1);
 
-	const fresh = transportAwareNative({ refusePiAgent: true });
+	const fresh = transportAwareNative({ refusalCode: TRANSPORT_REFUSAL_CODE });
 	await runFinalize(cwd, fresh.native, "fresh-probe-lineage");
 	assert.equal(fresh.agents.filter((agent) => agent === "pi").length, 1,
 		"transport refusal caching must not leak across fresh controller provider instances");


### PR DESCRIPTION
Closes #377

Part of #311.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Preserve explicit `agent: pi` identity through pre-START STATUS, negotiated START, and consent reconciliation.
- Reject foreign runtime consent without impersonating Claude while retaining typed agentless compatibility fallback.
- Validate and replay provider-issued Pi consent invocations exactly once, with generated runtime parity.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Probe Pi before START, thread the accepted agent, and retain it during reconciliation. |
| `lib/native-review-cli.ts` | Add typed START agent plumbing and exact Pi consent invocation validation. |
| `lib/review-integration-v2.ts` | Decode Pi-bound consent/v3 while preserving historical compatibility. |
| `runtime/*.mjs` | Regenerate the two runtime mirrors from TypeScript sources. |
| `tests/native-review-consent.test.ts` | Cover Pi START, foreign consent rejection, and exact granted/declined replay. |
| `tests/review-integration-v2-forward.test.ts` | Cover Pi consent decoder bindings. |
| `tests/review-relay-transport-agent.test.ts` | Prove fresh provider instances re-probe Pi. |
| `tests/review-controller-*.test.ts` | Keep existing START request expectations aligned with explicit Pi identity. |

## Test plan

- [x] Focused identity/consent tests: 50 passed, 0 failed.
- [x] START transport reconciliation tests: 7 passed, 0 failed.
- [x] `pnpm run check:transaction-runner`: five generated modules match.
- [x] `git diff --check`: clean.
- [x] Full candidate suite under clone-local RDD off: 1286 passed, 14 failed, 1 skipped.
- [x] Clean-base comparison reproduces all failures: the original 11 baseline failures plus three runtime tests caused by the shared clone-local RDD-off environment; candidate-only failures: 0.
- [x] Shellcheck: N/A — no shell scripts changed.
- [x] Independent read-only verifier confirmed the exact changed paths and focused behavior.

## Review focus

- Typed unsupported transport may fall back to the agentless route but must never substitute `claude-code`.
- Pi consent choices must contain provider-issued `--agent pi`; the adapter validates and replays returned tokens rather than synthesizing them.
- Ambiguous START failure reconciliation must retain Pi after successful negotiation and remain agentless after typed fallback.
- Consent/v2 and historical agentless v3 compatibility remain bounded to their existing route.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Added exactly one PR type.
- [x] Kept tests and generated mirrors with the behavior change.
- [x] Documented baseline failures without claiming they pass.
- [x] Used a Conventional Commit message.
- [x] Added no AI attribution or `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pi support for native review workflows.
  * Preserved the selected review agent across start, status, reconciliation, and consent actions.
  * Added agent-bound consent validation, including required Pi invocation options.

* **Bug Fixes**
  * Rejected mismatched, missing, duplicate, or malformed consent bindings.
  * Improved fallback and recovery after supported transport refusals or ambiguous start failures.
  * Added clearer handling for unsupported review transports.

* **Tests**
  * Expanded coverage for consent validation, replay, routing, and transport scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->