### PR TITLE
feat(quiet-tools): show Gentle AI command lifecycle

### DIFF
--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -109,6 +109,7 @@ const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+\S+=\S+\s+|command\s+|\w+=\S+\s
 const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
 const GENTLE_AI_ROUTINE_COMMAND = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}\s+(sdd-status|sdd-continue|sdd-attempt|review)(?:\s|$)`);
 const GENTLE_AI_SDD_ATTEMPT = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}\s+sdd-attempt\s+(?:acquire|settle)(?:\s|$)`);
+const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n]|\$\(/;
 
 /**
  * Matches only supported routine Gentle AI CLI calls, including bounded
@@ -117,6 +118,7 @@ const GENTLE_AI_SDD_ATTEMPT = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GE
  */
 export function gentleAiRoutineCommand(args: Record<string, unknown> | undefined): GentleAiRoutineCommand | undefined {
 	const command = typeof args?.command === "string" ? args.command.trim() : "";
+	if (SHELL_EXPANSION_OR_COMPOSITION.test(command)) return undefined;
 	const match = GENTLE_AI_ROUTINE_COMMAND.exec(command);
 	if (!match) return undefined;
 	if (match[1] === "sdd-attempt" && !GENTLE_AI_SDD_ATTEMPT.test(command)) return undefined;

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -103,6 +103,26 @@ function isGitCommand(args: Record<string, unknown> | undefined): boolean {
 	return /^(?:env\s+\S+=\S+\s+|command\s+|\w+=\S+\s+)*git(?:\s|$)/.test(command);
 }
 
+export type GentleAiRoutineCommand = "sdd-status" | "sdd-continue" | "sdd-attempt" | "review";
+
+const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+\S+=\S+\s+|command\s+|\w+=\S+\s+)*`;
+const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
+const GENTLE_AI_ROUTINE_COMMAND = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}\s+(sdd-status|sdd-continue|sdd-attempt|review)(?:\s|$)`);
+const GENTLE_AI_SDD_ATTEMPT = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}\s+sdd-attempt\s+(?:acquire|settle)(?:\s|$)`);
+
+/**
+ * Matches only supported routine Gentle AI CLI calls, including bounded
+ * package-local paths, not arbitrary shell output that merely mentions
+ * gentle-ai. These commands otherwise emit machine-readable SDD/RDD data.
+ */
+export function gentleAiRoutineCommand(args: Record<string, unknown> | undefined): GentleAiRoutineCommand | undefined {
+	const command = typeof args?.command === "string" ? args.command.trim() : "";
+	const match = GENTLE_AI_ROUTINE_COMMAND.exec(command);
+	if (!match) return undefined;
+	if (match[1] === "sdd-attempt" && !GENTLE_AI_SDD_ATTEMPT.test(command)) return undefined;
+	return match[1] as GentleAiRoutineCommand;
+}
+
 interface ToolResultFormatOptions {
 	expanded: boolean;
 	isError?: boolean;
@@ -116,6 +136,7 @@ export function formatToolResultOutput(
 ): string {
 	const text = safeText(extractTextContent(result));
 	if (expanded || isError) return text ? `\n${text}` : "";
+	if (toolName === "bash" && gentleAiRoutineCommand(args)) return "";
 
 	if (toolName === "bash" && isGitCommand(args)) {
 		const tail = tailLines(text, COLLAPSED_TAIL_LINE_LIMIT);
@@ -149,6 +170,11 @@ function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, 
 			return `${theme.fg("toolTitle", theme.bold("read"))} ${theme.fg("accent", path)}${lineRangeSuffix(args, theme)}`;
 		}
 		case "bash": {
+			const gentleAiCommand = gentleAiRoutineCommand(args);
+			if (gentleAiCommand) {
+				const label = gentleAiCommand === "sdd-attempt" ? "SDD attempt" : gentleAiCommand.replace("-", " ");
+				return theme.fg("toolTitle", theme.bold(`🌹︎ Gentle AI ${label} …`));
+			}
 			const command = safeText(asString(args.command, "..."));
 			const timeout = typeof args.timeout === "number" ? theme.fg("muted", ` (timeout ${args.timeout}s)`) : "";
 			return `${theme.fg("toolTitle", theme.bold(`$ ${command}`))}${timeout}`;

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -107,9 +107,67 @@ export type GentleAiRoutineCommand = "sdd-status" | "sdd-continue" | "sdd-attemp
 
 const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+\S+=\S+\s+|command\s+|\w+=\S+\s+)*`;
 const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
-const GENTLE_AI_ROUTINE_COMMAND = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}\s+(sdd-status|sdd-continue|sdd-attempt|review)(?:\s|$)`);
-const GENTLE_AI_SDD_ATTEMPT = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}\s+sdd-attempt\s+(?:acquire|settle)(?:\s|$)`);
-const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n]|\$\(/;
+const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}\s+(.+)$`);
+const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n$]/;
+
+const REVIEW_DIRECT_OPERATIONS = new Set([
+	"capabilities",
+	"start",
+	"finalize",
+	"status",
+	"repair",
+	"invalidate",
+	"abandon",
+	"recover",
+	"reclaim",
+	"validate",
+	"capture-result",
+	"capture-refuter",
+	"capture-validation",
+	"capture-evidence",
+	"preserve-result",
+	"lens-context",
+	"retry-final-verification",
+	"store-reset",
+	"inspect-authority",
+	"inspect-candidate",
+	"dispose-result",
+	"reopen-results",
+	"opencode-transport",
+	"bind-sdd",
+]);
+const REVIEW_MODE_VALUES = new Set(["enable", "disable", "status"]);
+const REVIEW_VALIDATE_GATES = new Set(["post-apply", "pre-commit", "pre-push", "pre-pr", "release"]);
+const REVIEW_SCHEMA_NAMES = new Set([
+	"capture-result-dry-run",
+	"final-verification-incident",
+	"refuter",
+	"reviewer",
+	"validator",
+	"verification-evidence",
+	"verification-evidence-record",
+]);
+
+function gentleAiCommandTokens(args: Record<string, unknown> | undefined): string[] | undefined {
+	const rawCommand = typeof args?.command === "string" ? args.command : "";
+	if (SHELL_EXPANSION_OR_COMPOSITION.test(rawCommand)) return undefined;
+	const command = rawCommand.trim();
+	const match = GENTLE_AI_COMMAND_ARGUMENTS.exec(command);
+	return match?.[1].trim().split(/\s+/) ?? undefined;
+}
+
+function displayToken(token: string): string {
+	return token.replace(/-/g, " ");
+}
+
+function validateGate(tokens: string[]): string | undefined {
+	const gateFlag = tokens.findIndex((token) => token === "--gate" || token.startsWith("--gate="));
+	if (gateFlag < 0) return undefined;
+	const gate = tokens[gateFlag]!.startsWith("--gate=")
+		? tokens[gateFlag]!.slice("--gate=".length)
+		: tokens[gateFlag + 1];
+	return gate !== undefined && REVIEW_VALIDATE_GATES.has(gate) ? gate : "";
+}
 
 /**
  * Matches only supported routine Gentle AI CLI calls, including bounded
@@ -117,12 +175,42 @@ const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n]|\$\(/;
  * gentle-ai. These commands otherwise emit machine-readable SDD/RDD data.
  */
 export function gentleAiRoutineCommand(args: Record<string, unknown> | undefined): GentleAiRoutineCommand | undefined {
-	const command = typeof args?.command === "string" ? args.command.trim() : "";
-	if (SHELL_EXPANSION_OR_COMPOSITION.test(command)) return undefined;
-	const match = GENTLE_AI_ROUTINE_COMMAND.exec(command);
-	if (!match) return undefined;
-	if (match[1] === "sdd-attempt" && !GENTLE_AI_SDD_ATTEMPT.test(command)) return undefined;
-	return match[1] as GentleAiRoutineCommand;
+	const tokens = gentleAiCommandTokens(args);
+	if (!tokens) return undefined;
+	if (tokens[0] === "sdd-status") return "sdd-status";
+	if (tokens[0] === "sdd-continue") return "sdd-continue";
+	if (tokens[0] === "sdd-attempt" && (tokens[1] === "acquire" || tokens[1] === "settle")) return "sdd-attempt";
+	if (tokens[0] === "review") return "review";
+	return undefined;
+}
+
+export function gentleAiOperationPath(args: Record<string, unknown> | undefined): string | undefined {
+	const tokens = gentleAiCommandTokens(args);
+	if (!tokens) return undefined;
+
+	if (tokens[0] === "sdd-status") return "sdd status";
+	if (tokens[0] === "sdd-continue") return "sdd continue";
+	if (tokens[0] === "sdd-attempt" && (tokens[1] === "acquire" || tokens[1] === "settle")) {
+		return `sdd attempt ${tokens[1]}`;
+	}
+	if (tokens[0] !== "review") return undefined;
+
+	const operation = tokens[1];
+	if (operation === undefined) return "review";
+	if (operation === "mode") {
+		const mode = tokens[2];
+		return mode !== undefined && REVIEW_MODE_VALUES.has(mode) ? `review mode ${displayToken(mode)}` : "review";
+	}
+	if (operation === "validate") {
+		const gate = validateGate(tokens);
+		if (gate === "") return "review";
+		return gate === undefined ? "review validate" : `review validate ${displayToken(gate)}`;
+	}
+	if (operation === "schema") {
+		const schema = tokens[2];
+		return schema !== undefined && REVIEW_SCHEMA_NAMES.has(schema) ? `review schema ${displayToken(schema)}` : "review schema";
+	}
+	return REVIEW_DIRECT_OPERATIONS.has(operation) ? `review ${displayToken(operation)}` : "review";
 }
 
 interface ToolResultFormatOptions {
@@ -165,6 +253,27 @@ function lineRangeSuffix(args: Record<string, unknown>, theme: ThemeLike): strin
 	return theme.fg("warning", `:${startLine}${endLine === undefined ? "" : `-${endLine}`}`);
 }
 
+interface ToolRenderContextLike {
+	args?: Record<string, unknown>;
+	executionStarted?: boolean;
+	isPartial?: boolean;
+	isError?: boolean;
+	lastComponent?: unknown;
+}
+
+function renderGentleAiCall(operationPath: string, theme: ThemeLike, context?: ToolRenderContextLike): Text {
+	const status = context?.isError
+		? "failed"
+		: !context?.executionStarted || context.isPartial
+			? "running"
+			: "completed";
+	const color = status === "running" ? "warning" : status === "completed" ? "success" : "error";
+	const value = theme.fg(color, theme.bold(`🌹︎ Gentle AI · ${status} · ${operationPath}`));
+	const component = context?.lastComponent instanceof Text ? context.lastComponent : new Text("", 0, 0);
+	component.setText(value);
+	return component;
+}
+
 function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, theme: ThemeLike): string {
 	switch (toolName) {
 		case "read": {
@@ -172,11 +281,6 @@ function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, 
 			return `${theme.fg("toolTitle", theme.bold("read"))} ${theme.fg("accent", path)}${lineRangeSuffix(args, theme)}`;
 		}
 		case "bash": {
-			const gentleAiCommand = gentleAiRoutineCommand(args);
-			if (gentleAiCommand) {
-				const label = gentleAiCommand === "sdd-attempt" ? "SDD attempt" : gentleAiCommand.replace("-", " ");
-				return theme.fg("toolTitle", theme.bold(`🌹︎ Gentle AI ${label} …`));
-			}
 			const command = safeText(asString(args.command, "..."));
 			const timeout = typeof args.timeout === "number" ? theme.fg("muted", ` (timeout ${args.timeout}s)`) : "";
 			return `${theme.fg("toolTitle", theme.bold(`$ ${command}`))}${timeout}`;
@@ -220,19 +324,29 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 			const runtimeTool = getBuiltInTools(ctx.cwd)[toolName];
 			return runtimeTool.execute(toolCallId, params, signal, onUpdate, ctx);
 		},
-		renderCall(args, theme) {
-			return new Text(formatToolCall(toolName, args as Record<string, unknown>, theme), 0, 0);
+		renderCall(args, theme, context) {
+			const callArgs = args as Record<string, unknown>;
+			const operationPath = toolName === "bash" ? gentleAiOperationPath(callArgs) : undefined;
+			if (operationPath) return renderGentleAiCall(operationPath, theme, context);
+			return new Text(formatToolCall(toolName, callArgs, theme), 0, 0);
 		},
 		renderResult(result, options, theme, context) {
+			const renderContext = context as ToolRenderContextLike | undefined;
+			const isError = renderContext?.isError ?? options.isError ?? false;
+			const routineCommand = toolName === "bash" && gentleAiRoutineCommand(renderContext?.args);
 			if (options.isPartial) {
-				return new Text(theme.fg("warning", partialLabel(toolName)), 0, 0);
+				if (routineCommand && !isError) {
+					if (!options.expanded) return new Text("", 0, 0);
+				} else if (!(routineCommand && isError)) {
+					return new Text(theme.fg("warning", partialLabel(toolName)), 0, 0);
+				}
 			}
 			const output = formatToolResultOutput(toolName, result, {
 				expanded: options.expanded,
-				isError: options.isError,
-				args: context.args as Record<string, unknown> | undefined,
+				isError,
+				args: renderContext?.args,
 			});
-			const color = options.expanded ? "toolOutput" : options.isError ? "error" : "muted";
+			const color = options.expanded ? "toolOutput" : isError ? "error" : "muted";
 			return new Text(output ? theme.fg(color, output) : "", 0, 0);
 		},
 	});

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -5,6 +5,7 @@ import quietTools, {
 	countNonEmptyLines,
 	extractTextContent,
 	formatToolResultOutput,
+	gentleAiRoutineCommand,
 	tailLines,
 } from "../extensions/quiet-tools.ts";
 
@@ -205,6 +206,41 @@ test("quiet tool rendering keeps compact collapsed summaries for search and list
 	assert.equal(formatToolResultOutput("write", textResult("wrote") as any, { expanded: false }), "\nwrote");
 	assert.equal(formatToolResultOutput("grep", textResult("a\nb\n") as any, { expanded: true }), "\na\nb\n");
 	assert.equal(formatToolResultOutput("read", textResult("ENOENT: missing file") as any, { expanded: false, isError: true }), "\nENOENT: missing file");
+});
+
+test("quiet tool rendering identifies only routine Gentle AI SDD and RDD commands", () => {
+	assert.equal(gentleAiRoutineCommand({ command: "gentle-ai sdd-status fix-rose --json" }), "sdd-status");
+	assert.equal(gentleAiRoutineCommand({ command: "env FOO=bar gentle-ai sdd-continue fix-rose" }), "sdd-continue");
+	assert.equal(gentleAiRoutineCommand({ command: "/package/.gentle-ai/v2.2.0/gentle-ai review status --next-transition" }), "review");
+	assert.equal(gentleAiRoutineCommand({ command: "./.gentle-ai/v2.2.0/gentle-ai sdd-status rose --json" }), "sdd-status");
+	assert.equal(gentleAiRoutineCommand({ command: ".\\.gentle-ai\\v2.2.0\\gentle-ai.exe review status --next-transition" }), "review");
+	assert.equal(gentleAiRoutineCommand({ command: "C:\\package\\.gentle-ai\\v2.2.0\\gentle-ai.exe sdd-continue rose" }), "sdd-continue");
+	assert.equal(gentleAiRoutineCommand({ command: "gentle-ai sdd-attempt acquire --change fix-rose" }), "sdd-attempt");
+	assert.equal(gentleAiRoutineCommand({ command: "gentle-ai sdd-attempt settle --change fix-rose" }), "sdd-attempt");
+	assert.equal(gentleAiRoutineCommand({ command: "gentle-ai review status --next-transition" }), "review");
+	assert.equal(gentleAiRoutineCommand({ command: "gentle-ai version" }), undefined);
+	assert.equal(gentleAiRoutineCommand({ command: "gentle-ai sdd-attempt inspect" }), undefined);
+	assert.equal(gentleAiRoutineCommand({ command: "/package/.gentle-ai/v2.2.0/gentle-ai-copy review status" }), undefined);
+	assert.equal(gentleAiRoutineCommand({ command: "echo gentle-ai review status" }), undefined);
+});
+
+test("quiet tool rendering compacts successful routine Gentle AI calls but preserves failures", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const command = "gentle-ai review status --next-transition";
+	const textRose = "\u{1F339}\uFE0E";
+	const tool = tools.get("bash");
+
+	const call = renderToString(tool.renderCall({ command }, passthroughTheme, {}));
+	const collapsed = renderToString(tool.renderResult(textResult('{"next_transition":"stop"}'), { expanded: false, isPartial: false }, passthroughTheme, { args: { command } }));
+	const expanded = renderToString(tool.renderResult(textResult('{"next_transition":"stop"}'), { expanded: true, isPartial: false }, passthroughTheme, { args: { command } }));
+	const failure = renderToString(tool.renderResult(textResult("review status failed: authority unavailable"), { expanded: false, isPartial: false, isError: true }, passthroughTheme, { args: { command } }));
+
+	assert.equal([...textRose].length, 2);
+	assert.equal(call.trimEnd(), `${textRose} Gentle AI review …`);
+	assert.equal(collapsed, "");
+	assert.match(expanded, /"next_transition":"stop"/);
+	assert.match(failure, /review status failed: authority unavailable/);
 });
 
 test("quiet tool rendering keeps collapsed git bash result tails", () => {

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -224,6 +224,33 @@ test("quiet tool rendering identifies only routine Gentle AI SDD and RDD command
 	assert.equal(gentleAiRoutineCommand({ command: "echo gentle-ai review status" }), undefined);
 });
 
+test("quiet tool rendering refuses to compact composed Gentle AI shell commands", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const commands = [
+		"gentle-ai review status --next-transition && rm -rf target",
+		"gentle-ai review status; rm -rf target",
+		"gentle-ai review status || rm -rf target",
+		"gentle-ai review status | tee status.json",
+		"gentle-ai review status & rm -rf target",
+		"gentle-ai review status\nrm -rf target",
+		"gentle-ai review status --next-transition $(rm -rf target)",
+		"gentle-ai review status --next-transition `rm -rf target`",
+		"gentle-ai review status --next-transition <(cat target)",
+		"gentle-ai review status --next-transition >(tee target)",
+		"gentle-ai review status --next-transition > status.json",
+		"gentle-ai review status --next-transition < status.json",
+	];
+
+	for (const command of commands) {
+		assert.equal(gentleAiRoutineCommand({ command }), undefined, command);
+		const call = renderToString(tools.get("bash").renderCall({ command }, passthroughTheme, {}));
+		const output = renderToString(tools.get("bash").renderResult(textResult("command output"), { expanded: true, isPartial: false }, passthroughTheme, { args: { command } }));
+		assert.equal(call.replace(/[ \t]+$/gm, "").trimEnd(), `$ ${command}`);
+		assert.match(output, /command output/);
+	}
+});
+
 test("quiet tool rendering compacts successful routine Gentle AI calls but preserves failures", () => {
 	const { pi, tools } = createPi();
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -18,6 +18,33 @@ const passthroughTheme = {
 	},
 };
 
+const statusTheme = {
+	bold(value: string) {
+		return value;
+	},
+	fg(color: string, value: string) {
+		return `<${color}>${value}</${color}>`;
+	},
+};
+
+function routineRenderContext(overrides: Record<string, unknown> = {}) {
+	return {
+		args: {},
+		toolCallId: "tool-call",
+		invalidate() {},
+		lastComponent: undefined,
+		state: {},
+		cwd: "/repo",
+		executionStarted: false,
+		argsComplete: true,
+		isPartial: true,
+		expanded: false,
+		showImages: false,
+		isError: false,
+		...overrides,
+	};
+}
+
 function renderToString(component: { render(width: number): string[] }): string {
 	return component.render(120).join("\n");
 }
@@ -240,13 +267,16 @@ test("quiet tool rendering refuses to compact composed Gentle AI shell commands"
 		"gentle-ai review status --next-transition >(tee target)",
 		"gentle-ai review status --next-transition > status.json",
 		"gentle-ai review status --next-transition < status.json",
+		"gentle-ai review status $HOME",
+		"gentle-ai review status ${HOME}",
+		"gentle-ai review status\n",
 	];
 
 	for (const command of commands) {
 		assert.equal(gentleAiRoutineCommand({ command }), undefined, command);
 		const call = renderToString(tools.get("bash").renderCall({ command }, passthroughTheme, {}));
 		const output = renderToString(tools.get("bash").renderResult(textResult("command output"), { expanded: true, isPartial: false }, passthroughTheme, { args: { command } }));
-		assert.equal(call.replace(/[ \t]+$/gm, "").trimEnd(), `$ ${command}`);
+		assert.equal(call.replace(/[ \t]+$/gm, "").trimEnd(), `$ ${command.trimEnd()}`);
 		assert.match(output, /command output/);
 	}
 });
@@ -264,10 +294,160 @@ test("quiet tool rendering compacts successful routine Gentle AI calls but prese
 	const failure = renderToString(tool.renderResult(textResult("review status failed: authority unavailable"), { expanded: false, isPartial: false, isError: true }, passthroughTheme, { args: { command } }));
 
 	assert.equal([...textRose].length, 2);
-	assert.equal(call.trimEnd(), `${textRose} Gentle AI review …`);
+	assert.equal(call.trimEnd(), `${textRose} Gentle AI · running · review status`);
 	assert.equal(collapsed, "");
 	assert.match(expanded, /"next_transition":"stop"/);
 	assert.match(failure, /review status failed: authority unavailable/);
+});
+
+test("quiet tool rendering transitions one Gentle AI header through lifecycle states", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const command = "gentle-ai review status --cwd /repo/private-change";
+
+	const initial = tool.renderCall({ command }, statusTheme, routineRenderContext());
+	const initialText = renderToString(initial).trimEnd();
+	const running = tool.renderCall(
+		{ command },
+		statusTheme,
+		routineRenderContext({ executionStarted: true, lastComponent: initial }),
+	);
+	const runningText = renderToString(running).trimEnd();
+	const completed = tool.renderCall(
+		{ command },
+		statusTheme,
+		routineRenderContext({
+			executionStarted: true,
+			isPartial: false,
+			lastComponent: running,
+		}),
+	);
+	const completedText = renderToString(completed).trimEnd();
+	const failed = tool.renderCall(
+		{ command },
+		statusTheme,
+		routineRenderContext({
+			executionStarted: true,
+			isPartial: false,
+			isError: true,
+			lastComponent: completed,
+		}),
+	);
+	const failedText = renderToString(failed).trimEnd();
+
+	assert.strictEqual(initial, running);
+	assert.strictEqual(running, completed);
+	assert.strictEqual(completed, failed);
+	assert.equal(initialText, "<warning>🌹︎ Gentle AI · running · review status</warning>");
+	assert.equal(runningText, "<warning>🌹︎ Gentle AI · running · review status</warning>");
+	assert.equal(completedText, "<success>🌹︎ Gentle AI · completed · review status</success>");
+	assert.equal(failedText, "<error>🌹︎ Gentle AI · failed · review status</error>");
+	assert.doesNotMatch(failedText, /private-change/);
+});
+
+test("quiet tool rendering displays only finite safe Gentle AI operation paths", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const rose = "🌹︎";
+	const cases = [
+		["gentle-ai sdd-status change-123 --cwd /repo/private", "sdd status"],
+		["gentle-ai sdd-continue change-123 --json", "sdd continue"],
+		["gentle-ai sdd-attempt acquire --change change-123", "sdd attempt acquire"],
+		["gentle-ai sdd-attempt settle --change change-123 --actor maintainer", "sdd attempt settle"],
+		["gentle-ai review capabilities --cwd /repo/private", "review capabilities"],
+		["gentle-ai review start --target sha256:secret --path src/private.ts", "review start"],
+		["gentle-ai review finalize --lineage lineage-secret --payload '{\"secret\":true}'", "review finalize"],
+		["gentle-ai review status --lineage lineage-secret", "review status"],
+		["gentle-ai review repair --reason private-reason", "review repair"],
+		["gentle-ai review invalidate --lineage lineage-secret", "review invalidate"],
+		["gentle-ai review abandon --lineage lineage-secret", "review abandon"],
+		["gentle-ai review recover --lineage lineage-secret", "review recover"],
+		["gentle-ai review reclaim --lineage lineage-secret", "review reclaim"],
+		["gentle-ai review validate --cwd /repo/private", "review validate"],
+		["gentle-ai review capture-result --input result.json", "review capture result"],
+		["gentle-ai review capture-refuter --input result.json", "review capture refuter"],
+		["gentle-ai review capture-validation --input result.json", "review capture validation"],
+		["gentle-ai review capture-evidence --input evidence.json", "review capture evidence"],
+		["gentle-ai review preserve-result --input result.json", "review preserve result"],
+		["gentle-ai review lens-context --lens reviewer", "review lens context"],
+		["gentle-ai review retry-final-verification --incident incident.json", "review retry final verification"],
+		["gentle-ai review store-reset --authorization secret", "review store reset"],
+		["gentle-ai review inspect-authority --path /repo/private", "review inspect authority"],
+		["gentle-ai review inspect-candidate --path /repo/private", "review inspect candidate"],
+		["gentle-ai review dispose-result --reference result-secret", "review dispose result"],
+		["gentle-ai review reopen-results --reference result-secret", "review reopen results"],
+		["gentle-ai review opencode-transport --payload secret", "review opencode transport"],
+		["gentle-ai review bind-sdd --change change-123 --lineage lineage-secret", "review bind sdd"],
+		["gentle-ai review mode enable --actor maintainer", "review mode enable"],
+		["gentle-ai review mode disable --actor maintainer", "review mode disable"],
+		["gentle-ai review mode status --json", "review mode status"],
+		["gentle-ai review validate --gate post-apply --cwd /repo/private", "review validate post apply"],
+		["gentle-ai review validate --gate pre-commit --cwd /repo/private", "review validate pre commit"],
+		["gentle-ai review validate --gate pre-push --cwd /repo/private", "review validate pre push"],
+		["gentle-ai review validate --gate pre-pr --cwd /repo/private", "review validate pre pr"],
+		["gentle-ai review validate --gate release --cwd /repo/private", "review validate release"],
+		["gentle-ai review schema capture-result-dry-run --path /tmp/private.json", "review schema capture result dry run"],
+		["gentle-ai review schema final-verification-incident --path /tmp/private.json", "review schema final verification incident"],
+		["gentle-ai review schema refuter --path /tmp/private.json", "review schema refuter"],
+		["gentle-ai review schema reviewer --path /tmp/private.json", "review schema reviewer"],
+		["gentle-ai review schema validator --path /tmp/private.json", "review schema validator"],
+		["gentle-ai review schema verification-evidence --path /tmp/private.json", "review schema verification evidence"],
+		["gentle-ai review schema verification-evidence-record --path /tmp/private.json", "review schema verification evidence record"],
+		["gentle-ai review unknown-operation --change change-123 --reason private-reason", "review"],
+		["gentle-ai review mode restart --actor maintainer", "review"],
+		["gentle-ai review validate --gate unknown-gate --cwd /repo/private", "review"],
+		["gentle-ai review schema unknown-schema --path /tmp/private.json", "review schema"],
+	];
+
+	for (const [command, path] of cases) {
+		const rendered = renderToString(
+			tool.renderCall(
+				{ command },
+				passthroughTheme,
+				routineRenderContext({ args: { command } }),
+			),
+		);
+		assert.equal(rendered.trimEnd(), `${rose} Gentle AI · running · ${path}`, command);
+		assert.doesNotMatch(rendered, /change-123|private|secret|lineage|sha256|result\.json|incident\.json/);
+	}
+});
+
+test("quiet tool rendering hides the routine partial result because the header owns state", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const command = "gentle-ai review status --cwd /repo/private";
+
+	const partial = renderToString(
+		tool.renderResult(
+			textResult("{\"status\":\"running\"}"),
+			{ expanded: false, isPartial: true },
+			passthroughTheme,
+			{ ...routineRenderContext({ args: { command } }), isError: false },
+		),
+	);
+	const partialExpanded = renderToString(
+		tool.renderResult(
+			textResult("{\"status\":\"running\"}"),
+			{ expanded: true, isPartial: true },
+			passthroughTheme,
+			{ ...routineRenderContext({ args: { command } }), isError: false },
+		),
+	);
+	const partialFailure = renderToString(
+		tool.renderResult(
+			textResult("review status failed: authority unavailable"),
+			{ expanded: false, isPartial: true },
+			passthroughTheme,
+			{ ...routineRenderContext({ args: { command } }), isError: true },
+		),
+	);
+
+	assert.equal(partial, "");
+	assert.match(partialExpanded, /"status":"running"/);
+	assert.match(partialFailure, /review status failed: authority unavailable/);
 });
 
 test("quiet tool rendering keeps collapsed git bash result tails", () => {


### PR DESCRIPTION
Closes #392

## Summary

- Render routine Gentle AI SDD and review Bash calls as one lifecycle indicator: `🌹︎ Gentle AI · running|completed|failed · <safe operation path>`.
- Expose only allow-listed operation paths while hiding variable arguments and rejecting lookalikes, arbitrary paths, shell composition, and unsupported commands.
- Keep successful routine output collapsed while preserving expanded output and all failure output unchanged.

## Changes

| File | Change |
|------|--------|
| `extensions/quiet-tools.ts` | Classify safe Gentle AI operation paths and render stateful, ellipsis-free command indicators. |
| `tests/quiet-tool-rendering.test.ts` | Cover lifecycle transitions, safe path families, fallbacks, exact rose code points, output visibility, and shell rejection. |

## Test plan

- [x] `node --experimental-strip-types --test tests/quiet-tool-rendering.test.ts` — 16 passed, 0 failed
- [x] `pnpm run test:harness`
- [x] `pnpm test` — 1300 passed, 0 failed, 1 skipped
- [x] `pnpm run test:packed-runner` — 13 states passed
- [x] `git diff --check`

## Contributor checklist

- [x] Linked approved issue #392
- [x] Added exactly one `type:*` label: `type:feature`
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recognized supported Gentle AI routine commands, including status, continuation, attempt, and review operations.
  - Displayed matching operations with dedicated Gentle AI labels and readable operation paths.

- **Improvements**
  - Simplified successful routine command output when collapsed to reduce visual clutter.
  - Preserved complete output when expanded or when a command fails.
  - Continued displaying full details for unrelated or combined commands.
  - Improved command validation by rejecting unsupported operations and composed shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->