### PR TITLE
fix(sdd): resolve preflight choices before prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Most coding-agent sessions fail for operational reasons, not model reasons:
 | **Configurable startup intro** | Adds a rose/text-logo startup intro, compact runtime panel, color presets, and commands to hide or show the decorative parts.                  |
 | **Work routing discipline**    | Small tasks stay inline. Context-heavy exploration can be delegated. Large or risky changes go through SDD/OpenSpec.                          |
 | **SDD/OpenSpec assets**        | Installs phase agents and chains for `init`, `onboard`, `explore`, `proposal`, `spec`, `design`, `tasks`, `apply`, `verify`, `sync`, and `archive`. |
-| **Lazy SDD preflight**         | Asks once per session for SDD mode, artifact store, PR chaining strategy, and review budget before the first SDD flow.                        |
+| **Lazy SDD preflight**         | Resolves SDD mode, artifact store, delivery strategy, and review budget once per session; prompts only when a choice is genuinely unresolved.              |
 | **Subagent orchestration**     | Keeps one parent session responsible while child agents explore, implement, test, or review with focused context.                             |
 | **Strict TDD support**         | When project config declares a test command, apply/verify phases must record RED → GREEN → TRIANGULATE → REFACTOR evidence.                   |
 | **Reviewer protection**        | Surfaces review workload risk before a task turns into an oversized PR.                                                                       |
@@ -386,7 +386,7 @@ Engram-only mode is different by design: Engram is working memory and does not m
 
 ## SDD preflight and project files
 
-`gentle-pi` does not require SDD agents to be copied into every project. The package ensures global Pi SDD assets exist under the Pi agent home and treats project-local files only as overrides/debug copies. Slash SDD flows such as `/sdd-*`, `/sdd-init`, and the explicit `/gentle:sdd-preflight` command run a lazy preflight and ask for session-scoped SDD preferences. For natural-language requests, the parent agent decides whether the work should use SDD and must run/reuse `/gentle:sdd-preflight` before continuing.
+`gentle-pi` does not require SDD agents to be copied into every project. The package ensures global Pi SDD assets exist under the Pi agent home and treats project-local files only as overrides/debug copies. Slash SDD flows such as `/sdd-*`, `/sdd-init`, and the explicit `/gentle:sdd-preflight` command run a lazy preflight and resolve session-scoped SDD preferences. For natural-language requests, the parent agent decides whether the work should use SDD and must run/reuse `/gentle:sdd-preflight` before continuing.
 
 ```text
 ~/.pi/agent/agents/sdd-*.md
@@ -394,12 +394,9 @@ Engram-only mode is different by design: Engram is working memory and does not m
 ~/.pi/agent/gentle-ai/support/strict-tdd*.md
 ```
 
-The preflight choices are reused for later SDD flows in the same session:
+Preflight values resolve in this order: explicit current user/session choice, valid persisted preference, capability or already-selected strategy constraint, canonical default, then a prompt only when genuinely unresolved. Resolved values are reused for later SDD flows in the session.
 
-- execution mode: `interactive` or `auto`;
-- artifact store: `openspec`, or `engram`/`both` when callable memory tools are available;
-- PR chaining strategy: `auto-forecast`, `ask-always`, `single-pr-default`, or `force-chained`;
-- review budget line threshold.
+Canonical values are `auto` execution mode, `openspec` artifact store, `ask-on-risk` delivery strategy, and a `400` changed-line review threshold. The delivery strategy domain is `ask-on-risk`, `auto-chain`, `single-pr`, or `exception-ok`; `chain_strategy` remains deferred until chaining is selected. `exception-ok` requires explicit `size:exception` acceptance and is never inferred. Consent, authorization, security, destructive/publishing, interactive phase approval, and ambiguous-scope gates remain human-controlled.
 
 It does **not** overwrite existing global assets unless you explicitly run:
 

--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -67,7 +67,7 @@ The detailed SDD workflow is intentionally not embedded in this always-on parent
 
 That lazy surface contains the SDD phases, native dispatcher rules, status contract, preflight/init guards, artifact-store policy, execution mode, Strict TDD forwarding, phase result contract, and review workload guard.
 
-Hard preflight invariant: `openspec/config.yaml`, existing SDD changes, installed `.pi`/global SDD assets, or a todo named "preflight" are not session preflight. Do not mark SDD preflight complete, start `sdd-init`, launch SDD subagents/chains, or move to explore/proposal/spec/design/tasks until this session has either an injected `## SDD Session Preflight` block or an explicit user answer covering the preflight choices.
+Hard preflight invariant: `openspec/config.yaml`, existing SDD changes, installed `.pi`/global SDD assets, or a todo named "preflight" are not session preflight. Do not mark SDD preflight complete, start `sdd-init`, launch SDD subagents/chains, or move to explore/proposal/spec/design/tasks until this session has an injected `## SDD Session Preflight` block or a canonical-authority resolution. Defaults and capability constraints may resolve fields without confirmation prompts; preserve unresolved-choice and safety gates.
 
 ## Memory Contract
 

--- a/assets/sdd-orchestrator-workflow.md
+++ b/assets/sdd-orchestrator-workflow.md
@@ -57,21 +57,15 @@ Do not guess the active change. If change selection is ambiguous, ask the user a
 
 Do not ask SDD setup questions on session start. The first time the user initiates an SDD process in a Pi session, run the SDD preflight once and keep those choices for the rest of that session. Runtime trigger detection is intentionally deterministic: slash SDD flows and `/sdd-init` run preflight automatically; for natural-language requests, the parent/orchestrator decides semantically whether SDD is needed and must run/reuse `/gentle:sdd-preflight` before continuing.
 
-**Hard gate:** `openspec/config.yaml`, existing SDD changes, installed `.pi`/global SDD assets, or a todo named "preflight" are not session preflight. They are project context only. Do not mark SDD preflight complete, start `sdd-init`, launch SDD subagents/chains, or move to explore/proposal/spec/design/tasks until this session has either:
+**Hard gate:** `openspec/config.yaml`, existing SDD changes, installed `.pi`/global SDD assets, or a todo named "preflight" are not session preflight. They are project context only. Do not mark SDD preflight complete, start `sdd-init`, launch SDD subagents/chains, or move to explore/proposal/spec/design/tasks until this session has an injected `## SDD Session Preflight` block or an equivalent resolution from the canonical authority order below.
 
-1. an injected `## SDD Session Preflight` block, or
-2. an explicit user answer in the current conversation covering all four preflight choices below.
+Resolve each field in this order: (1) explicit current user/session choice, (2) valid persisted preference, (3) capability or already-selected strategy constraint, (4) canonical documented default, and (5) ask only when the field is genuinely unresolved. If `/gentle:sdd-preflight` cannot be invoked, resolve the same order inline; do not recreate a four-question setup prompt. Missing Engram is a capability constraint that resolves the artifact store to `openspec` unless the user has made an incompatible explicit request, which remains a human decision.
 
-If neither exists and `/gentle:sdd-preflight` cannot be invoked from the current context, ask the four choices manually with `ask_user_question` before any SDD phase work. Treat missing Engram availability as a reason to ask/confirm artifact store, not as permission to assume defaults.
+Preflight canonical defaults are execution `auto`, artifact store `openspec`, delivery strategy `ask-on-risk`, and review budget `400`; capability and already-selected constraints may narrow them.
 
-The preflight captures:
+Selectors/inputs appear only for genuinely unresolved fields. Defaulted and one-option fields do not prompt; persisted/session values are reused, and an explicit current choice overrides them when presented. `chain_strategy` remains deferred, and `exception-ok` requires explicit `size:exception` acceptance and is never inferred.
 
-- execution mode: `interactive` or `auto`;
-- artifact store: `openspec`, `engram`, or `both` when callable memory tools are available;
-- chained PR strategy: the canonical `delivery_strategy` — `ask-on-risk`, `auto-chain`, `single-pr`, or `exception-ok`. The preflight menu offers the first three; `exception-ok` is reachable only when the user explicitly accepts `size:exception`, either up front or when `ask-on-risk` stops to ask;
-- review budget in changed lines.
-
-Those four PR values are exactly the `delivery_strategy` domain `sdd-tasks` and `sdd-apply` accept; never emit a value outside it. The preflight offers no separate chained option because `delivery_strategy` is only consulted once the tasks forecast flags review-budget risk: below that line there is nothing to chain, and above it `auto-chain` already resolves without asking again.
+The exact `delivery_strategy` domain accepted by `sdd-tasks` and `sdd-apply` is `ask-on-risk`, `auto-chain`, `single-pr`, or `exception-ok`; above the review threshold, `auto-chain` resolves without asking again.
 
 The package should ensure SDD assets are present as global Pi runtime assets without the user needing to remember per-project setup commands. If assets are missing, install them non-destructively into:
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -36,6 +36,8 @@ import {
 	isPackageManagedSddAsset,
 	isSddPreflightTrigger,
 	renderSddPreflightPrompt,
+	SDD_PREFLIGHT_FIELDS,
+	type SddPreflightField,
 	type SddPreflightPreferences,
 	updatePackageManagedSddAgentOwnership,
 } from "../lib/sdd-preflight.ts";
@@ -5579,12 +5581,8 @@ function createGentleAiExtensionForTesting(
 		},
 	});
 
-	function runSddPreflight(ctx: ExtensionContext): Promise<SddPreflightPreferences> {
-		return ensureSddPreflight(ctx, {
-			pi,
-			installAssets: (cwd) => installSddAssets(cwd, false),
-			applyModelConfig: async () => applySavedModelConfig(ctx),
-		});
+	function runSddPreflight(ctx: ExtensionContext, promptFields: readonly SddPreflightField[] = []): Promise<SddPreflightPreferences> {
+		return ensureSddPreflight(ctx, { pi, installAssets: (cwd) => installSddAssets(cwd, false), applyModelConfig: async () => applySavedModelConfig(ctx) }, { promptFields });
 	}
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -5704,7 +5702,7 @@ function createGentleAiExtensionForTesting(
 		description:
 			"Run or reuse the lazy SDD preflight for this Pi session.",
 		handler: async (_args, ctx) => {
-			await runSddPreflight(ctx);
+			await runSddPreflight(ctx, SDD_PREFLIGHT_FIELDS);
 		},
 	});
 

--- a/extensions/sdd-init.ts
+++ b/extensions/sdd-init.ts
@@ -775,11 +775,7 @@ export default function (pi: ExtensionAPI) {
 		description:
 			"Auto-detect project stack and bootstrap openspec/config.yaml for SDD.",
 		handler: async (_args: unknown, ctx: any) => {
-			const prefs = await ensureSddPreflight(ctx, {
-				pi,
-				installAssets: (cwd) => installSddAssets(cwd, false),
-				applyModelConfig: () => applySavedModelConfig(ctx),
-			});
+			const prefs = await ensureSddPreflight(ctx, { pi, installAssets: (cwd) => installSddAssets(cwd, false), applyModelConfig: () => applySavedModelConfig(ctx) }, { promptFields: [] });
 
 			const detection = detectProject(ctx.cwd);
 			const testSummary = detection.testCommand

--- a/lib/sdd-preflight.ts
+++ b/lib/sdd-preflight.ts
@@ -23,19 +23,36 @@ function gentlePiAgentHome(): string {
 }
 
 export type SddExecutionMode = "interactive" | "auto";
+export type SddDeliveryStrategy =
+	| "ask-on-risk"
+	| "auto-chain"
+	| "single-pr"
+	| "exception-ok";
+/** @deprecated Use SddDeliveryStrategy; legacy values normalize at persistence boundaries. */
 export type SddChainedPrStrategy =
+	| SddDeliveryStrategy
 	| "auto-forecast"
 	| "ask-always"
 	| "single-pr-default"
 	| "force-chained";
+export type SddPreflightField = "executionMode" | "artifactStore" | "chainedPrStrategy" | "reviewBudgetLines";
+export const SDD_PREFLIGHT_FIELDS = ["executionMode", "artifactStore", "chainedPrStrategy", "reviewBudgetLines"] as const;
 
 export interface SddPreflightPreferences {
 	executionMode: SddExecutionMode;
 	artifactStore: SddArtifactStore;
+	/** Runtime values are canonical; legacy assignments normalize at persistence/render boundaries. */
 	chainedPrStrategy: SddChainedPrStrategy;
 	reviewBudgetLines: number;
 	engramAvailable: boolean;
 	prompted: boolean;
+	sizeExceptionAccepted?: true;
+}
+
+export interface SddPreflightResolutionOptions {
+	persisted?: Partial<SddPreflightPreferences>;
+	promptFields?: readonly SddPreflightField[];
+	acceptSizeException?: true;
 }
 
 interface SddPreflightCallbacks {
@@ -69,20 +86,73 @@ interface LegacyManagedAssetsManifest extends ManagedAssetsManifest {
 	packageVersion: string;
 }
 
-const DEFAULT_SDD_PREFLIGHT: SddPreflightPreferences = {
-	executionMode: "interactive",
+export const DEFAULT_SDD_PREFLIGHT: SddPreflightPreferences = Object.freeze({
+	executionMode: "auto",
 	artifactStore: "openspec",
-	chainedPrStrategy: "auto-forecast",
+	chainedPrStrategy: "ask-on-risk",
 	reviewBudgetLines: 400,
 	engramAvailable: false,
 	prompted: false,
-};
+});
 
 const sddPreflightBySession = new Map<string, SddPreflightPreferences>();
 const sddPreflightInFlight = new Map<string, Promise<SddPreflightPreferences>>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSddExecutionMode(value: unknown): value is SddExecutionMode {
+	return value === "interactive" || value === "auto";
+}
+
+function isSddArtifactStore(value: unknown): value is SddArtifactStore {
+	return value === "openspec" || value === "engram" || value === "both" || value === "none";
+}
+
+function normalizeReviewBudgetValue(value: unknown): number | undefined {
+	const parsed = typeof value === "number"
+		? value
+		: typeof value === "string"
+			? Number.parseInt(value.trim(), 10)
+			: Number.NaN;
+	return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
+}
+
+function normalizeSddStrategySelection(
+	value: unknown,
+	allowExceptionOk: boolean,
+): SddDeliveryStrategy | undefined {
+	if (value === "exception-ok") return allowExceptionOk ? value : undefined;
+	if (value === "auto-forecast" || value === "ask-always") return "ask-on-risk";
+	if (value === "single-pr-default") return "single-pr";
+	if (value === "force-chained") return "auto-chain";
+	return value === "ask-on-risk" || value === "auto-chain" || value === "single-pr"
+		? value
+		: undefined;
+}
+
+export function normalizeSddChainedPrStrategy(
+	value: unknown,
+	allowExceptionOk = false,
+): SddDeliveryStrategy {
+	return normalizeSddStrategySelection(value, allowExceptionOk) ?? "ask-on-risk";
+}
+
+function normalizedSelections(
+	value: Partial<Record<SddPreflightField, unknown>> | undefined,
+	engramAvailable: boolean,
+	allowExceptionOk: boolean,
+): Partial<Record<SddPreflightField, unknown>> {
+	if (!value) return {};
+	const result: Partial<Record<SddPreflightField, unknown>> = {};
+	if (isSddExecutionMode(value.executionMode)) result.executionMode = value.executionMode;
+	if (isSddArtifactStore(value.artifactStore) && (engramAvailable || value.artifactStore === "openspec" || value.artifactStore === "none")) result.artifactStore = value.artifactStore;
+	const strategy = normalizeSddStrategySelection(value.chainedPrStrategy, allowExceptionOk);
+	if (strategy) result.chainedPrStrategy = strategy;
+	const reviewBudgetLines = normalizeReviewBudgetValue(value.reviewBudgetLines);
+	if (reviewBudgetLines !== undefined) result.reviewBudgetLines = reviewBudgetLines;
+	return result;
 }
 
 function emptyManagedAssetsManifest(): ManagedAssetsManifest {
@@ -273,28 +343,24 @@ export function readSddPreflightFromDisk(cwd: string): SddPreflightPreferences |
 	try {
 		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
 		if (!isRecord(parsed)) return undefined;
-		// Validate required fields to guard against stale/corrupt writes
+		// Validate required fields to guard against stale/corrupt writes.
 		const { executionMode, artifactStore, chainedPrStrategy, reviewBudgetLines, engramAvailable, prompted } = parsed;
 		if (
-			(executionMode !== "interactive" && executionMode !== "auto") ||
-			(artifactStore !== "openspec" && artifactStore !== "engram" && artifactStore !== "both" && artifactStore !== "none") ||
+			!isSddExecutionMode(executionMode) ||
+			!isSddArtifactStore(artifactStore) ||
 			typeof reviewBudgetLines !== "number" ||
+			!Number.isFinite(reviewBudgetLines) ||
+			reviewBudgetLines <= 0 ||
 			typeof engramAvailable !== "boolean" ||
 			typeof prompted !== "boolean"
 		) {
 			return undefined;
 		}
-		const normalizedChain: SddChainedPrStrategy =
-			chainedPrStrategy === "ask-always" ||
-			chainedPrStrategy === "single-pr-default" ||
-			chainedPrStrategy === "force-chained"
-				? (chainedPrStrategy as SddChainedPrStrategy)
-				: "auto-forecast";
 		return {
 			executionMode,
 			artifactStore,
-			chainedPrStrategy: normalizedChain,
-			reviewBudgetLines,
+			chainedPrStrategy: normalizeSddChainedPrStrategy(chainedPrStrategy),
+			reviewBudgetLines: normalizeReviewBudgetValue(reviewBudgetLines) ?? DEFAULT_SDD_PREFLIGHT.reviewBudgetLines,
 			engramAvailable,
 			prompted,
 		};
@@ -306,8 +372,19 @@ export function readSddPreflightFromDisk(cwd: string): SddPreflightPreferences |
 export function writeSddPreflightToDisk(cwd: string, prefs: SddPreflightPreferences): void {
 	try {
 		const path = sddPreflightDiskPath(cwd);
+		const prompted = prefs.prompted === true;
+		const canonical: SddPreflightPreferences = {
+			executionMode: isSddExecutionMode(prefs.executionMode) ? prefs.executionMode : DEFAULT_SDD_PREFLIGHT.executionMode,
+			artifactStore: isSddArtifactStore(prefs.artifactStore) ? prefs.artifactStore : DEFAULT_SDD_PREFLIGHT.artifactStore,
+			chainedPrStrategy: normalizeSddChainedPrStrategy(prefs.chainedPrStrategy),
+			reviewBudgetLines:
+				normalizeReviewBudgetValue(prefs.reviewBudgetLines) ??
+				DEFAULT_SDD_PREFLIGHT.reviewBudgetLines,
+			engramAvailable: prefs.engramAvailable === true,
+			prompted,
+		};
 		mkdirSync(dirname(path), { recursive: true });
-		writeFileSync(path, JSON.stringify(prefs, null, 2));
+		writeFileSync(path, JSON.stringify(canonical, null, 2));
 	} catch {
 		// Disk write failures are non-fatal; in-memory cache is the primary store
 	}
@@ -550,56 +627,67 @@ function hasWritableEngramTool(pi: ExtensionAPI): boolean {
 	}
 }
 
-function normalizeSddReviewBudget(value: string): number {
-	const parsed = Number.parseInt(value.trim(), 10);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : 400;
-}
-
-async function collectSddPreflightPreferences(
+export async function collectSddPreflightPreferences(
 	ctx: ExtensionContext,
 	engramAvailable: boolean,
+	options: SddPreflightResolutionOptions = {},
 ): Promise<SddPreflightPreferences> {
-	if (!ctx.hasUI) return { ...DEFAULT_SDD_PREFLIGHT, engramAvailable };
-	const executionMode = await ctx.ui.select("SDD execution mode", [
-		"interactive",
-		"auto",
-	]);
-	const artifactOptions = engramAvailable
-		? ["openspec", "engram", "both"]
-		: ["openspec"];
-	const artifactStore = await ctx.ui.select("SDD artifact store", artifactOptions);
-	const chainedPrStrategy = await ctx.ui.select("SDD PR chaining", [
-		"auto-forecast",
-		"ask-always",
-		"single-pr-default",
-		"force-chained",
-	]);
-	const reviewBudgetLines = normalizeSddReviewBudget(
-		(await ctx.ui.input("SDD review budget lines", "400")) ?? "400",
-	);
+	const persistedPrompted = options.persisted?.prompted === true;
+	const allowExceptionOk = options.acceptSizeException === true;
+	const persisted = normalizedSelections(options.persisted, engramAvailable, allowExceptionOk);
+	const resolved: Partial<Record<SddPreflightField, unknown>> = { ...persisted };
+	let prompted = persistedPrompted;
+	let sizeExceptionAccepted = allowExceptionOk && persisted.chainedPrStrategy === "exception-ok";
+	const promptFields = new Set(options.promptFields ?? []);
+
+	const usePromptedValue = (
+		field: SddPreflightField,
+		value: unknown,
+	): void => {
+		const candidate = normalizedSelections({ [field]: value }, engramAvailable, allowExceptionOk);
+		if (candidate[field] !== undefined) {
+			resolved[field] = candidate[field];
+			if (field === "chainedPrStrategy" && candidate[field] === "exception-ok") sizeExceptionAccepted = true;
+			prompted = true;
+		}
+	};
+
+	const promptField = async (
+		field: SddPreflightField,
+		read: () => Promise<unknown>,
+		enabled = true,
+	): Promise<void> => {
+		if (ctx.hasUI && enabled && promptFields.has(field)) {
+			usePromptedValue(field, await read());
+		}
+	};
+	const artifactOptions = engramAvailable ? ["openspec", "engram", "both"] : ["openspec"];
+	await promptField("executionMode", () => ctx.ui.select("SDD execution mode", ["interactive", "auto"]));
+	await promptField("artifactStore", () => ctx.ui.select("SDD artifact store", artifactOptions), artifactOptions.length > 1);
+	await promptField("chainedPrStrategy", () => ctx.ui.select("SDD delivery strategy", ["ask-on-risk", "auto-chain", "single-pr"]));
+	await promptField("reviewBudgetLines", () => ctx.ui.input("SDD review budget lines", String(DEFAULT_SDD_PREFLIGHT.reviewBudgetLines)));
+
+	const resolvedValue = <T>(field: SddPreflightField, fallback: T): T =>
+		(resolved[field] as T | undefined) ?? fallback;
 	return {
-		executionMode:
-			executionMode === "auto" ? "auto" : DEFAULT_SDD_PREFLIGHT.executionMode,
-		artifactStore:
-			artifactStore === "engram" || artifactStore === "both"
-				? artifactStore
-				: DEFAULT_SDD_PREFLIGHT.artifactStore,
-		chainedPrStrategy:
-			chainedPrStrategy === "ask-always" ||
-			chainedPrStrategy === "single-pr-default" ||
-			chainedPrStrategy === "force-chained"
-				? chainedPrStrategy
-				: DEFAULT_SDD_PREFLIGHT.chainedPrStrategy,
-		reviewBudgetLines,
+		executionMode: resolvedValue("executionMode", DEFAULT_SDD_PREFLIGHT.executionMode),
+		artifactStore: resolvedValue("artifactStore", DEFAULT_SDD_PREFLIGHT.artifactStore),
+		chainedPrStrategy: resolvedValue("chainedPrStrategy", DEFAULT_SDD_PREFLIGHT.chainedPrStrategy),
+		reviewBudgetLines: resolvedValue("reviewBudgetLines", DEFAULT_SDD_PREFLIGHT.reviewBudgetLines),
 		engramAvailable,
-		prompted: true,
+		prompted,
+		...(sizeExceptionAccepted ? { sizeExceptionAccepted: true as const } : {}),
 	};
 }
 
 export function renderSddPreflightPrompt(prefs: SddPreflightPreferences): string {
+	const deliveryStrategy = normalizeSddChainedPrStrategy(
+		prefs.chainedPrStrategy,
+		prefs.sizeExceptionAccepted === true,
+	);
 	const sourceLine = prefs.prompted
-		? "The user already chose these SDD preferences for this Pi session. Reuse them unless the user explicitly changes them."
-		: "No interactive UI was available for SDD preflight, so these default preferences were applied for this Pi session. Ask the user before making delivery decisions that depend on them.";
+		? "These SDD preferences are explicit current-session choices. Reuse them unless the user explicitly changes them."
+		: "These SDD preferences are canonical defaults or persisted choices. Treat them as authoritative; do not revisit dependent decisions unless a genuine human-control gate is reached.";
 	const interactiveRules =
 		prefs.executionMode === "interactive"
 			? [
@@ -615,25 +703,34 @@ export function renderSddPreflightPrompt(prefs: SddPreflightPreferences): string
 		sourceLine,
 		`- Execution mode: ${prefs.executionMode}`,
 		`- Artifact store: ${prefs.artifactStore}${prefs.engramAvailable ? "" : " (Engram unavailable in this session)"}`,
-		`- Chained PR strategy: ${prefs.chainedPrStrategy}`,
-		`- Review budget: ${prefs.reviewBudgetLines} changed lines`,
+		`- Delivery strategy: ${deliveryStrategy}`,
+		"- Delivery strategy domain: `ask-on-risk` | `auto-chain` | `single-pr` | `exception-ok`",
+		`- Review budget: ${prefs.reviewBudgetLines} changed lines (400 is the canonical threshold unless explicitly changed)`,
+		"- Chain strategy: deferred until chaining is selected.",
+		"- `exception-ok` is never inferred; it requires explicit acceptance of `size:exception`.",
 		...interactiveRules,
-		"- If task/workload forecasts conflict with these preferences, pause before sdd-apply and ask the user for a delivery decision.",
+		"- Preserve human-controlled consent, authorization, security, destructive/publishing, ambiguous-scope, and `size:exception` gates.",
+		"- When review-budget risk requires a delivery decision, use `ask-on-risk` to pause and ask; do not invent a chain strategy or an exception.",
 	].join("\n");
 }
 
 export async function ensureSddPreflight(
 	ctx: ExtensionContext,
 	callbacks: SddPreflightCallbacks,
+	resolutionOptions: SddPreflightResolutionOptions = {},
 ): Promise<SddPreflightPreferences> {
 	const sessionKey = sddPreflightSessionKey(ctx);
 	const existing = sddPreflightBySession.get(sessionKey);
-	if (existing) return existing;
+	if (existing && !(resolutionOptions.promptFields?.length ?? 0)) return existing;
 	const inFlight = sddPreflightInFlight.get(sessionKey);
-	if (inFlight) return inFlight;
+	if (inFlight && !(resolutionOptions.promptFields?.length ?? 0)) return inFlight;
 	const promise = (async () => {
 		const engramAvailable = hasWritableEngramTool(callbacks.pi);
-		const prefs = await collectSddPreflightPreferences(ctx, engramAvailable);
+		const persisted = resolutionOptions.persisted ?? readSddPreflightFromDisk(ctx.cwd);
+		const prefs = await collectSddPreflightPreferences(ctx, engramAvailable, {
+			...resolutionOptions,
+			persisted,
+		});
 		const result =
 			(await callbacks.installAssets?.(ctx.cwd)) ??
 			installSddAssets(ctx.cwd, false);
@@ -650,9 +747,9 @@ export async function ensureSddPreflight(
 					"Gentle AI SDD preflight complete.",
 					`Mode: ${prefs.executionMode}`,
 					`Artifacts: ${prefs.artifactStore}`,
-					`PR chaining: ${prefs.chainedPrStrategy}`,
+					`Delivery strategy: ${prefs.chainedPrStrategy}`,
 					`Review budget: ${prefs.reviewBudgetLines} changed lines`,
-					`Preference source: ${prefs.prompted ? "user prompt" : "defaults (no interactive UI available)"}`,
+					`Preference source: ${prefs.prompted ? "explicit session choice" : "canonical default or persisted preference"}`,
 					`Global SDD assets ready: ${result.agents} agent(s), ${result.chains} chain(s), ${result.support} support file(s), ${result.skipped} already present.`,
 					modelRoutingLine,
 				].join("\n"),

--- a/tests/artifact-language.test.ts
+++ b/tests/artifact-language.test.ts
@@ -67,14 +67,15 @@ test("rendered SDD preflight prompt is English artifact copy", () => {
 	const prefs: SddPreflightPreferences = {
 		executionMode: "interactive",
 		artifactStore: "openspec",
-		chainedPrStrategy: "ask-always",
+		chainedPrStrategy: "ask-on-risk",
 		reviewBudgetLines: 400,
 		engramAvailable: false,
 		prompted: true,
 	};
 	const prompt = renderSddPreflightPrompt(prefs);
 
-	assert.match(prompt, /The user already chose these SDD preferences/);
+	assert.match(prompt, /These SDD preferences are explicit current-session choices/);
+	assert.match(prompt, /Delivery strategy: ask-on-risk/);
 	assert.match(prompt, /Review budget: 400 changed lines/);
 	assert.match(prompt, /complete only the current SDD phase/i);
 	assert.match(prompt, /Do not start the next SDD phase/i);
@@ -82,9 +83,15 @@ test("rendered SDD preflight prompt is English artifact copy", () => {
 	assert.match(prompt, /offer the user a proposal question round/i);
 	assert.match(prompt, /business rules, implications, impact, edge cases/i);
 	assert.match(prompt, /second question round/i);
+	assert.match(prompt, /explicit acceptance of `size:exception`/);
+	assert.match(prompt, /human-controlled consent, authorization, security, destructive\/publishing/);
 	for (const pattern of SPANISH_PREFLIGHT_COPY) {
 		assert.doesNotMatch(prompt, pattern);
 	}
+
+	const headless = renderSddPreflightPrompt({ ...prefs, executionMode: "auto", prompted: false });
+	assert.match(headless, /canonical defaults or persisted choices/);
+	assert.match(headless, /ambiguous-scope/);
 });
 
 test("orchestrator Memory Contract carries the Engram memory lifecycle rule", async () => {
@@ -160,6 +167,9 @@ test("orchestrator lazy-loads detailed SDD workflow", async () => {
 
 	assert.match(orchestrator, /## SDD Workflow \(lazy-loaded\)/);
 	assert.match(orchestrator, /\{\{GENTLE_PI_SDD_WORKFLOW_PATH\}\}/);
+	assert.match(orchestrator, /injected `## SDD Session Preflight` block or a canonical-authority resolution/);
+	assert.match(orchestrator, /Defaults and capability constraints may resolve fields without confirmation prompts/);
+	assert.doesNotMatch(orchestrator, /or an explicit user answer covering the preflight choices/);
 	assert.doesNotMatch(orchestrator, /## Native SDD Dispatcher/);
 	assert.match(workflow, /## Native SDD Dispatcher/);
 	assert.match(workflow, /## SDD Status Contract/);

--- a/tests/orchestrator-budget.test.ts
+++ b/tests/orchestrator-budget.test.ts
@@ -233,6 +233,9 @@ function isNormativeLine(line: string): boolean {
 }
 
 const fixtureLines = readFileSync(FIXTURE_PATH, "utf8").split("\n");
+// Fixture line 191 predates canonical-authority resolution; keep its coverage by
+// asserting the intentionally updated production wording instead of weakening the range.
+const CURRENT_HARD_PREFLIGHT_INVARIANT = "Hard preflight invariant: `openspec/config.yaml`, existing SDD changes, installed `.pi`/global SDD assets, or a todo named \"preflight\" are not session preflight. Do not mark SDD preflight complete, start `sdd-init`, launch SDD subagents/chains, or move to explore/proposal/spec/design/tasks until this session has an injected `## SDD Session Preflight` block or a canonical-authority resolution. Defaults and capability constraints may resolve fields without confirmation prompts; preserve unresolved-choice and safety gates.";
 const SUPERSEDED_LIFECYCLE_REVIEW_LINES = new Set([
 	70,
 	// 74/77: the loose mode-choice background lines were replaced by the
@@ -266,6 +269,7 @@ for (const range of DISPOSITION_MAP) {
 				const raw = fixtureLines[ln - 1];
 				if (raw === undefined || !isNormativeLine(raw)) continue;
 				const trimmed = raw.trim();
+				const expected = ln === 191 ? CURRENT_HARD_PREFLIGHT_INVARIANT : trimmed;
 				if (SUPERSEDED_LIFECYCLE_REVIEW_LINES.has(ln)) {
 					assert.ok(
 						!targetContent.includes(trimmed),
@@ -281,8 +285,8 @@ for (const range of DISPOSITION_MAP) {
 					continue;
 				}
 				assert.ok(
-					targetContent.includes(trimmed),
-					`normative line lost: fixture:${ln} "${trimmed}" not found verbatim in ${TARGET_FILE[range.target]} (disposition: ${range.target}, section: ${range.label})`,
+					targetContent.includes(expected),
+					`normative line lost: fixture:${ln} "${expected}" not found verbatim in ${TARGET_FILE[range.target]} (disposition: ${range.target}, section: ${range.label})`,
 				);
 			}
 		},

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -1049,17 +1049,13 @@ async function run() {
 		assert.equal(existsSync(join(globalAgentHome, "agents", "sdd-sync.md")), true);
 		assert.equal(existsSync(join(globalAgentHome, "gentle-ai", "support", "sdd-status-contract.md")), true);
 		assert.equal(existsSync(join(globalAgentHome, "chains", "sdd-full.chain.md")), true);
-		assert.equal(ctx.ui.selections.length, 3);
-		assert.equal(ctx.ui.selections[0].label, "SDD execution mode");
-		assert.equal(ctx.ui.selections[1].label, "SDD artifact store");
-		assert.deepEqual(ctx.ui.selections[1].options, ["openspec"]);
-		assert.equal(ctx.ui.selections[2].label, "SDD PR chaining");
-		assert.match(ctx.ui.notifications.at(-1).message, /Preference source: user prompt/);
+		assert.equal(ctx.ui.selections.length, 0, "automatic SDD triggers must not render confirmation-only selectors");
+		assert.match(ctx.ui.notifications.at(-1).message, /Preference source: canonical default or persisted preference/);
 		assert.deepEqual(
 			await inputHook({ text: "please use sdd for this change", source: "interactive" }, ctx),
 			{ action: "continue" },
 		);
-		assert.equal(ctx.ui.selections.length, 3, "natural SDD trigger should reuse session choices");
+		assert.equal(ctx.ui.selections.length, 0, "natural SDD triggers reuse preferences without prompts");
 		assert.deepEqual(
 			await inputHook({ text: "/sdd", source: "interactive" }, ctx),
 			{ action: "continue" },
@@ -1072,7 +1068,7 @@ async function run() {
 			await inputHook({ text: "/sdd:plan", source: "interactive" }, ctx),
 			{ action: "continue" },
 		);
-		assert.equal(ctx.ui.selections.length, 3);
+		assert.equal(ctx.ui.selections.length, 0, "slash SDD triggers use automatic defaults without prompts");
 
 		assert.deepEqual(
 			await inputHook({ text: "/sdd-plan this change", source: "interactive" }, ctx),
@@ -1100,19 +1096,18 @@ async function run() {
 				"global SDD model routing must be materialized in agent frontmatter, not project settings overrides",
 			);
 		}
-		assert.equal(ctx.ui.selections.length, 3);
-		assert.deepEqual(ctx.ui.selections[1].options, ["openspec"]);
-		assert.match(ctx.ui.notifications.at(-1).message, /SDD preflight complete/);
+		assert.equal(ctx.ui.selections.length, 0, "automatic SDD routing must not render confirmation-only selectors");
+		assert.match(ctx.ui.notifications.at(-1).message, /Preference source: canonical default or persisted preference/);
 		await commands.get("gentle:status").handler("", ctx);
 		assert.match(ctx.ui.notifications.at(-1).message, /Global SDD assets stale: 0 file\(s\)/);
 		assert.doesNotMatch(ctx.ui.notifications.at(-1).message, /install-sdd --force/);
 
 		await inputHook({ text: "/sdd-plan another change", source: "interactive" }, ctx);
-		assert.equal(ctx.ui.selections.length, 3, "preflight should run only once per session");
+		assert.equal(ctx.ui.selections.length, 0, "automatic preflight should remain prompt-free for the session");
 		const promptHook = hooks.get("before_agent_start")[0];
 		const promptResult = await promptHook({ systemPrompt: "base" }, ctx);
 		assert.match(promptResult.systemPrompt, /SDD Session Preflight/);
-		assert.match(promptResult.systemPrompt, /Execution mode: interactive/);
+		assert.match(promptResult.systemPrompt, /Execution mode: auto/);
 		const workerPromptResult = await promptHook(
 			{ agentName: "worker", systemPrompt: "worker base" },
 			ctx,
@@ -1137,7 +1132,7 @@ async function run() {
 			});
 			assert.equal(existsSync(join(slashSddCwd, ".pi", "agents", "sdd-apply.md")), false);
 			assert.equal(existsSync(join(globalAgentHome, "agents", "sdd-apply.md")), true);
-			assert.equal(ctx.ui.selections.length, 3, `${text} should run canonical preflight`);
+			assert.equal(ctx.ui.selections.length, 0, `${text} should use automatic preflight without selectors`);
 		} finally {
 			await rm(slashSddCwd, { recursive: true, force: true });
 		}
@@ -1149,9 +1144,11 @@ async function run() {
 		await commands.get("gentle:sdd-preflight").handler("", ctx);
 		assert.equal(existsSync(join(commandSddCwd, ".pi", "agents", "sdd-apply.md")), false);
 		assert.equal(existsSync(join(globalAgentHome, "agents", "sdd-apply.md")), true);
-		assert.equal(ctx.ui.selections.length, 3);
+		assert.equal(ctx.ui.selections.length, 2, "explicit preflight prompts intentional choice fields");
+		assert.equal(ctx.ui.selections.some(({ label }) => label === "SDD artifact store"), false, "one-option artifact store must be elided");
+		assert.match(ctx.ui.notifications.at(-1).message, /Preference source: explicit session choice/);
 		await commands.get("gentle:sdd-preflight").handler("", ctx);
-		assert.equal(ctx.ui.selections.length, 3, "manual preflight command should reuse session choices");
+		assert.equal(ctx.ui.selections.length, 4, "explicit preflight remains an intentional re-prompt");
 	} finally {
 		await rm(commandSddCwd, { recursive: true, force: true });
 	}
@@ -1170,7 +1167,7 @@ async function run() {
 		assert.equal(existsSync(join(sddAgentGuardCwd, ".pi", "chains", "sdd-full.chain.md")), false);
 		assert.equal(existsSync(join(globalAgentHome, "agents", "sdd-apply.md")), true);
 		assert.equal(existsSync(join(globalAgentHome, "chains", "sdd-full.chain.md")), true);
-		assert.equal(ctx.ui.selections.length, 3);
+		assert.equal(ctx.ui.selections.length, 0, "automatic SDD-agent startup must not render selectors");
 		assert.match(promptResult.systemPrompt, /SDD Session Preflight/);
 		assert.doesNotMatch(
 			promptResult.systemPrompt,
@@ -1191,7 +1188,7 @@ async function run() {
 			},
 			ctx,
 		);
-		assert.equal(ctx.ui.selections.length, 3, "SDD agent guard should reuse session choices");
+		assert.equal(ctx.ui.selections.length, 0, "SDD-agent startup should reuse automatic preferences");
 		assert.doesNotMatch(
 			reusedPromptResult.systemPrompt,
 			/el Gentleman Identity and Harness/,
@@ -1213,7 +1210,7 @@ async function run() {
 			ctx,
 		);
 		assert.match(promptResult.systemPrompt, /SDD Session Preflight/);
-		assert.match(promptResult.systemPrompt, /No interactive UI was available/);
+		assert.match(promptResult.systemPrompt, /canonical defaults or persisted choices/);
 		assert.equal(ctx.ui.selections.length, 0);
 		assert.equal(existsSync(join(noUiSddAgentCwd, ".pi", "agents", "sdd-apply.md")), false);
 		assert.equal(existsSync(join(globalAgentHome, "agents", "sdd-apply.md")), true);
@@ -1326,7 +1323,7 @@ async function run() {
 		pi.setActiveTools(["read", "bash", "edit", "write", "engram_mem_save"]);
 		const ctx = createCtx(directEngramToolCwd, true, "direct-engram-session");
 		await commands.get("gentle:sdd-preflight").handler("", ctx);
-		assert.deepEqual(ctx.ui.selections[1].options, ["openspec"]);
+		assert.equal(ctx.ui.selections.some(({ label }) => label === "SDD artifact store"), false, "unrecognized Engram capability must elide the artifact selector");
 	} finally {
 		pi.setActiveTools(["read", "bash", "edit", "write"]);
 		await rm(directEngramToolCwd, { recursive: true, force: true });
@@ -1384,12 +1381,12 @@ async function run() {
 		assert.equal(existsSync(join(globalAgentHome, "agents", "sdd-sync.md")), true);
 		assert.equal(existsSync(join(globalAgentHome, "gentle-ai", "support", "sdd-status-contract.md")), true);
 		assert.equal(existsSync(join(globalAgentHome, "chains", "sdd-full.chain.md")), true);
-		assert.equal(ctx.ui.selections.length, 3);
+		assert.equal(ctx.ui.selections.length, 0, "sdd-init uses automatic preflight defaults");
 		assert.match(ctx.ui.notifications[0].message, /SDD preflight complete/);
 		assert.match(ctx.ui.notifications.at(-1).message, /Wrote openspec\/config\.yaml/);
 
 		await commands.get("gentle:sdd-preflight").handler("", ctx);
-		assert.equal(ctx.ui.selections.length, 3, "/sdd-init preflight should be reused by later manual preflight");
+		assert.equal(ctx.ui.selections.length, 2, "explicit preflight prompts after automatic sdd-init");
 	} finally {
 		await rm(sddCwd, { recursive: true, force: true });
 	}

--- a/tests/sdd-preflight.test.ts
+++ b/tests/sdd-preflight.test.ts
@@ -13,6 +13,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+	collectSddPreflightPreferences,
+	DEFAULT_SDD_PREFLIGHT,
 	installSddAssets,
 	readSddPreflightFromDisk,
 	sddPreflightDiskPath,
@@ -27,11 +29,43 @@ async function workspace(): Promise<string> {
 const SAMPLE_PREFS: SddPreflightPreferences = {
 	executionMode: "auto",
 	artifactStore: "engram",
-	chainedPrStrategy: "auto-forecast",
+	chainedPrStrategy: "auto-chain",
 	reviewBudgetLines: 400,
 	engramAvailable: true,
 	prompted: true,
 };
+
+function preflightContext(cwd: string, hasUI: boolean, calls: string[] = [], answers: Record<string, string> = {}) {
+	return { cwd, hasUI, ui: { select: async (title: string) => (calls.push(`select:${title}`), answers[title]), input: async (title: string) => (calls.push(`input:${title}`), answers[title]), notify: () => {} } } as Parameters<typeof collectSddPreflightPreferences>[0];
+}
+function writeRawPreflight(cwd: string, chainedPrStrategy: string, prompted = true): string {
+	const path = sddPreflightDiskPath(cwd); mkdirSync(join(cwd, ".pi", "gentle-ai"), { recursive: true }); writeFileSync(path, JSON.stringify({ executionMode: "auto", artifactStore: "openspec", chainedPrStrategy, reviewBudgetLines: 400, engramAvailable: false, prompted })); return path;
+}
+test("production callers distinguish automatic defaults from explicit preflight prompts", () => {
+	const root = join(import.meta.dirname, ".."), gentleAi = readFileSync(join(root, "extensions", "gentle-ai.ts"), "utf8"), sddInit = readFileSync(join(root, "extensions", "sdd-init.ts"), "utf8");
+	assert.match(gentleAi, /function runSddPreflight\(\s*ctx: ExtensionContext,\s*promptFields: readonly SddPreflightField\[\] = \[\]\s*\)/s); assert.match(gentleAi, /if \(isSddAgent && !getSddPreflightPreferences\(ctx\)\) \{\s*await runSddPreflight\(ctx\);/s); assert.match(gentleAi, /applyModelConfig: async \(\) => applySavedModelConfig\(ctx\)\s*\},\s*\{\s*promptFields\s*\}\s*\);/s); assert.match(gentleAi, /handler: async \(_args, ctx\) => \{\s*await runSddPreflight\(ctx, SDD_PREFLIGHT_FIELDS\);/s); assert.match(sddInit, /applyModelConfig: \(\) => applySavedModelConfig\(ctx\)\s*\},\s*\{\s*promptFields: \[\]\s*\}\s*\);/s);
+});
+test("capability-constrained artifact selector elision", async () => {
+	const calls: string[] = [], prefs = await collectSddPreflightPreferences(preflightContext(await workspace(), true, calls), false, { promptFields: ["artifactStore"] });
+	assert.deepEqual(prefs, DEFAULT_SDD_PREFLIGHT); assert.deepEqual(calls, []);
+});
+test("headless/UI canonical-domain parity", async () => {
+	const calls: string[] = [], ui = await collectSddPreflightPreferences(preflightContext(await workspace(), true, calls), false), headless = await collectSddPreflightPreferences(preflightContext(await workspace(), false), false);
+	assert.deepEqual(ui, DEFAULT_SDD_PREFLIGHT); assert.deepEqual(headless, ui); assert.deepEqual(calls, []);
+});
+test("explicit UI selections override defaults when a field is genuinely unresolved", async () => {
+	const calls: string[] = [], prefs = await collectSddPreflightPreferences(preflightContext(await workspace(), true, calls, { "SDD execution mode": "interactive", "SDD artifact store": "engram", "SDD delivery strategy": "auto-chain", "SDD review budget lines": "700" }), true, { persisted: DEFAULT_SDD_PREFLIGHT, promptFields: ["executionMode", "artifactStore", "chainedPrStrategy", "reviewBudgetLines"] });
+	assert.deepEqual({ executionMode: prefs.executionMode, artifactStore: prefs.artifactStore, chainedPrStrategy: prefs.chainedPrStrategy, reviewBudgetLines: prefs.reviewBudgetLines }, { executionMode: "interactive", artifactStore: "engram", chainedPrStrategy: "auto-chain", reviewBudgetLines: 700 }); assert.equal(prefs.prompted, true); assert.equal(calls.length, 4);
+});
+test("legacy persisted strategies normalize to canonical values", async () => {
+	const mappings = { "auto-forecast": "ask-on-risk", "ask-always": "ask-on-risk", "single-pr-default": "single-pr", "force-chained": "auto-chain" } as const;
+	for (const [legacy, canonical] of Object.entries(mappings)) { const cwd = await workspace(); writeRawPreflight(cwd, legacy); assert.equal(readSddPreflightFromDisk(cwd)?.chainedPrStrategy, canonical); }
+});
+test("exception-ok requires narrow delivery-gate provenance", async () => {
+	for (const prompted of [false, true]) { const cwd = await workspace(); writeRawPreflight(cwd, "exception-ok", prompted); assert.equal(readSddPreflightFromDisk(cwd)?.chainedPrStrategy, "ask-on-risk"); }
+	const accepted = await collectSddPreflightPreferences(preflightContext(await workspace(), false), false, { persisted: { ...DEFAULT_SDD_PREFLIGHT, chainedPrStrategy: "exception-ok" }, acceptSizeException: true }); assert.equal(accepted.chainedPrStrategy, "exception-ok"); assert.equal(accepted.sizeExceptionAccepted, true);
+	const durable = await workspace(); writeSddPreflightToDisk(durable, accepted); assert.equal(readSddPreflightFromDisk(durable)?.chainedPrStrategy, "ask-on-risk");
+});
 
 test("sddPreflightDiskPath returns project-local .pi/gentle-ai/sdd-preflight.json", async () => {
 	const cwd = await workspace();
@@ -62,18 +96,11 @@ test("readSddPreflightFromDisk returns persisted prefs after write", async () =>
 	assert.deepEqual(loaded, SAMPLE_PREFS);
 });
 
-test("persisted store survives a simulated cache miss (write then cold read)", async () => {
-	const cwd = await workspace();
-
-	// Simulate ensureSddPreflight writing to disk
-	writeSddPreflightToDisk(cwd, SAMPLE_PREFS);
-
-	// Simulate a fresh process where in-memory Map is empty — only disk store exists
-	const loaded = readSddPreflightFromDisk(cwd);
-	assert.ok(loaded !== undefined);
-	assert.equal(loaded.artifactStore, "engram");
-	assert.equal(loaded.executionMode, "auto");
-	assert.equal(loaded.prompted, true);
+test("persisted preferences are reused with zero prompts", async () => {
+	const cwd = await workspace(); writeSddPreflightToDisk(cwd, SAMPLE_PREFS);
+	const loaded = readSddPreflightFromDisk(cwd); assert.ok(loaded);
+	const calls: string[] = [], reused = await collectSddPreflightPreferences(preflightContext(cwd, true, calls), loaded!.engramAvailable, { persisted: loaded });
+	assert.deepEqual(reused, loaded); assert.deepEqual(calls, []);
 });
 
 test("readSddPreflightFromDisk returns undefined for corrupt JSON", async () => {
@@ -95,7 +122,7 @@ test("readSddPreflightFromDisk returns undefined for JSON with invalid fields", 
 	assert.equal(readSddPreflightFromDisk(cwd), undefined);
 });
 
-test("readSddPreflightFromDisk normalizes unknown chainedPrStrategy to auto-forecast", async () => {
+test("readSddPreflightFromDisk normalizes unknown chainedPrStrategy to ask-on-risk", async () => {
 	const cwd = await workspace();
 	const path = sddPreflightDiskPath(cwd);
 	mkdirSync(join(cwd, ".pi", "gentle-ai"), { recursive: true });
@@ -110,7 +137,7 @@ test("readSddPreflightFromDisk normalizes unknown chainedPrStrategy to auto-fore
 
 	const loaded = readSddPreflightFromDisk(cwd);
 	assert.ok(loaded !== undefined);
-	assert.equal(loaded.chainedPrStrategy, "auto-forecast");
+	assert.equal(loaded.chainedPrStrategy, "ask-on-risk");
 });
 
 test("writeSddPreflightToDisk is non-fatal when directory is not writable (no throw)", async () => {


### PR DESCRIPTION
Closes #401

## Summary

- Resolve SDD preflight choices through one canonical authority order before prompting.
- Keep automatic/headless flows prompt-free while preserving explicit preference and human-control gates.
- Normalize legacy delivery strategies and require explicit provenance for `size:exception`.

## Changes

| Area | Change |
|---|---|
| Runtime | Align preflight defaults and delivery-strategy values across automatic, explicit, and SDD-init callers. |
| Compatibility | Normalize persisted legacy strategy values without inferring `exception-ok`. |
| Orchestration | Keep injected preflight authority consistent and defer genuine delivery decisions until risk requires them. |
| Documentation | Align the README and packaged SDD workflow with runtime behavior. |
| Tests | Cover defaults, persisted preferences, capability constraints, explicit prompts, runtime wiring, prompt budget, and harness behavior. |

## Test plan

- [x] `git diff --check`
- [x] `node --experimental-strip-types --test tests/sdd-preflight.test.ts` — 17/17 passed
- [x] Focused four-file suite — 68/68 passed
- [x] `pnpm run test:harness`
- [x] `pnpm test` — 1220 passed, 0 failed, 1 Windows-only skipped
- [x] Rendered parent prompt — 8160/8192 bytes

## Review focus

1. Authority precedence and automatic versus explicit caller wiring.
2. Legacy strategy normalization and `exception-ok` provenance.
3. Preservation of interactive phase, product, consent, authorization, security, destructive, and publishing gates.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Uses exactly one PR type: bug fix (`type:bug`).
- [x] Shellcheck is not applicable; no shell scripts changed.
- [x] Updated documentation for the behavior change.
- [x] Used a Conventional Commit message.
- [x] Added no `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer SDD preflight preference resolution with persisted settings, canonical defaults, and prompts only when needed.
  * Added delivery strategy options including risk-based prompts, automatic chaining, single-PR delivery, and explicitly approved exceptions.
  * Reused preflight settings across sessions and supported injected or canonical preflight decisions.
  * Improved handling for unavailable capabilities and headless execution.

* **Documentation**
  * Expanded guidance on preflight precedence, defaults, delivery strategies, deferred chaining, and human approval gates.

* **Bug Fixes**
  * Legacy and unknown delivery strategy values are now normalized consistently.
  * Prevented unnecessary repeated prompts while preserving explicit-choice workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->