### PR TITLE
feat(sdd): add sdd-research executor and research pre-proposal gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ Adversarial review roles (the refuter and the targeted validator) are never Pi-a
 ```text
 init
   ↓
-explore → proposal → spec ─┬→ design ─┐
-                            └─────────┴→ tasks → apply → verify → sync → archive
+explore → research (optional) → proposal → spec ─┬→ design ─┐
+                                                  └─────────┴→ tasks → apply → verify → sync → archive
 ```
 
 The main loop is intentionally file-backed when you choose `openspec` or `both`:

--- a/assets/agents/sdd-proposal.md
+++ b/assets/agents/sdd-proposal.md
@@ -44,6 +44,8 @@ Read your own input artifacts directly from the active backend before doing the 
 
 Inputs to read (`engram`/`both`: use the injected Engram memory read tools for the topic key, then fetch the full observation; `openspec`: read the file under `openspec/changes/{change}/`):
 - Exploration (optional): `sdd/{change}/explore`
+- Research + pre-proposal state (optional, present only when research was selected): `sdd/{change}/research` and `sdd/{change}/preproposal` (openspec: `openspec/changes/{change}/research.md`)
+- The proposer receives the confirmed pre-proposal handoff from the orchestrator and MUST NOT interview the user about those confirmed product decisions or infer consent; the orchestrator owns product discovery.
 
 Persist this phase's artifact to the active backend before returning (mandatory):
 - `engram`/`both`: call the injected Engram save tool with title and `topic_key` `"sdd/{change}/proposal"`, `type: "architecture"`, `project` from context, and `capture_prompt: false` when the tool schema supports it (omit the field if an older schema rejects it).

--- a/assets/agents/sdd-research.md
+++ b/assets/agents/sdd-research.md
@@ -1,0 +1,54 @@
+---
+name: sdd-research
+description: Collect auditable external evidence for a selected SDD research lane.
+tools:
+  - read
+  - grep
+  - find
+  - edit
+  - write
+  - mem_search
+  - mem_get_observation
+  - mem_save
+---
+
+You are the SDD research executor for Gentle AI.
+
+## Skill Resolution Contract
+
+Use your assigned executor/phase skill for this SDD phase. For project/user skills, prefer parent-injected `## Skills to load before work` paths; read those exact `SKILL.md` files before work. Do not independently discover additional project/user skills or the registry during normal runtime.
+
+If skill paths are missing, explicit fallback loading is allowed only as degraded self-healing. Report `skill_resolution` as `paths-injected`, `fallback-registry`, `fallback-path`, or `none`; fallbacks mean the parent should pass indexed paths next time.
+
+- Run only when the orchestrator selects `sdd-research` and supplies the persisted research intent: the change name, the questions, the requested source classes, and the artifact store. Treat that intent as immutable; if it is absent, return `blocked` with no claims.
+- Evidence grants for this runtime are `documentation=[]; open-web=[]`. Never infer evidence capability from bash, persistence tools, or any inherited tool; persistence tools are not evidence grants. Unsupported or undeclared classes deny admission and emit no claims.
+- Because this runtime declares no evidence grants, retain the selected request, persist a `blocked` outcome with no claims, and stop.
+- Admission denial, partial evidence, invalid sources, or persistence divergence emits no unvalidated claim and blocks proposal readiness.
+- Keep evidence claims separate from non-authoritative product choices; the orchestrator owns product decisions and proposal admission.
+- Do NOT launch child subagents. Parent/orchestrator owns delegation.
+- Persist the research and pre-proposal artifacts per the Memory Contract below; never claim persistence you did not perform.
+- Keep output concise and return the SDD result contract.
+## Memory Contract
+
+Read any input artifacts directly from the active backend before doing the phase work; do not wait for the parent to inline them. The parent may pass artifact references and context, but retrieving required inputs is this phase's responsibility.
+
+Inputs to read (`engram`/`both`: use the injected Engram memory read tools for the topic key, then fetch the full observation; `openspec`: read the file under `openspec/changes/{change}/`):
+- Exploration (when it exists): `sdd/{change}/explore` (openspec: the exploration file under `openspec/changes/{change}/`).
+
+Persist this phase's artifact to the active backend before returning (mandatory):
+- `engram`/`both`: call the injected Engram save tool with title and `topic_key` `"sdd/{change}/research"`, `type: "architecture"`, `project` from context, and `capture_prompt: false` when the tool schema supports it (omit the field if an older schema rejects it).
+- `openspec`: write/update `openspec/changes/{change}/research.md`.
+- `none`: return the research record inline.
+
+The research artifact uses schema `gentle-ai.sdd-research/v1`: a positive `revision`, an explicit `done | partial | blocked` outcome, the questions, admission and the observed exact grants, sources, and validated claims where each claim maps to source IDs. For this runtime the outcome is `blocked` with an admission denial and no claims.
+
+Also update the pre-proposal state (`engram`/`both`: topic `"sdd/{change}/preproposal"`; same save conventions) using schema `gentle-ai.sdd-preproposal/v1`: a positive `revision`, the exploration reference, the research request and classes, the admission outcome, evidence references, product decisions (`pending | confirmed`), and `proposal_ready`.
+
+Hybrid (`both`) persistence means identical bytes in both stores. On hybrid mismatch or a one-sided write failure, never prefer one store: recover from the retained intent, not from a surviving store, and keep proposal readiness false for recovery.
+
+Never claim persistence you did not perform.
+
+
+## Key Learnings Closing
+
+Close your final report text with a `## Key Learnings` block (no trailing colon). Use 1–5 numbered items, each a standalone factual sentence of at least 20 characters and at least 4 words. This applies to final report text only — not intermediate tool output or saved artifact content. The Engram memory provider automatically extracts and persists these items as passive capture; you do not parse the block or invoke passive-capture tools yourself. Omit the block when there is genuinely no reusable learning; no filler or speculation. This closing block is separate from explicit `mem_save` artifact/decision persistence.

--- a/assets/orchestrator-memory.md
+++ b/assets/orchestrator-memory.md
@@ -9,6 +9,7 @@ Each SDD phase subagent reads its own required inputs directly from the active b
 | Phase          | Reads                                                   | Writes           |
 | -------------- | ------------------------------------------------------- | ---------------- |
 | `sdd-explore`  | nothing                                                 | `explore`        |
+| `sdd-research` | exploration                                             | `research` + `preproposal` |
 | `sdd-proposal` | exploration (optional)                                  | `proposal`       |
 | `sdd-spec`     | proposal (required)                                     | `spec`           |
 | `sdd-design`   | proposal (required)                                     | `design`         |
@@ -20,6 +21,7 @@ Each SDD phase subagent reads its own required inputs directly from the active b
 | `sdd-status`   | change artifacts (read-only)                            | nothing          |
 
 - SDD artifact keys: in memory/hybrid mode, phase artifacts use stable topic keys such as `sdd/<change>/proposal`, `sdd/<change>/spec`, `sdd/<change>/design`, `sdd/<change>/tasks`, `sdd/<change>/apply-progress`, `sdd/<change>/verify-report`, `sdd/<change>/sync-report`, and `sdd/<change>/archive-report`.
+- When the optional research lane is selected, `sdd-research` uses the additional topic keys `sdd/<change>/research` and `sdd/<change>/preproposal` (openspec: `openspec/changes/<change>/research.md`).
 - If memory tools are unavailable, do not pretend persistence exists; return artifacts inline and/or write OpenSpec files.
 
 Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):

--- a/assets/sdd-orchestrator-workflow.md
+++ b/assets/sdd-orchestrator-workflow.md
@@ -7,12 +7,13 @@ This is the lazy-loaded SDD workflow surface for el Gentleman on Pi. Read this f
 SDD phases:
 
 ```text
-init → explore → proposal → spec → design → tasks → apply → verify → sync → archive
+init → explore → research (optional) → proposal → spec → design → tasks → apply → verify → sync → archive
 ```
 
 Dependency graph:
 
 ```text
+explore → research (optional) → proposal
 proposal → spec ─┬→ tasks → apply → verify → sync → archive
 proposal → design ┘
 ```
@@ -119,6 +120,18 @@ Interactive approval is phase-scoped. A user response such as "continue", "dale"
 
 Before `sdd-proposal` in interactive mode, offer the user a proposal question round instead of silently deciding whether the proposal is clear enough. Explain that the questions are meant to improve the PRD/proposal by uncovering business understanding, business rules, implications, impact, edge cases, and product tradeoffs. Prefer 3–5 concrete product questions per round, then summarize the resulting assumptions and ask whether the user wants to correct anything or run a second question round. Cover business/product/PRD decisions: business problem, target users and situations, business rules, product outcome, current-state gap, implications and impact, edge cases, decision gaps, first-slice scope boundaries, non-goals, product constraints, and business tradeoffs. Do not ask about test commands, PR shape, changed-line budget, or other harness mechanics at proposal time unless the user explicitly asks to discuss delivery.
 
+## Research and Pre-Proposal Gate
+
+This gate is MANDATORY and applies in both execution modes; in interactive mode it runs alongside the proposal question round above, and the two never contradict: the question round shapes the proposal, the gate decides whether `sdd-proposal` may launch at all.
+
+- Offer `sdd-research` immediately after `sdd-explore`. Research is optional until selected; selection makes completion mandatory.
+- Before every proposal, invoke `sdd-proposal` only when selected research is `done` or research is unselected, product decisions are `confirmed`, evidence references are valid, and the selected artifact-store state is ready.
+- The orchestrator owns product discovery. In automatic mode, unresolved product choices require one lossless grouped prompt with all context, options, consequences, allowed answers, and exact tokens; the orchestrator MUST persist the pending pre-proposal state before prompting, then STOP without invoking `sdd-proposal`.
+- The proposer receives a confirmed pre-proposal handoff and MUST NOT interview the user or infer consent.
+- Pi's native `gentle-pi.sdd-status` contract remains the sole status contract. Research and pre-proposal state are orchestrator-owned prose and artifacts (`sdd/{change}/research`, `sdd/{change}/preproposal`, `openspec/changes/{change}/research.md`) layered on top — never a native status field.
+
+Runtime note: this runtime declares no evidence grants (`documentation=[]; open-web=[]`), so a SELECTED research lane fail-closes to a `blocked` outcome and blocks proposal readiness until the user deselects research or evidence capability arrives. SDD chains treat research as unselected.
+
 ## Delivery Strategy
 
 On the first SDD chain request in a session, resolve the delivery strategy from preflight (or ask once) and cache it:
@@ -174,7 +187,7 @@ Check every phase result against the Result Contract:
 
 Use cost-aware validation:
 
-- For lower-risk phases (`sdd-explore`, `sdd-spec`, `sdd-tasks`, `sdd-sync`, `sdd-archive`), the parent may validate inline by reading artifacts back and checking claims.
+- For lower-risk phases (`sdd-explore`, `sdd-research`, `sdd-spec`, `sdd-tasks`, `sdd-sync`, `sdd-archive`), the parent may validate inline by reading artifacts back and checking claims.
 - For higher-risk phases (`sdd-design`, `sdd-apply`), validate the artifact, declared paths, task state, and focused test evidence directly before continuing because errors there compound downstream.
 - If a gate finds any smell — missing artifact, status mismatch, unresolved path, likely drift, or critical risk — rerun the same SDD phase once with corrective feedback. SDD phase validation does not start ordinary review or Judgment Day.
 
@@ -231,6 +244,7 @@ On Pi, phase model routing is user-owned and persisted, not prompt-passed: `/gen
 | Phase        | Default tier   | Reason                                     |
 | ------------ | -------------- | ------------------------------------------ |
 | sdd-explore  | balanced       | Reads code, structural - not architectural |
+| sdd-research | balanced       | Fail-closed evidence record keeping        |
 | sdd-proposal | deep-reasoning | Architectural decisions                    |
 | sdd-spec     | balanced       | Structured writing                         |
 | sdd-design   | deep-reasoning | Architecture decisions                     |

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -869,6 +869,7 @@ const SDD_AGENT_NAMES = [
 	"sdd-init",
 	"sdd-onboard",
 	"sdd-explore",
+	"sdd-research",
 	"sdd-proposal",
 	"sdd-spec",
 	"sdd-design",

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -30,6 +30,7 @@ const requiredPaths = [
   "assets/agents/sdd-init.md",
   "assets/agents/sdd-onboard.md",
   "assets/agents/sdd-proposal.md",
+  "assets/agents/sdd-research.md",
   "assets/agents/sdd-spec.md",
   "assets/agents/sdd-status.md",
   "assets/agents/sdd-sync.md",

--- a/tests/delegated-key-learnings-contract.test.ts
+++ b/tests/delegated-key-learnings-contract.test.ts
@@ -87,13 +87,14 @@ test("no SDD phase executor infers Key Learnings through `standard phase envelop
 
 test("SDD executor coverage is exhaustive against actual agent files", () => {
 	const actual = sddAgents();
-	// Allowlist: the 12 known phase executors. A new sdd-*.md without a
+	// Allowlist: the 13 known phase executors. A new sdd-*.md without a
 	// Key Learnings Closing section fails the first test; this test proves
 	// the allowlist matches reality so coverage cannot silently drift.
 	const expected = [
 		"sdd-apply.md", "sdd-archive.md", "sdd-design.md", "sdd-explore.md",
-		"sdd-init.md", "sdd-onboard.md", "sdd-proposal.md", "sdd-spec.md",
-		"sdd-status.md", "sdd-sync.md", "sdd-tasks.md", "sdd-verify.md",
+		"sdd-init.md", "sdd-onboard.md", "sdd-proposal.md", "sdd-research.md",
+		"sdd-spec.md", "sdd-status.md", "sdd-sync.md", "sdd-tasks.md",
+		"sdd-verify.md",
 	];
 	assert.deepEqual(actual, expected, "SDD agent set must match the known allowlist");
 });
@@ -228,9 +229,10 @@ test("modified SDD agents are packaged and installed by the existing installer",
 		"assets/agents/sdd-apply.md", "assets/agents/sdd-archive.md",
 		"assets/agents/sdd-design.md", "assets/agents/sdd-explore.md",
 		"assets/agents/sdd-init.md", "assets/agents/sdd-onboard.md",
-		"assets/agents/sdd-proposal.md", "assets/agents/sdd-spec.md",
-		"assets/agents/sdd-status.md", "assets/agents/sdd-sync.md",
-		"assets/agents/sdd-tasks.md", "assets/agents/sdd-verify.md",
+		"assets/agents/sdd-proposal.md", "assets/agents/sdd-research.md",
+		"assets/agents/sdd-spec.md", "assets/agents/sdd-status.md",
+		"assets/agents/sdd-sync.md", "assets/agents/sdd-tasks.md",
+		"assets/agents/sdd-verify.md",
 	];
 	for (const path of expected) {
 		assert.match(verifier, new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${path} must be in the package verifier`);

--- a/tests/sdd-agent-tools.test.ts
+++ b/tests/sdd-agent-tools.test.ts
@@ -67,6 +67,7 @@ const requiredToolsByAgent: Record<string, string[]> = {
 	"sdd-init.md": ["read", "grep", "find", "edit", "write", "bash", "mem_search", "mem_get_observation", "mem_save", "mem_update"],
 	"sdd-onboard.md": ["read", "grep", "find", "edit", "write", "bash", "mem_search", "mem_get_observation", "mem_save", "mem_update"],
 	"sdd-proposal.md": ["read", "grep", "find", "edit", "write", "mem_search", "mem_get_observation", "mem_save"],
+	"sdd-research.md": ["read", "grep", "find", "edit", "write", "mem_search", "mem_get_observation", "mem_save"],
 	"sdd-spec.md": ["read", "grep", "find", "edit", "write", "mem_search", "mem_get_observation", "mem_save"],
 	"sdd-status.md": ["read", "grep", "find", "bash", "mem_search", "mem_get_observation"],
 	"sdd-sync.md": ["read", "grep", "find", "edit", "write", "bash", "mem_search", "mem_get_observation", "mem_save", "mem_update"],


### PR DESCRIPTION
Closes #422

## Summary

- Ports the `sdd-research` phase to gentle-pi as the canonical **fail-closed** executor for web-less runtimes (evidence grants `documentation=[]; open-web=[]`, same pattern gentle-ai uses for Cursor/Kimi): a selected research lane persists a `blocked` outcome with no claims and blocks proposal readiness.
- Adds the orchestrator-owned **Research and Pre-Proposal Gate** to `assets/sdd-orchestrator-workflow.md`: research is offered right after explore; before every proposal the orchestrator requires selected research `done` (or unselected), confirmed product decisions via one lossless grouped prompt, persisted pending state before prompting, and a confirmed handoff the proposer must not re-interview.
- Full parity wiring: agent registration, package manifest, orchestrator memory table, proposal inputs, README flow diagram, and test allowlists.

## Changes

| File | Change |
|------|--------|
| `assets/agents/sdd-research.md` | New fail-closed research executor (sdd-explore skeleton, `gentle-ai.sdd-research/v1` + `gentle-ai.sdd-preproposal/v1` persistence, verbatim Key Learnings Closing) |
| `assets/sdd-orchestrator-workflow.md` | Phase string + dependency graph include `research (optional)`; new `## Research and Pre-Proposal Gate` section; gatekeeper lower-risk list; Model Assignments row |
| `assets/orchestrator-memory.md` | `sdd-research` row in the phase table plus research/preproposal topic-key bullet |
| `assets/agents/sdd-proposal.md` | Optional research/pre-proposal inputs; proposer receives confirmed handoff and must not interview or infer consent |
| `extensions/gentle-ai.ts` | `"sdd-research"` added to `SDD_AGENT_NAMES` between explore and proposal |
| `scripts/verify-package-files.mjs` | `assets/agents/sdd-research.md` added to `requiredPaths` |
| `tests/delegated-key-learnings-contract.test.ts` | Executor allowlist and packaged-paths list extended to 13 agents |
| `tests/sdd-agent-tools.test.ts` | Required tools entry for `sdd-research.md` |
| `README.md` | Flow diagram: `explore → research (optional) → proposal` |

## Out of scope (deliberate)

- Native status: research stays out of `gentle-pi.sdd-status` — the next-action token vocabulary is owned by the Go binary (cross-repo).
- Chains: `sdd-full`/`sdd-plan` untouched — research is optional-until-selected; a mandatory chain step would wedge automatic runs.
- `assets/migrations/*` and `tests/fixtures/*`: frozen historical snapshots, not to be edited.

## Test plan

- [x] TDD: test allowlists updated first, confirmed RED on the missing agent file, then implementation, then GREEN
- [x] Full `tests/*.test.ts` suite: 1040 tests, 1010 pass — the 29 failures are environmental and byte-identical (stash + set-diff verified) to a clean main run in the same working copy; zero introduced
- [x] `node scripts/check-provider-contract.mjs` — pass
- [x] `tests/runtime-harness.mjs` — exit 0
- [x] `node scripts/verify-package-files.mjs` — pass (161 files)

## Checklist

- [x] Linked an approved issue (#422, `status:approved`)
- [x] Exactly one `type:*` label (`type:feature`)
- [x] Tests updated together with the change
- [x] Docs updated (README flow, orchestrator workflow)
- [x] Conventional commit format, no attribution trailers

https://claude.ai/code/session_01ADTfAdr61Y6rUFh6DGLeEw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional research step between exploration and proposal creation in the SDD/OpenSpec workflow.
  * Research can now produce research findings and a pre-proposal handoff before proposal work begins.
  * Added validation to confirm decisions, evidence, and required artifacts before proposals launch.

* **Documentation**
  * Updated workflow and memory guidance to describe the research phase and its outputs.

* **Quality**
  * Added coverage and packaging checks for the new research capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->