### PR TITLE
feat(quiet-tools): cover all Gentle AI tool calls

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -95,6 +95,7 @@ import {
 	type ReviewMode,
 	type ReviewProjectionV1,
 } from "../lib/review-snapshot.ts";
+import { renderGentleAiLifecycleCall, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
 import { sanitizeTerminalText, stripAnsi } from "../lib/terminal-theme.ts";
 import { CandidateViewError, CandidateViewRegistry, injectReviewCandidateView, readCandidateContextManifestPage, resolveCanonicalCandidateBase, type CandidateView } from "../lib/review-candidate-view.ts";
 import {
@@ -2366,6 +2367,17 @@ const REVIEW_CONTROLLER_OPERATION = {
 
 type ReviewControllerOperation =
 	(typeof REVIEW_CONTROLLER_OPERATION)[keyof typeof REVIEW_CONTROLLER_OPERATION];
+
+function reviewToolOperationPath(args: unknown): string {
+	const operation = isRecord(args) ? args.operation : undefined;
+	if (
+		typeof operation !== "string" ||
+		!Object.values(REVIEW_CONTROLLER_OPERATION).includes(operation as ReviewControllerOperation)
+	) {
+		return "review";
+	}
+	return `review ${operation.replaceAll("-", " ")}`;
+}
 
 const REVIEW_CONTROLLER_PARAMETERS = {
 	type: "object",
@@ -4841,6 +4853,13 @@ function createGentleAiExtensionForTesting(
 		description: "Read one bounded, integrity-checked page of the controller-owned frozen changed scope. This read-only tool never inspects the ambient or candidate tree.",
 		parameters: REVIEW_SCOPE_PARAMETERS,
 		executionMode: "parallel",
+		renderCall(_args, theme, context) {
+			return renderGentleAiLifecycleCall(
+				"review scope",
+				theme,
+				context as GentleAiRenderContext | undefined,
+			);
+		},
 		async execute(_toolCallId, parameters) {
 			const input = parameters as ReviewScopeParameters;
 			const details = readCandidateContextManifestPage(input.manifest, input.sha256, input.cursor ?? 0);
@@ -4894,6 +4913,13 @@ function createGentleAiExtensionForTesting(
 		],
 		parameters: REVIEW_CONTROLLER_PARAMETERS,
 		executionMode: "sequential",
+		renderCall(args, theme, context) {
+			return renderGentleAiLifecycleCall(
+				reviewToolOperationPath(args),
+				theme,
+				context as GentleAiRenderContext | undefined,
+			);
+		},
 		async execute(_toolCallId, parameters, signal, _onUpdate, ctx) {
 			if (signal?.aborted) throw new Error("Review controller operation was cancelled");
 			await authorizeDestructiveReviewOperation(parameters, ctx);

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4879,6 +4879,13 @@ function createGentleAiExtensionForTesting(
 		],
 		parameters: REVIEW_CAPTURE_PARAMETERS,
 		executionMode: "sequential",
+		renderCall(_args, theme, context) {
+			return renderGentleAiLifecycleCall(
+				"review capture",
+				theme,
+				context as GentleAiRenderContext | undefined,
+			);
+		},
 		async execute(_toolCallId, parameters, signal, _onUpdate, ctx) {
 			if (signal?.aborted) throw new Error("Review capture was cancelled");
 			const details = await executeReviewCaptureOperation(

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -11,6 +11,7 @@ import {
 import { Text } from "@earendil-works/pi-tui";
 import { homedir } from "node:os";
 import { quietToolsEnabled } from "../lib/quiet-tools-config.ts";
+import { renderGentleAiLifecycleCall, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
 import { sanitizeTerminalText } from "../lib/terminal-theme.ts";
 
 type QuietToolName = "read" | "bash" | "grep" | "find" | "ls" | "edit" | "write";
@@ -107,8 +108,9 @@ export type GentleAiRoutineCommand = "sdd-status" | "sdd-continue" | "sdd-attemp
 
 const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+\S+=\S+\s+|command\s+|\w+=\S+\s+)*`;
 const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
-const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}\s+(.+)$`);
+const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}(?:\s+(.*))?$`);
 const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n$]/;
+const SDD_ATTEMPT_VERBS = new Set(["acquire", "settle", "grant"]);
 
 const REVIEW_DIRECT_OPERATIONS = new Set([
 	"capabilities",
@@ -153,7 +155,11 @@ function gentleAiCommandTokens(args: Record<string, unknown> | undefined): strin
 	if (SHELL_EXPANSION_OR_COMPOSITION.test(rawCommand)) return undefined;
 	const command = rawCommand.trim();
 	const match = GENTLE_AI_COMMAND_ARGUMENTS.exec(command);
-	return match?.[1].trim().split(/\s+/) ?? undefined;
+	if (!match) return undefined;
+	const argumentsText = match[1]?.trim();
+	return argumentsText === undefined || argumentsText.length === 0
+		? []
+		: argumentsText.split(/\s+/);
 }
 
 function displayToken(token: string): string {
@@ -174,12 +180,16 @@ function validateGate(tokens: string[]): string | undefined {
  * package-local paths, not arbitrary shell output that merely mentions
  * gentle-ai. These commands otherwise emit machine-readable SDD/RDD data.
  */
+export function isGentleAiDirectCommand(args: Record<string, unknown> | undefined): boolean {
+	return gentleAiCommandTokens(args) !== undefined;
+}
+
 export function gentleAiRoutineCommand(args: Record<string, unknown> | undefined): GentleAiRoutineCommand | undefined {
 	const tokens = gentleAiCommandTokens(args);
 	if (!tokens) return undefined;
 	if (tokens[0] === "sdd-status") return "sdd-status";
 	if (tokens[0] === "sdd-continue") return "sdd-continue";
-	if (tokens[0] === "sdd-attempt" && (tokens[1] === "acquire" || tokens[1] === "settle")) return "sdd-attempt";
+	if (tokens[0] === "sdd-attempt" && SDD_ATTEMPT_VERBS.has(tokens[1] ?? "")) return "sdd-attempt";
 	if (tokens[0] === "review") return "review";
 	return undefined;
 }
@@ -190,10 +200,13 @@ export function gentleAiOperationPath(args: Record<string, unknown> | undefined)
 
 	if (tokens[0] === "sdd-status") return "sdd status";
 	if (tokens[0] === "sdd-continue") return "sdd continue";
-	if (tokens[0] === "sdd-attempt" && (tokens[1] === "acquire" || tokens[1] === "settle")) {
-		return `sdd attempt ${tokens[1]}`;
+	if (tokens[0] === "sdd-attempt") {
+		return SDD_ATTEMPT_VERBS.has(tokens[1] ?? "")
+			? `sdd attempt ${tokens[1]}`
+			: "sdd attempt";
 	}
-	if (tokens[0] !== "review") return undefined;
+	if (tokens[0] === "version") return "version";
+	if (tokens[0] !== "review") return "command";
 
 	const operation = tokens[1];
 	if (operation === undefined) return "review";
@@ -213,6 +226,11 @@ export function gentleAiOperationPath(args: Record<string, unknown> | undefined)
 	return REVIEW_DIRECT_OPERATIONS.has(operation) ? `review ${displayToken(operation)}` : "review";
 }
 
+export function isGentleAiGrantCommand(args: Record<string, unknown> | undefined): boolean {
+	const tokens = gentleAiCommandTokens(args);
+	return tokens?.[0] === "sdd-attempt" && tokens[1] === "grant";
+}
+
 interface ToolResultFormatOptions {
 	expanded: boolean;
 	isError?: boolean;
@@ -226,7 +244,7 @@ export function formatToolResultOutput(
 ): string {
 	const text = safeText(extractTextContent(result));
 	if (expanded || isError) return text ? `\n${text}` : "";
-	if (toolName === "bash" && gentleAiRoutineCommand(args)) return "";
+	if (toolName === "bash" && isGentleAiDirectCommand(args)) return "";
 
 	if (toolName === "bash" && isGitCommand(args)) {
 		const tail = tailLines(text, COLLAPSED_TAIL_LINE_LIMIT);
@@ -259,19 +277,6 @@ interface ToolRenderContextLike {
 	isPartial?: boolean;
 	isError?: boolean;
 	lastComponent?: unknown;
-}
-
-function renderGentleAiCall(operationPath: string, theme: ThemeLike, context?: ToolRenderContextLike): Text {
-	const status = context?.isError
-		? "failed"
-		: !context?.executionStarted || context.isPartial
-			? "running"
-			: "completed";
-	const color = status === "running" ? "warning" : status === "completed" ? "success" : "error";
-	const value = theme.fg(color, theme.bold(`🌹︎ Gentle AI · ${status} · ${operationPath}`));
-	const component = context?.lastComponent instanceof Text ? context.lastComponent : new Text("", 0, 0);
-	component.setText(value);
-	return component;
 }
 
 function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, theme: ThemeLike): string {
@@ -327,17 +332,24 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 		renderCall(args, theme, context) {
 			const callArgs = args as Record<string, unknown>;
 			const operationPath = toolName === "bash" ? gentleAiOperationPath(callArgs) : undefined;
-			if (operationPath) return renderGentleAiCall(operationPath, theme, context);
+			if (operationPath) {
+				return renderGentleAiLifecycleCall(
+					operationPath,
+					theme,
+					context as GentleAiRenderContext | undefined,
+					isGentleAiGrantCommand(callArgs) ? asString(callArgs.command) : undefined,
+				);
+			}
 			return new Text(formatToolCall(toolName, callArgs, theme), 0, 0);
 		},
 		renderResult(result, options, theme, context) {
 			const renderContext = context as ToolRenderContextLike | undefined;
 			const isError = renderContext?.isError ?? options.isError ?? false;
-			const routineCommand = toolName === "bash" && gentleAiRoutineCommand(renderContext?.args);
+			const directCommand = toolName === "bash" && isGentleAiDirectCommand(renderContext?.args);
 			if (options.isPartial) {
-				if (routineCommand && !isError) {
+				if (directCommand && !isError) {
 					if (!options.expanded) return new Text("", 0, 0);
-				} else if (!(routineCommand && isError)) {
+				} else if (!(directCommand && isError)) {
 					return new Text(theme.fg("warning", partialLabel(toolName)), 0, 0);
 				}
 			}

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -106,10 +106,11 @@ function isGitCommand(args: Record<string, unknown> | undefined): boolean {
 
 export type GentleAiRoutineCommand = "sdd-status" | "sdd-continue" | "sdd-attempt" | "review";
 
-const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+\S+=\S+\s+|command(?:\s+--)?\s+|\w+=\S+\s+)*`;
+const SHELL_COMMAND_ASSIGNMENT = String.raw`\w+=(?:'[^']*'|"[^"]*"|\S+)`;
+const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+(?:${SHELL_COMMAND_ASSIGNMENT}\s+)?|command(?:\s+--)?\s+|${SHELL_COMMAND_ASSIGNMENT}\s+)*`;
 const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai(?:\.exe)?|'gentle-ai(?:\.exe)?'|"gentle-ai(?:\.exe)?"|gentle\\-ai(?:\.exe|\\\.exe)?|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
 const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}(?:\s+(.*))?$`);
-const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n$]/;
+const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n$#]/;
 const SDD_ATTEMPT_VERBS = new Set(["acquire", "settle", "grant"]);
 
 const REVIEW_DIRECT_OPERATIONS = new Set([

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -106,8 +106,8 @@ function isGitCommand(args: Record<string, unknown> | undefined): boolean {
 
 export type GentleAiRoutineCommand = "sdd-status" | "sdd-continue" | "sdd-attempt" | "review";
 
-const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+\S+=\S+\s+|command\s+|\w+=\S+\s+)*`;
-const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
+const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+\S+=\S+\s+|command(?:\s+--)?\s+|\w+=\S+\s+)*`;
+const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai(?:\.exe)?|'gentle-ai(?:\.exe)?'|"gentle-ai(?:\.exe)?"|gentle\\-ai(?:\.exe|\\\.exe)?|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
 const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}(?:\s+(.*))?$`);
 const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n$]/;
 const SDD_ATTEMPT_VERBS = new Set(["acquire", "settle", "grant"]);

--- a/lib/gentle-ai-renderer.ts
+++ b/lib/gentle-ai-renderer.ts
@@ -1,0 +1,39 @@
+import { Text } from "@earendil-works/pi-tui";
+import { sanitizeTerminalText } from "./terminal-theme.ts";
+
+type GentleAiLifecycleColor = "warning" | "success" | "error" | "dim";
+
+export interface GentleAiRenderTheme {
+	bold(value: string): string;
+	fg(color: GentleAiLifecycleColor, value: string): string;
+}
+
+export interface GentleAiRenderContext {
+	executionStarted?: boolean;
+	isPartial?: boolean;
+	isError?: boolean;
+	lastComponent?: unknown;
+}
+
+export function renderGentleAiLifecycleCall(
+	operationPath: string,
+	theme: GentleAiRenderTheme,
+	context?: GentleAiRenderContext,
+	auditInvocation?: string,
+): Text {
+	const status = context?.isError
+		? "failed"
+		: !context?.executionStarted || context.isPartial
+			? "running"
+			: "completed";
+	const color = status === "running" ? "warning" : status === "completed" ? "success" : "error";
+	const lines = [
+		theme.fg(color, theme.bold(`🌹︎ Gentle AI · ${status} · ${operationPath}`)),
+	];
+	if (auditInvocation !== undefined) {
+		lines.push(theme.fg("dim", `audit: ${sanitizeTerminalText(auditInvocation)}`));
+	}
+	const component = context?.lastComponent instanceof Text ? context.lastComponent : new Text("", 0, 0);
+	component.setText(lines.join("\n"));
+	return component;
+}

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import { gzipSync } from "node:zlib";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -18,6 +20,113 @@ function writeMarkdown(path: string, content: string): void {
 	mkdirSync(dirname(path), { recursive: true });
 	writeFileSync(path, content);
 }
+
+const lifecycleTheme = {
+	bold(value: string): string {
+		return value;
+	},
+	fg(color: string, value: string): string {
+		return `<${color}>${value}</${color}>`;
+	},
+};
+
+function renderComponent(component: { render(width: number): string[] }): string {
+	return component.render(120).map((line) => line.replace(/[ \t]+$/g, "")).join("\n");
+}
+
+function registeredGentleTools(): Map<string, any> {
+	const tools = new Map<string, any>();
+	const pi = {
+		on() {},
+		registerCommand() {},
+		registerTool(tool: { name: string }) {
+			tools.set(tool.name, tool);
+		},
+	} as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli: null })(pi);
+	return tools;
+}
+
+function lifecycleContext(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		executionStarted: false,
+		isPartial: true,
+		isError: false,
+		lastComponent: undefined,
+		...overrides,
+	};
+}
+
+test("registered Gentle Review tools render reusable rose lifecycle call rows", () => {
+	const tools = registeredGentleTools();
+	const cases = [
+		["gentle_review", { operation: "status" }, "review status"],
+		["gentle_review", { operation: "future-operation", secret: "/private" }, "review"],
+		["gentle_review_scope", {}, "review scope"],
+	] as const;
+
+	for (const [name, args, operationPath] of cases) {
+		const tool = tools.get(name);
+		assert.ok(tool, `missing ${name}`);
+		const initial = tool.renderCall(args, lifecycleTheme, lifecycleContext());
+		const initialText = renderComponent(initial);
+		const running = tool.renderCall(
+			args,
+			lifecycleTheme,
+			lifecycleContext({ executionStarted: true, lastComponent: initial }),
+		);
+		const runningText = renderComponent(running);
+		const completed = tool.renderCall(
+			args,
+			lifecycleTheme,
+			lifecycleContext({ executionStarted: true, isPartial: false, lastComponent: running }),
+		);
+		const completedText = renderComponent(completed);
+		const failed = tool.renderCall(
+			args,
+			lifecycleTheme,
+			lifecycleContext({ executionStarted: true, isPartial: false, isError: true, lastComponent: completed }),
+		);
+		const failedText = renderComponent(failed);
+
+		assert.strictEqual(initial, running);
+		assert.strictEqual(running, completed);
+		assert.strictEqual(completed, failed);
+		assert.equal(initialText, `<warning>🌹︎ Gentle AI · running · ${operationPath}</warning>`);
+		assert.equal(runningText, `<warning>🌹︎ Gentle AI · running · ${operationPath}</warning>`);
+		assert.equal(completedText, `<success>🌹︎ Gentle AI · completed · ${operationPath}</success>`);
+		assert.equal(failedText, `<error>🌹︎ Gentle AI · failed · ${operationPath}</error>`);
+		assert.doesNotMatch(renderComponent(failed), /future-operation|secret|private/);
+	}
+});
+
+test("registered Gentle Review tools preserve result envelopes and default result visibility", async () => {
+	const tools = registeredGentleTools();
+	const scope = tools.get("gentle_review_scope");
+	const manifest = { version: 1, scopeByMode: { "100644": ["src/file.ts"] }, gitlinks: {} };
+	const bytes = Buffer.from(JSON.stringify(manifest), "utf8");
+	const encoded = gzipSync(bytes, { mtime: 0 }).toString("base64url");
+	const sha256 = createHash("sha256").update(bytes).digest("hex");
+
+	const result = await scope.execute(
+		"scope-call",
+		{ manifest: encoded, sha256, cursor: 0 },
+		undefined,
+		undefined,
+		{ cwd: process.cwd() } as ExtensionContext,
+	);
+	const visibleEnvelope = JSON.parse(result.content[0].text);
+	assert.deepEqual(visibleEnvelope, {
+		version: 1,
+		sha256,
+		cursor: 0,
+		totalPaths: 1,
+		entries: [{ path: "src/file.ts", mode: "100644" }],
+	});
+	assert.deepEqual(result.details, visibleEnvelope);
+	assert.equal(tools.get("gentle_review")?.renderResult, undefined);
+	assert.equal(scope.renderResult, undefined);
+});
 
 test("agent discovery skips skills directories", async (t) => {
 	const root = mkdtempSync(join(tmpdir(), "gentle-pi-agents-"));

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -63,7 +63,23 @@ test("registered Gentle Review tools render reusable rose lifecycle call rows", 
 		["gentle_review", { operation: "status" }, "review status"],
 		["gentle_review", { operation: "future-operation", secret: "/private" }, "review"],
 		["gentle_review_scope", {}, "review scope"],
+		[
+			"gentle_review_capture",
+			{
+				lineageId: "lineage-id",
+				collectBinding: "binding-id",
+				sha256: "sha256:hash-value",
+				secret: "secret-value",
+				arbitrary: "arbitrary-value",
+			},
+			"review capture",
+		],
 	] as const;
+
+	assert.deepEqual(
+		[...new Set(cases.map(([name]) => name))].sort(),
+		[...tools.keys()].filter((name) => name.startsWith("gentle_")).sort(),
+	);
 
 	for (const [name, args, operationPath] of cases) {
 		const tool = tools.get(name);
@@ -97,6 +113,9 @@ test("registered Gentle Review tools render reusable rose lifecycle call rows", 
 		assert.equal(completedText, `<success>🌹︎ Gentle AI · completed · ${operationPath}</success>`);
 		assert.equal(failedText, `<error>🌹︎ Gentle AI · failed · ${operationPath}</error>`);
 		assert.doesNotMatch(renderComponent(failed), /future-operation|secret|private/);
+		for (const forbiddenValue of ["lineage-id", "binding-id", "sha256:hash-value", "secret-value", "arbitrary-value"]) {
+			assert.doesNotMatch(failedText, new RegExp(forbiddenValue));
+		}
 	}
 });
 
@@ -126,6 +145,7 @@ test("registered Gentle Review tools preserve result envelopes and default resul
 	assert.deepEqual(result.details, visibleEnvelope);
 	assert.equal(tools.get("gentle_review")?.renderResult, undefined);
 	assert.equal(scope.renderResult, undefined);
+	assert.equal(tools.get("gentle_review_capture")?.renderResult, undefined);
 });
 
 test("agent discovery skips skills directories", async (t) => {

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -451,6 +451,11 @@ test("quiet tool rendering recognizes exact quoted, escaped, Windows, and comman
 		"gentle\\-ai\\.exe version",
 		"command -- gentle-ai version",
 		"command -- 'gentle-ai.exe' version",
+		"env gentle-ai version",
+		"FOO='a b' gentle-ai version",
+		'FOO="a b" gentle-ai version',
+		"env FOO='a b' gentle-ai version",
+		'env FOO="a b" gentle-ai version',
 	] as const;
 
 	for (const command of routineCommands) {
@@ -551,6 +556,7 @@ test("quiet tool rendering keeps shell compositions, expansions, and lookalikes 
 		"gentle-ai version | tee output",
 		"gentle-ai version $HOME",
 		"gentle-ai version $(printf nested)",
+		"gentle-ai sdd-attempt grant --change secret-change # ignored comment",
 		"/package/.gentle-ai/v2.2.0/gentle-ai-copy version",
 		"echo gentle-ai version",
 	];

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -437,6 +437,34 @@ test("quiet tool rendering covers version and future standalone Gentle AI comman
 	}
 });
 
+test("quiet tool rendering recognizes exact quoted, escaped, Windows, and command-prefixed Gentle AI executables", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const routineCommands = [
+		"gentle-ai.exe version",
+		"'gentle-ai' version",
+		'"gentle-ai" version',
+		"'gentle-ai.exe' version",
+		'"gentle-ai.exe" version',
+		"gentle\\-ai version",
+		"gentle\\-ai\\.exe version",
+		"command -- gentle-ai version",
+		"command -- 'gentle-ai.exe' version",
+	] as const;
+
+	for (const command of routineCommands) {
+		const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+		assert.equal(call.trimEnd(), "🌹︎ Gentle AI · running · version", command);
+	}
+
+	for (const command of ["'gentle-ai-copy' version", '"gentle-ai-copy.exe" version', "'gentle-ai' version && echo done"] as const) {
+		const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+		assert.equal(call.trimEnd(), `$ ${command}`);
+		assert.doesNotMatch(call, /🌹︎ Gentle AI/);
+	}
+});
+
 test("quiet tool rendering hides the routine partial result because the header owns state", () => {
 	const { pi, tools } = createPi();
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -414,6 +414,29 @@ test("quiet tool rendering displays only finite safe Gentle AI operation paths",
 	}
 });
 
+test("quiet tool rendering covers version and future standalone Gentle AI commands", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const rose = "🌹︎";
+	const cases = [
+		["gentle-ai version", "version"],
+		["gentle-ai future-command --authorization-root /repo/private", "command"],
+		["gentle-ai sdd-attempt future-verb --change secret-change", "sdd attempt"],
+		["gentle-ai review future-operation --path /repo/private", "review"],
+		["/package/.gentle-ai/v2.2.0/gentle-ai version", "version"],
+		["C:\\package\\.gentle-ai\\v2.2.0\\gentle-ai.exe future-command --root C:\\private", "command"],
+	] as const;
+
+	for (const [command, path] of cases) {
+		const rendered = renderToString(
+			tool.renderCall({ command }, passthroughTheme, routineRenderContext({ args: { command } })),
+		);
+		assert.equal(rendered.trimEnd(), `${rose} Gentle AI · running · ${path}`, command);
+		assert.doesNotMatch(rendered, /authorization-root|secret-change|private|C:\\\\private/);
+	}
+});
+
 test("quiet tool rendering hides the routine partial result because the header owns state", () => {
 	const { pi, tools } = createPi();
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
@@ -448,6 +471,71 @@ test("quiet tool rendering hides the routine partial result because the header o
 	assert.equal(partial, "");
 	assert.match(partialExpanded, /"status":"running"/);
 	assert.match(partialFailure, /review status failed: authority unavailable/);
+});
+
+test("quiet tool rendering keeps grant invocation auditing separate from the safe lifecycle path", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const command = "gentle-ai sdd-attempt grant --authorization-root /repo/root --authorization-root /other/root --change secret-change\x1b[31m";
+	const expectedAudit = command.replace("\x1b[31m", "");
+
+	const initial = tool.renderCall(
+		{ command },
+		statusTheme,
+		routineRenderContext({ args: { command } }),
+	);
+	const running = tool.renderCall(
+		{ command },
+		statusTheme,
+		routineRenderContext({ args: { command }, executionStarted: true, lastComponent: initial }),
+	);
+	const completed = tool.renderCall(
+		{ command },
+		statusTheme,
+		routineRenderContext({ args: { command }, executionStarted: true, isPartial: false, lastComponent: running }),
+	);
+	const failed = tool.renderCall(
+		{ command },
+		statusTheme,
+		routineRenderContext({ args: { command }, executionStarted: true, isPartial: false, isError: true, lastComponent: completed }),
+	);
+
+	assert.strictEqual(initial, running);
+	assert.strictEqual(running, completed);
+	assert.strictEqual(completed, failed);
+	const lines = renderToString(failed).split("\n").map((line) => line.replace(/[ \t]+$/g, ""));
+	assert.equal(lines[0], "<error>🌹︎ Gentle AI · failed · sdd attempt grant</error>");
+	const audit = lines.slice(1).join(" ").replace(/<\/?dim>/g, "").replace(/\s+/g, " ").trim();
+	assert.equal(audit, `audit: ${expectedAudit}`);
+	assert.match(audit, /--authorization-root \/repo\/root --authorization-root \/other\/root/);
+	assert.doesNotMatch(lines[0], /authorization-root|secret-change|other\/root/);
+	assert.doesNotMatch(audit, /\x1b\[/);
+});
+
+test("quiet tool rendering keeps shell compositions, expansions, and lookalikes generic", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const commands = [
+		"gentle-ai version && echo done",
+		"gentle-ai version; echo done",
+		"gentle-ai version | tee output",
+		"gentle-ai version $HOME",
+		"gentle-ai version $(printf nested)",
+		"/package/.gentle-ai/v2.2.0/gentle-ai-copy version",
+		"echo gentle-ai version",
+	];
+
+	for (const command of commands) {
+		const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+		const output = renderToString(
+			tool.renderResult(textResult("original command output"), { expanded: true, isPartial: false }, passthroughTheme, { args: { command } }),
+		);
+		assert.equal(call.trimEnd(), `$ ${command}`);
+		assert.doesNotMatch(call, /🌹︎ Gentle AI/);
+		assert.match(output, /original command output/);
+	}
 });
 
 test("quiet tool rendering keeps collapsed git bash result tails", () => {


### PR DESCRIPTION
Closes #417

## PR type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Apply the rose running/completed/failed lifecycle to every direct Gentle AI CLI invocation with safe future-command fallbacks.
- Cover exact bare Windows, quoted/escaped, `command --`, bounded `env`, and quoted-assignment executable forms while keeping comments and shell composition generic.
- Add the shared lifecycle renderer to every registered Gentle AI Pi tool: `gentle_review`, `gentle_review_scope`, and `gentle_review_capture`.
- Preserve review protocol result envelopes and a dedicated full audit row for `sdd-attempt grant` authorization roots.

## Changes

| File | Change |
|------|--------|
| `lib/gentle-ai-renderer.ts` | Share lifecycle state, color, `Text` reuse, and optional audit-line rendering. |
| `extensions/quiet-tools.ts` | Cover every direct exact Gentle AI executable call and bounded equivalent prefixes while retaining safe labels and fail-closed shell/comment behavior. |
| `extensions/gentle-ai.ts` | Render all three registered `gentle_*` tools with the shared rose lifecycle. |
| `tests/quiet-tool-rendering.test.ts` | Cover known, unknown, package-local, Windows, quoted/escaped, command/env-prefixed, comment, shell-safety, lifecycle, and grant-audit cases. |
| `tests/gentle-ai.test.ts` | Mechanically guard the complete registered-tool set, lifecycle rendering, redaction, and unchanged result visibility. |

## Test plan

- [x] Focused quiet-tool tests: 20 passed, 0 failed.
- [x] Full suite: 1036 passed, 1 skipped, 0 failed.
- [x] Runtime module parity: `pnpm run check:runtime-modules`.
- [x] Packed package E2E: `pnpm run test:packed-package`.
- [x] Whitespace validation: `git diff --check`.
- [x] Mechanical registration guard confirms 3/3 `gentle_*` tools have lifecycle renderers and no custom result renderer.
- [x] Two blind judges verified the scoped JD-A-001 matcher correction; informational JD-A-002/JD-B-001 were addressed afterward under ordinary policy with focused tests.
- [x] Effective PR diff remains under the 400-line review budget: 390 A+D.

## Contributor checklist

- [x] Linked approved issue #417.
- [x] PR uses exactly one feature type selection and exactly one `type:feature` label.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] Focused and full tests exercise the affected extensions.
- [x] User-facing behavior and safety boundaries are documented in the linked issue and this PR.
- [x] Commits use Conventional Commits.
- [x] No AI attribution or `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent lifecycle status displays for Gentle AI review and command operations.
  - Added support for argument-less commands, quoted or escaped executables, and `sdd-attempt grant`.
  - Added clearer operation paths for version and other non-review commands.

- **Bug Fixes**
  - Improved handling of partial and failed results across Gentle AI commands.
  - Sensitive command arguments are now kept in a separate sanitized audit line.
  - Unrecognized or composed commands retain generic rendering and command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->