### PR TITLE
fix(review): accept plain finalize advisory findings

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3195,6 +3195,7 @@ function mapNativeFinalizeResult(result: NativeFinalizeResult): Record<string, u
 		action: result.action,
 		store_revision: result.storeRevision,
 		...(result.receiptPath === undefined ? {} : { receipt_path: result.receiptPath }),
+		...(result.advisoryFindings === undefined ? {} : { advisory_findings: result.advisoryFindings }),
 	};
 }
 

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -13,6 +13,7 @@ import {
 	decodeReviewCapabilitiesV2,
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
+	decodeReviewAdvisoryFindingsV1,
 	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewRepairV2,
@@ -26,6 +27,7 @@ import {
 	type ReviewRepairV2,
 	type ReviewStartState,
 	type ReviewStatusV3,
+	type ReviewAdvisoryFindingsV1,
 } from "./review-integration-v2.ts";
 
 const execFileAsync = promisify(execFile);
@@ -698,7 +700,7 @@ export const NATIVE_START_ACTION = { CREATED: "created", RESUMED: "resumed", REU
 export type NativeStartAction = (typeof NATIVE_START_ACTION)[keyof typeof NATIVE_START_ACTION];
 export interface NativeStartResult { lineageId: string; state: ReviewStartState; riskLevel: string; selectedLenses: readonly string[]; changedFiles: number; changedLines: number; correctionBudget: number; action: NativeStartAction; lensesRequired: boolean; riskReasons?: readonly Record<string, unknown>[]; raw?: Readonly<Record<string, unknown>>; riskEvidence?: readonly string[]; hint?: string; }
 export interface NativeValidateResult { allowed: boolean; result: "allow" | "scope-changed" | "invalidated" | "escalated"; action: string; reason: string; gateContext: NativeGateContext; delivery?: ReviewGateDelivery; }
-export interface NativeFinalizeResult { lineageId: string; state: string; action: string; storeRevision: string; receiptPath?: string; validationRequest?: Readonly<Record<string, unknown>>; escalation?: string; }
+export interface NativeFinalizeResult { lineageId: string; state: string; action: string; storeRevision: string; receiptPath?: string; validationRequest?: Readonly<Record<string, unknown>>; escalation?: string; advisoryFindings?: ReviewAdvisoryFindingsV1; }
 export interface NativeBindSddResult {
 	revision: string;
 	change: string;
@@ -2529,6 +2531,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 				// nested object is private to lib/review-integration-v2.ts.
 				...(body.validation_request === undefined ? {} : { validationRequest: body.validation_request as Readonly<Record<string, unknown>> }),
 				...(body.escalation === undefined ? {} : { escalation: requiredString(body.escalation) }),
+				...(envelope.advisoryFindings === undefined ? {} : { advisoryFindings: envelope.advisoryFindings }),
 			};
 		} finally {
 			if (directory !== undefined) await this.cleanupDirectory(directory).catch(() => undefined);
@@ -2750,12 +2753,17 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 					storeRevision: requiredString(result.store_revision),
 					...(result.validation_request === undefined ? {} : { validationRequest: result.validation_request as Readonly<Record<string, unknown>> }),
 					...(result.escalation === undefined ? {} : { escalation: requiredString(result.escalation) }),
+					...(envelope.advisoryFindings === undefined ? {} : { advisoryFindings: envelope.advisoryFindings }),
 				};
 			}
-			const plain = exactObject(body, ["operation", "lineage_id", "state", "action", "store_revision"], ["receipt_path", "validation_request", "escalation"]);
+			const plain = exactObject(body, ["operation", "lineage_id", "state", "action", "store_revision"], ["receipt_path", "validation_request", "escalation", "advisory_findings"]);
 			if (plain.operation !== "review/finalize") throw new Error("wrong finalize discriminator");
 			const state = requiredString(plain.state);
 			if (!(NATIVE_FINALIZE_STATE as readonly string[]).includes(state)) throw new Error("unknown finalize state");
+			if (plain.advisory_findings !== undefined && state !== "approved") throw new TypeError("plain finalize advisory_findings requires state approved");
+			const advisoryFindings = plain.advisory_findings === undefined
+				? undefined
+				: decodeReviewAdvisoryFindingsV1(plain.advisory_findings, "plain finalize advisory_findings");
 			return {
 				lineageId: requiredString(plain.lineage_id),
 				state,
@@ -2764,6 +2772,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 				...(plain.receipt_path === undefined ? {} : { receiptPath: requiredString(plain.receipt_path) }),
 				...(plain.validation_request === undefined ? {} : { validationRequest: plain.validation_request as Readonly<Record<string, unknown>> }),
 				...(plain.escalation === undefined ? {} : { escalation: requiredString(plain.escalation) }),
+				...(advisoryFindings === undefined ? {} : { advisoryFindings }),
 			};
 		});
 	}

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -701,10 +701,39 @@ export interface ReviewFailureV2 {
 	raw: Readonly<Record<string, unknown>>;
 }
 
+export const REVIEW_ADVISORY_FINDING_SEVERITY = {
+	BLOCKER: "BLOCKER",
+	CRITICAL: "CRITICAL",
+	WARNING: "WARNING",
+	SUGGESTION: "SUGGESTION",
+} as const;
+export type ReviewAdvisoryFindingSeverity = (typeof REVIEW_ADVISORY_FINDING_SEVERITY)[keyof typeof REVIEW_ADVISORY_FINDING_SEVERITY];
+
+export const REVIEW_ADVISORY_FINDING_DISPOSITION = {
+	INFORMATIONAL: "informational",
+	FOLLOW_UP: "follow_up",
+	REFUTED: "refuted",
+} as const;
+export type ReviewAdvisoryFindingDisposition = (typeof REVIEW_ADVISORY_FINDING_DISPOSITION)[keyof typeof REVIEW_ADVISORY_FINDING_DISPOSITION];
+
+export interface ReviewAdvisoryFindingV1 {
+	id: string;
+	lens?: string;
+	location?: string;
+	severity: ReviewAdvisoryFindingSeverity;
+	disposition: ReviewAdvisoryFindingDisposition;
+}
+
+export interface ReviewAdvisoryFindingsV1 {
+	statement: string;
+	findings: readonly ReviewAdvisoryFindingV1[];
+}
+
 export interface ReviewOperationV2 {
 	contract: typeof REVIEW_INTEGRATION_CONTRACT;
 	operation: "review.finalize" | "review.validate" | "review.bind_sdd" | "review.retry_final_verification";
 	result: Readonly<Record<string, unknown>>;
+	advisoryFindings?: ReviewAdvisoryFindingsV1;
 	raw: Readonly<Record<string, unknown>>;
 }
 
@@ -1977,16 +2006,34 @@ export function decodeReviewFailureV2(value: unknown): ReviewFailureV2 {
 // operation/v2
 // ---------------------------------------------------------------------------
 
+export function decodeReviewAdvisoryFindingsV1(value: unknown, label: string): ReviewAdvisoryFindingsV1 {
+	const body = exactRecord(value, label, ["statement", "findings"]);
+	return {
+		statement: nonempty(body.statement, `${label}.statement`),
+		findings: array(body.findings, `${label}.findings`, (entry, itemLabel) => {
+			const finding = exactRecord(entry, itemLabel, ["id", "severity", "disposition"], ["lens", "location"]);
+			return {
+				id: nonempty(finding.id, `${itemLabel}.id`),
+				...(finding.lens === undefined ? {} : { lens: nonempty(finding.lens, `${itemLabel}.lens`) }),
+				...(finding.location === undefined ? {} : { location: nonempty(finding.location, `${itemLabel}.location`) }),
+				severity: enumeration(finding.severity, Object.values(REVIEW_ADVISORY_FINDING_SEVERITY), `${itemLabel}.severity`),
+				disposition: enumeration(finding.disposition, Object.values(REVIEW_ADVISORY_FINDING_DISPOSITION), `${itemLabel}.disposition`),
+			};
+		}, { minimum: 1 }),
+	};
+}
+
 export function decodeReviewOperationV2(value: unknown): ReviewOperationV2 {
 	const body = exactRecord(value, "operation", ["schema", "contract", "operation", "result"]);
 	requireIdentity(body, "gentle-ai.review-integration.operation/v2");
 	const operation = enumeration(body.operation, ["review.finalize", "review.validate", "review.bind_sdd", "review.retry_final_verification"] as const, "operation.operation");
 	let result: Record<string, unknown>;
+	let advisoryFindings: ReviewAdvisoryFindingsV1 | undefined;
 	if (operation === REVIEW_INTEGRATION_OPERATION.FINALIZE) {
-		result = exactRecord(body.result, "operation.result", ["operation", "lineage_id", "state", "action", "store_revision"], ["eligibility", "next_transition", "validation_request", "escalation"]);
+		result = exactRecord(body.result, "operation.result", ["operation", "lineage_id", "state", "action", "store_revision"], ["eligibility", "next_transition", "validation_request", "escalation", "advisory_findings"]);
 		if (result.operation !== "review/finalize") throw new TypeError("operation.result does not match review.finalize");
 		nonempty(result.lineage_id, "operation.result.lineage_id");
-		nonempty(result.state, "operation.result.state");
+		const state = nonempty(result.state, "operation.result.state");
 		nonempty(result.action, "operation.result.action");
 		sha256(result.store_revision, "operation.result.store_revision");
 		if (result.eligibility !== undefined) decodeEligibility(result.eligibility, "operation.result.eligibility");
@@ -1996,6 +2043,10 @@ export function decodeReviewOperationV2(value: unknown): ReviewOperationV2 {
 			if (result.state !== "correction_required") throw new TypeError("operation.result.validation_request requires state correction_required");
 		}
 		if (result.escalation !== undefined) nonempty(result.escalation, "operation.result.escalation");
+		if (result.advisory_findings !== undefined) {
+			if (state !== REVIEW_START_STATE.APPROVED) throw new TypeError("operation.result.advisory_findings requires state approved");
+			advisoryFindings = decodeReviewAdvisoryFindingsV1(result.advisory_findings, "operation.result.advisory_findings");
+		}
 	} else if (operation === REVIEW_INTEGRATION_OPERATION.VALIDATE) {
 		result = exactRecord(body.result, "operation.result", ["schema", "result", "allowed", "action", "reason", "context"], ["delivery"]);
 		if (result.schema !== "gentle-ai.review-gate-result/v1") throw new TypeError("operation.result does not match review.validate");
@@ -2032,7 +2083,13 @@ export function decodeReviewOperationV2(value: unknown): ReviewOperationV2 {
 		sha256(result.incident_digest, "operation.result.incident_digest");
 		if (result.recovery_disposition !== "final_verification_retry") throw new TypeError("operation.result.recovery_disposition must be final_verification_retry");
 	}
-	return { contract: REVIEW_INTEGRATION_CONTRACT, operation, result, raw: body };
+	return {
+		contract: REVIEW_INTEGRATION_CONTRACT,
+		operation,
+		result,
+		...(advisoryFindings === undefined ? {} : { advisoryFindings }),
+		raw: body,
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -14,12 +14,14 @@ import {
 	decodeReviewCapabilitiesV2,
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
+	decodeReviewAdvisoryFindingsV1,
 	decodeReviewFailureV2,
 	decodeReviewOperationV2,
 	decodeReviewRepairV2,
 	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
 	decodeReviewStatusV3,
+
 
 
 
@@ -2530,6 +2532,7 @@ export class NativeReviewCliV216                            {
 				// nested object is private to lib/review-integration-v2.ts.
 				...(body.validation_request === undefined ? {} : { validationRequest: body.validation_request                                      }),
 				...(body.escalation === undefined ? {} : { escalation: requiredString(body.escalation) }),
+				...(envelope.advisoryFindings === undefined ? {} : { advisoryFindings: envelope.advisoryFindings }),
 			};
 		} finally {
 			if (directory !== undefined) await this.cleanupDirectory(directory).catch(() => undefined);
@@ -2751,12 +2754,17 @@ export class NativeReviewCliV216                            {
 					storeRevision: requiredString(result.store_revision),
 					...(result.validation_request === undefined ? {} : { validationRequest: result.validation_request                                      }),
 					...(result.escalation === undefined ? {} : { escalation: requiredString(result.escalation) }),
+					...(envelope.advisoryFindings === undefined ? {} : { advisoryFindings: envelope.advisoryFindings }),
 				};
 			}
-			const plain = exactObject(body, ["operation", "lineage_id", "state", "action", "store_revision"], ["receipt_path", "validation_request", "escalation"]);
+			const plain = exactObject(body, ["operation", "lineage_id", "state", "action", "store_revision"], ["receipt_path", "validation_request", "escalation", "advisory_findings"]);
 			if (plain.operation !== "review/finalize") throw new Error("wrong finalize discriminator");
 			const state = requiredString(plain.state);
 			if (!(NATIVE_FINALIZE_STATE                     ).includes(state)) throw new Error("unknown finalize state");
+			if (plain.advisory_findings !== undefined && state !== "approved") throw new TypeError("plain finalize advisory_findings requires state approved");
+			const advisoryFindings = plain.advisory_findings === undefined
+				? undefined
+				: decodeReviewAdvisoryFindingsV1(plain.advisory_findings, "plain finalize advisory_findings");
 			return {
 				lineageId: requiredString(plain.lineage_id),
 				state,
@@ -2765,6 +2773,7 @@ export class NativeReviewCliV216                            {
 				...(plain.receipt_path === undefined ? {} : { receiptPath: requiredString(plain.receipt_path) }),
 				...(plain.validation_request === undefined ? {} : { validationRequest: plain.validation_request                                      }),
 				...(plain.escalation === undefined ? {} : { escalation: requiredString(plain.escalation) }),
+				...(advisoryFindings === undefined ? {} : { advisoryFindings }),
 			};
 		});
 	}

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -702,6 +702,35 @@ const FAILURE_CAUSE_CATEGORIES = ["inventory_io_or_layout", "lock_ambiguous", "r
 
 
 
+export const REVIEW_ADVISORY_FINDING_SEVERITY = {
+	BLOCKER: "BLOCKER",
+	CRITICAL: "CRITICAL",
+	WARNING: "WARNING",
+	SUGGESTION: "SUGGESTION",
+}         ;
+
+
+export const REVIEW_ADVISORY_FINDING_DISPOSITION = {
+	INFORMATIONAL: "informational",
+	FOLLOW_UP: "follow_up",
+	REFUTED: "refuted",
+}         ;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1978,16 +2007,34 @@ export function decodeReviewFailureV2(value         )                  {
 // operation/v2
 // ---------------------------------------------------------------------------
 
+export function decodeReviewAdvisoryFindingsV1(value         , label        )                           {
+	const body = exactRecord(value, label, ["statement", "findings"]);
+	return {
+		statement: nonempty(body.statement, `${label}.statement`),
+		findings: array(body.findings, `${label}.findings`, (entry, itemLabel) => {
+			const finding = exactRecord(entry, itemLabel, ["id", "severity", "disposition"], ["lens", "location"]);
+			return {
+				id: nonempty(finding.id, `${itemLabel}.id`),
+				...(finding.lens === undefined ? {} : { lens: nonempty(finding.lens, `${itemLabel}.lens`) }),
+				...(finding.location === undefined ? {} : { location: nonempty(finding.location, `${itemLabel}.location`) }),
+				severity: enumeration(finding.severity, Object.values(REVIEW_ADVISORY_FINDING_SEVERITY), `${itemLabel}.severity`),
+				disposition: enumeration(finding.disposition, Object.values(REVIEW_ADVISORY_FINDING_DISPOSITION), `${itemLabel}.disposition`),
+			};
+		}, { minimum: 1 }),
+	};
+}
+
 export function decodeReviewOperationV2(value         )                    {
 	const body = exactRecord(value, "operation", ["schema", "contract", "operation", "result"]);
 	requireIdentity(body, "gentle-ai.review-integration.operation/v2");
 	const operation = enumeration(body.operation, ["review.finalize", "review.validate", "review.bind_sdd", "review.retry_final_verification"]         , "operation.operation");
 	let result                         ;
+	let advisoryFindings                                      ;
 	if (operation === REVIEW_INTEGRATION_OPERATION.FINALIZE) {
-		result = exactRecord(body.result, "operation.result", ["operation", "lineage_id", "state", "action", "store_revision"], ["eligibility", "next_transition", "validation_request", "escalation"]);
+		result = exactRecord(body.result, "operation.result", ["operation", "lineage_id", "state", "action", "store_revision"], ["eligibility", "next_transition", "validation_request", "escalation", "advisory_findings"]);
 		if (result.operation !== "review/finalize") throw new TypeError("operation.result does not match review.finalize");
 		nonempty(result.lineage_id, "operation.result.lineage_id");
-		nonempty(result.state, "operation.result.state");
+		const state = nonempty(result.state, "operation.result.state");
 		nonempty(result.action, "operation.result.action");
 		sha256(result.store_revision, "operation.result.store_revision");
 		if (result.eligibility !== undefined) decodeEligibility(result.eligibility, "operation.result.eligibility");
@@ -1997,6 +2044,10 @@ export function decodeReviewOperationV2(value         )                    {
 			if (result.state !== "correction_required") throw new TypeError("operation.result.validation_request requires state correction_required");
 		}
 		if (result.escalation !== undefined) nonempty(result.escalation, "operation.result.escalation");
+		if (result.advisory_findings !== undefined) {
+			if (state !== REVIEW_START_STATE.APPROVED) throw new TypeError("operation.result.advisory_findings requires state approved");
+			advisoryFindings = decodeReviewAdvisoryFindingsV1(result.advisory_findings, "operation.result.advisory_findings");
+		}
 	} else if (operation === REVIEW_INTEGRATION_OPERATION.VALIDATE) {
 		result = exactRecord(body.result, "operation.result", ["schema", "result", "allowed", "action", "reason", "context"], ["delivery"]);
 		if (result.schema !== "gentle-ai.review-gate-result/v1") throw new TypeError("operation.result does not match review.validate");
@@ -2033,7 +2084,13 @@ export function decodeReviewOperationV2(value         )                    {
 		sha256(result.incident_digest, "operation.result.incident_digest");
 		if (result.recovery_disposition !== "final_verification_retry") throw new TypeError("operation.result.recovery_disposition must be final_verification_retry");
 	}
-	return { contract: REVIEW_INTEGRATION_CONTRACT, operation, result, raw: body };
+	return {
+		contract: REVIEW_INTEGRATION_CONTRACT,
+		operation,
+		result,
+		...(advisoryFindings === undefined ? {} : { advisoryFindings }),
+		raw: body,
+	};
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -950,6 +950,7 @@ test("finalizeTransition preserves approved burned advisory_findings", async () 
 			},
 		},
 		{ name: "plain transition", body: plainResult },
+		{ name: "plain non-approved transition", body: { ...plainResult, state: "escalated" }, rejects: true },
 	] as const;
 	for (const clientFactory of [
 		{
@@ -970,12 +971,17 @@ test("finalizeTransition preserves approved burned advisory_findings", async () 
 					{ stdout: JSON.stringify(await v216Capabilities(digest)) },
 					{ stdout: JSON.stringify(response.body) },
 				]);
-				const result = await clientFactory.create(queue.adapter).finalizeTransition({
+				const invocation = clientFactory.create(queue.adapter).finalizeTransition({
 					cwd: "/repo",
 					argumentTokens: ["--lineage=review-advisory-finalize", "--captured-results=true"],
 				});
 				const label = `${clientFactory.name}/${response.name}`;
-				assert.deepEqual(result.advisoryFindings, advisoryFindings, label);
+				if ("rejects" in response) {
+					await assert.rejects(invocation, { code: "schema-incompatible" }, label);
+				} else {
+					const result = await invocation;
+					assert.deepEqual(result.advisoryFindings, advisoryFindings, label);
+				}
 				assert.deepEqual(queue.calls.map((call) => call.arguments), [
 					["review", "capabilities", "--contract", "gentle-ai.review-integration/v2"],
 					["review", "finalize", "--lineage=review-advisory-finalize", "--captured-results=true"],

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -10,6 +10,7 @@ import {
 	NativeReviewCliV213 as NativeReviewCliV213Production,
 	NativeReviewCliV214,
 	NativeReviewCliV216,
+	clearNativeReviewCapabilitiesCacheForTesting,
 	createNodeExecFileAdapter,
 	type ExecFileAdapter,
 	type NativeStartRequest,
@@ -17,6 +18,7 @@ import {
 import {
 	NativeReviewCliV214 as RuntimeNativeReviewCliV214,
 	NativeReviewCliV216 as RuntimeNativeReviewCliV216,
+	clearNativeReviewCapabilitiesCacheForTesting as clearRuntimeNativeReviewCapabilitiesCacheForTesting,
 } from "../runtime/native-review-cli.mjs";
 import { GENTLE_AI_VERSION, setGentleAiDevBinaryEnvironmentForTesting } from "../lib/gentle-ai-binary.ts";
 
@@ -914,6 +916,74 @@ test("V216 executes the exact START operation and ordered tokens rendered by can
 			["review", "status", "--contract", "gentle-ai.review-integration/v2", "--cwd", "/repo", "--projection", "workspace", "--untracked-scope=select", `--expected-untracked-inventory=${`sha256:${"c".repeat(64)}`}`, "--intended-untracked=selected.ts", "--intended-untracked=second.ts", "--agent", "pi", "--next-transition"],
 			["review", "start", ...tokens],
 		]);
+	}
+});
+
+test("finalizeTransition preserves approved burned advisory_findings", async () => {
+	const digest = `sha256:${"a".repeat(64)}`;
+	const advisoryFindings = {
+		statement: "Approval stands; these findings require no correction.",
+		findings: [{
+			id: "review-advisory-001",
+			lens: "review-reliability",
+			location: "lib/review.ts:12",
+			severity: "WARNING",
+			disposition: "informational",
+		}],
+	};
+	const plainResult = {
+		operation: "review/finalize",
+		lineage_id: "review-advisory-finalize",
+		state: "approved",
+		action: "approval published",
+		store_revision: digest,
+		advisory_findings: advisoryFindings,
+	};
+	const responses = [
+		{
+			name: "negotiated envelope",
+			body: {
+				schema: "gentle-ai.review-integration.operation/v2",
+				contract: "gentle-ai.review-integration/v2",
+				operation: "review.finalize",
+				result: plainResult,
+			},
+		},
+		{ name: "plain transition", body: plainResult },
+	] as const;
+	for (const clientFactory of [
+		{
+			name: "source",
+			create: (adapter: ExecFileAdapter) => new NativeReviewCliV216(adapter, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024, async () => undefined, () => digest),
+			clearCapabilities: clearNativeReviewCapabilitiesCacheForTesting,
+		},
+		{
+			name: "generated runtime",
+			create: (adapter: ExecFileAdapter) => new RuntimeNativeReviewCliV216(adapter, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024, async () => undefined, () => digest),
+			clearCapabilities: clearRuntimeNativeReviewCapabilitiesCacheForTesting,
+		},
+	] as const) {
+		for (const response of responses) {
+			clientFactory.clearCapabilities();
+			try {
+				const queue = queuedAdapter([
+					{ stdout: JSON.stringify(await v216Capabilities(digest)) },
+					{ stdout: JSON.stringify(response.body) },
+				]);
+				const result = await clientFactory.create(queue.adapter).finalizeTransition({
+					cwd: "/repo",
+					argumentTokens: ["--lineage=review-advisory-finalize", "--captured-results=true"],
+				});
+				const label = `${clientFactory.name}/${response.name}`;
+				assert.deepEqual(result.advisoryFindings, advisoryFindings, label);
+				assert.deepEqual(queue.calls.map((call) => call.arguments), [
+					["review", "capabilities", "--contract", "gentle-ai.review-integration/v2"],
+					["review", "finalize", "--lineage=review-advisory-finalize", "--captured-results=true"],
+				], label);
+			} finally {
+				clientFactory.clearCapabilities();
+			}
+		}
 	}
 });
 

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -990,6 +990,50 @@ test("ambiguous native START runs target status first and follows only its decla
 	candidateViews.createOrReuse({ contributorRoot: cwd, replayKey }).cleanup();
 });
 
+test("schema-invalid post-mutation FINALIZE performs one FINALIZE and target-scoped STATUS only", async (t) => {
+	const cwd = repository(t);
+	const calls: string[] = [];
+	const statusRequests: Parameters<NonNullable<NativeReviewCli["targetStatus"]>>[0][] = [];
+	const initial = targetStatusFixture({ action: "finalize", lineageId: "schema-invalid-finalize" });
+	const reconciled = targetStatusFixture({
+		applicability: "ambiguous",
+		action: "select_lineage",
+		replayability: "status_required",
+		lineageId: "schema-invalid-finalize",
+	});
+	const { controller } = runtime(fakeNative({
+		targetStatus: async (request) => {
+			calls.push("status");
+			statusRequests.push(request);
+			return statusRequests.length === 1 ? initial : reconciled;
+		},
+		finalize: async () => {
+			calls.push("finalize");
+			throw new NativeReviewCliError(
+				NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE,
+				NATIVE_REVIEW_OPERATION.FINALIZE,
+				true,
+				true,
+				"native finalize response is schema incompatible",
+			);
+		},
+		reviewStatus: async () => {
+			throw new Error("schema-invalid finalize must not use inventory status");
+		},
+	}));
+	const result = await controller.execute("schema-invalid-finalize", {
+		operation: "finalize",
+		lineageId: "schema-invalid-finalize",
+		input: "{}",
+	}, undefined, undefined, context(cwd));
+	assert.deepEqual(calls, ["status", "finalize", "status"]);
+	assert.deepEqual(statusRequests.map((request) => ({ cwd: request.cwd, lineageId: request.lineageId })), [
+		{ cwd, lineageId: "schema-invalid-finalize" },
+		{ cwd, lineageId: "schema-invalid-finalize" },
+	]);
+	assert.equal((result.details as { outcome?: string }).outcome, "native-mutation-status-reconciled");
+});
+
 test("ambiguous native FINALIZE returns the target-status action without a second mutation", async (t) => {
 	const cwd = repository(t);
 	const calls: string[] = [];
@@ -1571,6 +1615,72 @@ test("ordinary final verification at validating captures evidence then executes 
 			assert.equal("correction_step" in details, false, "ordinary final verification is not a correction transaction");
 		});
 	}
+});
+
+test("ordinary final verification with advisory findings completes once without STATUS reconciliation", async (t) => {
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "app.ts"), "export const advisory = true;\n");
+	const frozen = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	const beforeCapture = bindCorrectionCollection(targetStatusFixture({
+		lineageId: "advisory-final-verification",
+		authorityState: "validating",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}));
+	const afterCapture = bindFinalVerificationTransition(targetStatusFixture({
+		lineageId: "advisory-final-verification",
+		authorityState: "validating",
+		baseTree: frozen.baseTree,
+		currentCandidateTree: frozen.candidateTree,
+		paths: frozen.paths,
+	}), "passed");
+	frozen.cleanup();
+	const advisoryFindings = {
+		statement: "Approval stands; these findings require no correction.",
+		findings: [{
+			id: "review-advisory-001",
+			lens: "review-reliability",
+			location: "lib/review.ts:12",
+			severity: "WARNING",
+			disposition: "informational",
+		}],
+	};
+	const calls: string[] = [];
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			calls.push("status");
+			return calls.filter((call) => call === "status").length === 1 ? beforeCapture : afterCapture;
+		},
+		captureEvidence: async () => {
+			calls.push("capture-evidence");
+			return capturedCorrectionEvidence(beforeCapture, "passed", "6");
+		},
+		finalizeTransition: async () => {
+			calls.push("finalize-transition");
+			return {
+				lineageId: "advisory-final-verification",
+				state: "approved",
+				action: "terminal",
+				storeRevision: "r2",
+				advisoryFindings,
+			};
+		},
+		finalize: async () => {
+			throw new Error("ordinary final verification must use the provider finalize transition");
+		},
+	}), undefined, new CandidateViewRegistry());
+	const result = await controller.execute("advisory-final-verification", {
+		operation: "finalize",
+		lineageId: "advisory-final-verification",
+		input: JSON.stringify({
+			final_evidence: "verification run: passed",
+			final_verification_outcome: "passed",
+		}),
+	}, undefined, undefined, context(cwd));
+	const details = result.details as { result?: { advisory_findings?: unknown } };
+	assert.deepEqual(calls, ["status", "capture-evidence", "status", "finalize-transition"]);
+	assert.deepEqual(details.result?.advisory_findings, advisoryFindings);
 });
 
 test("ordinary final verification rejects a Pi-authored targeted validation document before any capture", async (t) => {

--- a/tests/review-integration-v2.test.ts
+++ b/tests/review-integration-v2.test.ts
@@ -17,6 +17,7 @@ import {
 	decodeReviewStartV3,
 	decodeReviewStatusV3,
 } from "../lib/review-integration-v2.ts";
+import { decodeReviewOperationV2 as decodeRuntimeReviewOperationV2 } from "../runtime/review-integration-v2.mjs";
 
 const fixtureRoot = join(process.cwd(), "contracts", "review-integration", "v2", "fixtures");
 const fixture = <T = unknown>(name: string): T => JSON.parse(readFileSync(join(fixtureRoot, name), "utf8")) as T;
@@ -162,6 +163,64 @@ test("operation envelopes strictly bind the outer operation to one exact result 
 	assert.equal(decodeReviewOperationV2(envelope).operation, "review.finalize");
 	assertAdditionalProperty(decodeReviewOperationV2, envelope);
 	assertNestedRequired(decodeReviewOperationV2, envelope, ["result"], ["operation", "lineage_id", "state", "action", "store_revision"]);
+});
+
+function advisoryFindings(): JsonObject {
+	return {
+		statement: "Approval stands; these findings require no correction.",
+		findings: [{
+			id: "review-advisory-001",
+			lens: "review-reliability",
+			location: "lib/review.ts:12",
+			severity: "WARNING",
+			disposition: "informational",
+		}],
+	};
+}
+
+test("operation finalize accepts published advisory_findings and rejects malformed advisory rows", () => {
+	const decoders: readonly Decoder[] = [decodeReviewOperationV2, decodeRuntimeReviewOperationV2];
+	for (const decoder of decoders) {
+		const accepted = finalizeEnvelope();
+		(accepted.result as JsonObject).advisory_findings = advisoryFindings();
+		const decoded = decoder(accepted) as { advisoryFindings?: unknown };
+		assert.deepEqual(decoded.advisoryFindings, advisoryFindings());
+
+		for (const mutate of [
+			(value: JsonObject) => { ((value.findings as JsonObject[])[0]!).severity = "NOTICE"; },
+			(value: JsonObject) => { ((value.findings as JsonObject[])[0]!).disposition = "corrected"; },
+			(value: JsonObject) => { ((value.findings as JsonObject[])[0]!).id = 1; },
+			(value: JsonObject) => { ((value.findings as JsonObject[])[0]!).unadvertised = true; },
+			(value: JsonObject) => { value.findings = []; },
+		] as const) {
+			const malformed = finalizeEnvelope();
+			const findings = advisoryFindings();
+			mutate(findings);
+			(malformed.result as JsonObject).advisory_findings = findings;
+			assert.throws(() => decoder(malformed));
+		}
+
+		const wrongState = finalizeEnvelope();
+		(wrongState.result as JsonObject).state = "reviewing";
+		(wrongState.result as JsonObject).advisory_findings = advisoryFindings();
+		assert.throws(() => decoder(wrongState), /approved/);
+
+		const wrongOperation: JsonObject = {
+			schema: "gentle-ai.review-integration.operation/v2",
+			contract: REVIEW_INTEGRATION_CONTRACT,
+			operation: "review.validate",
+			result: {
+				schema: "gentle-ai.review-gate-result/v1",
+				result: "allow",
+				allowed: true,
+				action: "continue",
+				reason: "receipt matches",
+				context: { gate: "pre-commit" },
+				advisory_findings: advisoryFindings(),
+			},
+		};
+		assert.throws(() => decoder(wrongOperation), /advisory_findings.*not allowed/);
+	}
 });
 
 test("net-new decoders: consent, next-transition, and artifact-subject reject malformed payloads", () => {


### PR DESCRIPTION
Closes #397

## Summary

- Accept the published `advisory_findings` block on approved terminal FINALIZE responses.
- Preserve advisory findings opaquely through both negotiated and plain STATUS-driven FINALIZE paths.
- Keep strict decoding for malformed rows, unknown keys, invalid enums, wrong operations, and non-approved states.

## Changes

| Area | Change |
|------|--------|
| Review integration decoder | Adds the strict advisory findings schema to approved `review.finalize` results. |
| Native review client | Preserves advisories from negotiated envelopes and plain provider-rendered FINALIZE transitions. |
| Generated runtime | Synchronizes runtime modules with the TypeScript sources. |
| Regression coverage | Covers strict schema acceptance, terminal routing, no-reconciliation behavior, and both FINALIZE response shapes. |

## Test plan

- [x] Genuine RED: plain FINALIZE transition returned `schema-incompatible` before the correction.
- [x] Focused source/runtime regression test passes.
- [x] Three causal suites pass: 213 tests, 0 failures.
- [x] Full `pnpm test`: 1,215 tests; 1,214 passed, 1 skipped, 0 failed.
- [x] Runtime module parity, provider contract, harness, package resource, and diff checks pass.
- [x] Live Pi STATUS → FINALIZE fixture returns `approved` with two informational advisory findings and no reconciliation STATUS.

## Contributor checklist

- [x] Linked approved issue #397.
- [x] Exactly one `type:*` label: `type:bug`.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] Runtime behavior tested through the active Pi extension.
- [x] Generated runtime modules are synchronized.
- [x] Conventional commit used with no attribution trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advisory findings to finalized review results.
  * Findings include validated severity, disposition, statements, and details.
  * Findings are preserved across negotiated and standard finalization responses.

* **Bug Fixes**
  * Invalid advisory findings are now rejected.
  * Advisory findings are accepted only for approved finalizations.
  * Improved finalization verification when responses require compatibility reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->