### PR TITLE
feat(quiet-tools): add bounded cards and Gentle AI redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Most coding-agent sessions fail for operational reasons, not model reasons:
 | **Verified native runtime**    | Provisions the exact package-local Gentle AI v2.4.0 runtime: signed archives on Darwin/Linux and a Go SumDB-verified source build on Windows x64/arm64. It validates package-local integrity and rejects PATH, global, sibling, symlink, and mode fallbacks. |
 | **Runtime safety**             | Blocks destructive shell commands, asks for confirmation for sensitive operations, and blocks direct read/write/edit access to sensitive paths. |
 
+**Migration note:** Do not enable `pi-tool-cards` and `quiet-tools` together: Pi rejects duplicate `bash`, `read`, `edit`, and `write` registrations. Disable or remove the standalone package during migration; gentle-pi does not alter user configuration or delete that repository.
+
 ## Install
 
 ```bash

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -95,7 +95,7 @@ import {
 	type ReviewMode,
 	type ReviewProjectionV1,
 } from "../lib/review-snapshot.ts";
-import { renderGentleAiLifecycleCall, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
+import { renderGentleAiLifecycleCall, renderGentleAiResult, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
 import { sanitizeTerminalText, stripAnsi } from "../lib/terminal-theme.ts";
 import { CandidateViewError, CandidateViewRegistry, injectReviewCandidateView, readCandidateContextManifestPage, resolveCanonicalCandidateBase, type CandidateView } from "../lib/review-candidate-view.ts";
 import {
@@ -4865,6 +4865,9 @@ function createGentleAiExtensionForTesting(
 				context as GentleAiRenderContext | undefined,
 			);
 		},
+		renderResult(result, options) {
+			return renderGentleAiResult(result, options);
+		},
 		async execute(_toolCallId, parameters) {
 			const input = parameters as ReviewScopeParameters;
 			const details = readCandidateContextManifestPage(input.manifest, input.sha256, input.cursor ?? 0);
@@ -4890,6 +4893,9 @@ function createGentleAiExtensionForTesting(
 				theme,
 				context as GentleAiRenderContext | undefined,
 			);
+		},
+		renderResult(result, options) {
+			return renderGentleAiResult(result, options);
 		},
 		async execute(_toolCallId, parameters, signal, _onUpdate, ctx) {
 			if (signal?.aborted) throw new Error("Review capture was cancelled");
@@ -4931,6 +4937,9 @@ function createGentleAiExtensionForTesting(
 				theme,
 				context as GentleAiRenderContext | undefined,
 			);
+		},
+		renderResult(result, options) {
+			return renderGentleAiResult(result, options);
 		},
 		async execute(_toolCallId, parameters, signal, _onUpdate, ctx) {
 			if (signal?.aborted) throw new Error("Review controller operation was cancelled");

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -14,7 +14,7 @@ import { homedir } from "node:os";
 import { isAbsolute } from "node:path";
 import { resolveGentleAiDevBinaryOverride, type GentleAiDevBinaryOverride } from "../lib/gentle-ai-binary.ts";
 import { quietToolsEnabled } from "../lib/quiet-tools-config.ts";
-import { renderGentleAiLifecycleCall, renderGentleAiResult, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
+import { getGentleAiRenderState, renderGentleAiLifecycleCall, renderGentleAiResult, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
 import { sanitizeTerminalText } from "../lib/terminal-theme.ts";
 
 type QuietToolName = "read" | "bash" | "grep" | "find" | "ls" | "edit" | "write";
@@ -182,7 +182,11 @@ function createGentleAiCommandArguments(activeDevBinaryPath?: string): RegExp {
 	return new RegExp(`^(?:${GENTLE_AI_EXECUTABLE}|${escapedPath})$`);
 }
 
-function shellTokens(command: string): string[] | undefined {
+type ShellTokenization =
+	| { kind: "complete" | "incomplete"; tokens: string[] }
+	| { kind: "generic" };
+
+function shellTokens(command: string): ShellTokenization {
 	const tokens: string[] = [];
 	let token = "";
 	let quote: "single" | "double" | undefined;
@@ -194,7 +198,7 @@ function shellTokens(command: string): string[] | undefined {
 	};
 	for (let index = 0; index < command.length; index += 1) {
 		const character = command[index]!;
-		if (character === "\r" || character === "\n") return undefined;
+		if (character === "\r" || character === "\n") return { kind: "generic" };
 		if (quote === "single") {
 			if (character === "'") quote = undefined;
 			else token += character;
@@ -204,11 +208,11 @@ function shellTokens(command: string): string[] | undefined {
 			if (character === '"') { quote = undefined; continue; }
 			if (character === "\\") {
 				const next = command[++index];
-				if (next === undefined || next === "\r" || next === "\n") return undefined;
+				if (next === undefined || next === "\r" || next === "\n") return { kind: "incomplete", tokens };
 				token += "$`\"\\".includes(next) ? next : `\\${next}`;
 				continue;
 			}
-			if (character === "$" || character === "`") return undefined;
+			if (character === "$" || character === "`") return { kind: "generic" };
 			token += character;
 			continue;
 		}
@@ -217,22 +221,22 @@ function shellTokens(command: string): string[] | undefined {
 		if (character === '"') { quote = "double"; tokenStarted = true; continue; }
 		if (character === "\\") {
 			const next = command[++index];
-			if (next === undefined || next === "\r" || next === "\n") return undefined;
+			if (next === undefined || next === "\r" || next === "\n") return { kind: "incomplete", tokens };
 			const windowsPath = token === "." || /^[A-Za-z]:$/.test(token) || token.includes("\\");
 			token += windowsPath ? `\\${next}` : next;
 			tokenStarted = true;
 			continue;
 		}
-		if ("*?~{}".includes(character)) return undefined;
-		if (character === "[" && command.indexOf("]", index + 1) >= 0) return undefined;
-		if (";&|<>`()".includes(character) || character === "$" || character === "`") return undefined;
-		if (character === "#" && !tokenStarted) return undefined;
+		if ("*?~{}".includes(character)) return { kind: "generic" };
+		if (character === "[" && command.indexOf("]", index + 1) >= 0) return { kind: "generic" };
+		if (";&|<>`()".includes(character) || character === "$" || character === "`") return { kind: "generic" };
+		if (character === "#" && !tokenStarted) return { kind: "generic" };
 		token += character;
 		tokenStarted = true;
 	}
-	if (quote) return undefined;
+	if (quote) return { kind: "incomplete", tokens };
 	push();
-	return tokens;
+	return { kind: "complete", tokens };
 }
 
 function isAssignment(token: string): boolean {
@@ -278,10 +282,7 @@ const REVIEW_SCHEMA_NAMES = new Set([
 	"verification-evidence-record",
 ]);
 
-function gentleAiCommandTokens(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): string[] | undefined {
-	const rawCommand = typeof args?.command === "string" ? args.command : "";
-	const tokens = shellTokens(rawCommand);
-	if (!tokens) return undefined;
+function gentleAiCommandTokensFrom(tokens: string[], commandArguments: RegExp): string[] | undefined {
 	let index = 0;
 	while (isAssignment(tokens[index] ?? "")) index += 1;
 	if (tokens[index] === "command") {
@@ -296,6 +297,11 @@ function gentleAiCommandTokens(args: Record<string, unknown> | undefined, comman
 	}
 	if (!commandArguments.test(tokens[index] ?? "")) return undefined;
 	return tokens.slice(index + 1);
+}
+
+function gentleAiCommandTokens(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): string[] | undefined {
+	const shell = shellTokens(typeof args?.command === "string" ? args.command : "");
+	return shell.kind === "complete" ? gentleAiCommandTokensFrom(shell.tokens, commandArguments) : undefined;
 }
 
 function displayToken(token: string): string {
@@ -346,10 +352,7 @@ export function gentleAiRoutineCommand(args: Record<string, unknown> | undefined
 	return undefined;
 }
 
-export function gentleAiOperationPath(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): string | undefined {
-	const tokens = gentleAiCommandTokens(args, commandArguments);
-	if (!tokens) return undefined;
-
+function gentleAiOperationPathFrom(tokens: string[]): string {
 	if (tokens[0] === "sdd-status") return "sdd status";
 	if (tokens[0] === "sdd-continue") return "sdd continue";
 	if (tokens[0] === "sdd-attempt") {
@@ -380,6 +383,11 @@ export function gentleAiOperationPath(args: Record<string, unknown> | undefined,
 		return schema !== undefined && REVIEW_SCHEMA_NAMES.has(schema) ? `review schema ${displayToken(schema)}` : "review schema";
 	}
 	return REVIEW_DIRECT_OPERATIONS.has(operation) ? `review ${displayToken(operation)}` : "review";
+}
+
+export function gentleAiOperationPath(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): string | undefined {
+	const tokens = gentleAiCommandTokens(args, commandArguments);
+	return tokens ? gentleAiOperationPathFrom(tokens) : undefined;
 }
 
 export function isGentleAiGrantCommand(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): boolean {
@@ -452,8 +460,6 @@ export function formatToolResultOutput(
 		const count = toolName === "grep" ? grepMatchCount(text, args) : countNonEmptyLines(text);
 		return count > 0 ? ` → ${count} ${summaryLabel}` : "";
 	}
-	if (toolName === "bash" && isGentleAiDirectCommand(args)) return "";
-
 	if (toolName === "bash" && isGitCommand(args)) {
 		const tail = tailLines(text, COLLAPSED_TAIL_LINE_LIMIT);
 		return tail ? `\n${tail}` : "";
@@ -481,10 +487,12 @@ function lineRangeSuffix(args: Record<string, unknown>, theme: ThemeLike): strin
 
 interface ToolRenderContextLike {
 	args?: Record<string, unknown>;
+	argsComplete?: boolean;
 	executionStarted?: boolean;
 	isPartial?: boolean;
 	isError?: boolean;
 	lastComponent?: unknown;
+	state?: unknown;
 	cwd?: string;
 	[key: string]: unknown;
 }
@@ -562,7 +570,7 @@ function shouldRenderPreviewTail(
 }
 
 function partialLabel(toolName: QuietToolName, text: string): string {
-	const lineCount = outputLines(text).length;
+	const lineCount = countNonEmptyLines(text);
 	return lineCount === 0
 		? `… ${toolName}`
 		: `… ${toolName} · ${lineCount} ${lineCount === 1 ? "line" : "lines"}`;
@@ -594,6 +602,26 @@ function resolveQuietToolsDevBinaryPath(resolveOverride: GentleAiDevBinaryOverri
 	catch { return undefined; }
 }
 
+function gentleAiRenderTransition(
+	args: Record<string, unknown> | undefined, context: ToolRenderContextLike | undefined,
+	commandArguments: RegExp, options: { result?: boolean; isPartial?: boolean } = {},
+): { operationPath?: string; directResult: boolean } {
+	const state = getGentleAiRenderState(context?.state);
+	const tokenization = shellTokens(typeof args?.command === "string" ? args.command : "");
+	const directTokens = tokenization.kind === "generic" ? undefined : gentleAiCommandTokensFrom(tokenization.tokens, commandArguments);
+	const operationPath = directTokens ? gentleAiOperationPathFrom(directTokens) : undefined;
+	const argsComplete = context?.argsComplete === true;
+	const forResult = options.result === true;
+	const isPartial = options.isPartial === true || context?.isPartial === true;
+	if (operationPath && (tokenization.kind === "complete" || !argsComplete) && state?.genericLocked !== true) {
+		return { operationPath, directResult: forResult };
+	}
+	if (state && (tokenization.kind === "generic" || argsComplete || (forResult && !isPartial))) {
+		state.genericLocked = true; state.lifecycleComponent = false;
+	}
+	return { directResult: false };
+}
+
 function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArguments: RegExp): void {
 	const registrationTool = getBuiltInTools(process.cwd())[toolName];
 	const officialRenderResult = registrationTool.renderResult;
@@ -606,13 +634,13 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 		},
 		renderCall(args, theme, context) {
 			const callArgs = args as Record<string, unknown>;
-			const operationPath = toolName === "bash" ? gentleAiOperationPath(callArgs, commandArguments) : undefined;
+			const renderContext = sanitizedRenderContext(context as ToolRenderContextLike | undefined);
+			const operationPath = toolName === "bash"
+				? gentleAiRenderTransition(callArgs, renderContext, commandArguments).operationPath
+				: undefined;
 			if (operationPath) {
-				return renderGentleAiLifecycleCall(
-					operationPath,
-					theme,
-					sanitizedRenderContext(context as ToolRenderContextLike | undefined) as GentleAiRenderContext,
-				);
+				const detail = renderContext.expanded === true && typeof callArgs.command === "string" ? `$ ${callArgs.command}` : undefined;
+				return renderGentleAiLifecycleCall(operationPath, theme, renderContext as GentleAiRenderContext, detail);
 			}
 			return new Text(formatToolCall(toolName, callArgs, theme), 0, 0);
 		},
@@ -621,8 +649,13 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 			const safeResult = sanitizedResult(result);
 			const text = safeText(extractTextContent(safeResult));
 			const isError = renderContext?.isError ?? options.isError ?? false;
-			const directCommand = toolName === "bash" && isGentleAiDirectCommand(renderContext?.args, commandArguments);
-			if (directCommand) {
+			const directResult = toolName === "bash" && gentleAiRenderTransition(
+				renderContext?.args,
+				renderContext,
+				commandArguments,
+				{ result: true, isPartial: options.isPartial },
+			).directResult;
+			if (directResult) {
 				return renderGentleAiResult(safeResult, { expanded: options.expanded });
 			}
 			if (options.isPartial) {
@@ -646,7 +679,7 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 				isError,
 				args: renderContext?.args,
 			});
-			const hint = !options.expanded && !directCommand && hasExpandableContent(toolName, safeResult, text)
+			const hint = !options.expanded && !directResult && hasExpandableContent(toolName, safeResult, text)
 				? `\n${keyHint("app.tools.expand", "to expand")}`
 				: "";
 			const color = options.expanded ? "toolOutput" : isError ? "error" : "muted";

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -12,7 +12,7 @@ import {
 import { Text } from "@earendil-works/pi-tui";
 import { homedir } from "node:os";
 import { quietToolsEnabled } from "../lib/quiet-tools-config.ts";
-import { renderGentleAiLifecycleCall, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
+import { renderGentleAiLifecycleCall, renderGentleAiResult, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
 import { sanitizeTerminalText } from "../lib/terminal-theme.ts";
 
 type QuietToolName = "read" | "bash" | "grep" | "find" | "ls" | "edit" | "write";
@@ -215,6 +215,22 @@ function displayToken(token: string): string {
 	return token.replace(/-/g, " ");
 }
 
+function authorizationRootCount(tokens: string[]): number {
+	let count = 0;
+	for (let index = 0; index < tokens.length; index += 1) {
+		const token = tokens[index]!;
+		if (token === "--authorization-root") {
+			const value = tokens[index + 1];
+			if (value !== undefined && !value.startsWith("-")) count += 1;
+			continue;
+		}
+		if (token.startsWith("--authorization-root=") && token.slice("--authorization-root=".length).length > 0) {
+			count += 1;
+		}
+	}
+	return count;
+}
+
 function validateGate(tokens: string[]): string | undefined {
 	const gateFlag = tokens.findIndex((token) => token === "--gate" || token.startsWith("--gate="));
 	if (gateFlag < 0) return undefined;
@@ -250,9 +266,13 @@ export function gentleAiOperationPath(args: Record<string, unknown> | undefined)
 	if (tokens[0] === "sdd-status") return "sdd status";
 	if (tokens[0] === "sdd-continue") return "sdd continue";
 	if (tokens[0] === "sdd-attempt") {
-		return SDD_ATTEMPT_VERBS.has(tokens[1] ?? "")
-			? `sdd attempt ${tokens[1]}`
-			: "sdd attempt";
+		const verb = tokens[1] ?? "";
+		if (!SDD_ATTEMPT_VERBS.has(verb)) return "sdd attempt";
+		if (verb !== "grant") return `sdd attempt ${verb}`;
+		const rootCount = authorizationRootCount(tokens);
+		return rootCount > 0
+			? `sdd attempt grant · ${rootCount} root${rootCount === 1 ? "" : "s"}`
+			: "sdd attempt grant";
 	}
 	if (tokens[0] === "version") return "version";
 	if (tokens[0] !== "review") return "command";
@@ -464,7 +484,6 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 					operationPath,
 					theme,
 					sanitizedRenderContext(context as ToolRenderContextLike | undefined) as GentleAiRenderContext,
-					isGentleAiGrantCommand(callArgs) ? safeText(asString(callArgs.command)) : undefined,
 				);
 			}
 			return new Text(formatToolCall(toolName, callArgs, theme), 0, 0);
@@ -475,8 +494,10 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 			const text = safeText(extractTextContent(safeResult));
 			const isError = renderContext?.isError ?? options.isError ?? false;
 			const directCommand = toolName === "bash" && isGentleAiDirectCommand(renderContext?.args);
+			if (directCommand) {
+				return renderGentleAiResult(safeResult, { expanded: options.expanded });
+			}
 			if (options.isPartial) {
-				if (directCommand && !isError && !options.expanded) return new Text("", 0, 0);
 				const visible = options.expanded ? text : lastOutputLines(text, PREVIEW_LINE_LIMIT);
 				const label = theme.fg("warning", partialLabel(toolName, text));
 				const output = visible ? `${label}\n${theme.fg("muted", visible)}` : label;

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -156,7 +156,7 @@ function isGitCommand(args: Record<string, unknown> | undefined): boolean {
 
 export type GentleAiRoutineCommand = "sdd-status" | "sdd-continue" | "sdd-attempt" | "review";
 
-const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai(?:\.exe)?|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
+const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai(?:\.exe)?|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\r\n]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
 const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(`^${GENTLE_AI_EXECUTABLE}$`);
 
 function createGentleAiCommandArguments(activeDevBinaryPath?: string): RegExp {
@@ -206,6 +206,8 @@ function shellTokens(command: string): string[] | undefined {
 			tokenStarted = true;
 			continue;
 		}
+		if ("*?~{}".includes(character)) return undefined;
+		if (character === "[" && command.indexOf("]", index + 1) >= 0) return undefined;
 		if (";&|<>`()".includes(character) || character === "$" || character === "`") return undefined;
 		if (character === "#" && !tokenStarted) return undefined;
 		token += character;
@@ -265,15 +267,15 @@ function gentleAiCommandTokens(args: Record<string, unknown> | undefined, comman
 	if (!tokens) return undefined;
 	let index = 0;
 	while (isAssignment(tokens[index] ?? "")) index += 1;
-	if (tokens[index] === "env") {
-		index += 1;
-		while (isAssignment(tokens[index] ?? "")) index += 1;
-		if ((tokens[index] ?? "").startsWith("-")) return undefined;
-	}
 	if (tokens[index] === "command") {
 		index += 1;
 		if (tokens[index] === "--") index += 1;
 		else if ((tokens[index] ?? "").startsWith("-")) return undefined;
+	}
+	if (tokens[index] === "env") {
+		index += 1;
+		while (isAssignment(tokens[index] ?? "")) index += 1;
+		if ((tokens[index] ?? "").startsWith("-")) return undefined;
 	}
 	if (!commandArguments.test(tokens[index] ?? "")) return undefined;
 	return tokens.slice(index + 1);
@@ -507,18 +509,39 @@ function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, 
 	}
 }
 
-class BoundedRows implements Component {
-	private readonly sections: readonly { text: string; rows: number }[];
+interface BoundedRowSection {
+	text: string;
+	rows: number;
+	tail?: boolean;
+}
 
-	constructor(sections: readonly { text: string; rows: number }[]) {
+class BoundedRows implements Component {
+	private readonly sections: readonly BoundedRowSection[];
+
+	constructor(sections: readonly BoundedRowSection[]) {
 		this.sections = sections;
 	}
 
 	render(width: number): string[] {
-		return this.sections.flatMap(({ text, rows }) => new Text(text, 0, 0).render(width).slice(0, rows));
+		return this.sections.flatMap(({ text, rows, tail = false }) => {
+			if (rows <= 0) return [];
+			const rendered = new Text(text, 0, 0).render(width);
+			return tail ? rendered.slice(-rows) : rendered.slice(0, rows);
+		});
 	}
 
 	invalidate(): void {}
+}
+
+function shouldRenderPreviewTail(
+	toolName: QuietToolName,
+	text: string,
+	isError: boolean,
+	args: Record<string, unknown> | undefined,
+): boolean {
+	if (isError) return true;
+	if (toolName !== "bash") return false;
+	return isGitCommand(args) || semanticJsonPreview(text) === undefined;
 }
 
 function partialLabel(toolName: QuietToolName, text: string): string {
@@ -590,7 +613,7 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 				const visible = lastOutputLines(text, PREVIEW_LINE_LIMIT);
 				return new BoundedRows([
 					{ text: theme.fg("warning", partialLabel(toolName, text)), rows: 1 },
-					...(visible ? [{ text: theme.fg("muted", visible), rows: PREVIEW_LINE_LIMIT }] : []),
+					...(visible ? [{ text: theme.fg("muted", visible), rows: PREVIEW_LINE_LIMIT, tail: true }] : []),
 				]);
 			}
 			if (options.expanded && toolName === "read" && hasImageContent(safeResult) && officialRenderResult) {
@@ -612,8 +635,9 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 			const color = options.expanded ? "toolOutput" : isError ? "error" : "muted";
 			if (options.expanded) return new Text(output ? theme.fg(color, output) : "", 0, 0);
 			if (output) {
+				const tail = shouldRenderPreviewTail(toolName, text, isError, renderContext?.args);
 				return new BoundedRows([
-					{ text: theme.fg(color, output.replace(/^\n/, "")), rows: PREVIEW_LINE_LIMIT },
+					{ text: theme.fg(color, output.replace(/^\n/, "")), rows: PREVIEW_LINE_LIMIT, tail },
 					...(hint ? [{ text: theme.fg(color, hint.slice(1)), rows: 1 }] : []),
 				]);
 			}

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -97,6 +97,20 @@ function lastOutputLines(text: string, limit: number): string {
 	return outputLines(text).slice(-limit).join("\n");
 }
 
+function semanticJsonPreview(text: string): string | undefined {
+	const trimmed = text.trim();
+	if (!/^[\[{]/.test(trimmed)) return undefined;
+	try {
+		JSON.parse(trimmed);
+	} catch {
+		return undefined;
+	}
+	return outputLines(trimmed)
+		.filter((line) => !/^[\s{}\[\],]*$/.test(line))
+		.slice(0, PREVIEW_LINE_LIMIT)
+		.join("\n");
+}
+
 export function extractTextContent(result: AgentToolResult<unknown>): string {
 	return result.content
 		.flatMap((content) => (content.type === "text" ? [content.text] : []))
@@ -342,7 +356,8 @@ export function formatToolResultOutput(
 		return head ? `\n${head}` : "";
 	}
 	if (toolName === "bash") {
-		const tail = lastOutputLines(text, PREVIEW_LINE_LIMIT);
+		const preview = semanticJsonPreview(text);
+		const tail = preview ?? lastOutputLines(text, PREVIEW_LINE_LIMIT);
 		return tail ? `\n${tail}` : "";
 	}
 	if (toolName === "edit") return `\n${editSummary(result)}`;

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -5,8 +5,9 @@ import {
 	createFindTool,
 	createGrepTool,
 	createLsTool,
-	createReadTool,
+	createReadToolDefinition,
 	createWriteTool,
+	keyHint,
 } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { homedir } from "node:os";
@@ -21,7 +22,7 @@ type ThemeLike = {
 };
 
 const TOOL_CREATORS = {
-	read: createReadTool,
+	read: createReadToolDefinition,
 	bash: createBashTool,
 	grep: createGrepTool,
 	find: createFindTool,
@@ -36,9 +37,8 @@ const COLLAPSED_COUNT_LABELS: Partial<Record<QuietToolName, string>> = {
 	ls: "entries",
 };
 
-const NO_COLLAPSED_RESULT_TOOLS = new Set<QuietToolName>(["read", "bash"]);
-const COLLAPSED_TAIL_TOOLS = new Set<QuietToolName>(["edit", "write"]);
 const COLLAPSED_TAIL_LINE_LIMIT = 10;
+const PREVIEW_LINE_LIMIT = 3;
 
 const EMPTY_RESULT_MESSAGES: Partial<Record<QuietToolName, string[]>> = {
 	grep: ["No matches found"],
@@ -84,6 +84,19 @@ export function tailLines(text: string, limit: number): string {
 	return lines.slice(Math.max(0, lines.length - limit)).join("\n");
 }
 
+function outputLines(text: string): string[] {
+	const normalized = text.replace(/\r\n/g, "\n").replace(/\n$/, "");
+	return normalized.length > 0 ? normalized.split("\n") : [];
+}
+
+function firstLines(text: string, limit: number): string {
+	return outputLines(text).slice(0, limit).join("\n");
+}
+
+function lastOutputLines(text: string, limit: number): string {
+	return outputLines(text).slice(-limit).join("\n");
+}
+
 export function extractTextContent(result: AgentToolResult<unknown>): string {
 	return result.content
 		.flatMap((content) => (content.type === "text" ? [content.text] : []))
@@ -92,6 +105,27 @@ export function extractTextContent(result: AgentToolResult<unknown>): string {
 
 function safeText(value: string): string {
 	return sanitizeTerminalText(value);
+}
+
+function sanitizeValue(value: unknown): unknown {
+	if (typeof value === "string") return safeText(value);
+	if (Array.isArray(value)) return value.map(sanitizeValue);
+	if (value && typeof value === "object") {
+		return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, sanitizeValue(item)]));
+	}
+	return value;
+}
+
+function sanitizedArgs(args: Record<string, unknown> | undefined): Record<string, unknown> {
+	return (sanitizeValue(args ?? {}) as Record<string, unknown>) ?? {};
+}
+
+function sanitizedResult(result: AgentToolResult<unknown>): AgentToolResult<unknown> {
+	return {
+		...result,
+		content: result.content.map((content) => sanitizeValue(content) as typeof content),
+		details: sanitizeValue(result.details),
+	};
 }
 
 function isEmptyResultMessage(toolName: QuietToolName, text: string): boolean {
@@ -238,31 +272,82 @@ interface ToolResultFormatOptions {
 	args?: Record<string, unknown>;
 }
 
+function detailsRecord(result: AgentToolResult<unknown>): Record<string, unknown> {
+	const details = sanitizeValue(result.details);
+	return details && typeof details === "object" && !Array.isArray(details)
+		? details as Record<string, unknown>
+		: {};
+}
+
+function diffStats(diff: string): { additions: number; removals: number } {
+	let additions = 0;
+	let removals = 0;
+	for (const line of diff.split("\n")) {
+		if (line.startsWith("+") && !line.startsWith("+++")) additions++;
+		if (line.startsWith("-") && !line.startsWith("---")) removals++;
+	}
+	return { additions, removals };
+}
+
+function editSummary(result: AgentToolResult<unknown>): string {
+	const diff = detailsRecord(result).diff;
+	if (typeof diff === "string") {
+		const stats = diffStats(diff);
+		return `✓ +${stats.additions} / -${stats.removals}`;
+	}
+	return "✓ applied";
+}
+
+function writeSummary(text: string): string {
+	const bytes = text.match(/(?:Successfully )?wrote\s+(\d+)\s+bytes/i)?.[1];
+	return `✓ ${bytes ? `wrote ${bytes} bytes` : "written"}`;
+}
+
+function expandedResultText(toolName: QuietToolName, result: AgentToolResult<unknown>, text: string): string {
+	if (toolName === "edit") {
+		const diff = detailsRecord(result).diff;
+		if (typeof diff === "string") return diff;
+	}
+	return text;
+}
+
 export function formatToolResultOutput(
 	toolName: QuietToolName,
 	result: AgentToolResult<unknown>,
 	{ expanded, isError = false, args }: ToolResultFormatOptions,
 ): string {
 	const text = safeText(extractTextContent(result));
-	if (expanded || isError) return text ? `\n${text}` : "";
+	if (expanded) {
+		const detail = expandedResultText(toolName, result, text);
+		return detail ? `\n${detail}` : "";
+	}
+	if (isError) {
+		const tail = lastOutputLines(text, PREVIEW_LINE_LIMIT);
+		return tail ? `\n${tail}` : "";
+	}
+	const summaryLabel = COLLAPSED_COUNT_LABELS[toolName];
+	if (summaryLabel) {
+		if (isEmptyResultMessage(toolName, text)) return "";
+		const count = countNonEmptyLines(text);
+		return count > 0 ? ` → ${count} ${summaryLabel}` : "";
+	}
 	if (toolName === "bash" && isGentleAiDirectCommand(args)) return "";
 
 	if (toolName === "bash" && isGitCommand(args)) {
 		const tail = tailLines(text, COLLAPSED_TAIL_LINE_LIMIT);
 		return tail ? `\n${tail}` : "";
 	}
-	if (NO_COLLAPSED_RESULT_TOOLS.has(toolName)) return "";
-	if (COLLAPSED_TAIL_TOOLS.has(toolName)) {
-		const tail = tailLines(text, COLLAPSED_TAIL_LINE_LIMIT);
+	if (toolName === "read") {
+		const head = firstLines(text, PREVIEW_LINE_LIMIT);
+		return head ? `\n${head}` : "";
+	}
+	if (toolName === "bash") {
+		const tail = lastOutputLines(text, PREVIEW_LINE_LIMIT);
 		return tail ? `\n${tail}` : "";
 	}
-	if (isEmptyResultMessage(toolName, text)) return "";
-
-	const summaryLabel = COLLAPSED_COUNT_LABELS[toolName];
-	if (!summaryLabel) return "";
-
-	const count = countNonEmptyLines(text);
-	return count > 0 ? ` → ${count} ${summaryLabel}` : "";
+	if (toolName === "edit") return `\n${editSummary(result)}`;
+	if (toolName === "write") return `\n${writeSummary(text)}`;
+	return "";
 }
 
 function lineRangeSuffix(args: Record<string, unknown>, theme: ThemeLike): string {
@@ -278,6 +363,8 @@ interface ToolRenderContextLike {
 	isPartial?: boolean;
 	isError?: boolean;
 	lastComponent?: unknown;
+	cwd?: string;
+	[key: string]: unknown;
 }
 
 function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, theme: ThemeLike): string {
@@ -317,12 +404,36 @@ function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, 
 	}
 }
 
-function partialLabel(toolName: QuietToolName): string {
-	return toolName === "bash" ? "Running..." : `${toolName}...`;
+function partialLabel(toolName: QuietToolName, text: string): string {
+	const lineCount = outputLines(text).length;
+	return lineCount === 0
+		? `… ${toolName}`
+		: `… ${toolName} · ${lineCount} ${lineCount === 1 ? "line" : "lines"}`;
+}
+
+function hasImageContent(result: AgentToolResult<unknown>): boolean {
+	return result.content.some((content) => content.type === "image");
+}
+
+function hasExpandableContent(toolName: QuietToolName, result: AgentToolResult<unknown>, text: string): boolean {
+	if (COLLAPSED_COUNT_LABELS[toolName] && isEmptyResultMessage(toolName, text)) return false;
+	if (text.length > 0 || hasImageContent(result)) return true;
+	const diff = detailsRecord(result).diff;
+	return toolName === "edit" && typeof diff === "string" && diff.length > 0;
+}
+
+function sanitizedRenderContext(context: ToolRenderContextLike | undefined): ToolRenderContextLike {
+	if (!context) return { args: {} };
+	return {
+		...context,
+		args: sanitizedArgs(context.args),
+		cwd: typeof context.cwd === "string" ? safeText(context.cwd) : context.cwd,
+	};
 }
 
 function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 	const registrationTool = getBuiltInTools(process.cwd())[toolName];
+	const officialRenderResult = registrationTool.renderResult;
 
 	pi.registerTool({
 		...registrationTool,
@@ -337,30 +448,43 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 				return renderGentleAiLifecycleCall(
 					operationPath,
 					theme,
-					context as GentleAiRenderContext | undefined,
-					isGentleAiGrantCommand(callArgs) ? asString(callArgs.command) : undefined,
+					sanitizedRenderContext(context as ToolRenderContextLike | undefined) as GentleAiRenderContext,
+					isGentleAiGrantCommand(callArgs) ? safeText(asString(callArgs.command)) : undefined,
 				);
 			}
 			return new Text(formatToolCall(toolName, callArgs, theme), 0, 0);
 		},
 		renderResult(result, options, theme, context) {
 			const renderContext = context as ToolRenderContextLike | undefined;
+			const safeResult = sanitizedResult(result);
+			const text = safeText(extractTextContent(safeResult));
 			const isError = renderContext?.isError ?? options.isError ?? false;
 			const directCommand = toolName === "bash" && isGentleAiDirectCommand(renderContext?.args);
 			if (options.isPartial) {
-				if (directCommand && !isError) {
-					if (!options.expanded) return new Text("", 0, 0);
-				} else if (!(directCommand && isError)) {
-					return new Text(theme.fg("warning", partialLabel(toolName)), 0, 0);
-				}
+				if (directCommand && !isError && !options.expanded) return new Text("", 0, 0);
+				const visible = options.expanded ? text : lastOutputLines(text, PREVIEW_LINE_LIMIT);
+				const label = theme.fg("warning", partialLabel(toolName, text));
+				const output = visible ? `${label}\n${theme.fg("muted", visible)}` : label;
+				return new Text(output, 0, 0);
 			}
-			const output = formatToolResultOutput(toolName, result, {
+			if (options.expanded && toolName === "read" && hasImageContent(safeResult) && officialRenderResult) {
+				return officialRenderResult(
+					safeResult,
+					options,
+					theme,
+					sanitizedRenderContext(renderContext) as any,
+				);
+			}
+			const output = formatToolResultOutput(toolName, safeResult, {
 				expanded: options.expanded,
 				isError,
 				args: renderContext?.args,
 			});
+			const hint = !options.expanded && !directCommand && hasExpandableContent(toolName, safeResult, text)
+				? `\n${keyHint("app.tools.expand", "to expand")}`
+				: "";
 			const color = options.expanded ? "toolOutput" : isError ? "error" : "muted";
-			return new Text(output ? theme.fg(color, output) : "", 0, 0);
+			return new Text(output || hint ? theme.fg(color, `${output}${hint}`) : "", 0, 0);
 		},
 	});
 }

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -45,7 +45,8 @@ const PREVIEW_LINE_LIMIT = 3;
 const EMPTY_RESULT_MESSAGES: Partial<Record<QuietToolName, string[]>> = {
 	grep: ["No matches found"],
 	find: ["No files found matching pattern"],
-	ls: ["Directory is empty"],
+	ls: ["Directory is empty", "(empty directory)"],
+	bash: ["(no output)"],
 };
 
 const toolCache = new Map<string, Record<QuietToolName, any>>();
@@ -99,15 +100,25 @@ function lastOutputLines(text: string, limit: number): string {
 	return outputLines(text).slice(-limit).join("\n");
 }
 
+function lastMeaningfulOutputLines(text: string, limit: number): string {
+	return outputLines(text)
+		.filter((line) => line.trim().length > 0)
+		.slice(-limit)
+		.join("\n");
+}
+
 function semanticJsonPreview(text: string): string | undefined {
 	const trimmed = text.trim();
 	if (!/^[\[{]/.test(trimmed)) return undefined;
+	let parsed: unknown;
 	try {
-		JSON.parse(trimmed);
+		parsed = JSON.parse(trimmed);
 	} catch {
 		return undefined;
 	}
-	return outputLines(trimmed)
+	const normalized = JSON.stringify(parsed, null, 2);
+	if (normalized === undefined) return undefined;
+	return outputLines(normalized)
 		.filter((line) => !/^[\s{}\[\],]*$/.test(line))
 		.slice(0, PREVIEW_LINE_LIMIT)
 		.join("\n");
@@ -146,7 +157,13 @@ function sanitizedResult(result: AgentToolResult<unknown>): AgentToolResult<unkn
 
 function isEmptyResultMessage(toolName: QuietToolName, text: string): boolean {
 	const normalized = text.trim();
-	return EMPTY_RESULT_MESSAGES[toolName]?.some((message) => normalized.startsWith(message)) ?? false;
+	return EMPTY_RESULT_MESSAGES[toolName]?.some((message) => normalized === message) ?? false;
+}
+
+function grepMatchCount(text: string, args: Record<string, unknown> | undefined): number {
+	const context = args?.context;
+	if (typeof context !== "number" || context <= 0) return countNonEmptyLines(text);
+	return outputLines(text).filter((line) => /^\s*.+:\d+:\s?/.test(line)).length;
 }
 
 function isGitCommand(args: Record<string, unknown> | undefined): boolean {
@@ -426,13 +443,13 @@ export function formatToolResultOutput(
 		return detail ? `\n${detail}` : "";
 	}
 	if (isError) {
-		const tail = lastOutputLines(text, PREVIEW_LINE_LIMIT);
+		const tail = lastMeaningfulOutputLines(text, PREVIEW_LINE_LIMIT);
 		return tail ? `\n${tail}` : "";
 	}
 	const summaryLabel = COLLAPSED_COUNT_LABELS[toolName];
 	if (summaryLabel) {
 		if (isEmptyResultMessage(toolName, text)) return "";
-		const count = countNonEmptyLines(text);
+		const count = toolName === "grep" ? grepMatchCount(text, args) : countNonEmptyLines(text);
 		return count > 0 ? ` → ${count} ${summaryLabel}` : "";
 	}
 	if (toolName === "bash" && isGentleAiDirectCommand(args)) return "";
@@ -556,7 +573,7 @@ function hasImageContent(result: AgentToolResult<unknown>): boolean {
 }
 
 function hasExpandableContent(toolName: QuietToolName, result: AgentToolResult<unknown>, text: string): boolean {
-	if (COLLAPSED_COUNT_LABELS[toolName] && isEmptyResultMessage(toolName, text)) return false;
+	if (isEmptyResultMessage(toolName, text)) return false;
 	if (text.length > 0 || hasImageContent(result)) return true;
 	const diff = detailsRecord(result).diff;
 	return toolName === "edit" && typeof diff === "string" && diff.length > 0;

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -11,6 +11,8 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { homedir } from "node:os";
+import { isAbsolute } from "node:path";
+import { resolveGentleAiDevBinaryOverride, type GentleAiDevBinaryOverride } from "../lib/gentle-ai-binary.ts";
 import { quietToolsEnabled } from "../lib/quiet-tools-config.ts";
 import { renderGentleAiLifecycleCall, renderGentleAiResult, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
 import { sanitizeTerminalText } from "../lib/terminal-theme.ts";
@@ -158,6 +160,16 @@ const SHELL_COMMAND_ASSIGNMENT = String.raw`\w+=(?:'[^']*'|"[^"]*"|\S+)`;
 const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+(?:${SHELL_COMMAND_ASSIGNMENT}\s+)?|command(?:\s+--)?\s+|${SHELL_COMMAND_ASSIGNMENT}\s+)*`;
 const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai(?:\.exe)?|'gentle-ai(?:\.exe)?'|"gentle-ai(?:\.exe)?"|gentle\\-ai(?:\.exe|\\\.exe)?|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
 const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}(?:\s+(.*))?$`);
+
+function createGentleAiCommandArguments(activeDevBinaryPath?: string): RegExp {
+	if (!activeDevBinaryPath) return GENTLE_AI_COMMAND_ARGUMENTS;
+	const escapedPath = activeDevBinaryPath.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+	const executableForms = [escapedPath];
+	if (!activeDevBinaryPath.includes("'")) executableForms.push(`'${escapedPath}'`);
+	if (!activeDevBinaryPath.includes('"')) executableForms.push(`"${escapedPath}"`);
+	const executable = `(?:${GENTLE_AI_EXECUTABLE}|(?:${executableForms.join("|")}))`;
+	return new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${executable}(?:\s+(.*))?$`);
+}
 const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n$#]/;
 const SDD_ATTEMPT_VERBS = new Set(["acquire", "settle", "grant"]);
 
@@ -199,11 +211,11 @@ const REVIEW_SCHEMA_NAMES = new Set([
 	"verification-evidence-record",
 ]);
 
-function gentleAiCommandTokens(args: Record<string, unknown> | undefined): string[] | undefined {
+function gentleAiCommandTokens(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): string[] | undefined {
 	const rawCommand = typeof args?.command === "string" ? args.command : "";
 	if (SHELL_EXPANSION_OR_COMPOSITION.test(rawCommand)) return undefined;
 	const command = rawCommand.trim();
-	const match = GENTLE_AI_COMMAND_ARGUMENTS.exec(command);
+	const match = commandArguments.exec(command);
 	if (!match) return undefined;
 	const argumentsText = match[1]?.trim();
 	return argumentsText === undefined || argumentsText.length === 0
@@ -245,12 +257,12 @@ function validateGate(tokens: string[]): string | undefined {
  * package-local paths, not arbitrary shell output that merely mentions
  * gentle-ai. These commands otherwise emit machine-readable SDD/RDD data.
  */
-export function isGentleAiDirectCommand(args: Record<string, unknown> | undefined): boolean {
-	return gentleAiCommandTokens(args) !== undefined;
+export function isGentleAiDirectCommand(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): boolean {
+	return gentleAiCommandTokens(args, commandArguments) !== undefined;
 }
 
-export function gentleAiRoutineCommand(args: Record<string, unknown> | undefined): GentleAiRoutineCommand | undefined {
-	const tokens = gentleAiCommandTokens(args);
+export function gentleAiRoutineCommand(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): GentleAiRoutineCommand | undefined {
+	const tokens = gentleAiCommandTokens(args, commandArguments);
 	if (!tokens) return undefined;
 	if (tokens[0] === "sdd-status") return "sdd-status";
 	if (tokens[0] === "sdd-continue") return "sdd-continue";
@@ -259,8 +271,8 @@ export function gentleAiRoutineCommand(args: Record<string, unknown> | undefined
 	return undefined;
 }
 
-export function gentleAiOperationPath(args: Record<string, unknown> | undefined): string | undefined {
-	const tokens = gentleAiCommandTokens(args);
+export function gentleAiOperationPath(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): string | undefined {
+	const tokens = gentleAiCommandTokens(args, commandArguments);
 	if (!tokens) return undefined;
 
 	if (tokens[0] === "sdd-status") return "sdd status";
@@ -295,8 +307,8 @@ export function gentleAiOperationPath(args: Record<string, unknown> | undefined)
 	return REVIEW_DIRECT_OPERATIONS.has(operation) ? `review ${displayToken(operation)}` : "review";
 }
 
-export function isGentleAiGrantCommand(args: Record<string, unknown> | undefined): boolean {
-	const tokens = gentleAiCommandTokens(args);
+export function isGentleAiGrantCommand(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): boolean {
+	const tokens = gentleAiCommandTokens(args, commandArguments);
 	return tokens?.[0] === "sdd-attempt" && tokens[1] === "grant";
 }
 
@@ -466,7 +478,13 @@ function sanitizedRenderContext(context: ToolRenderContextLike | undefined): Too
 	};
 }
 
-function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
+type GentleAiDevBinaryOverrideResolver = () => GentleAiDevBinaryOverride | undefined;
+function resolveQuietToolsDevBinaryPath(resolveOverride: GentleAiDevBinaryOverrideResolver): string | undefined {
+	try { const path = resolveOverride()?.path; return typeof path === "string" && isAbsolute(path) ? path : undefined; }
+	catch { return undefined; }
+}
+
+function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArguments: RegExp): void {
 	const registrationTool = getBuiltInTools(process.cwd())[toolName];
 	const officialRenderResult = registrationTool.renderResult;
 
@@ -478,7 +496,7 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 		},
 		renderCall(args, theme, context) {
 			const callArgs = args as Record<string, unknown>;
-			const operationPath = toolName === "bash" ? gentleAiOperationPath(callArgs) : undefined;
+			const operationPath = toolName === "bash" ? gentleAiOperationPath(callArgs, commandArguments) : undefined;
 			if (operationPath) {
 				return renderGentleAiLifecycleCall(
 					operationPath,
@@ -493,7 +511,7 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 			const safeResult = sanitizedResult(result);
 			const text = safeText(extractTextContent(safeResult));
 			const isError = renderContext?.isError ?? options.isError ?? false;
-			const directCommand = toolName === "bash" && isGentleAiDirectCommand(renderContext?.args);
+			const directCommand = toolName === "bash" && isGentleAiDirectCommand(renderContext?.args, commandArguments);
 			if (directCommand) {
 				return renderGentleAiResult(safeResult, { expanded: options.expanded });
 			}
@@ -525,9 +543,10 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 	});
 }
 
-export default function quietTools(pi: ExtensionAPI): void {
+export default function quietTools(pi: ExtensionAPI, resolveOverride: GentleAiDevBinaryOverrideResolver = () => resolveGentleAiDevBinaryOverride()): void {
 	if (!quietToolsEnabled()) return;
+	const commandArguments = createGentleAiCommandArguments(resolveQuietToolsDevBinaryPath(resolveOverride));
 	for (const toolName of Object.keys(TOOL_CREATORS) as QuietToolName[]) {
-		registerQuietTool(pi, toolName);
+		registerQuietTool(pi, toolName, commandArguments);
 	}
 }

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -136,10 +136,6 @@ function safeText(value: string): string {
 
 function sanitizeValue(value: unknown): unknown {
 	if (typeof value === "string") return safeText(value);
-	if (Array.isArray(value)) return value.map(sanitizeValue);
-	if (value && typeof value === "object") {
-		return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, sanitizeValue(item)]));
-	}
 	return value;
 }
 
@@ -150,7 +146,7 @@ function sanitizedArgs(args: Record<string, unknown> | undefined): Record<string
 function sanitizedResult(result: AgentToolResult<unknown>): AgentToolResult<unknown> {
 	return {
 		...result,
-		content: result.content.map((content) => sanitizeValue(content) as typeof content),
+		content: result.content.map((content) => content.type === "text" ? { ...content, text: safeText(content.text) } : content.type === "image" ? { ...content, mimeType: safeText(content.mimeType) } : content),
 		details: sanitizeValue(result.details),
 	};
 }
@@ -435,7 +431,7 @@ function writeSummary(text: string): string {
 function expandedResultText(toolName: QuietToolName, result: AgentToolResult<unknown>, text: string): string {
 	if (toolName === "edit") {
 		const diff = detailsRecord(result).diff;
-		if (typeof diff === "string") return diff;
+		if (typeof diff === "string") return safeText(diff);
 	}
 	return text;
 }
@@ -616,13 +612,14 @@ function gentleAiRenderTransition(
 	if (operationPath && (tokenization.kind === "complete" || !argsComplete) && state?.genericLocked !== true) {
 		return { operationPath, directResult: forResult };
 	}
+	if (forResult && state?.lifecycleComponent === true && state.genericLocked !== true) return { directResult: true };
 	if (state && (tokenization.kind === "generic" || argsComplete || (forResult && !isPartial))) {
 		state.genericLocked = true; state.lifecycleComponent = false;
 	}
 	return { directResult: false };
 }
 
-function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArguments: RegExp): void {
+function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArguments: () => RegExp): void {
 	const registrationTool = getBuiltInTools(process.cwd())[toolName];
 	const officialRenderResult = registrationTool.renderResult;
 
@@ -636,7 +633,7 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 			const callArgs = args as Record<string, unknown>;
 			const renderContext = sanitizedRenderContext(context as ToolRenderContextLike | undefined);
 			const operationPath = toolName === "bash"
-				? gentleAiRenderTransition(callArgs, renderContext, commandArguments).operationPath
+				? gentleAiRenderTransition(callArgs, renderContext, commandArguments()).operationPath
 				: undefined;
 			if (operationPath) {
 				const detail = renderContext.expanded === true && typeof callArgs.command === "string" ? `$ ${callArgs.command}` : undefined;
@@ -652,7 +649,7 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 			const directResult = toolName === "bash" && gentleAiRenderTransition(
 				renderContext?.args,
 				renderContext,
-				commandArguments,
+				commandArguments(),
 				{ result: true, isPartial: options.isPartial },
 			).directResult;
 			if (directResult) {
@@ -698,8 +695,7 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 
 export default function quietTools(pi: ExtensionAPI, resolveOverride: GentleAiDevBinaryOverrideResolver = () => resolveGentleAiDevBinaryOverride()): void {
 	if (!quietToolsEnabled()) return;
-	const commandArguments = createGentleAiCommandArguments(resolveQuietToolsDevBinaryPath(resolveOverride));
 	for (const toolName of Object.keys(TOOL_CREATORS) as QuietToolName[]) {
-		registerQuietTool(pi, toolName, commandArguments);
+		registerQuietTool(pi, toolName, () => createGentleAiCommandArguments(resolveQuietToolsDevBinaryPath(resolveOverride)));
 	}
 }

--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -9,7 +9,7 @@ import {
 	createWriteTool,
 	keyHint,
 } from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
+import { Text, type Component } from "@earendil-works/pi-tui";
 import { homedir } from "node:os";
 import { isAbsolute } from "node:path";
 import { resolveGentleAiDevBinaryOverride, type GentleAiDevBinaryOverride } from "../lib/gentle-ai-binary.ts";
@@ -156,21 +156,69 @@ function isGitCommand(args: Record<string, unknown> | undefined): boolean {
 
 export type GentleAiRoutineCommand = "sdd-status" | "sdd-continue" | "sdd-attempt" | "review";
 
-const SHELL_COMMAND_ASSIGNMENT = String.raw`\w+=(?:'[^']*'|"[^"]*"|\S+)`;
-const SHELL_COMMAND_PREFIX = String.raw`(?:env\s+(?:${SHELL_COMMAND_ASSIGNMENT}\s+)?|command(?:\s+--)?\s+|${SHELL_COMMAND_ASSIGNMENT}\s+)*`;
-const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai(?:\.exe)?|'gentle-ai(?:\.exe)?'|"gentle-ai(?:\.exe)?"|gentle\\-ai(?:\.exe|\\\.exe)?|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
-const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${GENTLE_AI_EXECUTABLE}(?:\s+(.*))?$`);
+const GENTLE_AI_EXECUTABLE = String.raw`(?:gentle-ai(?:\.exe)?|(?:\.{1,2}[\\/]|(?:[A-Za-z]:)?(?:[\\/][^\\/\s]+)*[\\/])\.gentle-ai[\\/]v\d+\.\d+\.\d+[\\/]gentle-ai(?:\.exe)?)`;
+const GENTLE_AI_COMMAND_ARGUMENTS = new RegExp(`^${GENTLE_AI_EXECUTABLE}$`);
 
 function createGentleAiCommandArguments(activeDevBinaryPath?: string): RegExp {
 	if (!activeDevBinaryPath) return GENTLE_AI_COMMAND_ARGUMENTS;
 	const escapedPath = activeDevBinaryPath.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
-	const executableForms = [escapedPath];
-	if (!activeDevBinaryPath.includes("'")) executableForms.push(`'${escapedPath}'`);
-	if (!activeDevBinaryPath.includes('"')) executableForms.push(`"${escapedPath}"`);
-	const executable = `(?:${GENTLE_AI_EXECUTABLE}|(?:${executableForms.join("|")}))`;
-	return new RegExp(String.raw`^${SHELL_COMMAND_PREFIX}${executable}(?:\s+(.*))?$`);
+	return new RegExp(`^(?:${GENTLE_AI_EXECUTABLE}|${escapedPath})$`);
 }
-const SHELL_EXPANSION_OR_COMPOSITION = /[;&|`<>\r\n$#]/;
+
+function shellTokens(command: string): string[] | undefined {
+	const tokens: string[] = [];
+	let token = "";
+	let quote: "single" | "double" | undefined;
+	let tokenStarted = false;
+	const push = () => {
+		if (tokenStarted) tokens.push(token);
+		token = "";
+		tokenStarted = false;
+	};
+	for (let index = 0; index < command.length; index += 1) {
+		const character = command[index]!;
+		if (character === "\r" || character === "\n") return undefined;
+		if (quote === "single") {
+			if (character === "'") quote = undefined;
+			else token += character;
+			continue;
+		}
+		if (quote === "double") {
+			if (character === '"') { quote = undefined; continue; }
+			if (character === "\\") {
+				const next = command[++index];
+				if (next === undefined || next === "\r" || next === "\n") return undefined;
+				token += "$`\"\\".includes(next) ? next : `\\${next}`;
+				continue;
+			}
+			if (character === "$" || character === "`") return undefined;
+			token += character;
+			continue;
+		}
+		if (/\s/.test(character)) { push(); continue; }
+		if (character === "'") { quote = "single"; tokenStarted = true; continue; }
+		if (character === '"') { quote = "double"; tokenStarted = true; continue; }
+		if (character === "\\") {
+			const next = command[++index];
+			if (next === undefined || next === "\r" || next === "\n") return undefined;
+			const windowsPath = token === "." || /^[A-Za-z]:$/.test(token) || token.includes("\\");
+			token += windowsPath ? `\\${next}` : next;
+			tokenStarted = true;
+			continue;
+		}
+		if (";&|<>`()".includes(character) || character === "$" || character === "`") return undefined;
+		if (character === "#" && !tokenStarted) return undefined;
+		token += character;
+		tokenStarted = true;
+	}
+	if (quote) return undefined;
+	push();
+	return tokens;
+}
+
+function isAssignment(token: string): boolean {
+	return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
 const SDD_ATTEMPT_VERBS = new Set(["acquire", "settle", "grant"]);
 
 const REVIEW_DIRECT_OPERATIONS = new Set([
@@ -213,14 +261,22 @@ const REVIEW_SCHEMA_NAMES = new Set([
 
 function gentleAiCommandTokens(args: Record<string, unknown> | undefined, commandArguments = GENTLE_AI_COMMAND_ARGUMENTS): string[] | undefined {
 	const rawCommand = typeof args?.command === "string" ? args.command : "";
-	if (SHELL_EXPANSION_OR_COMPOSITION.test(rawCommand)) return undefined;
-	const command = rawCommand.trim();
-	const match = commandArguments.exec(command);
-	if (!match) return undefined;
-	const argumentsText = match[1]?.trim();
-	return argumentsText === undefined || argumentsText.length === 0
-		? []
-		: argumentsText.split(/\s+/);
+	const tokens = shellTokens(rawCommand);
+	if (!tokens) return undefined;
+	let index = 0;
+	while (isAssignment(tokens[index] ?? "")) index += 1;
+	if (tokens[index] === "env") {
+		index += 1;
+		while (isAssignment(tokens[index] ?? "")) index += 1;
+		if ((tokens[index] ?? "").startsWith("-")) return undefined;
+	}
+	if (tokens[index] === "command") {
+		index += 1;
+		if (tokens[index] === "--") index += 1;
+		else if ((tokens[index] ?? "").startsWith("-")) return undefined;
+	}
+	if (!commandArguments.test(tokens[index] ?? "")) return undefined;
+	return tokens.slice(index + 1);
 }
 
 function displayToken(token: string): string {
@@ -451,6 +507,20 @@ function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, 
 	}
 }
 
+class BoundedRows implements Component {
+	private readonly sections: readonly { text: string; rows: number }[];
+
+	constructor(sections: readonly { text: string; rows: number }[]) {
+		this.sections = sections;
+	}
+
+	render(width: number): string[] {
+		return this.sections.flatMap(({ text, rows }) => new Text(text, 0, 0).render(width).slice(0, rows));
+	}
+
+	invalidate(): void {}
+}
+
 function partialLabel(toolName: QuietToolName, text: string): string {
 	const lineCount = outputLines(text).length;
 	return lineCount === 0
@@ -516,10 +586,12 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 				return renderGentleAiResult(safeResult, { expanded: options.expanded });
 			}
 			if (options.isPartial) {
-				const visible = options.expanded ? text : lastOutputLines(text, PREVIEW_LINE_LIMIT);
-				const label = theme.fg("warning", partialLabel(toolName, text));
-				const output = visible ? `${label}\n${theme.fg("muted", visible)}` : label;
-				return new Text(output, 0, 0);
+				if (options.expanded) return new Text(`${theme.fg("warning", partialLabel(toolName, text))}\n${theme.fg("muted", text)}`, 0, 0);
+				const visible = lastOutputLines(text, PREVIEW_LINE_LIMIT);
+				return new BoundedRows([
+					{ text: theme.fg("warning", partialLabel(toolName, text)), rows: 1 },
+					...(visible ? [{ text: theme.fg("muted", visible), rows: PREVIEW_LINE_LIMIT }] : []),
+				]);
 			}
 			if (options.expanded && toolName === "read" && hasImageContent(safeResult) && officialRenderResult) {
 				return officialRenderResult(
@@ -538,7 +610,14 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName, commandArg
 				? `\n${keyHint("app.tools.expand", "to expand")}`
 				: "";
 			const color = options.expanded ? "toolOutput" : isError ? "error" : "muted";
-			return new Text(output || hint ? theme.fg(color, `${output}${hint}`) : "", 0, 0);
+			if (options.expanded) return new Text(output ? theme.fg(color, output) : "", 0, 0);
+			if (output) {
+				return new BoundedRows([
+					{ text: theme.fg(color, output.replace(/^\n/, "")), rows: PREVIEW_LINE_LIMIT },
+					...(hint ? [{ text: theme.fg(color, hint.slice(1)), rows: 1 }] : []),
+				]);
+			}
+			return new Text(hint ? theme.fg(color, hint.slice(1)) : "", 0, 0);
 		},
 	});
 }

--- a/lib/gentle-ai-renderer.ts
+++ b/lib/gentle-ai-renderer.ts
@@ -1,4 +1,4 @@
-import type { AgentToolResult } from "@earendil-works/pi-coding-agent";
+import { keyHint, type AgentToolResult } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { sanitizeTerminalText } from "./terminal-theme.ts";
 
@@ -24,10 +24,11 @@ export function renderGentleAiResult(
 	result: AgentToolResult<unknown>,
 	options: GentleAiResultRenderOptions,
 ): Text {
-	const text = result.content
-		.flatMap((content) => (content.type === "text" ? [sanitizeTerminalText(content.text)] : []))
-		.join("\n");
-	return new Text(options.expanded && text.length > 0 ? `\n${text}` : "", 0, 0);
+	const textItems = result.content.flatMap((content) => (content.type === "text" ? [sanitizeTerminalText(content.text)] : []));
+	const text = textItems.join("\n");
+	const hasExpandableText = textItems.some((item) => item.length > 0);
+	const output = !hasExpandableText ? "" : options.expanded ? `\n${text}` : `\n${keyHint("app.tools.expand", "to expand")}`;
+	return new Text(output, 0, 0);
 }
 
 export function renderGentleAiLifecycleCall(

--- a/lib/gentle-ai-renderer.ts
+++ b/lib/gentle-ai-renderer.ts
@@ -1,3 +1,4 @@
+import type { AgentToolResult } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { sanitizeTerminalText } from "./terminal-theme.ts";
 
@@ -15,11 +16,24 @@ export interface GentleAiRenderContext {
 	lastComponent?: unknown;
 }
 
+export interface GentleAiResultRenderOptions {
+	expanded?: boolean;
+}
+
+export function renderGentleAiResult(
+	result: AgentToolResult<unknown>,
+	options: GentleAiResultRenderOptions,
+): Text {
+	const text = result.content
+		.flatMap((content) => (content.type === "text" ? [sanitizeTerminalText(content.text)] : []))
+		.join("\n");
+	return new Text(options.expanded && text.length > 0 ? `\n${text}` : "", 0, 0);
+}
+
 export function renderGentleAiLifecycleCall(
 	operationPath: string,
 	theme: GentleAiRenderTheme,
 	context?: GentleAiRenderContext,
-	auditInvocation?: string,
 ): Text {
 	const status = context?.isError
 		? "failed"
@@ -30,9 +44,6 @@ export function renderGentleAiLifecycleCall(
 	const lines = [
 		theme.fg(color, theme.bold(`🌹︎ Gentle AI · ${status} · ${operationPath}`)),
 	];
-	if (auditInvocation !== undefined) {
-		lines.push(theme.fg("dim", `audit: ${sanitizeTerminalText(auditInvocation)}`));
-	}
 	const component = context?.lastComponent instanceof Text ? context.lastComponent : new Text("", 0, 0);
 	component.setText(lines.join("\n"));
 	return component;

--- a/lib/gentle-ai-renderer.ts
+++ b/lib/gentle-ai-renderer.ts
@@ -9,11 +9,24 @@ export interface GentleAiRenderTheme {
 	fg(color: GentleAiLifecycleColor, value: string): string;
 }
 
+export interface GentleAiRenderState {
+	lifecycleComponent?: boolean; genericLocked?: boolean;
+}
+
 export interface GentleAiRenderContext {
+	argsComplete?: boolean;
 	executionStarted?: boolean;
 	isPartial?: boolean;
 	isError?: boolean;
 	lastComponent?: unknown;
+	state?: unknown;
+}
+
+export function getGentleAiRenderState(state: unknown): GentleAiRenderState | undefined {
+	if (!state || typeof state !== "object" || Array.isArray(state)) return undefined;
+	const rowState = state as Record<string, unknown>, existing = rowState.gentleAiRender;
+	if (existing && typeof existing === "object" && !Array.isArray(existing)) return existing as GentleAiRenderState;
+	return (rowState.gentleAiRender = {} as GentleAiRenderState);
 }
 
 export interface GentleAiResultRenderOptions {
@@ -27,7 +40,7 @@ export function renderGentleAiResult(
 	const textItems = result.content.flatMap((content) => (content.type === "text" ? [sanitizeTerminalText(content.text)] : []));
 	const text = textItems.join("\n");
 	const hasExpandableText = textItems.some((item) => item.length > 0);
-	const output = !hasExpandableText ? "" : options.expanded ? `\n${text}` : `\n${keyHint("app.tools.expand", "to expand")}`;
+	const output = !hasExpandableText ? "" : options.expanded ? text : keyHint("app.tools.expand", "to expand");
 	return new Text(output, 0, 0);
 }
 
@@ -35,17 +48,23 @@ export function renderGentleAiLifecycleCall(
 	operationPath: string,
 	theme: GentleAiRenderTheme,
 	context?: GentleAiRenderContext,
+	detail?: string,
 ): Text {
 	const status = context?.isError
 		? "failed"
-		: !context?.executionStarted || context.isPartial
-			? "running"
-			: "completed";
-	const color = status === "running" ? "warning" : status === "completed" ? "success" : "error";
-	const lines = [
-		theme.fg(color, theme.bold(`🌹︎ Gentle AI · ${status} · ${operationPath}`)),
-	];
-	const component = context?.lastComponent instanceof Text ? context.lastComponent : new Text("", 0, 0);
+		: context?.argsComplete === false
+			? "preparing"
+			: !context?.executionStarted || context.isPartial
+				? "running"
+				: "completed";
+	const color = status === "preparing" || status === "running" ? "warning" : status === "completed" ? "success" : "error";
+	const lines = [theme.fg(color, theme.bold(`🌹︎ Gentle AI · ${status} · ${operationPath}`))];
+	if (detail) lines.push(theme.fg("dim", sanitizeTerminalText(detail)));
+	const state = getGentleAiRenderState(context?.state);
+	const component = context?.lastComponent instanceof Text && (!state || state.lifecycleComponent === true)
+		? context.lastComponent
+		: new Text("", 0, 0);
+	if (state) state.lifecycleComponent = true;
 	component.setText(lines.join("\n"));
 	return component;
 }

--- a/lib/terminal-theme.ts
+++ b/lib/terminal-theme.ts
@@ -1,6 +1,6 @@
 const NON_OSC_ANSI_ESCAPE_PATTERN =
 	/\x1B\[[0-?]*[ -/]*[@-~]|\x1B[@-Z\\-_]|\x9B[0-?]*[ -/]*[@-~]/g;
-const CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g;
+const CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000b-\u000d\u000e-\u001f\u007f-\u009f]/g;
 const OSC_ESCAPE_PATTERN = /(?:\x1B\]|\x9D)[\s\S]*?(?:\x07|\x1B\\|\x9C|$)/g;
 
 export function stripAnsi(value: string): string {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -158,10 +158,12 @@ test("registered Gentle Review tools preserve result envelopes and redact collap
 			{ expanded: false, isPartial: false, isError: true },
 		]) {
 			const collapsed = renderComponent(tool.renderResult({ content: [{ type: "text", text: resultText }] }, options, lifecycleTheme, {}));
-			assert.equal(collapsed, `\n${expandHint}`, `${name} collapsed output must contain one expand hint`);
+			assert.equal(collapsed, expandHint, `${name} collapsed output must contain one expand hint`);
+			assert.equal(collapsed.split("\n")[0], expandHint, `${name} collapsed output must start with the hint`);
 			assert.doesNotMatch(collapsed, /safe result|lineage=secret|private/);
 		}
 		const expanded = renderComponent(tool.renderResult({ content: [{ type: "text", text: resultText }] }, { expanded: true, isPartial: false, isError: true }, lifecycleTheme, {}));
+		assert.equal(expanded.split("\n")[0], "safe result");
 		assert.match(expanded, /safe result/);
 		assert.match(expanded, /lineage=secret body=private/);
 		assert.doesNotMatch(expanded, /to expand/);

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -119,7 +119,7 @@ test("registered Gentle Review tools render reusable rose lifecycle call rows", 
 	}
 });
 
-test("registered Gentle Review tools preserve result envelopes and default result visibility", async () => {
+test("registered Gentle Review tools preserve result envelopes and redact collapsed result rendering", async () => {
 	const tools = registeredGentleTools();
 	const scope = tools.get("gentle_review_scope");
 	const manifest = { version: 1, scopeByMode: { "100644": ["src/file.ts"] }, gitlinks: {} };
@@ -143,9 +143,27 @@ test("registered Gentle Review tools preserve result envelopes and default resul
 		entries: [{ path: "src/file.ts", mode: "100644" }],
 	});
 	assert.deepEqual(result.details, visibleEnvelope);
-	assert.equal(tools.get("gentle_review")?.renderResult, undefined);
-	assert.equal(scope.renderResult, undefined);
-	assert.equal(tools.get("gentle_review_capture")?.renderResult, undefined);
+
+	const resultText = "safe result\x1b[31m\nlineage=secret body=private";
+	for (const name of ["gentle_review", "gentle_review_scope", "gentle_review_capture"]) {
+		const tool = tools.get(name);
+		assert.equal(typeof tool?.renderResult, "function", `${name} must define result rendering`);
+		for (const options of [
+			{ expanded: false, isPartial: true, isError: false },
+			{ expanded: false, isPartial: false, isError: false },
+			{ expanded: false, isPartial: false, isError: true },
+		]) {
+			const collapsed = renderComponent(tool.renderResult({ content: [{ type: "text", text: resultText }] }, options, lifecycleTheme, {}));
+			assert.equal(collapsed, "", `${name} collapsed output must be empty`);
+			assert.doesNotMatch(collapsed, /lineage=secret|private/);
+		}
+		const expanded = renderComponent(tool.renderResult({ content: [{ type: "text", text: resultText }] }, { expanded: true, isPartial: false, isError: true }, lifecycleTheme, {}));
+		assert.match(expanded, /safe result/);
+		assert.match(expanded, /lineage=secret body=private/);
+		assert.doesNotMatch(expanded, /\x1b\[/);
+		const nonText = renderComponent(tool.renderResult({ content: [{ type: "image", data: "opaque", mimeType: "image/png" }] }, { expanded: true, isPartial: false }, lifecycleTheme, {}));
+		assert.equal(nonText, "");
+	}
 });
 
 test("session startup reports invalid project routing without mutating the profile", async (t) => {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { gzipSync } from "node:zlib";
+import { initTheme, keyHint } from "@earendil-works/pi-coding-agent";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -15,6 +16,8 @@ import { __testing, createGentleAiExtension } from "../extensions/gentle-ai.ts";
 import type { NativeReviewCli } from "../lib/native-review-cli.ts";
 import type { ReviewCollectInputV3, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 import { stripAnsi } from "../lib/terminal-theme.ts";
+
+initTheme("dark");
 
 function writeMarkdown(path: string, content: string): void {
 	mkdirSync(dirname(path), { recursive: true });
@@ -145,6 +148,7 @@ test("registered Gentle Review tools preserve result envelopes and redact collap
 	assert.deepEqual(result.details, visibleEnvelope);
 
 	const resultText = "safe result\x1b[31m\nlineage=secret body=private";
+	const expandHint = keyHint("app.tools.expand", "to expand");
 	for (const name of ["gentle_review", "gentle_review_scope", "gentle_review_capture"]) {
 		const tool = tools.get(name);
 		assert.equal(typeof tool?.renderResult, "function", `${name} must define result rendering`);
@@ -154,15 +158,18 @@ test("registered Gentle Review tools preserve result envelopes and redact collap
 			{ expanded: false, isPartial: false, isError: true },
 		]) {
 			const collapsed = renderComponent(tool.renderResult({ content: [{ type: "text", text: resultText }] }, options, lifecycleTheme, {}));
-			assert.equal(collapsed, "", `${name} collapsed output must be empty`);
-			assert.doesNotMatch(collapsed, /lineage=secret|private/);
+			assert.equal(collapsed, `\n${expandHint}`, `${name} collapsed output must contain one expand hint`);
+			assert.doesNotMatch(collapsed, /safe result|lineage=secret|private/);
 		}
 		const expanded = renderComponent(tool.renderResult({ content: [{ type: "text", text: resultText }] }, { expanded: true, isPartial: false, isError: true }, lifecycleTheme, {}));
 		assert.match(expanded, /safe result/);
 		assert.match(expanded, /lineage=secret body=private/);
+		assert.doesNotMatch(expanded, /to expand/);
 		assert.doesNotMatch(expanded, /\x1b\[/);
 		const nonText = renderComponent(tool.renderResult({ content: [{ type: "image", data: "opaque", mimeType: "image/png" }] }, { expanded: true, isPartial: false }, lifecycleTheme, {}));
 		assert.equal(nonText, "");
+		const empty = renderComponent(tool.renderResult({ content: [{ type: "text", text: "" }] }, { expanded: false, isPartial: false }, lifecycleTheme, {}));
+		assert.equal(empty, "");
 	}
 });
 

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -141,8 +141,22 @@ function registeredQuietTools() {
 	return tools;
 }
 
+function registeredQuietToolsWithResolver(resolveOverride: () => unknown) {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any, resolveOverride as any));
+	return tools;
+}
+
 function renderToolResult(tool: any, result: any, options: any, context: Record<string, unknown> = {}): string {
 	return renderToString(tool.renderResult(result, options, passthroughTheme, context));
+}
+
+function assertGenericBash(tool: any, command: string): void {
+	const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+	const output = renderToolResult(tool, textResult("original command output"), { expanded: true, isPartial: false }, { args: { command } });
+	assert.equal(call.trimEnd(), `$ ${command}`, command);
+	assert.doesNotMatch(call, /🌹︎ Gentle AI/);
+	assert.match(output, /original command output/);
 }
 
 test("quiet tool rendering registers noisy built-in tools", () => {
@@ -325,21 +339,30 @@ test("quiet tool rendering hides every collapsed direct Gentle AI result and pre
 	const textRose = "\u{1F339}\uFE0E";
 	const tool = tools.get("bash");
 	const failureText = "review status failed: authority unavailable\x1b[31m\nlineage=secret";
+	const expandHint = keyHint("app.tools.expand", "to expand");
 
 	const call = renderToString(tool.renderCall({ command }, passthroughTheme, {}));
 	const collapsed = renderToString(tool.renderResult(textResult('{"next_transition":"stop"}'), { expanded: false, isPartial: false }, passthroughTheme, { args: { command } }));
 	const expanded = renderToString(tool.renderResult(textResult('{"next_transition":"stop"}'), { expanded: true, isPartial: false }, passthroughTheme, { args: { command } }));
 	const failure = renderToString(tool.renderResult(textResult(failureText), { expanded: false, isPartial: false, isError: true }, passthroughTheme, { args: { command } }));
 	const expandedFailure = renderToString(tool.renderResult(textResult(failureText), { expanded: true, isPartial: false, isError: true }, passthroughTheme, { args: { command } }));
+	const empty = renderToString(tool.renderResult(textResult(""), { expanded: false, isPartial: false }, passthroughTheme, { args: { command } }));
+	const nonText = renderToString(tool.renderResult({ content: [{ type: "image", data: "opaque", mimeType: "image/png" }] }, { expanded: false, isPartial: false }, passthroughTheme, { args: { command } }));
 
 	assert.equal([...textRose].length, 2);
 	assert.equal(call.trimEnd(), `${textRose} Gentle AI · running · review status`);
-	assert.equal(collapsed, "");
+	assert.equal(collapsed, `\n${expandHint}`);
+	assert.doesNotMatch(collapsed, /next_transition|stop/);
 	assert.match(expanded, /"next_transition":"stop"/);
-	assert.equal(failure, "");
+	assert.doesNotMatch(expanded, /to expand/);
+	assert.equal(failure, `\n${expandHint}`);
+	assert.doesNotMatch(failure, /review status failed|authority unavailable|lineage=secret/);
 	assert.match(expandedFailure, /review status failed: authority unavailable/);
 	assert.match(expandedFailure, /lineage=secret/);
+	assert.doesNotMatch(expandedFailure, /to expand/);
 	assert.doesNotMatch(expandedFailure, /\x1b\[/);
+	assert.equal(empty, "");
+	assert.equal(nonText, "");
 });
 
 test("quiet tool rendering transitions one Gentle AI header through lifecycle states", () => {
@@ -512,12 +535,63 @@ test("quiet tool rendering recognizes exact quoted, escaped, Windows, and comman
 	}
 });
 
+test("quiet tool rendering recognizes only the exact resolved dev binary", () => {
+	const devPath = "/home/devel/projects/gentle-ai/dist/gentle-ai-main";
+	let resolutions = 0;
+	const tools = registeredQuietToolsWithResolver(() => {
+		resolutions += 1;
+		return { source: "registration", origin: "test", path: devPath, sha256: "test" };
+	});
+	const tool = tools.get("bash");
+	const cases = [
+		[`${devPath} review validate --gate pre-commit --cwd /repo/private`, "review validate pre commit"],
+		[`'${devPath}' review status --lineage secret`, "review status"],
+		[`"${devPath}" version`, "version"],
+		[`env FOO='a b' ${devPath} review capabilities`, "review capabilities"],
+		[`command -- "${devPath}" sdd-status hidden`, "sdd status"],
+	] as const;
+	for (const [command, operationPath] of cases) {
+		const call = renderToString(tool.renderCall({ command }, statusTheme, routineRenderContext({ args: { command } })));
+		assert.equal(call.trimEnd(), `<warning>🌹︎ Gentle AI · running · ${operationPath}</warning>`, command);
+		assert.doesNotMatch(call, /gentle-ai-main|private|secret|hidden/);
+	}
+	const command = `${devPath} review status --prompt hidden-prompt --lineage lineage-secret --body private-body`;
+	const text = "error: private failure\nlineage=secret body=hidden\x1b[31m";
+	const collapsed = renderToolResult(tool, textResult(text), { expanded: false, isPartial: false, isError: true }, { args: { command }, isError: true });
+	const expanded = renderToolResult(tool, textResult(text), { expanded: true, isPartial: false, isError: true }, { args: { command }, isError: true });
+	const hint = keyHint("app.tools.expand", "to expand");
+	assert.equal(collapsed, `\n${hint}`);
+	assert.equal(collapsed.split(hint).length - 1, 1);
+	assert.doesNotMatch(collapsed, /private|lineage|secret|hidden|error/);
+	assert.match(expanded, /private failure|lineage=secret body=hidden/);
+	assert.doesNotMatch(expanded, /to expand|\x1b\[/);
+	assert.equal(resolutions, 1);
+});
+test("quiet tool rendering keeps unregistered dev lookalikes and composed calls generic", () => {
+	const devPath = "/home/devel/projects/gentle-ai/dist/gentle-ai-main";
+	const active = registeredQuietToolsWithResolver(() => ({ source: "registration", origin: "test", path: devPath, sha256: "test" }));
+	for (const command of [
+		"gentle-ai-main review status",
+		"/tmp/alias/gentle-ai review status",
+		`${devPath}-sibling review status`, `${devPath}.bak review status`, `${devPath}x review status`,
+		`${devPath} review status | tee output`, `${devPath} review status && echo done`,
+		`'${devPath}' review status $(printf nested)`,
+	]) assertGenericBash(active.get("bash"), command);
+
+	const unresolved = `${devPath} review status`;
+	assertGenericBash(registeredQuietToolsWithResolver(() => undefined).get("bash"), unresolved);
+	let throwing: Map<string, any> | undefined;
+	assert.doesNotThrow(() => { throwing = registeredQuietToolsWithResolver(() => { throw new Error("invalid override"); }); });
+	assertGenericBash(throwing!.get("bash"), unresolved);
+	assertGenericBash(registeredQuietToolsWithResolver(() => ({ path: "relative/gentle-ai-main" })).get("bash"), unresolved);
+});
 test("quiet tool rendering hides the routine partial result because the header owns state", () => {
 	const { pi, tools } = createPi();
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
 	const tool = tools.get("bash");
 	const command = "gentle-ai review status --cwd /repo/private";
 
+	const expandHint = keyHint("app.tools.expand", "to expand");
 	const partial = renderToString(
 		tool.renderResult(
 			textResult("{\"status\":\"running\"}"),
@@ -542,10 +616,21 @@ test("quiet tool rendering hides the routine partial result because the header o
 			{ ...routineRenderContext({ args: { command } }), isError: true },
 		),
 	);
+	const completed = renderToString(
+		tool.renderResult(
+			textResult("{\"status\":\"running\"}"),
+			{ expanded: false, isPartial: false },
+			passthroughTheme,
+			{ ...routineRenderContext({ args: { command } }), isError: false },
+		),
+	);
 
-	assert.equal(partial, "");
+	assert.equal(partial, `\n${expandHint}`);
+	assert.equal(partial.split(expandHint).length - 1, 1);
 	assert.match(partialExpanded, /"status":"running"/);
-	assert.equal(partialFailure, "");
+	assert.doesNotMatch(partialExpanded, /to expand/);
+	assert.equal(partialFailure, `\n${expandHint}`);
+	assert.equal(completed, `\n${expandHint}`);
 
 	const partialExpandedFailure = renderToString(
 		tool.renderResult(
@@ -630,7 +715,7 @@ test("quiet tool rendering hides invocation secrets from collapsed Gentle AI cal
 	);
 
 	assert.equal(call.trimEnd(), "🌹︎ Gentle AI · running · review finalize");
-	assert.equal(collapsed, "");
+	assert.equal(collapsed, `\n${keyHint("app.tools.expand", "to expand")}`);
 	for (const forbidden of ["hidden-prompt", "lineage-secret", "private-body", "/private/root", "audit:"]) {
 		assert.doesNotMatch(call, new RegExp(forbidden));
 		assert.doesNotMatch(collapsed, new RegExp(forbidden));
@@ -687,8 +772,10 @@ test("quiet Bash previews semantic lines for generic JSON output", () => {
 	assert.equal(call.trimEnd(), `$ ${command}`);
 	assert.doesNotMatch(call, /🌹︎ Gentle AI/);
 	assert.doesNotMatch(collapsed, /^\n\s*[}\]]/);
-	assert.ok(collapsed.includes(keyHint("app.tools.expand", "to expand")));
+	const expandHint = keyHint("app.tools.expand", "to expand");
+	assert.equal(collapsed.split(expandHint).length - 1, 1);
 	assert.equal(expanded, `\n${object}`);
+	assert.doesNotMatch(expanded, /to expand/);
 });
 
 test("quiet tool rendering keeps collapsed git bash result tails", () => {

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -609,6 +609,32 @@ test("quiet tool rendering keeps shell compositions, expansions, and lookalikes 
 	}
 });
 
+test("quiet Bash previews semantic lines for generic JSON output", () => {
+	const tools = registeredQuietTools();
+	const tool = tools.get("bash");
+	const command = "gentle-ai review capabilities --contract gentle-ai.review-integration/v2 | python3 -m json.tool";
+	const json = (value: unknown) => JSON.stringify(value, null, 2);
+	const object = json({ schema: "gentle-ai.review-integration/v2", contract: "review", protocol: { version: 2 }, payload: { items: [{ value: true }] } });
+	const error = json({ error: "failed", payload: { items: [{ code: 1 }] } });
+	const cases = [
+		[object, '  "schema": "gentle-ai.review-integration/v2",\n  "contract": "review",\n  "protocol": {'],
+		[json(["alpha", "beta", { entry: true }]), '  "alpha",\n  "beta",\n    "entry": true'],
+		['{\n  "schema": "broken",\n  "contract": "partial",\n  "payload": [\n    "value"\n  ]', '  "payload": [\n    "value"\n  ]'],
+	] as const;
+	for (const [text, expected] of cases) {
+		assert.equal(formatToolResultOutput("bash", textResult(text) as any, { expanded: false, args: { command } }), `\n${expected}`);
+	}
+	assert.equal(formatToolResultOutput("bash", textResult(error) as any, { expanded: false, isError: true, args: { command } }), `\n${tailLines(error, 3)}`);
+	const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+	const collapsed = renderToolResult(tool, textResult(object), { expanded: false, isPartial: false }, { args: { command } });
+	const expanded = renderToolResult(tool, textResult(object), { expanded: true, isPartial: false }, { args: { command } });
+	assert.equal(call.trimEnd(), `$ ${command}`);
+	assert.doesNotMatch(call, /🌹︎ Gentle AI/);
+	assert.doesNotMatch(collapsed, /^\n\s*[}\]]/);
+	assert.ok(collapsed.includes(keyHint("app.tools.expand", "to expand")));
+	assert.equal(expanded, `\n${object}`);
+});
+
 test("quiet tool rendering keeps collapsed git bash result tails", () => {
 	const text = Array.from({ length: 12 }, (_, index) => `git line ${index + 1}`).join("\n");
 

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -695,7 +695,7 @@ test("quiet tool rendering recognizes exact quoted, escaped, Windows, and comman
 });
 
 test("quiet tool rendering recognizes only the exact resolved dev binary", () => {
-	const devPath = "/home/devel/projects/gentle-ai/dist/gentle-ai-main";
+	let devPath = "/home/devel/projects/gentle-ai/dist/gentle-ai-main";
 	let resolutions = 0;
 	const tools = registeredQuietToolsWithResolver(() => {
 		resolutions += 1;
@@ -715,16 +715,24 @@ test("quiet tool rendering recognizes only the exact resolved dev binary", () =>
 		assert.doesNotMatch(call, /gentle-ai-main|private|secret|hidden/);
 	}
 	const command = `${devPath} review status --prompt hidden-prompt --lineage lineage-secret --body private-body`;
+	const lifecycleContext = routineRenderContext({ args: { command }, state: {} });
+	assert.match(renderToString(tool.renderCall({ command }, passthroughTheme, lifecycleContext)), /Gentle AI · running · review status/);
+	devPath = "/new/dev/gentle-ai-main";
+	const refreshedCommand = `${devPath} review status --token token-secret`;
+	assert.match(renderToString(tool.renderCall({ command: refreshedCommand }, passthroughTheme, routineRenderContext({ args: { command: refreshedCommand } }))), /Gentle AI · running · review status/);
+	assertGenericBash(tool, cases[2][0]);
 	const text = "error: private failure\nlineage=secret body=hidden\x1b[31m";
-	const collapsed = renderToolResult(tool, textResult(text), { expanded: false, isPartial: false, isError: true }, { args: { command }, isError: true });
-	const expanded = renderToolResult(tool, textResult(text), { expanded: true, isPartial: false, isError: true }, { args: { command }, isError: true });
+	const collapsed = renderToolResult(tool, textResult(text), { expanded: false, isPartial: false, isError: true }, lifecycleContext);
+	const expanded = renderToolResult(tool, textResult(text), { expanded: true, isPartial: false, isError: true }, lifecycleContext);
+	const refreshed = renderToolResult(tool, textResult("result-secret"), { expanded: false, isPartial: false }, { args: { command: refreshedCommand } });
 	const hint = keyHint("app.tools.expand", "to expand");
 	assert.equal(collapsed, hint);
 	assert.equal(collapsed.split(hint).length - 1, 1);
 	assert.doesNotMatch(collapsed, /private|lineage|secret|hidden|error/);
 	assert.match(expanded, /private failure|lineage=secret body=hidden/);
 	assert.doesNotMatch(expanded, /to expand|\x1b\[/);
-	assert.equal(resolutions, 1);
+	assert.doesNotMatch(refreshed, /result-secret/);
+	assert.ok(resolutions > 1);
 });
 test("quiet tool rendering keeps unregistered dev lookalikes and composed calls generic", () => {
 	const devPath = "/home/devel/projects/gentle-ai/dist/gentle-ai-main";
@@ -961,9 +969,22 @@ test("quiet tool rendering sanitizes collapsed output and call rows", () => {
 	);
 	const call = renderToString(tools.get("bash").renderCall({ command: "echo \x1b[31mred\x1b[0m" }, passthroughTheme, {}));
 
+	const carriageReturn = renderToolResult(tools.get("bash"), textResult("prefix\rSECRET\r\nnext"), { expanded: false, isPartial: false }, { args: { command: "printf output" } });
 	assert.match(collapsed, /safered/);
 	assert.doesNotMatch(collapsed, /\x1b\[31m|\x1b\[0m/);
 	assert.equal(call.trimEnd(), "$ echo red");
+	assert.match(carriageReturn, /prefixSECRET\nnext/);
+	assert.doesNotMatch(carriageReturn, /\r/);
+});
+
+test("quiet tool rendering sanitizes only rendered fields", () => {
+	let argsReads = 0, detailReads = 0;
+	const counted = (record: Record<string, unknown>, increment: () => void) => Object.defineProperties(record, Object.fromEntries(Array.from({ length: 1000 }, (_, index) => [`unused${index}`, { enumerable: true, get() { increment(); return "ignored"; } }])));
+	const args = counted({ command: "printf output" }, () => argsReads++);
+	const details = counted({}, () => detailReads++);
+	renderToolResult(registeredQuietTools().get("bash"), textResult("first\nsecond", details), { expanded: false, isPartial: false }, { args });
+	assert.equal(argsReads, 0);
+	assert.equal(detailReads, 0);
 });
 
 test("quiet tool rendering call rows show tool calls without result output", () => {

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -962,3 +962,136 @@ test("quiet tool rendering preserves complete expanded text and delegates saniti
 	assert.ok(image.includes(imageFallback("image/png")));
 	assert.doesNotMatch(image, /\x1b/);
 });
+
+test("quiet tool rendering preserves directional visual preview rows at narrow widths", () => {
+	const tools = registeredQuietTools();
+	const bash = tools.get("bash");
+	const readTool = tools.get("read");
+	const narrowWidth = 12;
+	const renderCollapsed = (
+		text: string,
+		options: { expanded: false; isPartial: boolean; isError?: boolean },
+		context: Record<string, unknown>,
+	) => renderLines(bash.renderResult(textResult(text), options, passthroughTheme, context), narrowWidth);
+	const renderRead = (text: string) => renderLines(
+		readTool.renderResult(textResult(text), { expanded: false, isPartial: false }, passthroughTheme, {}),
+		narrowWidth,
+	);
+	const oldText = "older wrapped text ".repeat(16);
+
+	const partial = renderCollapsed(`${oldText}\nPARTIAL-NEW`, { expanded: false, isPartial: true }, { args: { command: "printf output" } });
+	const growingPartial = renderCollapsed(`${oldText}GROW-SUFFIX`, { expanded: false, isPartial: true }, { args: { command: "printf output" } });
+	const completedBash = renderCollapsed(`${oldText}\nBASH-NEW`, { expanded: false, isPartial: false }, { args: { command: "printf output" } });
+	const error = renderCollapsed(`${oldText}\nERROR-NEW`, { expanded: false, isPartial: false, isError: true }, { args: { command: "false" }, isError: true });
+	const git = renderCollapsed(`${oldText}\nGIT-NEW`, { expanded: false, isPartial: false }, { args: { command: "git diff" } });
+
+	for (const [lines, marker] of [
+		[partial, "PARTIAL-NEW"],
+		[growingPartial, "GROW-SUFFIX"],
+		[completedBash, "BASH-NEW"],
+		[error, "ERROR-NEW"],
+		[git, "GIT-NEW"],
+	] as const) {
+		assert.ok(lines.length <= 4, `expected fixed preview budget, got ${lines.length}`);
+		assert.match(lines.join("\n"), new RegExp(marker));
+	}
+	assert.match(partial[0] ?? "", /… bash/);
+	assert.match(completedBash.join("\n"), /to expand/);
+
+	const read = renderRead(`READ-FIRST\n${oldText}\nREAD-NEW`);
+	const semanticJson = renderCollapsed(
+		JSON.stringify({ first: "x".repeat(80), newest: "JSON-NEW" }, null, 2),
+		{ expanded: false, isPartial: false },
+		{ args: { command: "printf output" } },
+	);
+	assert.match(read.join("\n"), /READ-FIRST/);
+	assert.doesNotMatch(read.join("\n"), /READ-NEW/);
+	assert.match(semanticJson.join("\n"), /first/);
+	assert.doesNotMatch(semanticJson.join("\n"), /JSON-NEW/);
+	assert.match(
+		renderToolResult(bash, textResult(`${oldText}\nBASH-NEW`), { expanded: true, isPartial: false }, { args: { command: "printf output" } }),
+		/BASH-NEW/,
+	);
+});
+
+test("quiet tool rendering fails closed on unquoted shell expansions", () => {
+	const bash = registeredQuietTools().get("bash");
+	for (const command of [
+		"gentle-ai review status *",
+		"gentle-ai review status ?",
+		"gentle-ai review status [a-z]",
+		"gentle-ai review status ~",
+		"gentle-ai review status {one,two}",
+	]) {
+		assert.equal(gentleAiRoutineCommand({ command }), undefined, command);
+		assertGenericBash(bash, command);
+	}
+
+	for (const command of [
+		"gentle-ai review status '*'",
+		"gentle-ai review status \"?\"",
+		"gentle-ai review status '[a-z]'",
+		"gentle-ai review status \"~\"",
+		"gentle-ai review status '{one,two}'",
+		"gentle-ai review status \\*",
+		"gentle-ai review status \\?",
+		"gentle-ai review status \\[a-z\\]",
+		"gentle-ai review status \\~",
+		"gentle-ai review status \\{one,two\\}",
+	]) {
+		const call = renderToString(bash.renderCall({ command }, passthroughTheme, { args: { command } }));
+		const collapsed = renderToolResult(bash, textResult("dummy-secret"), { expanded: false, isPartial: false }, { args: { command } });
+		assert.equal(gentleAiRoutineCommand({ command }), "review", command);
+		assert.match(call, /🌹︎ Gentle AI · running · review status/, command);
+		assert.doesNotMatch(collapsed, /dummy-secret/, command);
+	}
+});
+
+test("quiet tool rendering redacts only exact package-local executable paths with spaces", () => {
+	const bash = registeredQuietTools().get("bash");
+	const validCommands = [
+		"'/opt/Gentle Package/.gentle-ai/v2.2.0/gentle-ai' review status --token single-secret",
+		'"/opt/Gentle Package/.gentle-ai/v2.2.0/gentle-ai" review status --token double-secret',
+		"/opt/Gentle\\ Package/.gentle-ai/v2.2.0/gentle-ai review status --token escaped-secret",
+	] as const;
+	for (const command of validCommands) {
+		const call = renderToString(bash.renderCall({ command }, passthroughTheme, { args: { command } }));
+		const collapsed = renderToolResult(bash, textResult("dummy-secret"), { expanded: false, isPartial: false }, { args: { command } });
+		assert.equal(gentleAiRoutineCommand({ command }), "review", command);
+		assert.match(call, /🌹︎ Gentle AI · running · review status/, command);
+		assert.doesNotMatch(call, /Gentle Package|secret/, command);
+		assert.doesNotMatch(collapsed, /dummy-secret/, command);
+	}
+
+	for (const command of [
+		"'/opt/Gentle Package/.gentle-ai/v2.2.0/gentle-ai-copy' review status --token copy-secret",
+		'"/opt/Gentle Package/.gentle-ai/v2.2.0/gentle-ai.exe.bak" review status --token backup-secret',
+		"/opt/Gentle\\ Package/.gentle-ai/v2.2.0/not-gentle-ai review status --token sibling-secret",
+	]) {
+		const call = renderToString(bash.renderCall({ command }, passthroughTheme, { args: { command } }));
+		const collapsed = renderToolResult(bash, textResult("dummy-secret"), { expanded: false, isPartial: false }, { args: { command } });
+		assert.equal(gentleAiRoutineCommand({ command }), undefined, command);
+		assert.equal(call.trimEnd(), `$ ${command}`, command);
+		assert.match(collapsed, /dummy-secret/, command);
+	}
+});
+
+test("quiet tool rendering respects command and env wrapper order", () => {
+	const bash = registeredQuietTools().get("bash");
+	for (const command of [
+		"FOO=bar command -- env BAR=baz gentle-ai review status",
+		"command -- env FOO=bar gentle-ai review status",
+		"env FOO=bar gentle-ai review status",
+		"command -- gentle-ai review status",
+	]) {
+		const call = renderToString(bash.renderCall({ command }, passthroughTheme, { args: { command } }));
+		const collapsed = renderToolResult(bash, textResult("dummy-secret"), { expanded: false, isPartial: false }, { args: { command } });
+		assert.equal(gentleAiRoutineCommand({ command }), "review", command);
+		assert.match(call, /🌹︎ Gentle AI · running · review status/, command);
+		assert.doesNotMatch(collapsed, /dummy-secret/, command);
+	}
+
+	const command = "env FOO=bar command -- gentle-ai review status";
+	assert.equal(gentleAiRoutineCommand({ command }), undefined);
+	assertGenericBash(bash, command);
+});

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { initTheme, keyHint } from "@earendil-works/pi-coding-agent";
-import { imageFallback } from "@earendil-works/pi-tui";
+import { imageFallback, visibleWidth } from "@earendil-works/pi-tui";
 import piPretty from "../extensions/pi-pretty.ts";
 import quietTools, {
 	countNonEmptyLines,
@@ -49,8 +49,12 @@ function routineRenderContext(overrides: Record<string, unknown> = {}) {
 	};
 }
 
-function renderToString(component: { render(width: number): string[] }): string {
-	return component.render(120).map((line) => line.trimEnd()).join("\n");
+function renderLines(component: { render(width: number): string[] }, width = 120): string[] {
+	return component.render(width).map((line) => line.trimEnd());
+}
+
+function renderToString(component: { render(width: number): string[] }, width = 120): string {
+	return renderLines(component, width).join("\n");
 }
 
 function textResult(text: string, details?: unknown) {
@@ -819,6 +823,73 @@ test("quiet tool rendering call rows show tool calls without result output", () 
 	assert.match(bashCall, /\$ printf noisy \(timeout 5s\)/);
 	assert.match(grepCall, /grep \/needle\/ in src \(\*\.ts\)/);
     });
+
+test("quiet tool rendering limits collapsed visual rows at the actual width", () => {
+	const tools = registeredQuietTools();
+	const bash = tools.get("bash");
+	const hint = keyHint("app.tools.expand", "to expand");
+	const narrowWidth = 12;
+	const cases = [
+		[textResult("x".repeat(80)), { expanded: false, isPartial: true }, { args: { command: "printf output" } }, 4],
+		[textResult("界".repeat(40)), { expanded: false, isPartial: false }, { args: { command: "printf output" } }, 4],
+		[textResult("e\u0301".repeat(40)), { expanded: false, isPartial: false, isError: true }, { args: { command: "false" }, isError: true }, 4],
+	] as const;
+	for (const [result, options, context, maxRows] of cases) {
+		const lines = renderLines(bash.renderResult(result, options, passthroughTheme, context), narrowWidth);
+		assert.ok(lines.length <= maxRows, `expected at most ${maxRows} rows, got ${lines.length}`);
+		assert.ok(lines.every((line) => visibleWidth(line) <= narrowWidth));
+	}
+	const completed = renderLines(bash.renderResult(textResult("😀".repeat(40)), { expanded: false, isPartial: false }, passthroughTheme, { args: { command: "printf output" } }), narrowWidth);
+	assert.equal(completed.filter((line) => line.includes(hint)).length, 1);
+	assert.ok(completed.every((line) => visibleWidth(line) <= narrowWidth));
+});
+
+test("quiet tool rendering classifies quoted and escaped literal shell metacharacters as direct Gentle AI calls", () => {
+	const tool = registeredQuietTools().get("bash");
+	for (const command of [
+		"gentle-ai review status '--note=$|#;'",
+		'"gentle-ai" review status "literal \\$|#;"',
+		"gentle\\-ai review status escaped\\ space",
+	]) {
+		const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+		const collapsed = renderToolResult(tool, textResult("private output"), { expanded: false, isPartial: false }, { args: { command } });
+		assert.match(call, /🌹︎ Gentle AI · running · review status/, command);
+		assert.doesNotMatch(collapsed, /private output/, command);
+	}
+});
+
+test("quiet tool rendering keeps unescaped expansions inside double quotes generic", () => {
+	const tool = registeredQuietTools().get("bash");
+	const commands = [
+		'gentle-ai review status "$VALUE"',
+		'gentle-ai review status "$(printf nested)"',
+		'gentle-ai review status "`printf nested`"',
+	] as const;
+
+	for (const command of commands) {
+		const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+		const collapsed = renderToolResult(
+			tool,
+			textResult("original command output"),
+			{ expanded: false, isPartial: false },
+			{ args: { command } },
+		);
+		assert.equal(gentleAiRoutineCommand({ command }), undefined, command);
+		assert.equal(call.trimEnd(), `$ ${command}`, command);
+		assert.match(collapsed, /original command output/, command);
+	}
+});
+
+test("quiet tool rendering recognizes a quoted exact dev override path containing spaces", () => {
+	const devPath = "/opt/Gentle AI/gentle-ai";
+	const tool = registeredQuietToolsWithResolver(() => ({ path: devPath })).get("bash");
+	const command = `"${devPath}" review status "literal \\$|#;"`;
+	const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+	const collapsed = renderToolResult(tool, textResult("private result"), { expanded: false, isPartial: false }, { args: { command } });
+	assert.equal(call.trimEnd(), "🌹︎ Gentle AI · running · review status");
+	assert.doesNotMatch(call, /\/opt\/Gentle AI\/gentle-ai|literal/);
+	assert.doesNotMatch(collapsed, /private result/);
+});
 
 test("quiet tool rendering bounds and sanitizes partial text without a completion hint", () => {
 	const tool = registeredQuietTools().get("bash");

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { initTheme, keyHint } from "@earendil-works/pi-coding-agent";
+import { imageFallback } from "@earendil-works/pi-tui";
 import piPretty from "../extensions/pi-pretty.ts";
 import quietTools, {
 	countNonEmptyLines,
@@ -17,6 +19,8 @@ const passthroughTheme = {
 		return value;
 	},
 };
+
+initTheme("dark");
 
 const statusTheme = {
 	bold(value: string) {
@@ -46,12 +50,13 @@ function routineRenderContext(overrides: Record<string, unknown> = {}) {
 }
 
 function renderToString(component: { render(width: number): string[] }): string {
-	return component.render(120).join("\n");
+	return component.render(120).map((line) => line.trimEnd()).join("\n");
 }
 
-function textResult(text: string) {
+function textResult(text: string, details?: unknown) {
 	return {
 		content: [{ type: "text", text }],
+		details,
 	};
 }
 
@@ -130,6 +135,16 @@ async function withEnvAsync<T>(updates: Record<string, string | undefined>, run:
 	}
 }
 
+function registeredQuietTools() {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	return tools;
+}
+
+function renderToolResult(tool: any, result: any, options: any, context: Record<string, unknown> = {}): string {
+	return renderToString(tool.renderResult(result, options, passthroughTheme, context));
+}
+
 test("quiet tool rendering registers noisy built-in tools", () => {
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => {
 		const { pi, tools } = createPi();
@@ -143,6 +158,21 @@ test("quiet tool rendering registers noisy built-in tools", () => {
 			assert.ok(tool.parameters, `${toolName} must preserve built-in parameters`);
 		}
 	});
+});
+
+test("quiet tool execution uses the tool-call cwd", async () => {
+	const tool = registeredQuietTools().get("bash");
+	const output = extractTextContent(await tool.execute("tool-call", { command: "pwd" }, new AbortController().signal, undefined, { cwd: "/tmp" })).trim();
+	assert.equal(output, "/tmp");
+	assert.notEqual(output, process.cwd());
+});
+
+test("quiet Bash rendering leaves configured shellPath outside its scope (#107)", () => {
+	const tool = registeredQuietTools().get("bash");
+	const render = (context: Record<string, unknown> = {}) => renderToString(tool.renderCall({ command: "printf output" }, passthroughTheme, routineRenderContext(context)));
+	const configured = render({ shellPath: "/configured/bash" });
+	assert.equal(configured, render());
+	assert.doesNotMatch(configured, /shellPath|configured\/bash/);
 });
 
 test("quiet tool rendering can be disabled by env", () => {
@@ -189,29 +219,36 @@ test("pi-pretty suppression is skipped when quiet tools are disabled", async () 
 	);
 });
 
-test("quiet tool rendering hides noisy result bodies while collapsed and restores them when expanded", () => {
+test("quiet tool rendering uses bounded previews while preserving search summaries", () => {
 	const { pi, tools } = createPi();
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
 
-	const cases = [
-		{ tool: "read", text: "first line\nsecond line", hidden: "first line", expanded: "second line" },
-		{ tool: "bash", text: "stdout line\nstderr line", hidden: "stdout line", expanded: "stderr line" },
-		{ tool: "grep", text: "src/a.ts:1:match\nsrc/b.ts:2:match", hidden: "src/a.ts", expanded: "src/b.ts" },
-		{ tool: "find", text: "src/a.ts\nsrc/b.ts", hidden: "src/a.ts", expanded: "src/b.ts" },
-		{ tool: "ls", text: "file-a.ts\nfile-b.ts", hidden: "file-a.ts", expanded: "file-b.ts" },
-	];
+	const read = renderToString(
+		tools.get("read").renderResult(textResult("first line\nsecond line"), { expanded: false, isPartial: false }, passthroughTheme, {}),
+	);
+	const bash = renderToString(
+		tools.get("bash").renderResult(textResult("stdout line\nstderr line"), { expanded: false, isPartial: false }, passthroughTheme, { args: { command: "printf output" } }),
+	);
+	assert.match(read, /first line\nsecond line/);
+	assert.match(bash, /stdout line\nstderr line/);
+	const configuredHint = keyHint("app.tools.expand", "to expand");
+	assert.ok(read.includes(configuredHint));
+	assert.ok(bash.includes(configuredHint));
 
-	for (const entry of cases) {
-		const tool = tools.get(entry.tool);
+	for (const [tool, text, label] of [
+		["grep", "src/a.ts:1:match\nsrc/b.ts:2:match", "2 matches"],
+		["find", "src/a.ts\nsrc/b.ts", "2 files"],
+		["ls", "file-a.ts\nfile-b.ts", "2 entries"],
+	] as const) {
 		const collapsed = renderToString(
-			tool.renderResult(textResult(entry.text), { expanded: false, isPartial: false }, passthroughTheme, {}),
+			tools.get(tool).renderResult(textResult(text), { expanded: false, isPartial: false }, passthroughTheme, {}),
 		);
 		const expanded = renderToString(
-			tool.renderResult(textResult(entry.text), { expanded: true, isPartial: false }, passthroughTheme, {}),
+			tools.get(tool).renderResult(textResult(text), { expanded: true, isPartial: false }, passthroughTheme, {}),
 		);
-
-		assert.doesNotMatch(collapsed, new RegExp(entry.hidden.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${entry.tool} collapsed output must not include result body`);
-		assert.match(expanded, new RegExp(entry.expanded.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${entry.tool} expanded output must include full result body`);
+		assert.match(collapsed, new RegExp(label));
+		assert.doesNotMatch(collapsed, /src\/a\.ts|file-a\.ts/);
+		assert.match(expanded, new RegExp(text.split("\n")[1]!));
 	}
 });
 
@@ -224,13 +261,13 @@ test("quiet tool rendering keeps compact collapsed summaries for search and list
 	assert.equal(formatToolResultOutput("grep", textResult("No matches found") as any, { expanded: false }), "");
 	assert.equal(formatToolResultOutput("find", textResult("No files found matching pattern") as any, { expanded: false }), "");
 	assert.equal(formatToolResultOutput("ls", textResult("Directory is empty") as any, { expanded: false }), "");
-	assert.equal(formatToolResultOutput("read", textResult("a\nb\n") as any, { expanded: false }), "");
-	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false }), "");
+	assert.equal(formatToolResultOutput("read", textResult("a\nb\n") as any, { expanded: false }), "\na\nb");
+	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false }), "\na\nb");
 	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false, args: { command: "git diff" } }), "\na\nb\n");
 	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false, args: { command: "git -C repo status" } }), "\na\nb\n");
-	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false, args: { command: "echo git diff" } }), "");
-	assert.equal(formatToolResultOutput("edit", textResult("updated") as any, { expanded: false }), "\nupdated");
-	assert.equal(formatToolResultOutput("write", textResult("wrote") as any, { expanded: false }), "\nwrote");
+	assert.equal(formatToolResultOutput("bash", textResult("a\nb\n") as any, { expanded: false, args: { command: "echo git diff" } }), "\na\nb");
+	assert.equal(formatToolResultOutput("edit", textResult("updated") as any, { expanded: false }), "\n✓ applied");
+	assert.equal(formatToolResultOutput("write", textResult("wrote") as any, { expanded: false }), "\n✓ written");
 	assert.equal(formatToolResultOutput("grep", textResult("a\nb\n") as any, { expanded: true }), "\na\nb\n");
 	assert.equal(formatToolResultOutput("read", textResult("ENOENT: missing file") as any, { expanded: false, isError: true }), "\nENOENT: missing file");
 });
@@ -579,12 +616,12 @@ test("quiet tool rendering keeps collapsed git bash result tails", () => {
 	assert.equal(formatToolResultOutput("bash", textResult(text) as any, { expanded: false, args: { command: "git status --short" } }), `\n${tailLines(text, 10)}`);
 });
 
-test("quiet tool rendering keeps collapsed edit and write result tails", () => {
+test("quiet tool rendering keeps concise collapsed edit and write summaries", () => {
 	const text = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n");
 
 	assert.equal(tailLines(text, 10), Array.from({ length: 10 }, (_, index) => `line ${index + 3}`).join("\n"));
-	assert.equal(formatToolResultOutput("edit", textResult(text) as any, { expanded: false }), `\n${tailLines(text, 10)}`);
-	assert.equal(formatToolResultOutput("write", textResult(text) as any, { expanded: false }), `\n${tailLines(text, 10)}`);
+	assert.equal(formatToolResultOutput("edit", textResult(text, { diff: "@@\n-old\n+new" }) as any, { expanded: false }), "\n✓ +1 / -1");
+	assert.equal(formatToolResultOutput("write", textResult("Successfully wrote 12 bytes\n" + text) as any, { expanded: false }), "\n✓ wrote 12 bytes");
 });
 
 test("quiet tool rendering sanitizes collapsed output and call rows", () => {
@@ -592,11 +629,12 @@ test("quiet tool rendering sanitizes collapsed output and call rows", () => {
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
 
 	const collapsed = renderToString(
-		tools.get("write").renderResult(textResult("safe\x1b[31mred\x1b[0m"), { expanded: false, isPartial: false }, passthroughTheme, {}),
+		tools.get("bash").renderResult(textResult("safe\x1b[31mred\x1b[0m"), { expanded: false, isPartial: false }, passthroughTheme, { args: { command: "printf output" } }),
 	);
 	const call = renderToString(tools.get("bash").renderCall({ command: "echo \x1b[31mred\x1b[0m" }, passthroughTheme, {}));
 
-	assert.equal(collapsed.replace(/[ \t]+$/gm, ""), "\nsafered");
+	assert.match(collapsed, /safered/);
+	assert.doesNotMatch(collapsed, /\x1b\[31m|\x1b\[0m/);
 	assert.equal(call.trimEnd(), "$ echo red");
 });
 
@@ -611,4 +649,76 @@ test("quiet tool rendering call rows show tool calls without result output", () 
 	assert.match(readCall, /read .*example\.ts:2-4/);
 	assert.match(bashCall, /\$ printf noisy \(timeout 5s\)/);
 	assert.match(grepCall, /grep \/needle\/ in src \(\*\.ts\)/);
+    });
+
+test("quiet tool rendering bounds and sanitizes partial text without a completion hint", () => {
+	const tool = registeredQuietTools().get("bash");
+	const result = textResult("first\nsecond\nthird\nfourth");
+	const collapsed = renderToolResult(tool, result, { expanded: false, isPartial: true }, { args: { command: "printf output" } });
+	const expanded = renderToolResult(tool, result, { expanded: true, isPartial: true }, { args: { command: "printf output" } });
+
+	assert.match(collapsed, /… bash · 4 lines/);
+	assert.doesNotMatch(collapsed, /first/);
+	assert.match(collapsed, /second\nthird\nfourth/);
+	assert.doesNotMatch(collapsed, /to expand|Ctrl\+O/);
+	assert.match(expanded, /first\nsecond\nthird\nfourth/);
+	assert.doesNotMatch(expanded, /to expand|Ctrl\+O/);
+
+	const sanitized = renderToolResult(tool, textResult("safe\x1b]52;c;Y2xpcGJvYXJk\x07\x1b[2Jdone"), { expanded: true, isPartial: true }, { args: { command: "echo safe" } });
+	assert.match(sanitized, /safedone/);
+	assert.doesNotMatch(sanitized, /\x1b/);
+
+	for (const [value, options] of [
+		[textResult(""), { expanded: false, isPartial: true }],
+		[{ content: [{ type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" }] }, { expanded: true, isPartial: true }],
+	] as const) {
+		assert.equal(renderToolResult(tool, value, options, { args: { command: "true" } }).trimEnd(), "… bash");
+	}
+});
+
+test("quiet tool rendering bounds completed previews, errors, and edit/write summaries", () => {
+	const tools = registeredQuietTools();
+	for (const [toolName, text, hidden, visible, context] of [
+		["read", "read one\nread two\nread three\nread four", "read four", "read one\nread two\nread three", {}],
+		["bash", "bash one\nbash two\nbash three\nbash four", "bash one", "bash two\nbash three\nbash four", { args: { command: "printf output" } }],
+	] as const) {
+		const rendered = renderToolResult(tools.get(toolName), textResult(text), { expanded: false, isPartial: false }, context);
+		assert.doesNotMatch(rendered, new RegExp(hidden));
+		assert.match(rendered, new RegExp(visible));
+		assert.match(rendered, /to expand/);
+	}
+
+	for (const toolName of ["read", "bash", "grep", "find", "ls", "edit", "write"] as const) {
+		const rendered = renderToolResult(tools.get(toolName), textResult("error one\nerror two\nerror three\nerror four"), { expanded: false, isPartial: false, isError: true }, { args: toolName === "bash" ? { command: "false" } : {} });
+		assert.doesNotMatch(rendered, /error one/);
+		assert.match(rendered, /error two\nerror three\nerror four/);
+		assert.match(rendered, /to expand/);
+	}
+
+	const edit = renderToolResult(tools.get("edit"), textResult("Applied", { diff: "@@\n-old\n+new" }), { expanded: false, isPartial: false }, { args: { path: "file.ts", edits: [] } });
+	const write = renderToolResult(tools.get("write"), textResult("Successfully wrote 4 bytes\nbody"), { expanded: false, isPartial: false }, { args: { path: "file.ts", content: "body" } });
+	assert.match(edit, /\+1 \/ -1/);
+	assert.doesNotMatch(edit, /Applied|old|new/);
+	assert.match(write, /wrote 4 bytes/);
+	assert.doesNotMatch(write, /body/);
+});
+
+test("quiet tool rendering preserves complete expanded text and delegates sanitized image reads", () => {
+	const tools = registeredQuietTools();
+	const expanded = renderToolResult(tools.get("bash"), textResult("first\nsecond\nthird\nfourth\nsafe\x1b]52;c;Y2xpcGJvYXJk\x07done"), { expanded: true, isPartial: false }, { args: { command: "printf safe" } });
+	assert.match(expanded, /first\nsecond\nthird\nfourth\nsafedone/);
+	assert.doesNotMatch(expanded, /\x1b/);
+
+	const edit = renderToolResult(tools.get("edit"), textResult("Applied", { diff: "@@\n-old\x1b]52;c;Y2xpcGJvYXJk\x07\n+new" }), { expanded: true, isPartial: false }, { args: { path: "file\x1b[2J.ts", edits: [{ oldText: "old\x1b[31m", newText: "new" }] } });
+	assert.match(edit, /-old\n\+new/);
+	assert.doesNotMatch(edit, /\x1b/);
+
+	const image = renderToolResult(
+		tools.get("read"),
+		{ content: [{ type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" }], details: { path: "image\x1b[2J.png", note: "safe\x1b]2;title\x07" } },
+		{ expanded: true, isPartial: false },
+		{ args: { path: "image\x1b[2J.png", offset: 1, limit: 2 }, cwd: "/repo\x1b[2J", showImages: false, isError: false },
+	);
+	assert.ok(image.includes(imageFallback("image/png")));
+	assert.doesNotMatch(image, /\x1b/);
 });

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -290,6 +290,123 @@ test("quiet tool rendering keeps compact collapsed summaries for search and list
 	assert.equal(formatToolResultOutput("read", textResult("ENOENT: missing file") as any, { expanded: false, isError: true }), "\nENOENT: missing file");
 });
 
+test("quiet search and placeholder summaries preserve exact-result behavior", async (t) => {
+	const grepRows = [["one", 12, "first"], ["two", 20, "second"], ["three", 28, "third"], ["four", 36, "fourth"], ["five", 44, "fifth"]] as const;
+	const contextText = grepRows.flatMap(([file, line, ordinal]) => [
+		`src/${file}.ts:${line}: ${ordinal} match`,
+		`src/${file}.ts-${line - 1}- context before`,
+		`src/${file}.ts-${line + 1}- context after`,
+	]).join("\n");
+	assert.deepEqual([grepRows.length, contextText.split("\n").length, contextText.split("\n").filter((line) => /:\d+:/.test(line)).length, contextText.split("\n").filter((line) => /-\d+-/.test(line)).length], [5, 15, 5, 10]);
+
+	const lsCollisionText = "(empty directory)\nreal-entry.txt";
+	const bashCollisionText = "(no output)\nreal output";
+	const tools = registeredQuietTools();
+	const hint = keyHint("app.tools.expand", "to expand");
+	const cases = [
+		["grep", "context rows count only match rows", "grep", contextText, { context: 1 }, " → 5 matches", undefined, /5 matches/, /15 matches/, 1],
+		["grep", "no-context output counts every non-empty row", "grep", "src/a.ts:1:match\nsrc/b.ts:2:match", {}, " → 2 matches", undefined, /2 matches/, undefined, 1],
+		["exact", "current empty-directory marker", "ls", "(empty directory)", {}, "", undefined, /^$/, /entries|to expand/, 0],
+		["exact", "legacy empty-directory marker", "ls", "Directory is empty", {}, "", undefined, /^$/, /entries|to expand/, 0],
+		["exact", "no-output marker", "bash", "(no output)", { command: "true" }, "\n(no output)", undefined, /^\(no output\)$/, /to expand/, 0],
+		["collision", "empty-directory marker with a real entry", "ls", lsCollisionText, {}, " → 2 entries", `\n${lsCollisionText}`, /2 entries/, /empty directory|real-entry\.txt/, 1],
+		["collision", "no-output marker with real output", "bash", bashCollisionText, { command: "printf output" }, `\n${bashCollisionText}`, `\n${bashCollisionText}`, /\(no output\)\nreal output/, undefined, 1],
+	] as const;
+	assert.equal(cases.length, 7);
+
+	const assertSummaryCase = (current: (typeof cases)[number]) => {
+		const [, name, toolName, text, args, collapsed, expanded, rendered, forbidden, hintCount] = current;
+		const result = textResult(text) as any;
+		const tool = tools.get(toolName);
+		assert.ok(tool, `${name}: missing ${toolName} renderer`);
+		assert.equal(formatToolResultOutput(toolName, result, { expanded: false, args }), collapsed, name);
+		if (expanded !== undefined) assert.equal(formatToolResultOutput(toolName, result, { expanded: true, args }), expanded, `${name} expanded output`);
+		const output = renderToolResult(tool, result, { expanded: false, isPartial: false }, { args });
+		assert.match(output, rendered, name);
+		if (forbidden) assert.doesNotMatch(output, forbidden, name);
+		assert.equal(output.split(hint).length - 1, hintCount, `${name}: hint count`);
+	};
+
+	for (const [section, count] of [["grep", 2], ["exact", 3], ["collision", 2]] as const) await t.test(section, () => {
+		const selected = cases.filter(([currentSection]) => currentSection === section);
+		assert.equal(selected.length, count, `${section}: case count`);
+		for (const current of selected) assertSummaryCase(current);
+	});
+});
+
+test("quiet Bash errors preserve meaningful rows for both public output orderings", () => {
+	const tool = registeredQuietTools().get("bash");
+	const hint = keyHint("app.tools.expand", "to expand");
+	const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/g, "");
+	const cases = [
+		["Pi session event", [
+			["    B3 stdout before failure", []],
+			["    B3 stderr detail that should require expansion", ["    ", "    "]],
+			["    Command exited with code 7", []],
+		]],
+		["registered execution probe", [
+			["probe stdout before failure", ["", ""]],
+			["probe stderr detail \x1b[31mwith terminal color\x1b[0m", ["", ""]],
+			["probe exit status: 7", []],
+		]],
+	] as const;
+	assert.equal(cases.length, 2);
+	const args = { command: "false" };
+	const renderResult = (result: any, expanded: boolean) => tool.renderResult(result, { expanded, isPartial: false, isError: true }, passthroughTheme, { args, isError: true });
+
+	for (const [name, rows] of cases) {
+		assert.equal(rows.length, 3, `${name}: three meaningful source rows`);
+		const text = rows.flatMap(([row, gaps]) => [row, ...gaps]).join("\n");
+		const previewRows = rows.map(([row]) => stripAnsi(row));
+		assert.ok(previewRows.every((row) => row.trim().length > 0), `${name}: preview rows are meaningful`);
+		const expandedText = stripAnsi(text);
+		const renderedExpandedText = expandedText.split("\n").map((line) => line.trimEnd()).join("\n");
+		const result = textResult(text) as any;
+		assert.equal(formatToolResultOutput("bash", result, { expanded: false, isError: true, args }), `\n${previewRows.join("\n")}`, name);
+		assert.equal(formatToolResultOutput("bash", result, { expanded: true, isError: true, args }), `\n${expandedText}`, `${name} expanded output`);
+
+		const collapsedLines = renderLines(renderResult(result, false), 120);
+		assert.ok(collapsedLines.length <= 4, `${name}: expected at most 4 visual rows, got ${collapsedLines.length}`);
+		assert.deepEqual(collapsedLines.slice(0, 3), previewRows, `${name}: preview rows`);
+		assert.equal(collapsedLines.filter((line) => line.trim().length === 0).length, 0, `${name}: no blank preview rows`);
+		assert.equal(collapsedLines.filter((line) => line.includes(hint)).length, 1, `${name}: one expansion hint`);
+		const expanded = renderToString(renderResult(result, true), 1000);
+		assert.equal(expanded, `\n${renderedExpandedText}`, `${name}: complete expanded sanitized text`);
+		assert.doesNotMatch(expanded, /\x1b\[/, `${name}: expanded output is ANSI-free`);
+	}
+});
+
+test("quiet Bash normalizes compact JSON for bounded previews while keeping expanded text complete", () => {
+	const compactJson = JSON.stringify({
+		schema: "review",
+		contract: "compact",
+		nested: { longTail: "this must stay out of the collapsed preview", deeper: { value: true } },
+	});
+	const result = textResult(compactJson) as any;
+	const commandArgs = { command: "printf json" };
+	const previewRows = [
+		'  "schema": "review",',
+		'  "contract": "compact",',
+		'  "nested": {',
+	];
+	const expectedPreview = `\n${previewRows.join("\n")}`;
+	const tool = registeredQuietTools().get("bash");
+
+	assert.equal(formatToolResultOutput("bash", result, { expanded: false, args: commandArgs }), expectedPreview);
+	assert.equal(formatToolResultOutput("bash", result, { expanded: true, args: commandArgs }), `\n${compactJson}`);
+
+	const collapsedLines = renderLines(tool.renderResult(result, { expanded: false, isPartial: false }, passthroughTheme, { args: commandArgs }), 120);
+	const collapsed = collapsedLines.join("\n");
+	assert.equal(previewRows.length, 3);
+	assert.ok(collapsedLines.length <= 4, `expected at most 4 visual rows, got ${collapsedLines.length}`);
+	assert.deepEqual(collapsedLines.slice(0, 3), previewRows);
+	assert.equal(collapsedLines.filter((line) => line.includes(keyHint("app.tools.expand", "to expand"))).length, 1);
+	assert.doesNotMatch(collapsed, /longTail|this must stay out of the collapsed preview|deeper/);
+
+	const expanded = renderToString(tool.renderResult(result, { expanded: true, isPartial: false }, passthroughTheme, { args: commandArgs }), 1000);
+	assert.equal(expanded, `\n${compactJson}`);
+});
+
 test("quiet tool rendering identifies only routine Gentle AI SDD and RDD commands", () => {
 	assert.equal(gentleAiRoutineCommand({ command: "gentle-ai sdd-status fix-rose --json" }), "sdd-status");
 	assert.equal(gentleAiRoutineCommand({ command: "env FOO=bar gentle-ai sdd-continue fix-rose" }), "sdd-continue");

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -318,23 +318,28 @@ test("quiet tool rendering refuses to compact composed Gentle AI shell commands"
 	}
 });
 
-test("quiet tool rendering compacts successful routine Gentle AI calls but preserves failures", () => {
+test("quiet tool rendering hides every collapsed direct Gentle AI result and preserves expanded errors", () => {
 	const { pi, tools } = createPi();
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
 	const command = "gentle-ai review status --next-transition";
 	const textRose = "\u{1F339}\uFE0E";
 	const tool = tools.get("bash");
+	const failureText = "review status failed: authority unavailable\x1b[31m\nlineage=secret";
 
 	const call = renderToString(tool.renderCall({ command }, passthroughTheme, {}));
 	const collapsed = renderToString(tool.renderResult(textResult('{"next_transition":"stop"}'), { expanded: false, isPartial: false }, passthroughTheme, { args: { command } }));
 	const expanded = renderToString(tool.renderResult(textResult('{"next_transition":"stop"}'), { expanded: true, isPartial: false }, passthroughTheme, { args: { command } }));
-	const failure = renderToString(tool.renderResult(textResult("review status failed: authority unavailable"), { expanded: false, isPartial: false, isError: true }, passthroughTheme, { args: { command } }));
+	const failure = renderToString(tool.renderResult(textResult(failureText), { expanded: false, isPartial: false, isError: true }, passthroughTheme, { args: { command } }));
+	const expandedFailure = renderToString(tool.renderResult(textResult(failureText), { expanded: true, isPartial: false, isError: true }, passthroughTheme, { args: { command } }));
 
 	assert.equal([...textRose].length, 2);
 	assert.equal(call.trimEnd(), `${textRose} Gentle AI · running · review status`);
 	assert.equal(collapsed, "");
 	assert.match(expanded, /"next_transition":"stop"/);
-	assert.match(failure, /review status failed: authority unavailable/);
+	assert.equal(failure, "");
+	assert.match(expandedFailure, /review status failed: authority unavailable/);
+	assert.match(expandedFailure, /lineage=secret/);
+	assert.doesNotMatch(expandedFailure, /\x1b\[/);
 });
 
 test("quiet tool rendering transitions one Gentle AI header through lifecycle states", () => {
@@ -540,15 +545,25 @@ test("quiet tool rendering hides the routine partial result because the header o
 
 	assert.equal(partial, "");
 	assert.match(partialExpanded, /"status":"running"/);
-	assert.match(partialFailure, /review status failed: authority unavailable/);
+	assert.equal(partialFailure, "");
+
+	const partialExpandedFailure = renderToString(
+		tool.renderResult(
+			textResult("review status failed: authority unavailable\x1b[31m"),
+			{ expanded: true, isPartial: true },
+			passthroughTheme,
+			{ ...routineRenderContext({ args: { command } }), isError: true },
+		),
+	);
+	assert.match(partialExpandedFailure, /review status failed: authority unavailable/);
+	assert.doesNotMatch(partialExpandedFailure, /\x1b\[/);
 });
 
-test("quiet tool rendering keeps grant invocation auditing separate from the safe lifecycle path", () => {
+test("quiet tool rendering collapses grant calls to action and authorization-root cardinality", () => {
 	const { pi, tools } = createPi();
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
 	const tool = tools.get("bash");
 	const command = "gentle-ai sdd-attempt grant --authorization-root /repo/root --authorization-root /other/root --change secret-change\x1b[31m";
-	const expectedAudit = command.replace("\x1b[31m", "");
 
 	const initial = tool.renderCall(
 		{ command },
@@ -574,13 +589,52 @@ test("quiet tool rendering keeps grant invocation auditing separate from the saf
 	assert.strictEqual(initial, running);
 	assert.strictEqual(running, completed);
 	assert.strictEqual(completed, failed);
-	const lines = renderToString(failed).split("\n").map((line) => line.replace(/[ \t]+$/g, ""));
-	assert.equal(lines[0], "<error>🌹︎ Gentle AI · failed · sdd attempt grant</error>");
-	const audit = lines.slice(1).join(" ").replace(/<\/?dim>/g, "").replace(/\s+/g, " ").trim();
-	assert.equal(audit, `audit: ${expectedAudit}`);
-	assert.match(audit, /--authorization-root \/repo\/root --authorization-root \/other\/root/);
-	assert.doesNotMatch(lines[0], /authorization-root|secret-change|other\/root/);
-	assert.doesNotMatch(audit, /\x1b\[/);
+	const rendered = renderToString(failed);
+	assert.equal(rendered, "<error>🌹︎ Gentle AI · failed · sdd attempt grant · 2 roots</error>");
+	assert.doesNotMatch(rendered, /authorization-root|secret-change|repo\/root|other\/root|audit:|\x1b\[/);
+});
+
+test("quiet tool rendering counts grant authorization roots without rendering values", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const cases = [
+		["gentle-ai sdd-attempt grant --change change", "sdd attempt grant"],
+		["gentle-ai sdd-attempt grant --authorization-root /repo/root", "sdd attempt grant · 1 root"],
+		["gentle-ai sdd-attempt grant --authorization-root=/repo/root", "sdd attempt grant · 1 root"],
+		["gentle-ai sdd-attempt grant --authorization-root --change change", "sdd attempt grant"],
+		["gentle-ai sdd-attempt grant --authorization-root /one --authorization-root=/two --authorization-root /three", "sdd attempt grant · 3 roots"],
+		["gentle-ai sdd-attempt grant --authorization-root= --authorization-root /one", "sdd attempt grant · 1 root"],
+	] as const;
+
+	for (const [command, expected] of cases) {
+		const rendered = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+		assert.equal(rendered.trimEnd(), `🌹︎ Gentle AI · running · ${expected}`, command);
+		assert.doesNotMatch(rendered, /authorization-root|\/repo\/root|\/one|\/two|\/three|change/);
+	}
+});
+
+test("quiet tool rendering hides invocation secrets from collapsed Gentle AI calls and results", () => {
+	const { pi, tools } = createPi();
+	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
+	const tool = tools.get("bash");
+	const command = "gentle-ai review finalize --prompt hidden-prompt --lineage lineage-secret --body private-body --authorization-root /private/root";
+	const call = renderToString(tool.renderCall({ command }, passthroughTheme, { args: { command } }));
+	const collapsed = renderToString(
+		tool.renderResult(
+			textResult("audit: lineage-secret body=private-body prompt=hidden-prompt root=/private/root"),
+			{ expanded: false, isPartial: false, isError: true },
+			passthroughTheme,
+			{ args: { command }, isError: true },
+		),
+	);
+
+	assert.equal(call.trimEnd(), "🌹︎ Gentle AI · running · review finalize");
+	assert.equal(collapsed, "");
+	for (const forbidden of ["hidden-prompt", "lineage-secret", "private-body", "/private/root", "audit:"]) {
+		assert.doesNotMatch(call, new RegExp(forbidden));
+		assert.doesNotMatch(collapsed, new RegExp(forbidden));
+	}
 });
 
 test("quiet tool rendering keeps shell compositions, expansions, and lookalikes generic", () => {
@@ -594,6 +648,8 @@ test("quiet tool rendering keeps shell compositions, expansions, and lookalikes 
 		"gentle-ai version $HOME",
 		"gentle-ai version $(printf nested)",
 		"gentle-ai sdd-attempt grant --change secret-change # ignored comment",
+		"gentle-ai sdd-attempt grant --authorization-root /private/root && echo done",
+		"gentle-ai sdd-attempt grant --authorization-root=/private/root | tee output",
 		"/package/.gentle-ai/v2.2.0/gentle-ai-copy version",
 		"echo gentle-ai version",
 	];

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -37,7 +37,6 @@ function routineRenderContext(overrides: Record<string, unknown> = {}) {
 		toolCallId: "tool-call",
 		invalidate() {},
 		lastComponent: undefined,
-		state: {},
 		cwd: "/repo",
 		executionStarted: false,
 		argsComplete: true,
@@ -472,11 +471,13 @@ test("quiet tool rendering hides every collapsed direct Gentle AI result and pre
 
 	assert.equal([...textRose].length, 2);
 	assert.equal(call.trimEnd(), `${textRose} Gentle AI · running · review status`);
-	assert.equal(collapsed, `\n${expandHint}`);
+	assert.equal(collapsed, expandHint);
+	assert.equal(collapsed.split("\n")[0], expandHint);
 	assert.doesNotMatch(collapsed, /next_transition|stop/);
+	assert.equal(expanded.split("\n")[0], '{"next_transition":"stop"}');
 	assert.match(expanded, /"next_transition":"stop"/);
 	assert.doesNotMatch(expanded, /to expand/);
-	assert.equal(failure, `\n${expandHint}`);
+	assert.equal(failure, expandHint);
 	assert.doesNotMatch(failure, /review status failed|authority unavailable|lineage=secret/);
 	assert.match(expandedFailure, /review status failed: authority unavailable/);
 	assert.match(expandedFailure, /lineage=secret/);
@@ -530,6 +531,43 @@ test("quiet tool rendering transitions one Gentle AI header through lifecycle st
 	assert.equal(completedText, "<success>🌹︎ Gentle AI · completed · review status</success>");
 	assert.equal(failedText, "<error>🌹︎ Gentle AI · failed · review status</error>");
 	assert.doesNotMatch(failedText, /private-change/);
+});
+
+test("quiet Bash keeps direct Gentle AI calls seamless while streaming", () => {
+	const tool = registeredQuietTools().get("bash");
+	const rose = /🌹︎/;
+	const render = (command: string, state: Record<string, unknown>, overrides: Record<string, unknown> = {}) => {
+		const component = tool.renderCall({ command }, passthroughTheme, routineRenderContext({ args: { command }, state, argsComplete: false, ...overrides }));
+		return [component, renderToString(component)] as const;
+	};
+	const command = "gentle-ai review status --token 'lineage-secret";
+	const state = {};
+	const [preparing, collapsed] = render(command, state);
+	assert.equal(collapsed, "🌹︎ Gentle AI · preparing · review status");
+	assert.doesNotMatch(collapsed, /token|lineage-secret/);
+	const expanded = render(command, state, { expanded: true, lastComponent: preparing })[1];
+	assert.match(expanded, /^🌹︎ Gentle AI · preparing · review status\n\$ gentle-ai review status --token 'lineage-secret$/);
+
+	const direct = "gentle-ai review status";
+	const [running, runningText] = render(direct, state, { argsComplete: true, executionStarted: true, lastComponent: preparing });
+	assert.strictEqual(running, preparing); assert.equal(runningText, "🌹︎ Gentle AI · running · review status");
+	const genericState = {};
+	const [generic, genericText] = render("gentle-ai review status | cat", genericState);
+	assert.doesNotMatch(genericText, rose); assert.match(genericText, /\| cat/);
+	assert.doesNotMatch(render(direct, genericState, { argsComplete: true, lastComponent: generic })[1], rose);
+	assert.match(render(direct, {}, { argsComplete: true })[1], rose);
+
+	for (const malformed of ["gentle-ai\x1b[31m review status", 'gentle-ai review status "unfinished']) {
+		const text = render(malformed, {}, { argsComplete: true })[1];
+		assert.doesNotMatch(text, rose); assert.match(text, /\$ gentle-ai.*review status/);
+	}
+	for (const bracket of ["[", "]"]) assert.match(render(`${direct} ${bracket}`, {})[1], rose);
+
+	const genericResult = renderToolResult(tool, textResult("generic result"), { expanded: false, isPartial: false }, { args: { command: direct }, state: genericState, argsComplete: true });
+	assert.equal(genericResult.split("\n")[0], "generic result");
+	const directState = {}; render(direct, directState, { argsComplete: true });
+	const directResult = renderToolResult(tool, textResult("direct result"), { expanded: false, isPartial: false }, { args: { command: direct }, state: directState, argsComplete: true });
+	assert.equal(directResult, keyHint("app.tools.expand", "to expand"));
 });
 
 test("quiet tool rendering displays only finite safe Gentle AI operation paths", () => {
@@ -681,7 +719,7 @@ test("quiet tool rendering recognizes only the exact resolved dev binary", () =>
 	const collapsed = renderToolResult(tool, textResult(text), { expanded: false, isPartial: false, isError: true }, { args: { command }, isError: true });
 	const expanded = renderToolResult(tool, textResult(text), { expanded: true, isPartial: false, isError: true }, { args: { command }, isError: true });
 	const hint = keyHint("app.tools.expand", "to expand");
-	assert.equal(collapsed, `\n${hint}`);
+	assert.equal(collapsed, hint);
 	assert.equal(collapsed.split(hint).length - 1, 1);
 	assert.doesNotMatch(collapsed, /private|lineage|secret|hidden|error/);
 	assert.match(expanded, /private failure|lineage=secret body=hidden/);
@@ -746,12 +784,12 @@ test("quiet tool rendering hides the routine partial result because the header o
 		),
 	);
 
-	assert.equal(partial, `\n${expandHint}`);
+	assert.equal(partial, expandHint);
 	assert.equal(partial.split(expandHint).length - 1, 1);
 	assert.match(partialExpanded, /"status":"running"/);
 	assert.doesNotMatch(partialExpanded, /to expand/);
-	assert.equal(partialFailure, `\n${expandHint}`);
-	assert.equal(completed, `\n${expandHint}`);
+	assert.equal(partialFailure, expandHint);
+	assert.equal(completed, expandHint);
 
 	const partialExpandedFailure = renderToString(
 		tool.renderResult(
@@ -836,7 +874,7 @@ test("quiet tool rendering hides invocation secrets from collapsed Gentle AI cal
 	);
 
 	assert.equal(call.trimEnd(), "🌹︎ Gentle AI · running · review finalize");
-	assert.equal(collapsed, `\n${keyHint("app.tools.expand", "to expand")}`);
+	assert.equal(collapsed, keyHint("app.tools.expand", "to expand"));
 	for (const forbidden of ["hidden-prompt", "lineage-secret", "private-body", "/private/root", "audit:"]) {
 		assert.doesNotMatch(call, new RegExp(forbidden));
 		assert.doesNotMatch(collapsed, new RegExp(forbidden));
@@ -1020,6 +1058,7 @@ test("quiet tool rendering bounds and sanitizes partial text without a completio
 	assert.doesNotMatch(collapsed, /to expand|Ctrl\+O/);
 	assert.match(expanded, /first\nsecond\nthird\nfourth/);
 	assert.doesNotMatch(expanded, /to expand|Ctrl\+O/);
+	assert.match(renderToolResult(tool, textResult("first\n\nsecond\n\n"), { expanded: false, isPartial: true }, { args: { command: "printf output" } }), /… bash · 2 lines/);
 
 	const sanitized = renderToolResult(tool, textResult("safe\x1b]52;c;Y2xpcGJvYXJk\x07\x1b[2Jdone"), { expanded: true, isPartial: true }, { args: { command: "echo safe" } });
 	assert.match(sanitized, /safedone/);


### PR DESCRIPTION
Closes #421

## PR type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Add sanitized partial streaming and contextual completed previews bounded by actual terminal rows, including direction-aware Bash, Git, partial, and error tails.
- Render recognized direct Gentle AI calls as stable `preparing → running → completed/failed` rose cards that never expose arguments while collapsed and reveal sanitized command details only on explicit expansion.
- Fail closed on real shell composition, substitution, expansion, globs, wrapper-order ambiguity, aliases, and executable lookalikes while preserving quoted and escaped literals.
- Align compact summaries with Pi's public runtime outputs for grep context counts, non-empty partial line totals, empty `ls`/Bash sentinels, meaningful error rows, and one-line JSON; remove renderer-owned leading result blanks.

## Changes

| File | Change |
|------|--------|
| `extensions/quiet-tools.ts` | Bound previews after public TUI width-aware rendering; preserve head/tail direction by result type; count contextual grep matches and non-empty partial lines accurately; recognize exact public empty sentinels; normalize compact JSON previews; classify streamed direct commands from raw quote/escape-aware tokens; preserve stable preparing cards; reject real expansion, substitution, globs, wrapper-order ambiguity, and composition; preserve exact dev-binary identity, grant cardinality, and official expanded image rendering. |
| `lib/gentle-ai-renderer.ts` | Share row-local preparing/running/completed/failed lifecycle state, omit renderer-owned leading blank rows, hide collapsed envelopes, show one configured expansion hint, and append sanitized command details only when explicitly expanded. |
| `extensions/gentle-ai.ts` | Apply the shared result renderer to `gentle_review`, `gentle_review_scope`, and `gentle_review_capture`. |
| `tests/quiet-tool-rendering.test.ts` | Cover narrow-width directional row limits, wide Unicode, streamed preparing cards, collapsed argument secrecy, expansion-only command detail, non-empty partial counts, exact and prefixed sentinel controls, contextual grep counts, compact JSON, meaningful error tails, wrapper order, shell-boundary negatives, executable identity/lookalikes, generic shell visibility, image delegation, runtime cwd, and the #107 shellPath boundary. |
| `tests/gentle-ai.test.ts` | Cover first-row collapsed and expanded native review-tool result rendering, configured expansion hints, envelope integrity, and terminal sanitization. |
| `README.md` | Document migration behavior when `pi-tool-cards` is installed. |

## Re-review focus

1. Collapsed previews are sliced only after `Text.render(width)` and preserve head/tail direction by result type, so narrow terminals stay bounded without dropping the newest Bash, Git, partial, or error rows.
2. Quoted or escaped literals remain recognizable while unquoted expansion, substitution, globs, wrapper-order ambiguity, aliases, and executable lookalikes fail closed to generic Bash rendering.
3. Pi's public runtime shapes now drive summaries: grep context rows do not inflate match counts, exact empty sentinels do not advertise false expansion, Bash errors keep meaningful rows, and compact JSON gets semantic fields.
4. Direct Gentle AI calls switch to a stable `preparing` rose card as soon as the trusted executable is proven, never expose streamed arguments while collapsed, and reveal the sanitized command only through explicit expansion.
5. Definitive shell composition still switches immediately to generic Bash, native review/direct result details begin on the first row, and partial labels ignore blank separators.

## Test plan

- [x] Strict TDD: visual-row and quoted-literal regressions failed before implementation, then passed.
- [x] Final combined focused renderer/native-review suite: 56 passed, 0 failed.
- [x] Final isolated full Node suite: 1,065 total, 1,062 passed, 3 existing platform-gated skips, 0 failed.
- [x] Background-subagent isolation suite: 40 passed, 0 failed.
- [x] Provider contract `1.1.0`: 8 bundle entries and 2 generated baselines.
- [x] Runtime harness completed successfully.
- [x] Runtime module parity: 4 modules match TypeScript sources.
- [x] Package verification: 161 files and 67 byte-identical v2.4.0 contract artifacts.
- [x] Packed E2E: temporary package install and runtime verification passed for gentle-pi 2.2.0 / Gentle AI 2.4.0.
- [x] `git diff --check` passed.
- [x] Pi dev-mode manual matrix verified contextual grep counts, empty `ls`/Bash sentinels, meaningful Bash errors, semantic compact JSON, direct redaction, and generic shell negative controls.
- [x] Live Pi streaming verified and user accepted stable `preparing → running → completed/failed`, collapsed parameter secrecy, expansion-only command detail, and first-row result layout.
- [x] Two blind Judgment Day judges verified both original maintainer-blocking findings after the scoped fix.
- [x] Historical high-risk RDD lineage `review-d08123f6b62f2425` approved and burned the prior corrected candidate after its bounded double-quoted expansion/substitution fix.
- [x] Fresh combined-candidate reliability review lineage `review-cb65ba8622295397` approved and burned tree `9b77484c3323496faf77bb994478c0027d732de4` at store revision `sha256:e9e33456617d8fc1c26054d9ef2e3b7cd22a385eb1c3cff6f308d96c0cca2527`; delivery gates delegated to ordinary repository policy.
- [x] Fresh seamless-streaming reliability review lineage `review-0eb55a90b0bbbaf1` approved and burned exact tree `9ee1131533067bb97af6d5fe88240070ce18a4e4` at store revision `sha256:00f9310ff879ebb9b25de126726f048c6b6964eb99e8407391a620a80d36c98b`; delivery gates delegated to ordinary repository policy.
- [x] Final review budget: 1,300 A+D with approved `size:exception` (limit 1,350 A+D).

## Contributor checklist

- [x] Linked approved issue #421.
- [x] PR uses exactly one feature type selection and exactly one `type:feature` label.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] Focused, isolated full-suite, runtime, package, and packed tests exercise the affected extensions and shared renderer.
- [x] User-facing compatibility behavior is documented.
- [x] Commits use Conventional Commits.
- [x] No AI attribution or `Co-Authored-By` trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quiet tool results now provide clearer previews, concise edit and write summaries, line counts, search totals, and Git output tails.
  - Expanded reads support complete sanitized output, image-aware handling, and helpful expansion hints.
  - Gentle AI review results now use consistent rendering with improved authorization details.

- **Bug Fixes**
  - Sensitive content, ANSI formatting, and secrets are hidden in collapsed or partial results.
  - Added migration guidance to avoid enabling conflicting tool-display options together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

