### PR TITLE
feat(agents): add owned activity projection contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Most coding-agent sessions fail for operational reasons, not model reasons:
 | **Verified native runtime**    | Provisions the exact package-local Gentle AI v2.4.0 runtime: signed archives on Darwin/Linux and a Go SumDB-verified source build on Windows x64/arm64. It validates package-local integrity and rejects PATH, global, sibling, symlink, and mode fallbacks. |
 | **Runtime safety**             | Blocks destructive shell commands, asks for confirmation for sensitive operations, and blocks direct read/write/edit access to sensitive paths. |
 
+### Gentle-owned agent activity projection
+
+`gentle-pi` ships the internal `gentle-pi.agent-activity/v1` contract and event seam from [#432](https://github.com/Gentleman-Programming/gentle-pi/issues/432).
+
+- **Ownership:** [#419](https://github.com/Gentleman-Programming/gentle-pi/issues/419) remains the sole task-manager producer; this seam retains only the latest bounded snapshot.
+- **Boundary:** consumers use Pi's documented request/changed event bus; they receive snapshots only and cannot create, control, or cancel tasks.
+- **Unavailable behavior:** consumers remain unavailable before registration, during `starting`/`replacing`, after `shutdown`, or after malformed input; stale snapshots are cleared.
+- **Safety:** this is observational and never authorizes [#347](https://github.com/Gentleman-Programming/gentle-pi/issues/347) worktree/session switching. [#430](https://github.com/Gentleman-Programming/gentle-pi/issues/430) is the later presentation-only consumer.
+- **Provenance and order:** the seam is independently authored from #419 requirements and Pi's public extension/event API, with no third-party runtime source; delivery is contract first, manager integration second, and UI consumer last.
+
 ## Install
 
 ```bash

--- a/lib/agent-activity-projection.ts
+++ b/lib/agent-activity-projection.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from "node:crypto";
+
+export const AGENT_ACTIVITY_VERSION = "gentle-pi.agent-activity/v1" as const;
+export const AGENT_ACTIVITY_REQUEST_CHANNEL = "gentle-pi:agent-activity:v1:request" as const;
+export const AGENT_ACTIVITY_CHANGED_CHANNEL = "gentle-pi:agent-activity:v1:changed" as const;
+export const AGENT_ACTIVITY_INPUT_LIMIT = 1_000;
+export const AGENT_ACTIVITY_OUTPUT_LIMIT = 100;
+
+export type AgentActivityState = "queued" | "running" | "waiting-for-input" | "blocked" | "stopping" | "completed" | "failed" | "cancelled" | "interrupted";
+export type AgentActivityPhase = "starting" | "preparing" | "running-tool" | "streaming" | "waiting" | "stopping" | "done";
+export interface AgentActivityEntry { id: string; name: string; kind: "managed-task"; state: AgentActivityState; parent_id?: string; activity?: AgentActivityPhase; tool_name?: string; model_provider?: string; model_id?: string; effort?: string; started_at_ms?: number; ended_at_ms?: number; input_tokens?: number; output_tokens?: number; cached_tokens?: number; total_tokens?: number; context_window_tokens?: number }
+export type AgentActivityEntryInput = Record<string, unknown>;
+export interface AgentActivitySnapshot { version: typeof AGENT_ACTIVITY_VERSION; source_generation: string | null; revision: number; availability: "available" | "unavailable"; tasks: readonly AgentActivityEntry[]; total_count: number; truncated: boolean; reason?: "not-started" | "starting" | "replacing" | "shutdown" }
+export interface AgentActivityEventBus { on(channel: string, handler: (data: unknown) => void): () => void; emit(channel: string, data: unknown): void }
+export interface AgentActivityProducer { publish(candidate: readonly AgentActivityEntryInput[]): void; dispose(): void }
+export interface AgentActivityProjection { getSnapshot(): AgentActivitySnapshot; registerProducer(): AgentActivityProducer }
+export interface AgentActivityConsumer { getSnapshot(): AgentActivitySnapshot | undefined; subscribe(listener: (snapshot: AgentActivitySnapshot | undefined) => void): () => void; request(): void }
+
+const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const GENERATION = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const TOOL = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
+const PROVIDER = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const MODEL = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const EFFORT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/;
+const STATES = new Set<AgentActivityState>(["queued", "running", "waiting-for-input", "blocked", "stopping", "completed", "failed", "cancelled", "interrupted"]);
+const PHASES = new Set<AgentActivityPhase>(["starting", "preparing", "running-tool", "streaming", "waiting", "stopping", "done"]);
+const unavailableReasons = new Set(["not-started", "starting", "replacing", "shutdown"]);
+const isRecord = (value: unknown): value is Record<string, unknown> => !!value && typeof value === "object" && !Array.isArray(value);
+const safe = (value: unknown): value is number => typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+const valid = (value: unknown, grammar: RegExp): value is string => typeof value === "string" && grammar.test(value);
+const fail = (message: string): never => { throw new TypeError(`Invalid agent activity: ${message}`); };
+
+function entry(value: unknown): AgentActivityEntry {
+	if (!isRecord(value) || !valid(value.id, ID) || !valid(value.name, NAME) || value.kind !== "managed-task" || typeof value.state !== "string" || !STATES.has(value.state as AgentActivityState)) fail("required entry field");
+	const out: AgentActivityEntry = { id: value.id as string, name: value.name as string, kind: "managed-task", state: value.state as AgentActivityState };
+	const optional = (key: keyof AgentActivityEntry, value: unknown, grammar?: RegExp) => { if (value === undefined || value === null || (grammar ? !valid(value, grammar) : !PHASES.has(value as AgentActivityPhase))) return; (out as Record<string, unknown>)[key] = value; };
+	optional("parent_id", value.parent_id, ID); optional("activity", value.activity); optional("tool_name", value.tool_name, TOOL); optional("model_provider", value.model_provider, PROVIDER); optional("model_id", value.model_id, MODEL); optional("effort", value.effort, EFFORT);
+	const start = safe(value.started_at_ms) ? value.started_at_ms : undefined; const end = safe(value.ended_at_ms) && (start === undefined || value.ended_at_ms >= start) ? value.ended_at_ms : undefined;
+	if (start !== undefined) out.started_at_ms = start; if (end !== undefined) out.ended_at_ms = end;
+	for (const key of ["input_tokens", "output_tokens", "cached_tokens", "total_tokens", "context_window_tokens"] as const) if (safe(value[key])) out[key] = value[key];
+	return Object.freeze(out);
+}
+
+export function validateAgentActivityCandidate(value: unknown): readonly AgentActivityEntry[] {
+	if (!Array.isArray(value) || value.length > AGENT_ACTIVITY_INPUT_LIMIT) fail("candidate size");
+	const out = value.map(entry); if (new Set(out.map((item) => item.id)).size !== out.length) fail("duplicate entry id"); return Object.freeze(out);
+}
+
+const snapshot = (value: { source_generation: string | null; revision: number; availability: "available" | "unavailable"; tasks: readonly AgentActivityEntry[]; total_count: number; truncated: boolean; reason?: AgentActivitySnapshot["reason"] }): AgentActivitySnapshot => Object.freeze({ version: AGENT_ACTIVITY_VERSION, ...value, tasks: Object.freeze([...value.tasks]) });
+const initial = (): AgentActivitySnapshot => snapshot({ source_generation: null, revision: 0, availability: "unavailable", tasks: [], total_count: 0, truncated: false, reason: "not-started" });
+
+export function validateAgentActivitySnapshot(value: unknown): AgentActivitySnapshot {
+	if (!isRecord(value) || value.version !== AGENT_ACTIVITY_VERSION || !safe(value.revision) || (value.availability !== "available" && value.availability !== "unavailable") || !Array.isArray(value.tasks)) fail("snapshot envelope");
+	const generation = value.source_generation === null ? null : valid(value.source_generation, GENERATION) ? value.source_generation : fail("generation");
+	const tasks = validateAgentActivityCandidate(value.tasks); if (tasks.length > AGENT_ACTIVITY_OUTPUT_LIMIT) fail("snapshot task cap");
+	if (!safe(value.total_count) || value.total_count > AGENT_ACTIVITY_INPUT_LIMIT || value.total_count < tasks.length || typeof value.truncated !== "boolean") fail("derived count");
+	if (value.availability === "available") { if (generation === null || value.revision === 0 || Object.hasOwn(value, "reason") || value.truncated !== (value.total_count > tasks.length)) fail("available envelope"); return snapshot({ source_generation: generation, revision: value.revision, availability: "available", tasks, total_count: value.total_count, truncated: value.truncated }); }
+	if (tasks.length !== 0 || value.total_count !== 0 || value.truncated !== false || typeof value.reason !== "string" || !unavailableReasons.has(value.reason) || (generation === null ? value.reason !== "not-started" || value.revision !== 0 : value.reason === "not-started") || ((value.reason === "starting" || value.reason === "replacing") ? value.revision !== 0 : value.reason === "shutdown" && value.revision === 0)) fail("unavailable envelope");
+	return snapshot({ source_generation: generation, revision: value.revision, availability: "unavailable", tasks: [], total_count: 0, truncated: false, reason: value.reason as AgentActivitySnapshot["reason"] });
+}
+
+export function createAgentActivityProjection(events: AgentActivityEventBus): AgentActivityProjection {
+	let current = initial(); let registered = false; let active: symbol | undefined;
+	const changed = () => events.emit(AGENT_ACTIVITY_CHANGED_CHANNEL, current);
+	events.on(AGENT_ACTIVITY_REQUEST_CHANNEL, () => changed());
+	return { getSnapshot: () => current, registerProducer: () => {
+		const token = randomUUID(); const capability = Symbol(token); const replacing = registered; active = capability; registered = true; current = snapshot({ source_generation: token, revision: 0, availability: "unavailable", tasks: [], total_count: 0, truncated: false, reason: replacing ? "replacing" : "starting" }); changed(); let revision = 0; let disposed = false;
+		return { publish(candidate) { if (active !== capability || disposed) return; const tasks = validateAgentActivityCandidate(candidate); revision += 1; current = snapshot({ source_generation: token, revision, availability: "available", tasks: tasks.slice(0, AGENT_ACTIVITY_OUTPUT_LIMIT), total_count: tasks.length, truncated: tasks.length > AGENT_ACTIVITY_OUTPUT_LIMIT }); changed(); }, dispose() { if (active !== capability || disposed) return; disposed = true; revision += 1; current = snapshot({ source_generation: token, revision, availability: "unavailable", tasks: [], total_count: 0, truncated: false, reason: "shutdown" }); changed(); } };
+	} };
+}
+
+export function createAgentActivityConsumer(events: AgentActivityEventBus): AgentActivityConsumer {
+	let current: AgentActivitySnapshot | undefined; const listeners = new Set<(snapshot: AgentActivitySnapshot | undefined) => void>();
+	events.on(AGENT_ACTIVITY_CHANGED_CHANNEL, (value) => { try { current = validateAgentActivitySnapshot(value); } catch { current = undefined; } for (const listener of listeners) listener(current); });
+	return { getSnapshot: () => current, subscribe(listener) { listeners.add(listener); return () => listeners.delete(listener); }, request() { events.emit(AGENT_ACTIVITY_REQUEST_CHANNEL, undefined); } };
+}

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -52,6 +52,7 @@ const requiredPaths = [
   "extensions/gentle-ai.ts",
   "extensions/sdd-init.ts",
   "extensions/skill-registry.ts",
+  "lib/agent-activity-projection.ts",
   "lib/gentle-ai-binary.ts",
   "lib/native-review-cli.ts",
   "lib/provider-contract-bundle.ts",

--- a/tests/agent-activity-projection.test.ts
+++ b/tests/agent-activity-projection.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	AGENT_ACTIVITY_CHANGED_CHANNEL,
+	AGENT_ACTIVITY_REQUEST_CHANNEL,
+	createAgentActivityConsumer,
+	createAgentActivityProjection,
+	validateAgentActivitySnapshot,
+} from "../lib/agent-activity-projection.ts";
+
+class Bus {
+	readonly records: Array<{ channel: string; data: unknown }> = [];
+	readonly handlers = new Map<string, Array<(data: unknown) => void>>();
+
+	on(channel: string, handler: (data: unknown) => void): () => void {
+		const handlers = this.handlers.get(channel) ?? [];
+		handlers.push(handler);
+		this.handlers.set(channel, handlers);
+		return () => this.handlers.set(channel, handlers.filter((item) => item !== handler));
+	}
+
+	emit(channel: string, data?: unknown): void {
+		this.records.push({ channel, data });
+		for (const handler of [...(this.handlers.get(channel) ?? [])]) handler(data);
+	}
+}
+
+const entry = (id = "task-1", extra: Record<string, unknown> = {}) => ({
+	id, name: "worker", kind: "managed-task", state: "running", ...extra,
+});
+const changedCount = (bus: Bus) => bus.records.filter(({ channel }) => channel === AGENT_ACTIVITY_CHANGED_CHANNEL).length;
+const available = (generation: string, revision: number) => ({
+	version: "gentle-pi.agent-activity/v1", source_generation: generation, revision,
+	availability: "available", tasks: [], total_count: 0, truncated: false,
+});
+const unavailable = (reason: string, generation: string | null, revision: number) => ({
+	version: "gentle-pi.agent-activity/v1", source_generation: generation, revision,
+	availability: "unavailable", tasks: [], total_count: 0, truncated: false, reason,
+});
+function assertUnavailable(snapshot: unknown, reason: string, generation: string | null, revision: number): void {
+	assert.deepEqual(snapshot, unavailable(reason, generation, revision));
+}
+
+test("snapshot validation enforces lifecycle revisions and generation grammar", () => {
+	const generation = "generation-1";
+	const invalid = [
+		["available revision 0", available(generation, 0)],
+		["starting revision 1", unavailable("starting", generation, 1)],
+		["replacing revision 1", unavailable("replacing", generation, 1)],
+		["shutdown revision 0", unavailable("shutdown", generation, 0)],
+		["generation control", available("generation\n1", 1)],
+		["generation too long", available("a".repeat(129), 1)],
+	] as const;
+	const accepted: string[] = [];
+	for (const [name, snapshot] of invalid) {
+		try { validateAgentActivitySnapshot(snapshot); accepted.push(name); } catch { /* expected rejection */ }
+	}
+	assert.deepEqual(accepted, []);
+});
+
+test("projection emits lifecycle envelopes and rejects stale capabilities", () => {
+	const bus = new Bus();
+	const projection = createAgentActivityProjection(bus);
+	assertUnavailable(projection.getSnapshot(), "not-started", null, 0);
+	assert.deepEqual(Object.keys(projection.getSnapshot()), ["version", "source_generation", "revision", "availability", "tasks", "total_count", "truncated", "reason"]);
+	const first = projection.registerProducer();
+	const generation = projection.getSnapshot().source_generation;
+	assert.equal(typeof generation, "string");
+	assertUnavailable(projection.getSnapshot(), "starting", generation, 0);
+	first.publish([entry()]);
+	assert.deepEqual(projection.getSnapshot(), {
+		version: "gentle-pi.agent-activity/v1", source_generation: generation, revision: 1,
+		availability: "available", tasks: [entry()], total_count: 1, truncated: false,
+	});
+	const second = projection.registerProducer();
+	const replacementGeneration = projection.getSnapshot().source_generation;
+	assert.notEqual(replacementGeneration, generation);
+	assertUnavailable(projection.getSnapshot(), "replacing", replacementGeneration, 0);
+	assert.equal(changedCount(bus), 3);
+	assert.ok(bus.records.filter(({ channel }) => channel === AGENT_ACTIVITY_CHANGED_CHANNEL).every(({ data }) => Object.isFrozen(data)));
+	first.publish([entry("stale")]);
+	first.dispose();
+	assertUnavailable(projection.getSnapshot(), "replacing", replacementGeneration, 0);
+	second.publish([entry("current")]);
+	second.dispose();
+	assertUnavailable(projection.getSnapshot(), "shutdown", replacementGeneration, 2);
+	second.dispose();
+	assertUnavailable(projection.getSnapshot(), "shutdown", replacementGeneration, 2);
+	const consumer = createAgentActivityConsumer(bus);
+	consumer.request();
+	assert.deepEqual(consumer.getSnapshot(), projection.getSnapshot());
+});
+
+test("fresh seam instances mint unequal privacy-safe generations", () => {
+	const first = createAgentActivityProjection(new Bus());
+	const second = createAgentActivityProjection(new Bus());
+	first.registerProducer();
+	second.registerProducer();
+	const firstGeneration = first.getSnapshot().source_generation;
+	const secondGeneration = second.getSnapshot().source_generation;
+	assert.notEqual(firstGeneration, secondGeneration);
+	assert.match(firstGeneration ?? "", /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/);
+	assert.match(secondGeneration ?? "", /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/);
+});
+
+test("publish applies exact output bounds and invalid input is atomic", () => {
+	const bus = new Bus();
+	const projection = createAgentActivityProjection(bus);
+	const producer = projection.registerProducer();
+	for (const [count, truncated] of [[100, false], [101, true]] as const) {
+		producer.publish(Array.from({ length: count }, (_, index) => entry(`task-${count}-${index}`)));
+		const snapshot = projection.getSnapshot();
+		assert.equal(snapshot.total_count, count);
+		assert.equal(snapshot.tasks.length, 100);
+		assert.equal(snapshot.truncated, truncated);
+	}
+	const before = projection.getSnapshot();
+	const emissions = changedCount(bus);
+	assert.throws(() => producer.publish(Array.from({ length: 1_001 }, (_, index) => entry(`too-many-${index}`))));
+	assert.equal(projection.getSnapshot(), before);
+	assert.equal(changedCount(bus), emissions);
+});
+
+test("required privacy grammars reject while optional and forbidden fields are omitted", () => {
+	const bus = new Bus();
+	const projection = createAgentActivityProjection(bus);
+	const producer = projection.registerProducer();
+	const invalidRequired = [
+		["empty id", { id: "" }], ["id control", { id: "task\n1" }], ["id length", { id: "a".repeat(129) }],
+		["empty name", { name: "" }], ["name control", { name: "worker\t1" }], ["name length", { name: "a".repeat(65) }],
+		["kind", { kind: "other" }], ["state", { state: "chatting" }],
+	] as const;
+	for (const [name, fields] of invalidRequired) {
+		const before = projection.getSnapshot();
+		const emissions = changedCount(bus);
+		assert.throws(() => producer.publish([entry("invalid", fields)]), TypeError, name);
+		assert.equal(projection.getSnapshot(), before);
+		assert.equal(changedCount(bus), emissions);
+	}
+	producer.publish([entry("safe", {
+		parent_id: null, activity: "waiting\n", tool_name: "tool/name", model_provider: "a".repeat(65),
+		model_id: "a".repeat(129), effort: "bad effort", started_at_ms: -1, ended_at_ms: "secret",
+		input_tokens: -1, output_tokens: "secret", cached_tokens: Number.MAX_SAFE_INTEGER + 1,
+		total_tokens: null, context_window_tokens: {}, prompt: "private prompt", path: "/private/project", credentials: "token",
+	})]);
+	assert.deepEqual(projection.getSnapshot().tasks, [entry("safe")]);
+	assert.throws(() => producer.publish([entry("safe"), entry("safe")]));
+});
+
+test("valid optional fields remain bounded and snapshots are immutable", () => {
+	const bus = new Bus();
+	const projection = createAgentActivityProjection(bus);
+	const producer = projection.registerProducer();
+	const candidate = [entry("first"), entry("second")];
+	producer.publish(candidate);
+	candidate[0]!.name = "changed outside the seam";
+	assert.deepEqual(projection.getSnapshot().tasks.map((task) => task.id), ["first", "second"]);
+	assert.throws(() => { (projection.getSnapshot().tasks[0] as { name: string }).name = "mutate"; });
+	producer.publish([entry("rich", {
+		parent_id: "parent-1", activity: "running-tool", tool_name: "gentle.read_file", model_provider: "provider-name",
+		model_id: "model:v1", effort: "medium", started_at_ms: 10, ended_at_ms: 5, total_tokens: 2, context_window_tokens: 3,
+	})]);
+	assert.deepEqual(projection.getSnapshot().tasks, [{
+		id: "rich", name: "worker", kind: "managed-task", state: "running", parent_id: "parent-1", activity: "running-tool",
+		tool_name: "gentle.read_file", model_provider: "provider-name", model_id: "model:v1", effort: "medium",
+		started_at_ms: 10, total_tokens: 2, context_window_tokens: 3,
+	}]);
+});
+
+test("consumer subscribes before requesting and clears malformed changes fail-closed", () => {
+	const bus = new Bus();
+	const projection = createAgentActivityProjection(bus);
+	const producer = projection.registerProducer();
+	const consumer = createAgentActivityConsumer(bus);
+	const seen: unknown[] = [];
+	consumer.subscribe((snapshot) => seen.push(snapshot));
+	consumer.request();
+	assert.equal(bus.records.at(-2)?.channel, AGENT_ACTIVITY_REQUEST_CHANNEL);
+	assert.equal(bus.records.at(-2)?.data, undefined);
+	assert.equal(seen.length, 1);
+	producer.publish([entry()]);
+	consumer.request();
+	assert.equal(seen.length, 3);
+	assert.deepEqual(consumer.getSnapshot(), projection.getSnapshot());
+	assert.deepEqual(Object.keys(consumer).sort(), ["getSnapshot", "request", "subscribe"]);
+	bus.emit(AGENT_ACTIVITY_CHANGED_CHANNEL, { version: "wrong/v9", availability: "available" });
+	assert.equal(consumer.getSnapshot(), undefined);
+	assert.equal(seen.at(-1), undefined);
+	bus.emit(AGENT_ACTIVITY_CHANGED_CHANNEL, null);
+	assert.equal(consumer.getSnapshot(), undefined);
+	const firstBus = new Bus();
+	const firstConsumer = createAgentActivityConsumer(firstBus);
+	firstConsumer.request();
+	assert.equal(firstConsumer.getSnapshot(), undefined);
+	const firstProjection = createAgentActivityProjection(firstBus);
+	firstProjection.registerProducer();
+	assert.equal(firstConsumer.getSnapshot()?.reason, "starting");
+});


### PR DESCRIPTION
Closes #432

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- add the independently authored `gentle-pi.agent-activity/v1` snapshot contract and validator
- provide a single-producer, read-only Pi event seam with deterministic generation, revision, replacement, and shutdown behavior
- fail closed on malformed or unsafe activity while keeping runtime production and the #430 UI out of this work unit

## Changes

| File | Change |
|---|---|
| `lib/agent-activity-projection.ts` | Define immutable snapshots, privacy validation, producer lifecycle, event discovery, and read-only consumption. |
| `tests/agent-activity-projection.test.ts` | Cover lifecycle envelopes, reload-safe generations, stale capabilities, bounds, privacy, both load orders, and fail-closed input. |
| `scripts/verify-package-files.mjs` | Require the new contract module in packaged artifacts. |
| `README.md` | Document ownership, safety boundaries, dependencies, and delivery order. |

## Review path

1. Review the lifecycle and validation rules in `lib/agent-activity-projection.ts`.
2. Confirm the focused tests exercise malformed envelopes, replacement, shutdown replay, 100/1,000 bounds, and privacy grammars.
3. Confirm README scope: #419 is the sole future producer, #430 remains a later UI-only consumer, and #347 cannot use this observational snapshot as a safety barrier.

## Test plan

- [x] `node --experimental-strip-types --test tests/agent-activity-projection.test.ts` — 7 passed
- [x] `pnpm test` — 1,046 passed, 1 skipped
- [x] `pnpm run check:runtime-modules`
- [x] `node scripts/verify-package-files.mjs`
- [x] `pnpm run test:packed-package`
- [x] `pnpm run test:cross-lane`
- [x] direct lifecycle/generation/bounds probe
- [x] `git diff --check upstream/main`

## Scope

This PR adds no task manager, runtime producer, UI, external-runtime adapter, task controls, persistence, polling, history replay, filesystem discovery, dynamic package loading, or third-party subagent-runtime dependency/source reuse.

Parent: #419. Dependent UI: #430.

Review workload: 286 changed lines / 400.

## Contributor checklist

- [x] Linked approved issue #432
- [x] Exactly one `type:*` label (`type:feature`)
- [x] Shellcheck not applicable; no shell scripts changed
- [x] Agent/skill assets not changed
- [x] Documentation updated with the behavior
- [x] Conventional commit used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agent activity projection that provides validated, versioned activity snapshots.
  * Added support for requesting and receiving activity updates through the event system.
  * Activity entries are sanitized, bounded in size, and protected from malformed data.

* **Documentation**
  * Documented the agent activity projection’s availability, lifecycle behavior, and scope.

* **Tests**
  * Added coverage for validation, lifecycle transitions, update ordering, immutability, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->