### PR TITLE
fix(installer): give the Windows source build its own timeout and report timeouts precisely

### DIFF
--- a/scripts/gentle-ai-installer.mjs
+++ b/scripts/gentle-ai-installer.mjs
@@ -601,7 +601,7 @@ async function installWindowsGentleAiFromGoSumdb(options, packageRoot, architect
 			await assertGoToolchain(execute, goPath, environment, stagingDirectory);
 			try { await runCommand(execute, goPath, ["install", GENTLE_AI_WINDOWS_SOURCE_PACKAGE], commandOptions(environment, stagingDirectory, GO_SOURCE_BUILD_TIMEOUT_MS)); }
 			catch (error) {
-				if (isCommandTimeoutError(error)) throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_TIMEOUT_CODE, `Gentle AI source build for ${GENTLE_AI_WINDOWS_SOURCE_PACKAGE} exceeded the ${GO_SOURCE_BUILD_TIMEOUT_MS / 1000}s build bound. This is a build-duration limit, not a checksum or SumDB verification failure; re-run the installation, ideally with fewer concurrent workloads.`, error);
+				if (isCommandTimeoutError(error)) throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_TIMEOUT_CODE, `Gentle AI source installation for ${GENTLE_AI_WINDOWS_SOURCE_PACKAGE} did not finish within its ${GO_SOURCE_BUILD_TIMEOUT_MS / 1000}s time limit and was stopped; re-run the installation to retry (slow disks, cold module caches, or concurrent workloads can extend the build).`, error);
 				throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, `Gentle AI Go SumDB source installation failed for ${GENTLE_AI_WINDOWS_SOURCE_PACKAGE}.`, error);
 			}
 			const builtBinary = join(environment.GOBIN, "gentle-ai.exe"), binaryPath = join(stagingDirectory, "gentle-ai.exe");

--- a/scripts/gentle-ai-installer.mjs
+++ b/scripts/gentle-ai-installer.mjs
@@ -615,7 +615,14 @@ async function installWindowsGentleAiFromGoSumdb(options, packageRoot, architect
 			await safeRemoveDirectory(buildDirectory);
 			const published = await publishBundle(runtimeRoot, stagingDirectory, options);
 			return { installed: true, binaryPath: join(published, "gentle-ai.exe"), method: GENTLE_AI_INSTALL_METHOD.GO_SUMDB_SOURCE_BUILD };
-		} finally { await safeRemoveDirectory(stagingDirectory); }
+		} finally {
+			// A straggling build child can keep staging files open on Windows (execFile's
+			// timeout kill terminates go.exe but not its compiler descendants), and an
+			// exception thrown here would mask the primary installer error. Removal
+			// failures degrade to cleanupStaleStagingBundles sweeping the directory on
+			// the next install instead.
+			await safeRemoveDirectory(stagingDirectory).catch(() => {});
+		}
 	});
 }
 

--- a/scripts/gentle-ai-installer.mjs
+++ b/scripts/gentle-ai-installer.mjs
@@ -23,6 +23,12 @@ const MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
 const MAX_REDIRECTS = 3;
 const DOWNLOAD_TIMEOUTS = { headers: 10_000, body: 30_000, attempts: 2, retryDelay: 100 };
 const GO_COMMAND_TIMEOUT_MS = 120_000;
+// The pinned source build compiles the full Gentle AI module tree from a cold
+// cache, and a clean Windows x64 build has been measured at ~232s (#400) — well
+// past the 120s bound that every other (fast) go command keeps. The build gets
+// its own bound with headroom for slower disks; it stays finite so a wedged
+// build cannot hang the package postinstall forever.
+const GO_SOURCE_BUILD_TIMEOUT_MS = 600_000;
 const GO_COMMAND_MAX_BUFFER = 1024 * 1024;
 const WINDOWS_SYSTEM_ROOT = "C:\\Windows";
 // The one authoritative pinned Gentle AI version. Every other location in this
@@ -50,6 +56,7 @@ export const GENTLE_AI_WINDOWS_MINIMUM_GO_VERSION = "1.25.10";
 export const GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE_CODE = "GENTLE_AI_GO_TOOLCHAIN_UNAVAILABLE";
 export const GENTLE_AI_GO_TOOLCHAIN_TOO_OLD_CODE = "GENTLE_AI_GO_TOOLCHAIN_TOO_OLD";
 export const GENTLE_AI_GO_INSTALL_FAILED_CODE = "GENTLE_AI_GO_INSTALL_FAILED";
+export const GENTLE_AI_GO_INSTALL_TIMEOUT_CODE = "GENTLE_AI_GO_INSTALL_TIMEOUT";
 export const GENTLE_AI_VERSION_MISMATCH_CODE = "GENTLE_AI_VERSION_MISMATCH";
 
 export class GentleAiInstallerError extends Error {
@@ -249,8 +256,16 @@ function isCanonicalManifest(contents, parsed, expected) {
 
 function commandOutput(result) { return typeof result?.stdout === "string" ? result.stdout : ""; }
 
-function commandOptions(env, cwd) {
-	return { cwd, env, shell: false, windowsHide: true, timeout: GO_COMMAND_TIMEOUT_MS, maxBuffer: GO_COMMAND_MAX_BUFFER };
+function commandOptions(env, cwd, timeout = GO_COMMAND_TIMEOUT_MS) {
+	return { cwd, env, shell: false, windowsHide: true, timeout, maxBuffer: GO_COMMAND_MAX_BUFFER };
+}
+
+// execFile reports a timeout kill as killed=true with the kill signal and a null
+// exit code; a maxBuffer kill carries ERR_CHILD_PROCESS_STDIO_MAXBUFFER instead,
+// so requiring a nullish code keeps that (and real build failures) out.
+function isCommandTimeoutError(error) {
+	if (error?.code === "ETIMEDOUT") return true;
+	return error?.killed === true && typeof error?.signal === "string" && error?.code == null;
 }
 
 function outputVersion(output) {
@@ -584,8 +599,11 @@ async function installWindowsGentleAiFromGoSumdb(options, packageRoot, architect
 			const existing = versionBundlePath(runtimeRoot);
 			if (await existingWindowsSourceBundleMatches(existing, execute, goPath, environment, architecture)) return { installed: false, binaryPath: join(existing, "gentle-ai.exe"), method: GENTLE_AI_INSTALL_METHOD.GO_SUMDB_SOURCE_BUILD };
 			await assertGoToolchain(execute, goPath, environment, stagingDirectory);
-			try { await runCommand(execute, goPath, ["install", GENTLE_AI_WINDOWS_SOURCE_PACKAGE], commandOptions(environment, stagingDirectory)); }
-			catch (error) { throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, `Gentle AI Go SumDB source installation failed for ${GENTLE_AI_WINDOWS_SOURCE_PACKAGE}.`, error); }
+			try { await runCommand(execute, goPath, ["install", GENTLE_AI_WINDOWS_SOURCE_PACKAGE], commandOptions(environment, stagingDirectory, GO_SOURCE_BUILD_TIMEOUT_MS)); }
+			catch (error) {
+				if (isCommandTimeoutError(error)) throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_TIMEOUT_CODE, `Gentle AI source build for ${GENTLE_AI_WINDOWS_SOURCE_PACKAGE} exceeded the ${GO_SOURCE_BUILD_TIMEOUT_MS / 1000}s build bound. This is a build-duration limit, not a checksum or SumDB verification failure; re-run the installation, ideally with fewer concurrent workloads.`, error);
+				throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, `Gentle AI Go SumDB source installation failed for ${GENTLE_AI_WINDOWS_SOURCE_PACKAGE}.`, error);
+			}
 			const builtBinary = join(environment.GOBIN, "gentle-ai.exe"), binaryPath = join(stagingDirectory, "gentle-ai.exe");
 			const details = await lstat(builtBinary);
 			if (!details.isFile() || details.isSymbolicLink()) throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, "Gentle AI Go installation produced a non-regular gentle-ai.exe.");

--- a/tests/gentle-ai-installer.test.ts
+++ b/tests/gentle-ai-installer.test.ts
@@ -155,7 +155,10 @@ test("Windows source install reports missing or too-old Go without publishing a 
 
 test("Windows source install cleans staging after Go failure or wrong built version", async () => {
 	for (const fixtureOptions of [
-		{ installError: Object.assign(new Error("go install timed out"), { code: "ETIMEDOUT" }), expectedCode: "GENTLE_AI_GO_INSTALL_FAILED" },
+		{ installError: Object.assign(new Error("go install timed out"), { code: "ETIMEDOUT" }), expectedCode: "GENTLE_AI_GO_INSTALL_TIMEOUT" },
+		// execFile reports its own timeout kill as killed + kill signal with a null exit code.
+		{ installError: Object.assign(new Error("Command failed"), { killed: true, signal: "SIGTERM", code: null }), expectedCode: "GENTLE_AI_GO_INSTALL_TIMEOUT" },
+		{ installError: Object.assign(new Error("build failed"), { code: 1 }), expectedCode: "GENTLE_AI_GO_INSTALL_FAILED" },
 		{ reportedVersion: "gentle-ai 2.2.1\n", expectedCode: "GENTLE_AI_VERSION_MISMATCH" },
 	] as const) {
 		const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-windows-cleanup-"));
@@ -171,6 +174,21 @@ test("Windows source install cleans staging after Go failure or wrong built vers
 		assert.ok(fixture.calls.some((call) => call.arguments_[0] === "install"));
 		assert.equal(existsSync(join(runtimeDirectory, "gentle-ai.exe")), false);
 		assert.equal(existsSync(runtimeDirectory) && (await readdir(runtimeDirectory)).some((entry) => entry.startsWith(".go-install-") || entry.endsWith(".tmp")), false);
+	}
+});
+
+test("Windows source build gets the extended build bound while every other go command keeps the command timeout", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-windows-timeout-"));
+	const fixture = windowsGoFixture();
+	const goPath = join(packageRoot, "go.exe");
+	await writeFile(goPath, "trusted local Go executable");
+	fixture.setGoExecutable(goPath);
+	await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: async () => goPath });
+	const installCalls = fixture.calls.filter((call) => call.arguments_[0] === "install");
+	assert.equal(installCalls.length, 1);
+	assert.equal(installCalls[0].options.timeout, 600_000);
+	for (const call of fixture.calls.filter((entry) => entry.file === goPath && entry.arguments_[0] !== "install")) {
+		assert.equal(call.options.timeout, 120_000);
 	}
 });
 


### PR DESCRIPTION
Closes #400

## What this fixes

The package postinstall gives every Go command a fixed 120s timeout (`GO_COMMAND_TIMEOUT_MS`). That bound is right for the fast commands (`go version`, `go version -m`), but the Windows source build compiles the entire pinned Gentle AI module tree from a cold, sealed cache — and on real Windows x64 machines a *clean, healthy* build sits at or past the bound:

| Measurement | Machine | Duration |
| --- | --- | --- |
| Bare `go install` of the pinned tag (issue report) | Windows x64 #1 | ~232s |
| Bare `go install` of the pinned tag | Windows x64 #2 (mine) | 119.3s |
| Full sealed installer run (end-to-end, patched) | Windows x64 #2 (mine) | 130.7s |

The 130.7s end-to-end run is the exact code path the postinstall executes: with the current bound it would have been killed at 120s; with this change it completes and atomically publishes the verified runtime (`installed: true`, module checksum match).

On top of the timeout policy, the failure was misreported: every failing `go install` throws the same *"Go SumDB source installation failed"* message, so a timeout kill sends users off to debug module integrity that already verified fine — exactly what the issue documents.

## The change

1. **`GO_SOURCE_BUILD_TIMEOUT_MS = 600_000`, applied only to the `go install` invocation.** Every other go command keeps the 120s bound. 600s gives clean-build headroom over the observed 232s worst case while staying finite, so a wedged build still cannot hang the postinstall forever.
2. **Timeout kills are now reported as what they are.** `isCommandTimeoutError` recognizes `execFile`'s timeout shape (`killed` + kill signal + null exit code — which keeps `maxBuffer` kills and real build failures out) plus `ETIMEDOUT`, and throws a new `GENTLE_AI_GO_INSTALL_TIMEOUT` error explaining it is a build-duration limit, not a checksum or SumDB verification failure. All other failures keep the existing `GENTLE_AI_GO_INSTALL_FAILED` path.

No integrity or publication guarantees change: same sealed environment, same pinned checksums, same atomic staging/publish flow.

## Test plan

- Updated the failure-mapping cases: `ETIMEDOUT` and the `execFile` timeout shape (`killed`/`SIGTERM`/null code) now map to `GENTLE_AI_GO_INSTALL_TIMEOUT`; a plain build failure still maps to `GENTLE_AI_GO_INSTALL_FAILED`; staging cleanup asserts unchanged.
- New test: the `go install` call receives the extended bound while every other go command keeps `120_000`.
- Red-green: both fail without the source change and pass with it. The 4 remaining suite failures on Windows are pre-existing POSIX-specific tests (verified identical on a clean checkout).
- End-to-end on Windows x64: full sealed source build through the patched installer completes in 130.7s and publishes the runtime.

---

Investigated and validated with AI assistance; I reviewed every change and the measurements are from real runs on my machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installation handling for lengthy Go builds.
  * Extended the Go compilation timeout to 10 minutes while keeping standard checks unchanged.
  * Added a clear timeout-specific error when builds exceed the allowed duration.
  * Preserved the existing installation error for other build failures.
  * Improved error reporting so cleanup issues do not obscure the primary installation failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->