### PR TITLE
fix(prompt): make budget path-independent

### DIFF
--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -8,6 +8,8 @@ Defined once in the identity/harness section injected above (the `Current person
 
 ## Core Role
 
+Package assets root: `{{GENTLE_PI_ASSETS_ROOT}}`. Lazy asset paths below are relative to this root.
+
 You are a COORDINATOR, not the default executor for substantial work. Maintain one thin conversation thread, delegate real phase work to Pi subagents when available, and synthesize results for the user.
 
 Keep synthesis short by default: decision, outcome, next action. Expand only when the user asks or the situation requires detail.
@@ -20,7 +22,7 @@ Generated technical artifacts — whether by the parent inline or by subagents �
 
 Public/contextual comments and replies are different from technical artifacts. When using `comment-writer` or drafting a human-facing GitHub, PR review, Slack, Discord, or async comment, write in the target context language by default. Spanish issue/thread -> Spanish comment. English thread -> English comment. Mixed context -> target message language. Explicit user language or tone override wins. Spanish comments default to neutral/professional Spanish unless the user or target context clearly calls for regional tone.
 
-Subagent-facing English delegation and the quote/UI/SDD-artifact exceptions: `{{GENTLE_PI_DELEGATION_PATH}}`.
+Subagent-facing English delegation and the quote/UI/SDD-artifact exceptions: `orchestrator-delegation.md`.
 
 ## Mental Model
 
@@ -45,7 +47,7 @@ Route work through the smallest harness that is safe. Three tiers:
 
 Core question: does this inflate parent context without need?
 
-The canonical per-action table is the mirrored gentle-ai canon Delegation Rules table in `{{GENTLE_PI_DELEGATION_PATH}}`.
+The canonical per-action table is the mirrored gentle-ai canon Delegation Rules table in `orchestrator-delegation.md`.
 
 Mandatory Delegation Triggers — stop rules; once fired, delegate through the best available subagent runtime (prefer `subagent_run`, else Pi's native `Agent`):
 
@@ -57,13 +59,13 @@ Mandatory Delegation Triggers — stop rules; once fired, delegate through the b
 
 {{GENTLE_PI_BACKGROUND_POLICY}}; rules: the background-subagents block in the delegation contract.
 
-Full table, Work Routing Ladder examples/model-routing detail, Cost and Context Balance, Canonical Workflows, and the mirrored gentle-ai canon (blocking-prompt relays, language, and delegation): `{{GENTLE_PI_DELEGATION_PATH}}`.
+Full table, Work Routing Ladder examples/model-routing detail, Cost and Context Balance, Canonical Workflows, and the mirrored gentle-ai canon (blocking-prompt relays, language, and delegation): `orchestrator-delegation.md`.
 
 ## SDD Workflow (lazy-loaded)
 
 The detailed SDD workflow is intentionally not embedded in this always-on parent prompt. Before handling any `/sdd-*` command, natural-language SDD request, SDD continuation/routing, apply/verify/sync/archive work, or SDD/Judgment-Day phase delegation, read this package asset first:
 
-`{{GENTLE_PI_SDD_WORKFLOW_PATH}}`
+`sdd-orchestrator-workflow.md`
 
 That lazy surface contains the SDD phases, native dispatcher rules, status contract, preflight/init guards, artifact-store policy, execution mode, Strict TDD forwarding, phase result contract, and review workload guard.
 
@@ -71,17 +73,17 @@ Hard preflight invariant: `openspec/config.yaml`, existing SDD changes, installe
 
 ## Memory Contract
 
-When memory is available, the parent selects context and subagents save significant discoveries before returning. SDD phase table, artifact keys, and persistence guidance: `{{GENTLE_PI_MEMORY_PATH}}`.
+When memory is available, the parent selects context and subagents save significant discoveries before returning. SDD phase table, artifact keys, and persistence guidance: `orchestrator-memory.md`.
 
 ## Skill Registry Protocol
 
 The parent resolves matching skill paths once per session and passes them under `## Skills to load before work`. Subagents read those exact `SKILL.md` files before work; if the registry is absent, report that project-specific paths were unavailable.
 
-Fallback-report semantics (`paths-injected`/`fallback-registry`/`fallback-path`/`none`) and the SDD-executor skill distinction: `{{GENTLE_PI_SKILLS_PATH}}`.
+Fallback-report semantics (`paths-injected`/`fallback-registry`/`fallback-path`/`none`) and the SDD-executor skill distinction: `orchestrator-skills.md`.
 
 ## Intent-Driven Skill Discovery
 
-For skill-shaped requests, do not treat injected `<available_skills>` as complete; use the registry/filesystem only as a discovery aid, never to override a small request or a user's concrete ask. Discovery order, the common intent-hint table, and fallback behavior when no skill matches: `{{GENTLE_PI_SKILLS_PATH}}`.
+For skill-shaped requests, do not treat injected `<available_skills>` as complete; use the registry/filesystem only as a discovery aid, never to override a small request or a user's concrete ask. Discovery order, the common intent-hint table, and fallback behavior when no skill matches: `orchestrator-skills.md`.
 
 ## Gentle AI RDD ownership
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -568,22 +568,7 @@ function renderOrchestratorPrompt(
 	background: BackgroundSubagentsRendering = DEFAULT_BACKGROUND_SUBAGENTS_RENDERING,
 ): string {
 	return readFileSync(join(assetsDir, "orchestrator.md"), "utf8")
-		.replaceAll(
-			"{{GENTLE_PI_SDD_WORKFLOW_PATH}}",
-			join(assetsDir, "sdd-orchestrator-workflow.md"),
-		)
-		.replaceAll(
-			"{{GENTLE_PI_DELEGATION_PATH}}",
-			join(assetsDir, "orchestrator-delegation.md"),
-		)
-		.replaceAll(
-			"{{GENTLE_PI_MEMORY_PATH}}",
-			join(assetsDir, "orchestrator-memory.md"),
-		)
-		.replaceAll(
-			"{{GENTLE_PI_SKILLS_PATH}}",
-			join(assetsDir, "orchestrator-skills.md"),
-		)
+		.replaceAll("{{GENTLE_PI_ASSETS_ROOT}}", assetsDir)
 		.replaceAll(
 			"{{GENTLE_PI_BACKGROUND_POLICY}}",
 			renderBackgroundSubagentsStatusLine(background),

--- a/tests/artifact-language.test.ts
+++ b/tests/artifact-language.test.ts
@@ -166,7 +166,9 @@ test("orchestrator lazy-loads detailed SDD workflow", async () => {
 	const workflow = await readFile(join(ROOT, "assets/sdd-orchestrator-workflow.md"), "utf8");
 
 	assert.match(orchestrator, /## SDD Workflow \(lazy-loaded\)/);
-	assert.match(orchestrator, /\{\{GENTLE_PI_SDD_WORKFLOW_PATH\}\}/);
+	assert.match(orchestrator, /Package assets root: `\{\{GENTLE_PI_ASSETS_ROOT\}\}`\. Lazy asset paths below are relative to this root\./);
+	assert.match(orchestrator, /`sdd-orchestrator-workflow\.md`/);
+	assert.doesNotMatch(orchestrator, /\{\{GENTLE_PI_SDD_WORKFLOW_PATH\}\}/);
 	assert.match(orchestrator, /injected `## SDD Session Preflight` block or a canonical-authority resolution/);
 	assert.match(orchestrator, /Defaults and capability constraints may resolve fields without confirmation prompts/);
 	assert.doesNotMatch(orchestrator, /or an explicit user answer covering the preflight choices/);

--- a/tests/orchestrator-budget.test.ts
+++ b/tests/orchestrator-budget.test.ts
@@ -9,8 +9,8 @@ import test, { after } from "node:test";
 // orchestrator-lazy-diet migration tests
 //
 // Locks the split of the always-on `assets/orchestrator.md` into a thin core
-// plus three path-substituted lazy reference files (see design.md "Core
-// budget rebuilt from measured drafts" and "Appendix: drafted core texts").
+// plus lazy reference files (see design.md "Core budget rebuilt from measured
+// drafts" and "Appendix: drafted core texts").
 //
 // `getOrchestratorPrompt`'s rendered return value is memoized in a
 // module-level cache (first-read-wins for the process lifetime — see design.md
@@ -19,17 +19,19 @@ import test, { after } from "node:test";
 // ambient environment variables, so production runtime asset resolution stays
 // deterministic. The representative production assets directory below is
 // populated by COPYING the real repo assets (dynamically, at test-run time)
-// into a short-path tmpdir — this isolates byte-budget measurement from the
-// real repo's absolute path length while keeping content representative of
-// production. Tests that need to inspect the real repo files directly (the
-// disposition-mapped union sweep, the core-alone token assertions) read
-// `assets/*.md` directly via `readFileSync`, sidestepping the cache entirely.
+// into short and deliberately long tmpdir paths. This isolates byte-budget
+// measurement from the real repo's absolute path length while keeping content
+// representative of production. Tests that need to inspect the real repo files
+// directly (the disposition-mapped union sweep, the core-alone token
+// assertions) read `assets/*.md` directly via `readFileSync`, sidestepping the
+// cache entirely.
 // ---------------------------------------------------------------------------
 
 const REPO_ROOT = join(import.meta.dirname, "..");
 const REAL_ASSETS_DIR = join(REPO_ROOT, "assets");
 const FIXTURE_PATH = join(import.meta.dirname, "fixtures", "orchestrator.pre-diet.md");
-const BUDGET_BYTES = 10240;
+const BUDGET_BYTES = 8192;
+const MIN_CONTROLLED_LONG_ASSETS_ROOT_CHARS = 93;
 
 const LAZY_ASSET_NAMES = [
 	"orchestrator.md",
@@ -38,6 +40,7 @@ const LAZY_ASSET_NAMES = [
 	"orchestrator-memory.md",
 	"orchestrator-skills.md",
 ] as const;
+const LAZY_REFERENCE_FILE_NAMES = LAZY_ASSET_NAMES.slice(1);
 
 const representativeProductionAssetsDir = mkdtempSync(join(tmpdir(), "gp-b-"));
 for (const name of LAZY_ASSET_NAMES) {
@@ -49,31 +52,32 @@ for (const name of LAZY_ASSET_NAMES) {
 }
 const { __testing } = await import("../extensions/gentle-ai.ts");
 
-const MIN_REALISTIC_INSTALL_ASSETS_PATH_CHARS = 59;
-
-// Realistic-length assets path: mirrors an actual installed path such as
-// `~/.pi/agent/npm/node_modules/gentle-pi/assets`, so the budget assertion is
-// not laundered through an artificially short mkdtemp path. The helper is also
-// exercised in a fresh child process (`tests/fixtures/measure-orchestrator-prompt.mjs`)
-// to keep production cache behavior separate from fixture measurements.
-const realisticBaseDir = mkdtempSync(join(tmpdir(), "gp-realistic-"));
-const realisticDir = join(realisticBaseDir, ".pi", "agent", "npm", "node_modules", "gentle-pi", "assets");
-mkdirSync(realisticDir, { recursive: true });
+// A controlled long assets root proves the parent prompt remains within the
+// canonical budget independently of the checkout or installed-package path.
+// The child-process measurement keeps production cache behavior separate from
+// fixture measurements.
+const controlledLongBaseDir = mkdtempSync(join(tmpdir(), "gp-long-"));
+const controlledLongAssetsDir = join(
+	controlledLongBaseDir,
+	"path-independent-prompt-budget-".repeat(3),
+	"assets",
+);
+mkdirSync(controlledLongAssetsDir, { recursive: true });
 assert.ok(
-	realisticDir.length >= MIN_REALISTIC_INSTALL_ASSETS_PATH_CHARS,
-	`realistic scratch assets path is only ${realisticDir.length} chars, need >= ${MIN_REALISTIC_INSTALL_ASSETS_PATH_CHARS} to mirror a real install path`,
+	controlledLongAssetsDir.length >= MIN_CONTROLLED_LONG_ASSETS_ROOT_CHARS,
+	`controlled long assets root is only ${controlledLongAssetsDir.length} chars, need >= ${MIN_CONTROLLED_LONG_ASSETS_ROOT_CHARS}`,
 );
 for (const name of LAZY_ASSET_NAMES) {
 	const src = join(REAL_ASSETS_DIR, name);
 	writeFileSync(
-		join(realisticDir, name),
+		join(controlledLongAssetsDir, name),
 		existsSync(src) ? readFileSync(src) : `stub placeholder for ${name} (not authored yet)\n`,
 	);
 }
 
 after(() => {
 	rmSync(representativeProductionAssetsDir, { recursive: true, force: true });
-	rmSync(realisticBaseDir, { recursive: true, force: true });
+	rmSync(controlledLongBaseDir, { recursive: true, force: true });
 });
 
 function readRealAsset(name: string): string {
@@ -98,7 +102,7 @@ function measureOrchestratorPromptBytes(assetsDir: string): number {
 // 2.2 — Byte budget (Spec: Always-On Injection Byte Budget)
 // ---------------------------------------------------------------------------
 
-test("getOrchestratorPrompt return value stays within the 10,240 B budget (short-path stub sanity check)", () => {
+test("getOrchestratorPrompt return value stays within the canonical 8,192 B budget at a short assets root", () => {
 	const rendered = __testing.renderOrchestratorPrompt(representativeProductionAssetsDir);
 	const bytes = Buffer.byteLength(rendered, "utf8");
 	assert.ok(
@@ -107,12 +111,27 @@ test("getOrchestratorPrompt return value stays within the 10,240 B budget (short
 	);
 });
 
-test(`getOrchestratorPrompt return value stays within the 10,240 B budget at a realistic (>= ${MIN_REALISTIC_INSTALL_ASSETS_PATH_CHARS} char) install path length`, () => {
-	const bytes = measureOrchestratorPromptBytes(realisticDir);
+test(`getOrchestratorPrompt keeps a controlled long (>= ${MIN_CONTROLLED_LONG_ASSETS_ROOT_CHARS} char) assets root within the canonical budget`, () => {
+	const rendered = __testing.renderOrchestratorPrompt(controlledLongAssetsDir);
+	const bytes = measureOrchestratorPromptBytes(controlledLongAssetsDir);
+	assert.equal(bytes, Buffer.byteLength(rendered, "utf8"), "child-process and direct render byte counts must match");
 	assert.ok(
 		bytes <= BUDGET_BYTES,
-		`getOrchestratorPrompt() returned ${bytes} B at a realistic ${realisticDir.length}-char ASSETS_DIR path, exceeds the ${BUDGET_BYTES} B budget`,
+		`getOrchestratorPrompt() returned ${bytes} B at controlled ${controlledLongAssetsDir.length}-char assets root, exceeds the ${BUDGET_BYTES} B budget`,
 	);
+	assert.equal(
+		rendered.split(controlledLongAssetsDir).length - 1,
+		1,
+		"the absolute assets root must be declared exactly once",
+	);
+	assert.ok(
+		rendered.includes(`Package assets root: \`${controlledLongAssetsDir}\`. Lazy asset paths below are relative to this root.`),
+		"the parent prompt must declare how to resolve relative lazy asset paths",
+	);
+	for (const name of LAZY_REFERENCE_FILE_NAMES) {
+		assert.ok(rendered.includes(`\`${name}\``), `lazy asset filename is missing: ${name}`);
+	}
+	assert.doesNotMatch(rendered, /\{\{/, "unresolved {{...}} placeholder leaked into the rendered prompt");
 });
 
 // ---------------------------------------------------------------------------
@@ -233,8 +252,10 @@ function isNormativeLine(line: string): boolean {
 }
 
 const fixtureLines = readFileSync(FIXTURE_PATH, "utf8").split("\n");
-// Fixture line 191 predates canonical-authority resolution; keep its coverage by
-// asserting the intentionally updated production wording instead of weakening the range.
+// Fixture lines 187 and 191 predate the root-relative lazy-asset contract and
+// canonical-authority resolution. Keep their coverage by asserting the
+// intentionally updated production wording instead of weakening the range.
+const CURRENT_SDD_WORKFLOW_PATH = "`sdd-orchestrator-workflow.md`";
 const CURRENT_HARD_PREFLIGHT_INVARIANT = "Hard preflight invariant: `openspec/config.yaml`, existing SDD changes, installed `.pi`/global SDD assets, or a todo named \"preflight\" are not session preflight. Do not mark SDD preflight complete, start `sdd-init`, launch SDD subagents/chains, or move to explore/proposal/spec/design/tasks until this session has an injected `## SDD Session Preflight` block or a canonical-authority resolution. Defaults and capability constraints may resolve fields without confirmation prompts; preserve unresolved-choice and safety gates.";
 const SUPERSEDED_LIFECYCLE_REVIEW_LINES = new Set([
 	70,
@@ -269,7 +290,12 @@ for (const range of DISPOSITION_MAP) {
 				const raw = fixtureLines[ln - 1];
 				if (raw === undefined || !isNormativeLine(raw)) continue;
 				const trimmed = raw.trim();
-				const expected = ln === 191 ? CURRENT_HARD_PREFLIGHT_INVARIANT : trimmed;
+				const expected =
+					ln === 187
+						? CURRENT_SDD_WORKFLOW_PATH
+						: ln === 191
+							? CURRENT_HARD_PREFLIGHT_INVARIANT
+							: trimmed;
 				if (SUPERSEDED_LIFECYCLE_REVIEW_LINES.has(ln)) {
 					assert.ok(
 						!targetContent.includes(trimmed),
@@ -360,20 +386,11 @@ test("relocated lazy bodies are not double-delivered in the always-on core", () 
 	);
 });
 
-test("relocated lazy files are reachable via in-core pointer paths", () => {
+test("relocated lazy files are reachable via root-relative in-core filenames", () => {
 	const rendered = __testing.getOrchestratorPrompt();
-	assert.ok(
-		rendered.includes(join(REAL_ASSETS_DIR, "orchestrator-delegation.md")),
-		"core is missing a reachable pointer to orchestrator-delegation.md",
-	);
-	assert.ok(
-		rendered.includes(join(REAL_ASSETS_DIR, "orchestrator-memory.md")),
-		"core is missing a reachable pointer to orchestrator-memory.md",
-	);
-	assert.ok(
-		rendered.includes(join(REAL_ASSETS_DIR, "orchestrator-skills.md")),
-		"core is missing a reachable pointer to orchestrator-skills.md",
-	);
+	for (const name of LAZY_REFERENCE_FILE_NAMES) {
+		assert.ok(rendered.includes(`\`${name}\``), `core is missing a reachable pointer to ${name}`);
+	}
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/orchestrator-budget.test.ts
+++ b/tests/orchestrator-budget.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
@@ -42,14 +42,16 @@ const LAZY_ASSET_NAMES = [
 ] as const;
 const LAZY_REFERENCE_FILE_NAMES = LAZY_ASSET_NAMES.slice(1);
 
-const representativeProductionAssetsDir = mkdtempSync(join(tmpdir(), "gp-b-"));
-for (const name of LAZY_ASSET_NAMES) {
-	const src = join(REAL_ASSETS_DIR, name);
-	writeFileSync(
-		join(representativeProductionAssetsDir, name),
-		existsSync(src) ? readFileSync(src) : `stub placeholder for ${name} (not authored yet)\n`,
-	);
+function copyRequiredLazyAssets(destination: string): void {
+	for (const name of LAZY_ASSET_NAMES) {
+		const source = join(REAL_ASSETS_DIR, name);
+		assert.ok(existsSync(source), `missing packaged lazy asset: ${name}`);
+		copyFileSync(source, join(destination, name));
+	}
 }
+
+const representativeProductionAssetsDir = mkdtempSync(join(tmpdir(), "gp-b-"));
+copyRequiredLazyAssets(representativeProductionAssetsDir);
 const { __testing } = await import("../extensions/gentle-ai.ts");
 
 // A controlled long assets root proves the parent prompt remains within the
@@ -67,13 +69,7 @@ assert.ok(
 	controlledLongAssetsDir.length >= MIN_CONTROLLED_LONG_ASSETS_ROOT_CHARS,
 	`controlled long assets root is only ${controlledLongAssetsDir.length} chars, need >= ${MIN_CONTROLLED_LONG_ASSETS_ROOT_CHARS}`,
 );
-for (const name of LAZY_ASSET_NAMES) {
-	const src = join(REAL_ASSETS_DIR, name);
-	writeFileSync(
-		join(controlledLongAssetsDir, name),
-		existsSync(src) ? readFileSync(src) : `stub placeholder for ${name} (not authored yet)\n`,
-	);
-}
+copyRequiredLazyAssets(controlledLongAssetsDir);
 
 after(() => {
 	rmSync(representativeProductionAssetsDir, { recursive: true, force: true });

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -384,10 +384,13 @@ async function run() {
 		assert.doesNotMatch(promptResult.systemPrompt, /default\s*\|\s*sonnet\s*\|\s*Non-SDD general delegation/);
 		assert.match(promptResult.systemPrompt, /openspec\/config\.yaml.*not session preflight/s);
 		assert.match(promptResult.systemPrompt, /Do not mark SDD preflight complete/);
-		assert.match(
-			promptResult.systemPrompt,
-			new RegExp(`${ROOT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}.*assets.*sdd-orchestrator-workflow\\.md`),
+		assert.ok(
+			promptResult.systemPrompt.includes(
+				`Package assets root: \`${join(ROOT, "assets")}\`. Lazy asset paths below are relative to this root.`,
+			),
+			"parent prompt must declare the one absolute root for relative lazy asset paths",
 		);
+		assert.match(promptResult.systemPrompt, /`sdd-orchestrator-workflow\.md`/);
 		assert.doesNotMatch(
 			promptResult.systemPrompt,
 			new RegExp(ambientTestAssetsDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),


### PR DESCRIPTION
Closes #415

## Type

- [x] Bug fix

## Summary

- declare the absolute Gentle Pi assets root once in the parent prompt;
- reference lazy-loaded assets by exact relative filename instead of repeating an unbounded package path;
- make the 8 KiB prompt budget deterministic across short and long installation paths.

## Changes

| File | Change |
|---|---|
| `assets/orchestrator.md` | Declares one assets root and uses relative lazy-asset references. |
| `extensions/gentle-ai.ts` | Replaces four per-file absolute-path substitutions with one root substitution. |
| `tests/orchestrator-budget.test.ts` | Enforces the 8,192-byte contract under controlled short and long roots. |
| `tests/artifact-language.test.ts` | Verifies the root-plus-relative workflow contract. |
| `tests/runtime-harness.mjs` | Verifies runtime rendering exposes one root and the relative workflow filename. |

## Evidence

- Mechanical RED with base production and candidate tests: controlled 120-character root rendered **8,433 B**, exceeding 8,192 B.
- GREEN/TRIANGULATE:
  - short controlled root: **7,678 B**;
  - long controlled root: **7,782 B**;
  - actual worktree root: **7,754 B**;
  - absolute assets root occurs exactly once;
  - no unresolved placeholders;
  - all four lazy asset filenames remain exact.

## Test plan

- [x] Focused prompt tests: **91/91 passed**.
- [x] Full unit surface: **1,031 tests; 1,030 passed; 1 skipped; 0 failed**.
- [x] Runtime harness passed.
- [x] Runtime module generation and parity check passed.
- [x] Provider contract `1.1.0` passed.
- [x] Package resource verification passed: 160 files, 67 exact v2.4.0 artifacts.
- [x] Packed-package E2E passed with Gentle Pi 2.2.0 and Gentle AI 2.4.0.
- [x] `git diff --check` passed.

The local full-suite wrapper required a temporary PATH shim that delegates nested `pnpm` calls back through Corepack. Without it, this machine's nested lifecycle resolved pnpm 11.12.0 despite the repository requiring 11.1.1; with the exact 11.1.1 shim, the complete suite passed. No global package-manager state was changed.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Shellcheck is not applicable; no shell scripts changed.
- [x] Runtime and package loading surfaces were tested.
- [x] Prompt documentation changed with its behavior.
- [x] Commit follows Conventional Commits and has no attribution trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Orchestration prompts now use a consistent assets-root reference.
  - Delegation, skills, memory, and workflow guidance are easier to discover and access.
  - Prompt behavior remains within the established size limit while supporting longer asset paths.

- **Tests**
  - Expanded validation for asset discovery, lazy-loaded workflow access, prompt structure, and runtime behavior.
  - Updated checks to reflect the streamlined asset-path configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->