### PR TITLE
fix(sdd): remove provider-specific model pin from sdd-init

### DIFF
--- a/lib/sdd-preflight.ts
+++ b/lib/sdd-preflight.ts
@@ -439,25 +439,24 @@ function copyDirectoryFiles(
 				: managedAssetHash(installedContent);
 			if (managedHash === undefined) {
 				const legacyHashes = legacyAssetHashes?.()[ownershipKey];
+				const exactLegacyMatch =
+					installedHash !== undefined && legacyHashes?.includes(installedHash) === true;
 				const comparableLegacyHash = installedContent === undefined
 					? undefined
 					: managedAssetHash(
 							legacyComparableAssetContent(ownershipKey, installedContent),
 						);
-				if (
-					legacyHashes === undefined ||
-					comparableLegacyHash === undefined ||
-					!legacyHashes.includes(comparableLegacyHash)
-				) {
+				const comparableLegacyMatch =
+					comparableLegacyHash !== undefined &&
+					legacyHashes?.includes(comparableLegacyHash) === true;
+				if (!exactLegacyMatch && !comparableLegacyMatch) {
 					delete manifest.assets[ownershipKey];
 					skipped += 1;
 					continue;
 				}
-				nextSource = migrateLegacyAssetContent(
-					ownershipKey,
-					installedContent,
-					source,
-				);
+				nextSource = exactLegacyMatch
+					? source
+					: migrateLegacyAssetContent(ownershipKey, installedContent ?? "", source);
 			} else if (installedHash !== managedHash) {
 				delete manifest.assets[ownershipKey];
 				skipped += 1;

--- a/tests/fixtures/v0.13/assets/agents/sdd-init.md
+++ b/tests/fixtures/v0.13/assets/agents/sdd-init.md
@@ -1,10 +1,11 @@
 ---
 name: sdd-init
 description: Initialize project SDD context, testing capabilities, and skill registry.
+model: openai-codex/gpt-5.3-codex
 tools:
   - read
   - grep
-  - find
+  - glob
   - write
   - edit
   - bash
@@ -23,29 +24,21 @@ Use your assigned executor/phase skill for this SDD phase. For project/user skil
 If skill paths are missing, explicit fallback loading is allowed only as degraded self-healing. Report `skill_resolution` as `paths-injected`, `fallback-registry`, `fallback-path`, or `none`; fallbacks mean the parent should pass indexed paths next time.
 
 - Inspect the project stack, test runner, conventions, and existing docs.
-- If the artifact store is `openspec` or `both` and `openspec/config.yaml` is missing, create it automatically with project context, `strict_tdd`, phase rules, and testing runner details. If the artifact store is `engram` or `none`, do not create `openspec/` files.
+- If `openspec/config.yaml` is missing, create it automatically with project context, `strict_tdd`, phase rules, and testing runner details.
 - If `openspec/config.yaml` already exists, read it, summarize the current SDD/testing configuration, and do not block the caller. Update only safe derived context when explicitly necessary; never destructively rewrite user-maintained SDD configuration.
 - Ensure `.atl/skill-registry.md` exists when skill registry data is available, or report that it is missing.
 - Do NOT launch child subagents. Parent/orchestrator owns delegation.
 - Return the standard phase envelope with status, executive_summary, artifacts, next_recommended, risks, and skill_resolution.
-
 ## Memory Contract
 
 Read any existing project context directly from the active backend before bootstrapping; do not wait for the parent to inline it. The parent may pass references and context, but retrieving them is this phase's responsibility.
 
 Inputs to read (`engram`/`both`: use the injected Engram memory read tools for the topic key, then fetch the full observation; `openspec`: read the file under `openspec/`):
-
 - Existing project context (if re-initializing): `sdd-init/{project}`
 
 Persist this phase's artifact to the active backend before returning (mandatory):
-
 - `engram`/`both`: call the injected Engram save tool with title and `topic_key` `"sdd-init/{project}"`, `type: "architecture"`, `project` from context, and `capture_prompt: false` when the tool schema supports it (omit the field if an older schema rejects it).
 - `openspec`: write the project context file under `openspec/`.
 - `none`: return the project context inline.
 
 Never claim persistence you did not perform.
-
-
-## Key Learnings Closing
-
-Close your final report text with a `## Key Learnings` block (no trailing colon). Use 1–5 numbered items, each a standalone factual sentence of at least 20 characters and at least 4 words. This applies to final report text only — not intermediate tool output or saved artifact content. The Engram memory provider automatically extracts and persists these items as passive capture; you do not parse the block or invoke passive-capture tools yourself. Omit the block when there is genuinely no reusable learning; no filler or speculation. This closing block is separate from explicit `mem_save` artifact/decision persistence.

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -20,6 +20,7 @@ const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const MANAGED_EXEMPLAR_FILE = "gentle-ai-explore.md";
 const RETIRED_REFUTER_FILE = "review-refuter.md";
 const REVIEW_RISK_FILE = "review-risk.md";
+const SDD_INIT_FILE = "sdd-init.md";
 const V013_REVIEW_RISK_FIXTURE = join(
 	PACKAGE_ROOT,
 	"tests",
@@ -28,6 +29,15 @@ const V013_REVIEW_RISK_FIXTURE = join(
 	"assets",
 	"agents",
 	REVIEW_RISK_FILE,
+);
+const V013_SDD_INIT_FIXTURE = join(
+	PACKAGE_ROOT,
+	"tests",
+	"fixtures",
+	"v0.13",
+	"assets",
+	"agents",
+	SDD_INIT_FILE,
 );
 const V013_MANAGED_ASSETS = join(
 	PACKAGE_ROOT,
@@ -430,6 +440,14 @@ test("packaged agents use YAML list syntax for tool allowlists", () => {
 	}
 });
 
+test("package-owned sdd-init does not pin a provider-specific model", () => {
+	const frontmatter = readAgentFrontmatter(
+		join(PACKAGE_ROOT, "assets", "agents", SDD_INIT_FILE),
+	);
+
+	assert.doesNotMatch(frontmatter, /^model:\s*\S+$/m);
+});
+
 // The Pi child-session tool registry exposes `find` for filesystem discovery
 // and has no `glob` or `webfetch` builtin (see tests/runtime-harness.mjs and
 // the working builtin `reviewer` canary in issue #62). A packaged agent that
@@ -536,6 +554,92 @@ test("v0.13 ownership evidence is bundled and matches the self-contained upgrade
 		sha256(legacyReviewRisk),
 		"published migration evidence must fingerprint the exact v0.13 package asset",
 	);
+	assert.equal(
+		legacyManifest.assets[`agents/${SDD_INIT_FILE}`],
+		sha256(readFileSync(V013_SDD_INIT_FIXTURE, "utf8")),
+		"published migration evidence must fingerprint the exact legacy sdd-init asset",
+	);
+});
+
+test("first forced sync migrates exact legacy sdd-init ownership and records the current hash", () => {
+	const temporaryAgentHome = mkdtempSync(join(tmpdir(), "gentle-pi-sdd-init-v013-upgrade-"));
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const installedSddInit = join(temporaryAgentHome, "agents", SDD_INIT_FILE);
+	const managedAssetsManifest = join(
+		temporaryAgentHome,
+		"gentle-ai",
+		"managed-assets.json",
+	);
+	const legacySource = readFileSync(V013_SDD_INIT_FIXTURE, "utf8");
+
+	try {
+		process.env.GENTLE_PI_AGENT_HOME = temporaryAgentHome;
+		mkdirSync(dirname(installedSddInit), { recursive: true });
+		writeFileSync(installedSddInit, legacySource);
+		assert.equal(existsSync(managedAssetsManifest), false, "legacy installs had no ownership manifest");
+
+		installSddAssets(PACKAGE_ROOT, true);
+
+		const currentPackageSource = readFileSync(
+			join(PACKAGE_ROOT, "assets", "agents", SDD_INIT_FILE),
+			"utf8",
+		);
+		assert.equal(
+			readFileSync(installedSddInit, "utf8"),
+			currentPackageSource,
+			"an untouched legacy sdd-init must migrate to the provider-neutral package asset",
+		);
+		assert.doesNotMatch(readFileSync(installedSddInit, "utf8"), /^model:\s*\S+$/m);
+
+		const manifest = JSON.parse(
+			readFileSync(managedAssetsManifest, "utf8"),
+		) as ManagedAssetsManifest;
+		assert.equal(
+			manifest.assets[`agents/${SDD_INIT_FILE}`],
+			sha256(currentPackageSource),
+			"the migrated asset must be owned by its current package hash",
+		);
+	} finally {
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		rmSync(temporaryAgentHome, { recursive: true, force: true });
+	}
+});
+
+test("first forced sync preserves an explicitly routed legacy sdd-init asset", () => {
+	const temporaryAgentHome = mkdtempSync(join(tmpdir(), "gentle-pi-sdd-init-v013-routed-"));
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const installedSddInit = join(temporaryAgentHome, "agents", SDD_INIT_FILE);
+	const routedLegacySource = readFileSync(V013_SDD_INIT_FIXTURE, "utf8").replace(
+		"model: openai-codex/gpt-5.3-codex",
+		"model: private/user-model",
+	);
+
+	try {
+		process.env.GENTLE_PI_AGENT_HOME = temporaryAgentHome;
+		mkdirSync(dirname(installedSddInit), { recursive: true });
+		writeFileSync(installedSddInit, routedLegacySource);
+
+		installSddAssets(PACKAGE_ROOT, true);
+
+		assert.deepEqual(
+			readFileSync(installedSddInit),
+			Buffer.from(routedLegacySource),
+			"an explicitly routed legacy definition must remain byte-for-byte intact",
+		);
+		const manifest = JSON.parse(
+			readFileSync(join(temporaryAgentHome, "gentle-ai", "managed-assets.json"), "utf8"),
+		) as ManagedAssetsManifest;
+		assert.equal(
+			manifest.assets[`agents/${SDD_INIT_FILE}`],
+			undefined,
+			"a user-routed legacy definition must not be re-certified as package-owned",
+		);
+	} finally {
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		rmSync(temporaryAgentHome, { recursive: true, force: true });
+	}
 });
 
 test("v0.14 ownership evidence is bundled and matches the self-contained bounded-review fixture", () => {


### PR DESCRIPTION
Closes #216

## Summary

- remove the provider-specific model pin from the package-owned `sdd-init` agent
- migrate exact legacy managed copies to the provider-neutral asset
- preserve explicit routing and user-modified legacy copies

## Changes

| File | Change |
|---|---|
| `assets/agents/sdd-init.md` | Remove the hardcoded model field. |
| `lib/sdd-preflight.ts` | Recognize exact legacy managed hashes without overwriting modified copies. |
| `tests/package-manifest.test.ts` | Cover provider neutrality, migration, ownership hashes, and preservation. |
| `tests/fixtures/v0.13/assets/agents/sdd-init.md` | Add the byte-identical historical managed asset fixture. |

## Test plan

- [x] `node --experimental-strip-types --test tests/package-manifest.test.ts tests/sdd-preflight.test.ts` — 53 passed
- [x] `pnpm test` — 1033 passed, 10 skipped
- [x] `pnpm run check:runtime-modules`
- [x] `node scripts/verify-package-files.mjs`
- [x] `pnpm run test:packed-package`
- [x] `git diff --check`
- [ ] Native-binary-required mode — package-local Gentle AI 2.4.0 binary unavailable; global 2.4.1 was intentionally not substituted

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Included tests and migration fixture with the behavior change
- [x] Used a conventional commit
- [x] Added no attribution trailers
