### PR TITLE
fix(review): preserve committed status selectors

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3207,6 +3207,13 @@ interface RetainedNativeUntrackedSelection {
 	readonly intendedUntracked: readonly string[];
 }
 
+interface RetainedNativeCaptureRoute { readonly workspaceRoot: string; readonly lineageId: string; readonly baseRef?: string; readonly committedOnly?: true; }
+
+type RetainedNativeStatusSelection = RetainedNativeUntrackedSelection | RetainedNativeCaptureRoute;
+
+const MAX_RETAINED_NATIVE_STATUS_SELECTIONS = 64;
+class NativeCaptureRouteRegistrationError extends Error {}
+
 function isNativeStartUntrackedPath(value: unknown): value is string {
 	return isCanonicalProcessString(value)
 		&& !isAbsolute(value)
@@ -3328,7 +3335,7 @@ export class PendingReviewConsentRegistry {
 }
 
 const processPendingReviewConsentRegistry = new PendingReviewConsentRegistry();
-const processRetainedUntrackedSelections = new Map<PendingReviewConsentSessionKey, Map<string, RetainedNativeUntrackedSelection>>();
+const processRetainedNativeStatusSelections = new Map<PendingReviewConsentSessionKey, Map<string, RetainedNativeStatusSelection>>();
 
 function pendingReviewConsentSessionKey(context: ExtensionContext | undefined, fallbackKey: symbol): PendingReviewConsentSessionKey {
 	try {
@@ -3452,6 +3459,15 @@ function nativeOperationFailure(operation: ReviewControllerOperation | "gentle_r
 			next_action: "resolve-consent-binding",
 		};
 	}
+	if (error instanceof NativeCaptureRouteRegistrationError) {
+		return {
+			operation,
+			status: "blocked",
+			outcome: "capture-route-registration-rejected",
+			mutation_performed: false,
+			mutation_outcome: "none",
+		};
+	}
 	const mutationOutcome = value.mutationOutcome === "unknown" ? "unknown" : "none";
 	const nativeCliError = asNativeReviewCliError(error);
 	if (nativeCliError?.code === NATIVE_REVIEW_ERROR_CODE.PACKAGE_BINARY_MISSING) return nativeStatusPackageBinaryMissing(operation, nativeCliError.diagnostics);
@@ -3502,6 +3518,7 @@ async function reconcileNativeMutationFailure(
 	error: unknown,
 	nativeReviewCli: NativeReviewCli,
 	target: Parameters<NonNullable<NativeReviewCli["targetStatus"]>>[0],
+	retainedSelections: Map<string, RetainedNativeStatusSelection>,
 	preOperationRevision?: string,
 	canonicalRetentionRoot = target.cwd,
 ): Promise<Record<string, unknown>> {
@@ -3518,7 +3535,7 @@ async function reconcileNativeMutationFailure(
 	}
 	try {
 		const status = await nativeReviewCli.targetStatus(target);
-		clearRetainedNativeUntrackedSelectionOnTerminal(retainedUntrackedSelectionsByNativeReviewCli.get(nativeReviewCli)!, canonicalRetentionRoot, status.authority?.lineageId, status.authority?.state);
+		syncRetainedNativeStatusSelections(retainedSelections, canonicalRetentionRoot, status, target.baseRef);
 		const { required_status_action: staleStatusDirective, ...reconciledBase } = failure;
 		void staleStatusDirective;
 		// Field defect (fambig, 2026-08-16): an envelope-less mutating failure
@@ -3613,6 +3630,10 @@ function reviewLifecycleStorageKey(workspaceRoot: string, lineageId: string): st
 	return `${workspaceRoot}\u0000${lineageId}`;
 }
 
+function reviewCaptureSelectionStorageKey(collectBinding: string): string {
+	return `capture\u0000${collectBinding}`;
+}
+
 function cloneRetainedNativeUntrackedSelection(selection: NativeStartUntrackedSelection): RetainedNativeUntrackedSelection | undefined {
 	if (selection.untrackedScope === undefined || selection.expectedUntrackedInventory === undefined) return undefined;
 	return Object.freeze({
@@ -3622,13 +3643,24 @@ function cloneRetainedNativeUntrackedSelection(selection: NativeStartUntrackedSe
 	});
 }
 
-function retainNativeUntrackedSelection(selections: Map<string, RetainedNativeUntrackedSelection>, workspaceRoot: string, lineageId: string, selection: RetainedNativeUntrackedSelection | undefined): void {
-	if (selection !== undefined) selections.set(reviewLifecycleStorageKey(workspaceRoot, lineageId), selection);
+function retainNativeStatusSelection(selections: Map<string, RetainedNativeStatusSelection>, key: string, selection: RetainedNativeStatusSelection): void {
+	if (!selections.has(key)) {
+		while (selections.size >= MAX_RETAINED_NATIVE_STATUS_SELECTIONS) {
+			const oldestKey = selections.keys().next().value;
+			if (oldestKey === undefined) return;
+			selections.delete(oldestKey);
+		}
+	}
+	selections.set(key, selection);
 }
 
-function readRetainedNativeUntrackedSelection(selections: Map<string, RetainedNativeUntrackedSelection>, workspaceRoot: string, lineageId: string): NativeStartUntrackedSelection {
+function retainNativeUntrackedSelection(selections: Map<string, RetainedNativeStatusSelection>, workspaceRoot: string, lineageId: string, selection: RetainedNativeUntrackedSelection | undefined): void {
+	if (selection !== undefined) retainNativeStatusSelection(selections, reviewLifecycleStorageKey(workspaceRoot, lineageId), selection);
+}
+
+function readRetainedNativeUntrackedSelection(selections: Map<string, RetainedNativeStatusSelection>, workspaceRoot: string, lineageId: string): NativeStartUntrackedSelection {
 	const selection = selections.get(reviewLifecycleStorageKey(workspaceRoot, lineageId));
-	return selection === undefined
+	return selection === undefined || "baseRef" in selection
 		? {}
 		: {
 			untrackedScope: selection.untrackedScope,
@@ -3637,8 +3669,39 @@ function readRetainedNativeUntrackedSelection(selections: Map<string, RetainedNa
 		};
 }
 
-function clearRetainedNativeUntrackedSelectionOnTerminal(selections: Map<string, RetainedNativeUntrackedSelection>, workspaceRoot: string, lineageId: string | undefined, state: string | undefined): void {
-	if (lineageId !== undefined && (state === "approved" || state === "escalated")) selections.delete(reviewLifecycleStorageKey(workspaceRoot, lineageId));
+function isRetainedNativeCaptureRoute(selection: RetainedNativeStatusSelection | undefined): selection is RetainedNativeCaptureRoute {
+	return selection !== undefined && "workspaceRoot" in selection;
+}
+
+function retainNativeCaptureRoutes(selections: Map<string, RetainedNativeStatusSelection>, workspaceRoot: string, status: ReviewStatusV3, baseRef: string | undefined): void {
+	const lineageId = status.authority?.lineageId;
+	if (status.applicability !== "current_target" || !isCanonicalProcessString(lineageId) || isTerminalReviewAuthorityState(status.authority?.state)) return;
+	const routes = (status.nextTransition?.kind === "collect" ? status.nextTransition.collect?.inputs ?? [] : []).map((input) => ({ key: reviewCaptureSelectionStorageKey(canonicalReviewCaptureBinding(input)), route: Object.freeze({ workspaceRoot, lineageId, ...(baseRef === undefined ? {} : { baseRef, committedOnly: true as const }) }) }));
+	for (const { key, route } of routes) {
+		const existing = selections.get(key);
+		if (isRetainedNativeCaptureRoute(existing) && (existing.workspaceRoot !== route.workspaceRoot || existing.lineageId !== route.lineageId || existing.baseRef !== route.baseRef || existing.committedOnly !== route.committedOnly)) throw new NativeCaptureRouteRegistrationError("Provider collectBinding collides with a different registered route");
+	}
+	const current = new Set(routes.map(({ key }) => key));
+	for (const [key, selection] of selections) if (isRetainedNativeCaptureRoute(selection) && selection.workspaceRoot === workspaceRoot && selection.lineageId === lineageId && !current.has(key)) selections.delete(key);
+	for (const { key, route } of routes) if (!selections.has(key)) retainNativeStatusSelection(selections, key, route);
+}
+
+function readRetainedNativeCaptureRoute(selections: Map<string, RetainedNativeStatusSelection>, collectBinding: string): RetainedNativeCaptureRoute | undefined {
+	const selection = selections.get(reviewCaptureSelectionStorageKey(collectBinding));
+	return isRetainedNativeCaptureRoute(selection) ? selection : undefined;
+}
+
+function isTerminalReviewAuthorityState(state: string | undefined): boolean { return state === "invalidated" || state === "approved" || state === "escalated"; }
+
+function clearRetainedNativeStatusSelectionsOnTerminal(selections: Map<string, RetainedNativeStatusSelection>, workspaceRoot: string, lineageId: string | undefined, state: string | undefined): void {
+	if (lineageId === undefined || !isTerminalReviewAuthorityState(state)) return;
+	selections.delete(reviewLifecycleStorageKey(workspaceRoot, lineageId));
+	for (const [key, selection] of selections) if (isRetainedNativeCaptureRoute(selection) && selection.workspaceRoot === workspaceRoot && selection.lineageId === lineageId) selections.delete(key);
+}
+
+function syncRetainedNativeStatusSelections(selections: Map<string, RetainedNativeStatusSelection>, workspaceRoot: string, status: ReviewStatusV3, baseRef: string | undefined): void {
+	clearRetainedNativeStatusSelectionsOnTerminal(selections, workspaceRoot, status.authority?.lineageId, status.authority?.state);
+	retainNativeCaptureRoutes(selections, workspaceRoot, status, baseRef);
 }
 
 function requiresExplicitTargetLifecycleRoot(requested: string | undefined, sessionCwd: string, workspaceRoot: string): boolean {
@@ -3708,6 +3771,17 @@ function mapLastEventClosure(
 	};
 }
 
+function mapAndClearLastEventClosure(
+	closure: ReviewLastEventClosureV1,
+	binding: ReviewLastEventClosureBinding,
+	selections: Map<string, RetainedNativeStatusSelection>,
+	workspaceRoot: string,
+): Record<string, unknown> {
+	const mapped = mapLastEventClosure(closure, binding);
+	clearRetainedNativeStatusSelectionsOnTerminal(selections, workspaceRoot, closure.lineageId, closure.state);
+	return mapped;
+}
+
 function decodeRelayLastEventClosure(submission: string): ReviewLastEventClosureV1 | undefined {
 	let body: unknown;
 	try { body = JSON.parse(submission); } catch { throw new CandidateViewError("host relay submission returned malformed JSON", "last-event-closure-decode-failed"); }
@@ -3720,11 +3794,14 @@ async function reconcileUnknownReviewCaptureFailure(
 	nativeReviewCli: NativeReviewCli,
 	cwd: string,
 	binding: ReviewLastEventClosureBinding,
+	selections: Map<string, RetainedNativeStatusSelection>,
+	route: RetainedNativeCaptureRoute | undefined,
 ): Promise<Record<string, unknown>> {
 	const failure = nativeOperationFailure("gentle_review_capture", error);
 	if (!nativeMutationRequiresStatus(error)) return failure;
 	try {
-		const status = await reconcileUnknownReviewLastEventCapture(nativeReviewCli, cwd, binding);
+		const status = await reconcileUnknownReviewLastEventCapture(nativeReviewCli, cwd, binding, route);
+		syncRetainedNativeStatusSelections(selections, cwd, status, route?.baseRef);
 		return {
 			tool: "gentle_review_capture",
 			status: "reconciled",
@@ -3750,6 +3827,8 @@ async function executeReviewHostRelayCapture(
 	nativeReviewCli: NativeReviewCli,
 	cwd: string,
 	binding: ReviewLastEventClosureBinding,
+	selections: Map<string, RetainedNativeStatusSelection>,
+	route: RetainedNativeCaptureRoute | undefined,
 	signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
 	try {
@@ -3767,7 +3846,7 @@ async function executeReviewHostRelayCapture(
 			...(signal === undefined ? {} : { signal }),
 		});
 		const closure = decodeRelayLastEventClosure(result.submission);
-		if (closure !== undefined) return mapLastEventClosure(closure, binding);
+		if (closure !== undefined) return mapAndClearLastEventClosure(closure, binding, selections, cwd);
 		return {
 			tool: "gentle_review_capture",
 			status: "captured",
@@ -3784,8 +3863,8 @@ async function executeReviewHostRelayCapture(
 			},
 		};
 	} catch (error) {
-		if (!(error instanceof ReviewHostRelayError)) return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding);
-		if (error.mutationOutcome === "unknown") return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding);
+		if (!(error instanceof ReviewHostRelayError)) return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding, selections, route);
+		if (error.mutationOutcome === "unknown") return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding, selections, route);
 		if (error.kind === REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE) {
 			return {
 				tool: "gentle_review_capture",
@@ -3830,6 +3909,8 @@ async function executeProviderRoleVectorCapture(
 	nativeReviewCli: NativeReviewCli,
 	cwd: string,
 	binding: ReviewLastEventClosureBinding,
+	selections: Map<string, RetainedNativeStatusSelection>,
+	route: RetainedNativeCaptureRoute | undefined,
 	signal?: AbortSignal,
 ): Promise<Record<string, unknown>> {
 	if (nativeReviewCli.captureProviderRole === undefined) {
@@ -3849,7 +3930,7 @@ async function executeProviderRoleVectorCapture(
 			cwd,
 			...(signal === undefined ? {} : { signal }),
 		});
-		if ("operation" in artifact) return mapLastEventClosure(artifact, binding);
+		if ("operation" in artifact) return mapAndClearLastEventClosure(artifact, binding, selections, cwd);
 		return {
 			tool: "gentle_review_capture",
 			status: "captured",
@@ -3864,7 +3945,7 @@ async function executeProviderRoleVectorCapture(
 			},
 		};
 	} catch (error) {
-		const outcome = await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding);
+		const outcome = await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding, selections, route);
 		return {
 			...outcome,
 			...(outcome.status === "reconciled" ? {} : { retry_discipline: REVIEW_PROVIDER_ROLE_RETRY_ACTION }),
@@ -3926,7 +4007,6 @@ interface NegotiatedHostTransportStatus {
 	transport?: ReviewTransportRefusal;
 }
 const reviewTransportRefusalByProvider = new WeakMap<object, ReviewTransportRefusal>();
-const retainedUntrackedSelectionsByNativeReviewCli = new WeakMap<NativeReviewCli, Map<string, RetainedNativeUntrackedSelection>>();
 
 function clearReviewTransportProbeForTesting(nativeReviewCli: NativeReviewCli | null): void {
 	if (nativeReviewCli !== null) reviewTransportRefusalByProvider.delete(nativeReviewCli as unknown as object);
@@ -3956,6 +4036,7 @@ function hostTransportUnavailable(
 async function negotiatedStatusForHostTransport(
 	nativeReviewCli: NativeReviewCli,
 	request: NativeTargetStatusRequest,
+	retainedSelections: Map<string, RetainedNativeStatusSelection>,
 	canonicalRetentionRoot = request.cwd,
 ): Promise<NegotiatedHostTransportStatus> {
 	const provider = nativeReviewCli as unknown as object;
@@ -3963,7 +4044,7 @@ async function negotiatedStatusForHostTransport(
 	if (remembered !== undefined) return { transport: remembered };
 	try {
 		const status = await nativeReviewCli.targetStatus!({ ...request, agent: REVIEW_HOST_AGENT });
-		clearRetainedNativeUntrackedSelectionOnTerminal(retainedUntrackedSelectionsByNativeReviewCli.get(nativeReviewCli)!, canonicalRetentionRoot, status.authority?.lineageId, status.authority?.state);
+		syncRetainedNativeStatusSelections(retainedSelections, canonicalRetentionRoot, status, request.baseRef);
 		return { status };
 	} catch (error) {
 		const code = error instanceof NativeReviewIntegrationError ? error.failureEnvelope.code : undefined;
@@ -4082,7 +4163,8 @@ async function executeReviewCaptureOperation(
 	nativeReviewCli: NativeReviewCli | null,
 	signal?: AbortSignal,
 	candidateViews: CandidateViewRegistry | null = new CandidateViewRegistry(),
-	retainedUntrackedSelections: Map<string, RetainedNativeUntrackedSelection> = new Map(),
+	retainedUntrackedSelections: Map<string, RetainedNativeStatusSelection> = new Map(),
+	requireRegisteredRoute = false,
 ): Promise<Record<string, unknown>> {
 	const parameters = parseReviewCaptureParameters(parametersValue);
 	if (nativeReviewCli === null || nativeReviewCli.targetStatus === undefined) {
@@ -4094,17 +4176,21 @@ async function executeReviewCaptureOperation(
 			mutation_outcome: "none",
 		};
 	}
-	retainedUntrackedSelectionsByNativeReviewCli.set(nativeReviewCli, retainedUntrackedSelections);
 	const canonicalBinding = parseCanonicalReviewCaptureBinding(parameters.collectBinding);
 	const cwd = resolveReviewControllerWorkspaceRoot(parameters.workspaceRoot, sessionCwd, candidateViews, parameters.lineageId);
+	const route = readRetainedNativeCaptureRoute(retainedUntrackedSelections, canonicalBinding);
+	if (requireRegisteredRoute && (route === undefined || route.workspaceRoot !== cwd || route.lineageId !== parameters.lineageId)) {
+		return captureBindingRejected("collectBinding is unknown, expired, or belongs to a different session route");
+	}
 	let status: ReviewStatusV3;
 	try {
 		const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, {
 			cwd,
 			lineageId: parameters.lineageId,
+			...(route?.baseRef === undefined ? {} : { baseRef: route.baseRef, committedOnly: true }),
 			...readRetainedNativeUntrackedSelection(retainedUntrackedSelections, cwd, parameters.lineageId),
 			...(signal === undefined ? {} : { signal }),
-		}, cwd);
+		}, retainedUntrackedSelections, cwd);
 		if (negotiated.transport !== undefined) return hostTransportUnavailable("gentle_review_capture", negotiated.transport);
 		status = negotiated.status!;
 	} catch (error) {
@@ -4130,7 +4216,7 @@ async function executeReviewCaptureOperation(
 				mutation_outcome: "none",
 			};
 		}
-		return await executeReviewHostRelayCapture(hostRelaySlots[0]!, nativeReviewCli, cwd, selected.binding, signal);
+		return await executeReviewHostRelayCapture(hostRelaySlots[0]!, nativeReviewCli, cwd, selected.binding, retainedUntrackedSelections, route, signal);
 	}
 
 	if (selected.input.captureOperation === "review.capture-correction-plan") {
@@ -4160,9 +4246,9 @@ async function executeReviewCaptureOperation(
 				cwd,
 				...(signal === undefined ? {} : { signal }),
 			});
-			return mapLastEventClosure(closure, selected.binding);
+			return mapAndClearLastEventClosure(closure, selected.binding, retainedUntrackedSelections, cwd);
 		} catch (error) {
-			return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, selected.binding);
+			return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, selected.binding, retainedUntrackedSelections, route);
 		}
 	}
 
@@ -4171,7 +4257,7 @@ async function executeReviewCaptureOperation(
 		if (parameters.reviewerRunAcknowledged !== undefined || parameters.correctionLines !== undefined) {
 			return captureBindingRejected("reviewerRunAcknowledged and correctionLines are not valid for a provider role capture");
 		}
-		return await executeProviderRoleVectorCapture(providerRoleSlots[0]!, nativeReviewCli, cwd, selected.binding, signal);
+		return await executeProviderRoleVectorCapture(providerRoleSlots[0]!, nativeReviewCli, cwd, selected.binding, retainedUntrackedSelections, route, signal);
 	}
 	return captureBindingRejected(`unsupported provider capture operation: ${selected.input.captureOperation}`);
 }
@@ -4210,7 +4296,7 @@ async function executeReviewControllerOperation(
 	signal?: AbortSignal,
 	candidateViews: CandidateViewRegistry | null = new CandidateViewRegistry(),
 	context?: ExtensionContext,
-	retainedUntrackedSelections: Map<string, RetainedNativeUntrackedSelection> = new Map(),
+	retainedUntrackedSelections: Map<string, RetainedNativeStatusSelection> = new Map(),
 	pendingReviewConsentRegistry: PendingReviewConsentRegistry = processPendingReviewConsentRegistry,
 	pendingReviewConsentFallbackKey: symbol = Symbol("pending-review-consent-fallback"),
 	writeReviewConsentLatch: typeof recordReviewConsentLatch = recordReviewConsentLatch,
@@ -4218,7 +4304,6 @@ async function executeReviewControllerOperation(
 	reviewConsentScheduleTimer: (callback: () => void, delayMs: number) => { unref: () => void } = setTimeout,
 ): Promise<Record<string, unknown>> {
 	const parameters = parseReviewControllerParameters(parametersValue);
-	if (nativeReviewCli !== null) retainedUntrackedSelectionsByNativeReviewCli.set(nativeReviewCli, retainedUntrackedSelections);
 	const defaultCwd = resolveReviewControllerWorkspaceRoot(parameters.workspaceRoot, sessionCwd, candidateViews, parameters.lineageId);
 	const pendingReviewConsentSession = pendingReviewConsentSessionKey(context, pendingReviewConsentFallbackKey);
 	const useTargetLifecycleRoot = requiresExplicitTargetLifecycleRoot(parameters.workspaceRoot, sessionCwd, defaultCwd);
@@ -4253,7 +4338,7 @@ async function executeReviewControllerOperation(
 				const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, {
 					cwd: defaultCwd,
 					...(signal === undefined ? {} : { signal }),
-				}, defaultCwd);
+				}, retainedUntrackedSelections, defaultCwd);
 				if (negotiated.transport !== undefined) {
 					return {
 						...hostTransportUnavailable(parameters.operation, negotiated.transport),
@@ -4308,7 +4393,7 @@ async function executeReviewControllerOperation(
 		const statusRequest = {
 			cwd: defaultCwd,
 			lineageId: String(input.predecessorLineage),
-			...(frozenTarget?.committedOnly === true ? { baseRef: frozenTarget.baseCommit } : {}),
+			...(frozenTarget?.committedOnly === true ? { baseRef: frozenTarget.baseCommit, committedOnly: true } : {}),
 			...(signal === undefined ? {} : { signal }),
 		};
 		let status: ReviewStatusV3;
@@ -4379,12 +4464,14 @@ async function executeReviewControllerOperation(
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.REPAIR) {
 		if (nativeReviewCli?.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
+		const frozenTarget = parameters.lineageId === undefined || !candidateViews?.hasProjection(parameters.lineageId, defaultCwd) ? undefined : candidateViews.resolveProjection(parameters.lineageId, defaultCwd);
 		let status: ReviewStatusV3;
 		try {
-			status = await nativeReviewCli.targetStatus({ cwd: defaultCwd, ...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }), ...(signal === undefined ? {} : { signal }) });
+			status = await nativeReviewCli.targetStatus({ cwd: defaultCwd, ...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }), ...(frozenTarget?.committedOnly === true ? { baseRef: frozenTarget.baseCommit, committedOnly: true } : {}), ...(signal === undefined ? {} : { signal }) });
 		} catch (error) {
 			return nativeStatusFailed(parameters.operation, error);
 		}
+		clearRetainedNativeStatusSelectionsOnTerminal(retainedUntrackedSelections, defaultCwd, status.authority?.lineageId, status.authority?.state); retainNativeCaptureRoutes(retainedUntrackedSelections, defaultCwd, status, frozenTarget?.committedOnly === true ? frozenTarget.baseCommit : undefined);
 		if (status.authority?.version === "compact-v2") return { operation: parameters.operation, repaired: false, compact_authority: "immutable-untouched", status: mapNativeTargetStatus(parameters.operation, status, parameters.lineageId) };
 		if (status.authority?.version !== "legacy-v1") return mapNativeTargetStatus(parameters.operation, status, parameters.lineageId);
 		const store = ReviewTransactionStore.forRepository(defaultCwd);
@@ -4442,9 +4529,9 @@ async function executeReviewControllerOperation(
 			if (value.mutationOutcome === "none") pending.cleanupCandidate();
 			return await reconcileNativeMutationFailure(parameters.operation, error, nativeReviewCli, {
 				cwd: pending.authorityCwd,
-				...(pending.candidateView.committedOnly ? { baseRef: pending.candidateView.baseCommit } : {}),
+				...(pending.candidateView.committedOnly ? { baseRef: pending.candidateView.baseCommit, committedOnly: true } : {}),
 				projection: "workspace",
-			});
+			}, retainedUntrackedSelections);
 		}
 		if (input.answer === "granted") {
 			try {
@@ -4501,10 +4588,10 @@ async function executeReviewControllerOperation(
 				const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, {
 					cwd: defaultCwd,
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
-					...(canonicalBaseRef === undefined ? {} : { baseRef: canonicalBaseRef }),
+					...(canonicalBaseRef === undefined ? {} : { baseRef: canonicalBaseRef, committedOnly: true }),
 					...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
 					...(signal === undefined ? {} : { signal }),
-				}, defaultCwd);
+				}, retainedUntrackedSelections, defaultCwd);
 				if (negotiated.transport !== undefined) return hostTransportUnavailable(parameters.operation, negotiated.transport);
 				target = negotiated.status!;
 				if (target.nextTransition?.kind === "collect" || target.applicability !== "unrelated" || target.action !== "start") return mapNativeTargetStatus(parameters.operation, target, parameters.lineageId);
@@ -4610,10 +4697,10 @@ async function executeReviewControllerOperation(
 				return reconcileNativeMutationFailure(parameters.operation, failure, nativeReviewCli, {
 					cwd: defaultCwd,
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
-					...(canonicalBaseRef === undefined ? {} : { baseRef: candidateView?.baseCommit ?? canonicalBaseRef }),
+					...(canonicalBaseRef === undefined ? {} : { baseRef: candidateView?.baseCommit ?? canonicalBaseRef, committedOnly: true }),
 					...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
 					projection: "workspace",
-				});
+				}, retainedUntrackedSelections);
 			}
 		}
 		if (rawStart.mode === REVIEW_MODE.ORDINARY) {
@@ -4700,12 +4787,16 @@ async function executeReviewControllerOperation(
 			: parseControllerJson(parameters.input, REVIEW_CONTROLLER_OPERATION.STATUS);
 		const unknownField = rawStatus === undefined
 			? undefined
-			: Object.keys(rawStatus).find((field) => !["untrackedScope", "expectedUntrackedInventory", "intendedUntracked"].includes(field));
+			: Object.keys(rawStatus).find((field) => !["baseRef", "committedOnly", "untrackedScope", "expectedUntrackedInventory", "intendedUntracked"].includes(field));
 		if (unknownField !== undefined) return nativeStatusInputRejection("unknown-field", unknownField);
+		const baseRef = rawStatus?.baseRef;
+		if (baseRef !== undefined && !isCanonicalProcessString(baseRef)) return nativeStatusInputRejection("base-ref-invalid");
+		if (baseRef !== undefined && rawStatus?.committedOnly !== true) return nativeStatusInputRejection("committed-only-required");
+		if (baseRef === undefined && rawStatus !== undefined && "committedOnly" in rawStatus) return nativeStatusInputRejection("committed-only-invalid");
 		const untrackedSelection = rawStatus === undefined ? {} : validateNativeStartUntrackedSelection(rawStatus);
 		if (
 			rawStatus !== undefined &&
-			(untrackedSelection.reason !== undefined || untrackedSelection.untrackedScope === undefined)
+			(untrackedSelection.reason !== undefined || (baseRef === undefined && untrackedSelection.untrackedScope === undefined))
 		) return nativeStatusInputRejection(untrackedSelection.reason ?? "untracked-selection-invalid");
 		const retainedUntrackedSelection = cloneRetainedNativeUntrackedSelection(untrackedSelection);
 		if (nativeReviewCli?.targetStatus !== undefined) {
@@ -4713,9 +4804,10 @@ async function executeReviewControllerOperation(
 				const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, {
 					cwd: defaultCwd,
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
+					...(baseRef === undefined ? {} : { baseRef, committedOnly: true }),
 					...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
 					...(signal === undefined ? {} : { signal }),
-				}, defaultCwd);
+				}, retainedUntrackedSelections, defaultCwd);
 				if (negotiated.transport !== undefined) {
 					return {
 						...hostTransportUnavailable(parameters.operation, negotiated.transport),
@@ -4729,7 +4821,7 @@ async function executeReviewControllerOperation(
 					status.applicability === "current_target" &&
 					status.authority?.lineageId === parameters.lineageId
 				) retainNativeUntrackedSelection(retainedUntrackedSelections, defaultCwd, parameters.lineageId, retainedUntrackedSelection);
-				clearRetainedNativeUntrackedSelectionOnTerminal(retainedUntrackedSelections, defaultCwd, status.authority?.lineageId, status.authority?.state);
+				clearRetainedNativeStatusSelectionsOnTerminal(retainedUntrackedSelections, defaultCwd, status.authority?.lineageId, status.authority?.state);
 				hydrateDispatchBindingFromStatus(candidateViews, defaultCwd, status);
 				return { ...mapNativeTargetStatus(parameters.operation, status, parameters.lineageId, defaultCwd), ...(includeWorkspaceRoot ? { workspace_root: defaultCwd } : {}) };
 			} catch (error) {
@@ -4849,7 +4941,7 @@ function createGentleAiExtensionForTesting(
 	pi.on("session_shutdown", (_event, context) => {
 		const sessionKey = pendingReviewConsentSessionKey(context, pendingReviewConsentFallbackKey);
 		cleanupAllPendingReviewConsents(pendingReviewConsentRegistry, sessionKey);
-		processRetainedUntrackedSelections.delete(sessionKey);
+		processRetainedNativeStatusSelections.delete(sessionKey);
 	});
 
 	pi.registerTool({
@@ -4899,7 +4991,8 @@ function createGentleAiExtensionForTesting(
 				nativeReviewCli,
 				signal,
 				candidateViews,
-				((sessionKey: PendingReviewConsentSessionKey) => processRetainedUntrackedSelections.get(sessionKey) ?? processRetainedUntrackedSelections.set(sessionKey, new Map()).get(sessionKey)!)(pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey)),
+				((sessionKey: PendingReviewConsentSessionKey) => processRetainedNativeStatusSelections.get(sessionKey) ?? processRetainedNativeStatusSelections.set(sessionKey, new Map()).get(sessionKey)!)(pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey)),
+				true,
 			);
 			return {
 				content: [{ type: "text", text: JSON.stringify(details) }],
@@ -4942,7 +5035,7 @@ function createGentleAiExtensionForTesting(
 				signal,
 				candidateViews,
 				ctx,
-				((sessionKey: PendingReviewConsentSessionKey) => processRetainedUntrackedSelections.get(sessionKey) ?? processRetainedUntrackedSelections.set(sessionKey, new Map()).get(sessionKey)!)(pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey)),
+				((sessionKey: PendingReviewConsentSessionKey) => processRetainedNativeStatusSelections.get(sessionKey) ?? processRetainedNativeStatusSelections.set(sessionKey, new Map()).get(sessionKey)!)(pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey)),
 				pendingReviewConsentRegistry,
 				pendingReviewConsentFallbackKey,
 				writeReviewConsentLatch,

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -467,6 +467,7 @@ export interface NativeTargetStatusRequest extends NativeUntrackedSelectionReque
 	cwd: string;
 	lineageId?: string;
 	baseRef?: string;
+	committedOnly?: boolean;
 	projection?: "workspace" | "staged";
 	/**
 	 * The immutable reviewer runtime this host provides. Measured against the
@@ -1867,7 +1868,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		const status = await this.targetStatus({
 			cwd: request.cwd,
 			projection,
-			...(request.baseRef === undefined ? {} : { baseRef: request.baseRef }),
+			...(request.baseRef === undefined ? {} : { baseRef: request.baseRef, committedOnly: true }),
 			...(request.lineageId === undefined ? {} : { lineageId: request.lineageId }),
 			...selection,
 			agent: "pi",
@@ -1966,12 +1967,15 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 	}
 
 	async targetStatus(request: NativeTargetStatusRequest): Promise<ReviewStatusV3> {
+		if (request.baseRef !== undefined && !isCanonicalProcessString(request.baseRef)) throw new TypeError("Native STATUS baseRef must be a non-empty, trimmed, NUL-free string");
+		if (request.baseRef !== undefined && request.committedOnly !== true) throw new TypeError("Native STATUS baseRef requires explicit committedOnly acknowledgement");
+		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native STATUS committedOnly requires an explicit baseRef");
 		const selection = nativeUntrackedSelection(request);
 		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.STATUS, request.cwd, [
 			"review", "status", "--contract", REVIEW_INTEGRATION_CONTRACT, "--cwd", request.cwd,
 			"--projection", request.projection ?? "workspace",
 			...nativeUntrackedSelectionArguments(selection),
-			...(request.baseRef === undefined ? [] : ["--base-ref", request.baseRef]),
+			...(request.baseRef === undefined ? [] : ["--base-ref", request.baseRef, "--committed-only"]),
 			...(request.lineageId === undefined ? [] : ["--lineage", request.lineageId]),
 			...(request.agent === undefined ? [] : ["--agent", request.agent]),
 			"--next-transition",

--- a/lib/review-last-event-controller.ts
+++ b/lib/review-last-event-controller.ts
@@ -1,6 +1,11 @@
 import type { NativeReviewCli } from "./native-review-cli.ts";
 import type { ReviewLastEventClosureBinding, ReviewStatusV3 } from "./review-integration-v2.ts";
 
+export interface ReviewLastEventCaptureSelector {
+	readonly baseRef?: string;
+	readonly committedOnly?: true;
+}
+
 /**
  * Reconcile exactly one ambiguous native capture outcome. Successful captures
  * return their native artifact or closure directly; this helper is never a
@@ -10,11 +15,16 @@ export async function reconcileUnknownReviewLastEventCapture(
 	nativeReviewCli: NativeReviewCli,
 	cwd: string,
 	binding: ReviewLastEventClosureBinding,
+	selector?: ReviewLastEventCaptureSelector,
 ): Promise<ReviewStatusV3> {
 	if (nativeReviewCli.targetStatus === undefined) {
 		throw new TypeError("native target-scoped STATUS is required to reconcile an ambiguous capture outcome");
 	}
-	const status = await nativeReviewCli.targetStatus({ cwd, lineageId: binding.lineageId });
+	const status = await nativeReviewCli.targetStatus({
+		cwd,
+		lineageId: binding.lineageId,
+		...(selector === undefined ? {} : selector),
+	});
 	if (binding.targetIdentity !== undefined && status.targetIdentity !== binding.targetIdentity) {
 		throw new TypeError("capture reconciliation returned a different target");
 	}

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -481,6 +481,7 @@ export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "dec
 
 
 
+
 export const NATIVE_REVIEW_AUTHORITY_STATUS = {
 	CLEAN: "clean",
 	ACTIVE: "active",
@@ -1868,7 +1869,7 @@ export class NativeReviewCliV216                            {
 		const status = await this.targetStatus({
 			cwd: request.cwd,
 			projection,
-			...(request.baseRef === undefined ? {} : { baseRef: request.baseRef }),
+			...(request.baseRef === undefined ? {} : { baseRef: request.baseRef, committedOnly: true }),
 			...(request.lineageId === undefined ? {} : { lineageId: request.lineageId }),
 			...selection,
 			agent: "pi",
@@ -1967,12 +1968,15 @@ export class NativeReviewCliV216                            {
 	}
 
 	async targetStatus(request                           )                          {
+		if (request.baseRef !== undefined && !isCanonicalProcessString(request.baseRef)) throw new TypeError("Native STATUS baseRef must be a non-empty, trimmed, NUL-free string");
+		if (request.baseRef !== undefined && request.committedOnly !== true) throw new TypeError("Native STATUS baseRef requires explicit committedOnly acknowledgement");
+		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native STATUS committedOnly requires an explicit baseRef");
 		const selection = nativeUntrackedSelection(request);
 		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.STATUS, request.cwd, [
 			"review", "status", "--contract", REVIEW_INTEGRATION_CONTRACT, "--cwd", request.cwd,
 			"--projection", request.projection ?? "workspace",
 			...nativeUntrackedSelectionArguments(selection),
-			...(request.baseRef === undefined ? [] : ["--base-ref", request.baseRef]),
+			...(request.baseRef === undefined ? [] : ["--base-ref", request.baseRef, "--committed-only"]),
 			...(request.lineageId === undefined ? [] : ["--lineage", request.lineageId]),
 			...(request.agent === undefined ? [] : ["--agent", request.agent]),
 			"--next-transition",

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -184,6 +184,7 @@ test("negotiated STATUS forwards its exact ordered workspace, base, lineage, and
 		cwd: "/repo with spaces",
 		projection: "staged",
 		baseRef: "origin/main",
+		committedOnly: true,
 		lineageId: "review-current",
 		agent: "pi",
 		untrackedScope: "select",
@@ -194,10 +195,38 @@ test("negotiated STATUS forwards its exact ordered workspace, base, lineage, and
 	assert.deepEqual(queue.calls[0]?.arguments, [
 		"review", "status", "--contract", "gentle-ai.review-integration/v2", "--cwd", "/repo with spaces",
 		"--projection", "staged", "--untracked-scope=select", "--expected-untracked-inventory=inventory-sha256",
-		"--intended-untracked=new.txt", "--intended-untracked=nested/other.txt", "--base-ref", "origin/main",
+		"--intended-untracked=new.txt", "--intended-untracked=nested/other.txt", "--base-ref", "origin/main", "--committed-only",
 		"--lineage", "review-current", "--agent", "pi", "--next-transition",
 	]);
 	assert.equal(queue.calls[0]?.timeoutMs, 30_000);
+});
+
+test("negotiated STATUS emits the explicit committed selector argv", async () => {
+	const queue = queuedAdapter([{ stdout: JSON.stringify(currentStatusFixture()) }]);
+	await client(queue.adapter).targetStatus({
+		cwd: "/repo",
+		baseRef: "refs/heads/main",
+		committedOnly: true,
+	});
+	assert.deepEqual(queue.calls[0]?.arguments, [
+		"review", "status", "--contract", "gentle-ai.review-integration/v2", "--cwd", "/repo",
+		"--projection", "workspace", "--base-ref", "refs/heads/main", "--committed-only", "--next-transition",
+	]);
+});
+
+test("negotiated STATUS rejects malformed committed selectors before launching a process", async () => {
+	for (const request of [
+		{ cwd: "/repo", baseRef: "", committedOnly: true },
+		{ cwd: "/repo", baseRef: 42, committedOnly: true },
+		{ cwd: "/repo", committedOnly: true },
+		{ cwd: "/repo", baseRef: "refs/heads/main" },
+		{ cwd: "/repo", baseRef: "refs/heads/main", committedOnly: false },
+		{ cwd: "/repo", baseRef: "refs/heads/main", committedOnly: "true" },
+	]) {
+		const queue = queuedAdapter([]);
+		await assert.rejects(() => client(queue.adapter).targetStatus(request), TypeError);
+		assert.equal(queue.calls.length, 0);
+	}
 });
 
 test("negotiated STATUS rejects malformed untracked selection before launching a process", async () => {

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { __testing, createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import { __testing, createGentleAiExtension, PendingReviewConsentRegistry } from "../extensions/gentle-ai.ts";
 import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
 import { NATIVE_REVIEW_ERROR_CODE, NativeReviewCliError, NativeReviewConsentRequiredError, type NativeReviewCli } from "../lib/native-review-cli.ts";
 import { decodeReviewConsentV3, type ReviewCollectInputV3, type ReviewStatusV3 } from "../lib/review-integration-v2.ts";
@@ -48,12 +48,15 @@ function collectInput(lineageId: string): ReviewCollectInputV3 {
 	};
 }
 
-function status(lineageId: string): ReviewStatusV3 {
-	const input = collectInput(lineageId);
+function status(
+	lineageId: string,
+	inputs: readonly ReviewCollectInputV3[] = [collectInput(lineageId)],
+	authorityState = "reviewing",
+): ReviewStatusV3 {
 	return {
 		contract: "gentle-ai.review-integration/v2",
 		applicability: "current_target",
-		authority: { version: "compact-v2", lineageId, state: "reviewing", generation: 1, revision: SHA },
+		authority: { version: "compact-v2", lineageId, state: authorityState, generation: 1, revision: SHA },
 		receipt: { status: "expected_missing" },
 		action: "stop",
 		replayability: "not_replayable",
@@ -74,9 +77,18 @@ function status(lineageId: string): ReviewStatusV3 {
 		},
 		repair: { schema: "gentle-ai.review-authority-repair-assessment/v1", status: "unsupported", counts: { lineages: 0, compactLineages: 0, legacyLineages: 0, events: 0, bytes: 0, eligibleCandidates: 0, unsupportedLineages: 0, conflicts: 0 }, supportedOperations: ["review/complete-fix", "review/validate-fix"], authorizationSchema: "gentle-ai.review-repair-authorization/v1" },
 		candidates: [],
-		nextTransition: { kind: "collect", reasonCode: "capture_required", collect: { inputs: [input] } },
+		nextTransition: { kind: "collect", reasonCode: "capture_required", collect: { inputs } },
 		raw: { schema: "gentle-ai.review-integration.status/v5" },
 	} as unknown as ReviewStatusV3;
+}
+
+function correctionPlanInput(lineageId: string): ReviewCollectInputV3 {
+	const arguments_ = [{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` }, { name: "target", value: SHA, token: `--target=${SHA}` }];
+	return { name: "correction_plan", schema: "https://gentle-ai.dev/schema/review/correction-plan/v1", captureOperation: "review.capture-correction-plan", arguments: arguments_, submission: { operationToken: "capture-correction-plan", argumentTokens: [`--lineage=${lineageId}`, "--correction-lines={{value}}"], values: [{ slot: "correction_lines", domain: "integer", substitutionLocation: 1, minimum: 1, maximum: 200 }] } } as unknown as ReviewCollectInputV3;
+}
+
+function bindingOf(result: Record<string, unknown>): string {
+	return (result.collectBindings as readonly { collectBinding: string }[])[0]!.collectBinding;
 }
 
 test("public STATUS exposes one opaque current collect binding without advancing authority", async () => {
@@ -87,6 +99,8 @@ test("public STATUS exposes one opaque current collect binding without advancing
 			statusCalls += 1;
 			assert.equal(request.lineageId, lineageId);
 			assert.equal(request.agent, "pi");
+			assert.equal("baseRef" in request, false);
+			assert.equal("committedOnly" in request, false);
 			return status(lineageId);
 		},
 	} as unknown as NativeReviewCli;
@@ -100,6 +114,85 @@ test("public STATUS exposes one opaque current collect binding without advancing
 	const collectBindings = result.collectBindings as readonly { collectBinding: string }[];
 	assert.equal(collectBindings.length, 1);
 	assert.deepEqual(JSON.parse(collectBindings[0]!.collectBinding), collectInput(lineageId));
+});
+
+test("interleaved sessions sharing a CLI retain only their own capture routes", async () => {
+	const [a, b] = ["interleaved-a", "interleaved-b"];
+	const inputs = new Map([[a, correctionPlanInput(a)], [b, correctionPlanInput(b)]]);
+	const requests: Array<Record<string, unknown>> = [];
+	let releaseA!: () => void, releaseB!: () => void, readyA!: () => void, readyB!: () => void;
+	const waits = [new Promise<void>((resolve) => { releaseA = resolve; }), new Promise<void>((resolve) => { releaseB = resolve; })];
+	const ready = [new Promise<void>((resolve) => { readyA = resolve; }), new Promise<void>((resolve) => { readyB = resolve; })];
+	let captures = 0;
+	const native = {
+		targetStatus: async (request: Record<string, unknown>) => {
+			requests.push(request);
+			const index = requests.length - 1;
+			if (index < 2) { [readyA, readyB][index]!(); await waits[index]!; }
+			const lineageId = String(request.lineageId);
+			return status(lineageId, [inputs.get(lineageId)!]);
+		},
+		captureCorrectionPlan: async ({ argumentTokens }: { argumentTokens: readonly string[] }) => {
+			captures += 1;
+			const lineageId = argumentTokens.find((token) => token.startsWith("--lineage="))!.slice("--lineage=".length);
+			return { schema: "gentle-ai.review-last-event-closure/v1", operation: "review.capture-correction-plan", lineageId, state: "correction_required", storeRevision: SHA };
+		},
+	} as unknown as NativeReviewCli;
+	const { controller, capture, sessionShutdown } = reviewRuntime(native, new CandidateViewRegistry());
+	const contexts = [a, b].map((id) => ({ ...reviewContext(process.cwd()), sessionManager: { getSessionId: () => id } } as unknown as ExtensionContext));
+	const listedA = controller.execute("", { operation: "status", lineageId: a, input: JSON.stringify({ baseRef: "base-a", committedOnly: true }) }, undefined, undefined, contexts[0]!);
+	await ready[0];
+	const listedB = controller.execute("", { operation: "status", lineageId: b, input: JSON.stringify({ baseRef: "base-b", committedOnly: true }) }, undefined, undefined, contexts[1]!);
+	await ready[1]; releaseA(); await listedA; releaseB();
+	const [resultA, resultB] = await Promise.all([listedA, listedB]);
+	const ownA = await capture.execute("", { lineageId: a, collectBinding: bindingOf(resultA.details as Record<string, unknown>), correctionLines: 1 }, undefined, undefined, contexts[0]!);
+	const ownB = await capture.execute("", { lineageId: b, collectBinding: bindingOf(resultB.details as Record<string, unknown>), correctionLines: 1 }, undefined, undefined, contexts[1]!);
+	const foreign = await capture.execute("", { lineageId: a, collectBinding: bindingOf(resultA.details as Record<string, unknown>), correctionLines: 1 }, undefined, undefined, contexts[1]!);
+	await sessionShutdown({}, contexts[0]!);
+	const cleaned = await capture.execute("", { lineageId: a, collectBinding: bindingOf(resultA.details as Record<string, unknown>), correctionLines: 1 }, undefined, undefined, contexts[0]!);
+	assert.deepEqual({
+		outcomes: [ownA, ownB, foreign, cleaned].map(({ details }) => (details as { outcome?: string }).outcome),
+		revalidationCalls: requests.length - 2,
+		captures,
+	}, { outcomes: ["native-last-event-closure", "native-last-event-closure", "capture-binding-rejected", "capture-binding-rejected"], revalidationCalls: 2, captures: 2 });
+});
+
+test("REPAIR retains frozen committed collect selectors and leaves workspace routes unselected", async (t) => {
+	const candidateViews = new CandidateViewRegistry(); t.after(() => candidateViews.cleanupAll());
+	const cwd = repository(t), lineageId = "repair-committed", input = correctionPlanInput(lineageId); const view = candidateViews.create({ contributorRoot: cwd, baseRef: execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim(), committedOnly: true });
+	candidateViews.retain(view.token, lineageId); const frozenTarget = candidateViews.resolveProjection(lineageId, cwd), selections = new Map(), requests: Array<Record<string, unknown>> = [];
+	const native = {
+		targetStatus: async (request: Record<string, unknown>) => { requests.push(request); return requests.length === 3 ? status(lineageId, [], "approved") : status(lineageId, [input]); },
+		captureCorrectionPlan: async () => { throw Object.assign(new Error("lost response"), { mutationOutcome: "unknown", nextAction: "review.status" }); },
+	} as unknown as NativeReviewCli;
+	await __testing.executeReviewControllerOperation({ operation: "repair", lineageId }, cwd, native, undefined, candidateViews, undefined, selections);
+	const result = await __testing.executeReviewCaptureOperation({ lineageId, collectBinding: JSON.stringify(input), correctionLines: 1 }, cwd, native, undefined, candidateViews, selections, true);
+	const workspaceLineage = "repair-workspace", workspaceRequests: Array<Record<string, unknown>> = [];
+	await __testing.executeReviewControllerOperation({ operation: "repair", lineageId: workspaceLineage }, cwd, { targetStatus: async (request: Record<string, unknown>) => { workspaceRequests.push(request); return status(workspaceLineage); } } as unknown as NativeReviewCli, undefined, candidateViews);
+	assert.deepEqual({ outcome: result.outcome, routes: selections.size, selectors: requests.map(({ cwd: requestCwd, lineageId: id, baseRef, committedOnly }) => ({ cwd: requestCwd, lineageId: id, baseRef, committedOnly })) }, { outcome: "native-capture-outcome-unknown", routes: 0, selectors: Array.from({ length: 3 }, () => ({ cwd, lineageId, baseRef: frozenTarget.baseCommit, committedOnly: true })) });
+	assert.deepEqual(workspaceRequests, [{ cwd, lineageId: workspaceLineage }]);
+});
+
+test("route retention caps, rejects collisions and invalid selectors, and clears every terminal state", async () => {
+	const native = { targetStatus: async (request: Record<string, unknown>) => status(String(request.lineageId)) } as unknown as NativeReviewCli;
+	const selections = new Map();
+	for (let index = 0; index <= 64; index += 1) await __testing.executeReviewControllerOperation({ operation: "status", lineageId: `bounded-${index}`, input: JSON.stringify({ baseRef: `base-${index}`, committedOnly: true }) }, process.cwd(), native, undefined, undefined, undefined, selections);
+	const evicted = await __testing.executeReviewCaptureOperation({ lineageId: "bounded-0", collectBinding: JSON.stringify(collectInput("bounded-0")) }, process.cwd(), native, undefined, undefined, selections, true);
+	const collision = new Map(), lineageId = "route-collision", input = correctionPlanInput(lineageId);
+	await __testing.executeReviewControllerOperation({ operation: "status", lineageId, input: JSON.stringify({ baseRef: "base-a", committedOnly: true }) }, process.cwd(), { targetStatus: async () => status(lineageId, [input]) } as unknown as NativeReviewCli, undefined, undefined, undefined, collision);
+	const rejected = await __testing.executeReviewControllerOperation({ operation: "status", lineageId, input: JSON.stringify({ baseRef: "base-b", committedOnly: true }) }, process.cwd(), { targetStatus: async () => status(lineageId, [input]) } as unknown as NativeReviewCli, undefined, undefined, undefined, collision);
+	for (const state of ["invalidated", "approved", "escalated"]) {
+		const routes = new Map(), id = `terminal-${state}`;
+		await __testing.executeReviewControllerOperation({ operation: "status", lineageId: id, input: JSON.stringify({ baseRef: "base", committedOnly: true }) }, process.cwd(), { targetStatus: async () => status(id, [input]) } as unknown as NativeReviewCli, undefined, undefined, undefined, routes);
+		await __testing.executeReviewControllerOperation({ operation: "status", lineageId: id }, process.cwd(), { targetStatus: async () => status(id, [], state) } as unknown as NativeReviewCli, undefined, undefined, undefined, routes);
+		assert.equal(routes.size, 0, state);
+	}
+	let calls = 0;
+	for (const value of [{ baseRef: "", committedOnly: true }, { committedOnly: true }, { baseRef: "base" }, { baseRef: "base", committedOnly: false }]) {
+		const result = await __testing.executeReviewControllerOperation({ operation: "status", input: JSON.stringify(value) }, process.cwd(), { targetStatus: async () => { calls += 1; return status("unreachable"); } } as unknown as NativeReviewCli);
+		assert.equal(result.outcome, "native-status-input-invalid");
+	}
+	assert.deepEqual({ routes: selections.size, evicted: evicted.outcome, collision: rejected.outcome, calls }, { routes: 64, evicted: "capture-binding-rejected", collision: "capture-route-registration-rejected", calls: 0 });
 });
 
 test("public INSPECT and STATUS publish the exact pi-bound binding that capture revalidates", async () => {
@@ -199,24 +292,31 @@ interface RegisteredControllerTool {
 function reviewRuntime(nativeReviewCli: NativeReviewCli, candidateViews: CandidateViewRegistry) {
 	const tools = new Map<string, RegisteredControllerTool>();
 	let toolCall: ((event: { toolName: string; input: unknown }, ctx: ExtensionContext) => Promise<unknown>) | undefined;
+	let sessionShutdown: ((event: unknown, ctx: ExtensionContext) => unknown) | undefined;
 	createGentleAiExtension({ nativeReviewCli, candidateViews })({
-		on(name: string, handler: (event: { toolName: string; input: unknown }, ctx: ExtensionContext) => Promise<unknown>) { if (name === "tool_call") toolCall = handler; },
+		on(name: string, handler: (event: { toolName: string; input: unknown }, ctx: ExtensionContext) => Promise<unknown>) {
+			if (name === "tool_call") toolCall = handler;
+			if (name === "session_shutdown") sessionShutdown = handler as unknown as (event: unknown, ctx: ExtensionContext) => unknown;
+		},
 		registerTool(definition: RegisteredControllerTool & { name: string }) { tools.set(definition.name, definition); },
 		registerCommand() {},
 	} as unknown as ExtensionAPI);
 	const controller = tools.get("gentle_review");
+	const capture = tools.get("gentle_review_capture");
 	assert.ok(controller);
+	assert.ok(capture);
 	assert.ok(toolCall);
-	return { controller, toolCall };
+	assert.ok(sessionShutdown);
+	return { controller, capture, toolCall, sessionShutdown };
 }
 
 function reviewContext(cwd: string): ExtensionContext {
 	return { cwd, hasUI: false, ui: { confirm: async () => true } } as unknown as ExtensionContext;
 }
 
-function startStatus(cwd: string): ReviewStatusV3 {
+function startStatus(cwd: string, baseRef?: string): ReviewStatusV3 {
 	const candidateViews = new CandidateViewRegistry();
-	const view = candidateViews.create({ contributorRoot: cwd });
+	const view = candidateViews.create({ contributorRoot: cwd, ...(baseRef === undefined ? {} : { baseRef, committedOnly: true }) });
 	try {
 		return {
 			contract: "gentle-ai.review-integration/v2",
@@ -622,6 +722,39 @@ test("ordinary START keeps default and explicit base selection fail-closed befor
 		assert.equal(rejected.mutation_outcome, "none");
 	}
 	assert.equal(targetCalls, 0);
+});
+
+test("START and consent ambiguity reconciliation register their returned committed collect route", async (t) => {
+	const cwd = repository(t), baseRef = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
+	const lineageId = "reconciled-collect", input = correctionPlanInput(lineageId), unknown = () => { throw new NativeReviewCliError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, "review/start", true, true, "unknown mutation"); };
+	const selectors = (requests: readonly Record<string, unknown>[]) => requests.map(({ baseRef: base, committedOnly }) => ({ baseRef: base, committedOnly }));
+	const directRequests: Array<Record<string, unknown>> = [], directRoutes = new Map();
+	const directNative = {
+		targetStatus: async (request: Record<string, unknown>) => { directRequests.push(request); return directRequests.length === 1 ? startStatus(cwd, baseRef) : status(lineageId, [input]); },
+		start: unknown,
+		captureCorrectionPlan: async () => ({ schema: "gentle-ai.review-last-event-closure/v1", operation: "review.capture-correction-plan", lineageId, state: "correction_required", storeRevision: SHA }),
+	} as unknown as NativeReviewCli;
+	await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef, committedOnly: true }) }, cwd, directNative, undefined, undefined, undefined, directRoutes);
+	const directCapture = await __testing.executeReviewCaptureOperation({ lineageId, collectBinding: JSON.stringify(input), correctionLines: 1 }, cwd, directNative, undefined, undefined, directRoutes, true);
+	const consent = decodeReviewConsentV3(JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "consent-v3.captured.json"), "utf8")));
+	const consentRequests: Array<Record<string, unknown>> = [], consentRoutes = new Map(), registry = new PendingReviewConsentRegistry(), session = Symbol("consent-session");
+	const consentNative = {
+		targetStatus: async (request: Record<string, unknown>) => { consentRequests.push(request); return consentRequests.length === 1 ? startStatus(cwd, baseRef) : status(lineageId, [input]); },
+		start: async () => { throw new NativeReviewConsentRequiredError(consent); },
+		answerConsent: unknown,
+		captureCorrectionPlan: directNative.captureCorrectionPlan,
+	} as unknown as NativeReviewCli;
+	const run = (parameters: Record<string, unknown>) => __testing.executeReviewControllerOperation(parameters, cwd, consentNative, undefined, undefined, undefined, consentRoutes, registry, session);
+	const pending = await run({ operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef, committedOnly: true }) });
+	await run({ operation: "answer-consent", input: JSON.stringify({ consentBinding: pending.consent_binding, answer: "granted" }) });
+	const consentCapture = await __testing.executeReviewCaptureOperation({ lineageId, collectBinding: JSON.stringify(input), correctionLines: 1 }, cwd, consentNative, undefined, undefined, consentRoutes, true);
+	assert.deepEqual({
+		outcomes: [directCapture.outcome, consentCapture.outcome],
+		selectors: [selectors(directRequests), selectors(consentRequests)],
+	}, {
+		outcomes: ["native-last-event-closure", "native-last-event-closure"],
+		selectors: [Array.from({ length: 3 }, () => ({ baseRef, committedOnly: true })), Array.from({ length: 3 }, () => ({ baseRef, committedOnly: true }))],
+	});
 });
 
 test("ordinary START refuses a target projection that no longer matches the frozen candidate", async (t) => {

--- a/tests/review-last-event-closure.test.ts
+++ b/tests/review-last-event-closure.test.ts
@@ -332,15 +332,20 @@ test("terminal capture closes directly, nonterminal capture does not auto-follow
 });
 
 test("unknown-capture reconciliation validates the target-scoped lineage without replay", async () => {
-	let calls = 0;
+	const calls: Array<Record<string, unknown>> = [];
 	const native = {
-		targetStatus: async (request: { cwd: string; lineageId?: string }) => {
-			calls += 1;
+		targetStatus: async (request: Record<string, unknown>) => {
+			calls.push(request);
 			assert.equal(request.lineageId, "reconcile-lineage");
 			return { targetIdentity: SHA, authority: { lineageId: "reconcile-lineage" } } as ReviewStatusV3;
 		},
 	} as unknown as NativeReviewCli;
 	const result = await reconcileUnknownReviewLastEventCapture(native, "/repo", { lineageId: "reconcile-lineage", targetIdentity: SHA });
-	assert.equal(calls, 1);
+	await reconcileUnknownReviewLastEventCapture(native, "/repo", { lineageId: "reconcile-lineage", targetIdentity: SHA }, { baseRef: "refs/heads/main", committedOnly: true });
+	assert.deepEqual(calls, [{ cwd: "/repo", lineageId: "reconcile-lineage" }, { cwd: "/repo", lineageId: "reconcile-lineage", baseRef: "refs/heads/main", committedOnly: true }]);
 	assert.equal(result.targetIdentity, SHA);
+	let launches = 0;
+	const strictNative = new nativeReviewCliModule.NativeReviewCliV216(async () => { launches += 1; throw new Error("must not launch"); }, "/package/.gentle-ai/gentle-ai");
+	for (const selector of [{ committedOnly: true }, { baseRef: "refs/heads/main" }, { baseRef: "refs/heads/main", committedOnly: false }] as unknown as readonly Parameters<typeof reconcileUnknownReviewLastEventCapture>[3][]) await assert.rejects(() => reconcileUnknownReviewLastEventCapture(strictNative, "/repo", { lineageId: "reconcile-lineage", targetIdentity: SHA }, selector));
+	assert.equal(launches, 0);
 });


### PR DESCRIPTION
Closes #433

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Forward `baseRef` with `committedOnly: true` through every committed STATUS and reconciliation route.
- Bind provider collect routes to the exact Pi session, canonical workspace, lineage, and selector.
- Fail closed for unknown, evicted, cleaned, cross-session, or colliding capture bindings.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Preserve committed selectors, isolate session route state, cap retention, and clean terminal routes. |
| `lib/native-review-cli.ts` | Validate and forward committed STATUS selector arguments. |
| `runtime/native-review-cli.mjs` | Keep the generated runtime mirror synchronized. |
| `lib/review-last-event-controller.ts` | Preserve selector pairs during ambiguous capture reconciliation. |
| `tests/native-review-cli.test.ts` | Cover selector validation and argv forwarding. |
| `tests/review-controller-native-routing.test.ts` | Cover continuity, concurrency, collision, eviction, cleanup, START/consent, and REPAIR routes. |
| `tests/review-last-event-closure.test.ts` | Cover valid and malformed reconciliation selector pairs. |

## Test Plan

- [x] Focused review routing tests: 65 passed, 0 failed.
- [x] Full suite: 1,036 passed, 10 skipped, 0 failed.
- [x] Runtime modules match TypeScript sources: 4 modules.
- [x] Package resource verification: 161 files, 67 byte-identical contract artifacts.
- [x] Packed-package E2E passed for Gentle Pi 2.2.0 and Gentle AI 2.4.0.
- [x] Live STATUS-to-capture selector continuity was field-tested in Pi.
- [x] Native RDD high-risk review completed with one bounded correction and approved targeted validation.

## Contributor Checklist

- [x] Linked an approved issue with `Closes #433`.
- [x] Added exactly one `type:*` label: `type:bug`.
- [x] Shellcheck is not applicable; no shell scripts changed.
- [x] Tested the affected adapter in Pi and through the packed package.
- [x] Documentation changes are not required for this internal routing fix.
- [x] Commit uses Conventional Commits format.
- [x] Commit contains no `Co-Authored-By` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reviewing committed ranges using a specified base reference.
  - Preserved review selections across capture, status, repair, recovery, and consent workflows.
  - Added session-scoped handling for pending review consent.

- **Bug Fixes**
  - Improved validation for committed-range status and start requests.
  - Prevented invalid or conflicting selections from launching review operations.
  - Improved reconciliation after uncertain captures and session shutdown.
  - Ensured temporary review routes are cleaned up when captures complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->