### PR TITLE
fix(quiet-tools): preserve Pi's configured Bash shellPath on Windows

### DIFF
--- a/extensions/quiet-tools.ts
+++ b/extensions/quiet-tools.ts
@@ -1,6 +1,5 @@
 import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
-	createBashTool,
 	createEditTool,
 	createFindTool,
 	createGrepTool,
@@ -14,7 +13,8 @@ import { quietToolsEnabled } from "../lib/quiet-tools-config.ts";
 import { renderGentleAiLifecycleCall, type GentleAiRenderContext } from "../lib/gentle-ai-renderer.ts";
 import { sanitizeTerminalText } from "../lib/terminal-theme.ts";
 
-type QuietToolName = "read" | "bash" | "grep" | "find" | "ls" | "edit" | "write";
+type QuietToolName = "read" | "grep" | "find" | "ls" | "edit" | "write";
+type ToolName = QuietToolName | "bash";
 type ThemeLike = {
 	bold(value: string): string;
 	fg(color: string, value: string): string;
@@ -22,7 +22,6 @@ type ThemeLike = {
 
 const TOOL_CREATORS = {
 	read: createReadTool,
-	bash: createBashTool,
 	grep: createGrepTool,
 	find: createFindTool,
 	ls: createLsTool,
@@ -30,17 +29,17 @@ const TOOL_CREATORS = {
 	write: createWriteTool,
 } satisfies Record<QuietToolName, (cwd: string) => any>;
 
-const COLLAPSED_COUNT_LABELS: Partial<Record<QuietToolName, string>> = {
+const COLLAPSED_COUNT_LABELS: Partial<Record<ToolName, string>> = {
 	grep: "matches",
 	find: "files",
 	ls: "entries",
 };
 
-const NO_COLLAPSED_RESULT_TOOLS = new Set<QuietToolName>(["read", "bash"]);
-const COLLAPSED_TAIL_TOOLS = new Set<QuietToolName>(["edit", "write"]);
+const NO_COLLAPSED_RESULT_TOOLS = new Set<ToolName>(["read", "bash"]);
+const COLLAPSED_TAIL_TOOLS = new Set<ToolName>(["edit", "write"]);
 const COLLAPSED_TAIL_LINE_LIMIT = 10;
 
-const EMPTY_RESULT_MESSAGES: Partial<Record<QuietToolName, string[]>> = {
+const EMPTY_RESULT_MESSAGES: Partial<Record<ToolName, string[]>> = {
 	grep: ["No matches found"],
 	find: ["No files found matching pattern"],
 	ls: ["Directory is empty"],
@@ -94,7 +93,7 @@ function safeText(value: string): string {
 	return sanitizeTerminalText(value);
 }
 
-function isEmptyResultMessage(toolName: QuietToolName, text: string): boolean {
+function isEmptyResultMessage(toolName: ToolName, text: string): boolean {
 	const normalized = text.trim();
 	return EMPTY_RESULT_MESSAGES[toolName]?.some((message) => normalized.startsWith(message)) ?? false;
 }
@@ -239,7 +238,7 @@ interface ToolResultFormatOptions {
 }
 
 export function formatToolResultOutput(
-	toolName: QuietToolName,
+	toolName: ToolName,
 	result: AgentToolResult<unknown>,
 	{ expanded, isError = false, args }: ToolResultFormatOptions,
 ): string {
@@ -280,7 +279,7 @@ interface ToolRenderContextLike {
 	lastComponent?: unknown;
 }
 
-function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, theme: ThemeLike): string {
+function formatToolCall(toolName: ToolName, args: Record<string, unknown>, theme: ThemeLike): string {
 	switch (toolName) {
 		case "read": {
 			const path = safeText(shortenPath(args.path) || "...");
@@ -317,20 +316,13 @@ function formatToolCall(toolName: QuietToolName, args: Record<string, unknown>, 
 	}
 }
 
-function partialLabel(toolName: QuietToolName): string {
+function partialLabel(toolName: ToolName): string {
 	return toolName === "bash" ? "Running..." : `${toolName}...`;
 }
 
-function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
-	const registrationTool = getBuiltInTools(process.cwd())[toolName];
-
-	pi.registerTool({
-		...registrationTool,
-		async execute(toolCallId, params, signal, onUpdate, ctx) {
-			const runtimeTool = getBuiltInTools(ctx.cwd)[toolName];
-			return runtimeTool.execute(toolCallId, params, signal, onUpdate, ctx);
-		},
-		renderCall(args, theme, context) {
+export function createQuietToolRenderer(toolName: ToolName) {
+	return {
+		renderCall(args: any, theme: ThemeLike, context: any) {
 			const callArgs = args as Record<string, unknown>;
 			const operationPath = toolName === "bash" ? gentleAiOperationPath(callArgs) : undefined;
 			if (operationPath) {
@@ -343,7 +335,7 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 			}
 			return new Text(formatToolCall(toolName, callArgs, theme), 0, 0);
 		},
-		renderResult(result, options, theme, context) {
+		renderResult(result: AgentToolResult<unknown>, options: any, theme: ThemeLike, context: any) {
 			const renderContext = context as ToolRenderContextLike | undefined;
 			const isError = renderContext?.isError ?? options.isError ?? false;
 			const directCommand = toolName === "bash" && isGentleAiDirectCommand(renderContext?.args);
@@ -362,6 +354,19 @@ function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
 			const color = options.expanded ? "toolOutput" : isError ? "error" : "muted";
 			return new Text(output ? theme.fg(color, output) : "", 0, 0);
 		},
+	};
+}
+
+function registerQuietTool(pi: ExtensionAPI, toolName: QuietToolName): void {
+	const registrationTool = getBuiltInTools(process.cwd())[toolName];
+
+	pi.registerTool({
+		...registrationTool,
+		async execute(toolCallId, params, signal, onUpdate, ctx) {
+			const runtimeTool = getBuiltInTools(ctx.cwd)[toolName];
+			return runtimeTool.execute(toolCallId, params, signal, onUpdate, ctx);
+		},
+		...createQuietToolRenderer(toolName),
 	});
 }
 

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import piPretty from "../extensions/pi-pretty.ts";
 import quietTools, {
 	countNonEmptyLines,
+	createQuietToolRenderer,
 	extractTextContent,
 	formatToolResultOutput,
 	gentleAiRoutineCommand,
@@ -55,27 +56,26 @@ function textResult(text: string) {
 	};
 }
 
-function createPi(options: { throwOnToolConflict?: boolean } = {}) {
+function createPi(options: { throwOnToolConflict?: boolean; nativeBash?: boolean } = {}) {
 	const tools = new Map<string, any>();
 	const commands = new Map<string, any>();
 	const hooks = new Map<string, any[]>();
-	return {
-		tools,
-		pi: {
-			registerTool(tool: any) {
-				if (options.throwOnToolConflict && tools.has(tool.name)) {
-					throw new Error(`Tool ${tool.name} already registered`);
-				}
-				tools.set(tool.name, tool);
-			},
-			registerCommand(name: string, command: any) {
-				commands.set(name, command);
-			},
-			on(name: string, handler: any) {
-				hooks.set(name, [...(hooks.get(name) ?? []), handler]);
-			},
+	const pi = {
+		registerTool(tool: any) {
+			if (options.throwOnToolConflict && tools.has(tool.name)) {
+				throw new Error(`Tool ${tool.name} already registered`);
+			}
+			tools.set(tool.name, tool);
+		},
+		registerCommand(name: string, command: any) {
+			commands.set(name, command);
+		},
+		on(name: string, handler: any) {
+			hooks.set(name, [...(hooks.get(name) ?? []), handler]);
 		},
 	};
+	if (options.nativeBash !== false) pi.registerTool(createNativeBashTool());
+	return { tools, pi };
 }
 
 function createSdkTool(name: string) {
@@ -85,6 +85,14 @@ function createSdkTool(name: string) {
 		description: `${name} tool`,
 		parameters: { type: "object", properties: {} },
 		execute: async () => textResult(`${name} result`),
+	};
+}
+
+function createNativeBashTool() {
+	return {
+		...createSdkTool("bash"),
+		...createQuietToolRenderer("bash"),
+		shellPath: "C:\\Users\\Admin\\scoop\\apps\\git\\2.54.0\\bin\\bash.exe",
 	};
 }
 
@@ -130,13 +138,16 @@ async function withEnvAsync<T>(updates: Record<string, string | undefined>, run:
 	}
 }
 
-test("quiet tool rendering registers noisy built-in tools", () => {
+test("quiet tools preserve native Bash while registering quiet built-in tools", () => {
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => {
 		const { pi, tools } = createPi();
+		const nativeBash = tools.get("bash");
 
 		quietTools(pi as any);
 
-		for (const toolName of ["read", "bash", "grep", "find", "ls", "edit", "write"]) {
+		assert.strictEqual(tools.get("bash"), nativeBash);
+		assert.equal(tools.get("bash")?.shellPath, nativeBash.shellPath);
+		for (const toolName of ["read", "grep", "find", "ls", "edit", "write"]) {
 			const tool = tools.get(toolName);
 			assert.ok(tool, `missing quiet renderer for ${toolName}`);
 			assert.equal(typeof tool.execute, "function", `${toolName} must delegate execution`);
@@ -148,10 +159,12 @@ test("quiet tool rendering registers noisy built-in tools", () => {
 test("quiet tool rendering can be disabled by env", () => {
 	withEnv({ GENTLE_PI_QUIET_TOOLS: "0" }, () => {
 		const { pi, tools } = createPi();
+		const nativeBash = tools.get("bash");
 
 		quietTools(pi as any);
 
-		assert.equal(tools.size, 0);
+		assert.strictEqual(tools.get("bash"), nativeBash);
+		assert.equal(tools.size, 1);
 	});
 });
 
@@ -159,12 +172,12 @@ test("pi-pretty suppresses overlapping tools before quiet tools register", async
 	await withEnvAsync(
 		{ GENTLE_PI_QUIET_TOOLS: undefined, PRETTY_DISABLE_TOOLS: "multi_grep" },
 		async () => {
-			const { pi, tools } = createPi({ throwOnToolConflict: true });
+			const { pi, tools } = createPi({ throwOnToolConflict: true, nativeBash: false });
 
 			await piPretty(pi as any, fakePiPrettyDeps as any);
 			quietTools(pi as any);
 
-			for (const toolName of ["read", "bash", "grep", "find", "ls", "edit", "write"]) {
+			for (const toolName of ["read", "grep", "find", "ls", "edit", "write"]) {
 				assert.ok(tools.has(toolName), `missing quiet tool ${toolName}`);
 			}
 			assert.equal(process.env.PRETTY_DISABLE_TOOLS, "multi_grep,read,bash,ls,find,grep");

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -334,7 +334,7 @@ async function run() {
 	assert.ok(hooks.has("input"), "missing input hook");
 	assert.ok(hooks.has("before_agent_start"), "missing before_agent_start hook");
 	assert.ok(hooks.has("tool_call"), "missing tool_call hook");
-	for (const toolName of ["read", "bash", "grep", "find", "ls", "edit", "write"]) {
+	for (const toolName of ["read", "grep", "find", "ls", "edit", "write"]) {
 		assert.ok(tools.has(toolName), `missing quiet built-in tool renderer ${toolName}`);
 	}
 	assert.ok(tools.has("gentle_review"), "missing registered bounded review controller tool");


### PR DESCRIPTION
Closes #107

## Summary

- preserve Pi's native Bash tool so its configured `shellPath` is not replaced
- register quiet rendering only for the six non-Bash tools
- add focused and runtime-harness regressions for native Bash identity and registration behavior

## Changes

| File | Change |
|---|---|
| `extensions/quiet-tools.ts` | Stop recreating and registering Bash while retaining the other quiet tools. |
| `tests/quiet-tool-rendering.test.ts` | Assert native Bash identity and `shellPath` remain untouched. |
| `tests/runtime-harness.mjs` | Align harness expectations with six non-Bash quiet tools. |

## Test plan

- [x] `node --experimental-strip-types --test tests/quiet-tool-rendering.test.ts` — 20 passed
- [x] `pnpm run test:harness`
- [x] `pnpm test` — 1030 passed, 10 skipped
- [x] `pnpm run check:runtime-modules`
- [x] `node scripts/verify-package-files.mjs`
- [x] `pnpm run test:packed-package`
- [x] `git diff --check`

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Included tests with the behavior change
- [x] Used a conventional commit
- [x] Added no attribution trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quiet tool rendering while preserving partial results and output formatting.
  * Ensured native Bash behavior and shell paths remain intact when quiet tools are enabled.
  * Prevented quiet-tool handling from replacing Bash when it is managed separately.

* **Tests**
  * Expanded coverage for Bash registration, rendering, conflicts, and suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->