### PR TITLE
feat(runtime): add authoritative managed-task registry

### DIFF
--- a/lib/agent-runtime/agent-task-registry.ts
+++ b/lib/agent-runtime/agent-task-registry.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+
+export type AgentTaskState =
+  | "queued" | "running" | "waiting-for-input" | "blocked" | "stopping"
+  | "completed" | "failed" | "cancelled" | "interrupted";
+export type AgentTaskFailureCode =
+  | "invalid-input" | "invalid-name" | "invalid-parent" | "capacity-exceeded"
+  | "invalid-id" | "duplicate-id" | "unknown-task" | "invalid-transition"
+  | "invalid-clock" | "notification-in-progress" | "revision-exhausted";
+export interface AgentTaskRecord {
+  readonly id: string;
+  readonly name: string;
+  readonly kind: "managed-task";
+  readonly state: AgentTaskState;
+  readonly parent_id?: string;
+  readonly started_at_ms?: number;
+  readonly ended_at_ms?: number;
+}
+export interface AgentTaskRegistrySnapshot {
+  readonly revision: number;
+  readonly tasks: readonly AgentTaskRecord[];
+}
+export type AgentTaskMutationResult =
+  | Readonly<{ kind: "ok"; task: AgentTaskRecord; snapshot: AgentTaskRegistrySnapshot }>
+  | Readonly<{ kind: "error"; code: AgentTaskFailureCode }>;
+export interface AgentTaskRegistry {
+  create(input: unknown): AgentTaskMutationResult;
+  transition(id: unknown, state: unknown): AgentTaskMutationResult;
+  getSnapshot(): AgentTaskRegistrySnapshot;
+  subscribe(listener: (snapshot: AgentTaskRegistrySnapshot) => void): () => void;
+}
+
+type CreateInput = { name: unknown; parent_id: unknown; hasParent: boolean };
+type Listener = (snapshot: AgentTaskRegistrySnapshot) => void;
+
+const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const states = new Set<AgentTaskState>([
+  "queued", "running", "waiting-for-input", "blocked", "stopping",
+  "completed", "failed", "cancelled", "interrupted",
+]);
+const terminalStates = new Set<AgentTaskState>([
+  "completed", "failed", "cancelled", "interrupted",
+]);
+const transitions: Partial<Record<AgentTaskState, readonly AgentTaskState[]>> = {
+  queued: ["running", "failed", "cancelled", "interrupted"],
+  running: ["waiting-for-input", "blocked", "stopping", "completed", "failed", "cancelled", "interrupted"],
+  "waiting-for-input": ["running", "blocked", "stopping", "failed", "cancelled", "interrupted"],
+  blocked: ["running", "waiting-for-input", "stopping", "failed", "cancelled", "interrupted"],
+  stopping: ["completed", "failed", "cancelled", "interrupted"],
+};
+
+const failure = (code: AgentTaskFailureCode): AgentTaskMutationResult =>
+  Object.freeze({ kind: "error", code });
+const isTerminal = (state: AgentTaskState): boolean => terminalStates.has(state);
+const isValidClock = (value: unknown, previous: number | undefined): value is number =>
+  typeof value === "number"
+  && Number.isSafeInteger(value)
+  && value >= 0
+  && (previous === undefined || value >= previous);
+
+const compareTasks = (left: AgentTaskRecord, right: AgentTaskRecord): number => {
+  const leftTerminal = isTerminal(left.state);
+  const rightTerminal = isTerminal(right.state);
+  if (leftTerminal !== rightTerminal) return leftTerminal ? 1 : -1;
+  if (!leftTerminal) return 0;
+  const leftEnded = left.ended_at_ms;
+  const rightEnded = right.ended_at_ms;
+  if (leftEnded === undefined || rightEnded === undefined) return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+  const endedDifference = rightEnded - leftEnded;
+  return endedDifference || (left.id < right.id ? -1 : left.id > right.id ? 1 : 0);
+};
+
+const readExactCreateInput = (input: unknown): CreateInput | undefined => {
+  try {
+    if (!input || typeof input !== "object" || Array.isArray(input)) return undefined;
+    const prototype = Object.getPrototypeOf(input);
+    if (prototype !== Object.prototype && prototype !== null) return undefined;
+    if (Object.getOwnPropertySymbols(input).length > 0) return undefined;
+    const keys = Object.getOwnPropertyNames(input);
+    if (!keys.includes("name") || keys.some(key => key !== "name" && key !== "parent_id")) return undefined;
+    const descriptors = Object.getOwnPropertyDescriptors(input);
+    const name = descriptors.name;
+    if (!name || !("value" in name)) return undefined;
+    const parent = descriptors.parent_id;
+    if (parent && !("value" in parent)) return undefined;
+    return { name: name.value, parent_id: parent?.value, hasParent: Boolean(parent) };
+  } catch { return undefined; }
+};
+
+export const nextAgentTaskRevision = (revision: number): number | undefined =>
+  revision < Number.MAX_SAFE_INTEGER ? revision + 1 : undefined;
+
+export function createAgentTaskRegistry(
+  options: { createId?: () => unknown; now?: () => unknown } = {},
+): AgentTaskRegistry {
+  const createId = options.createId ?? randomUUID;
+  const now = options.now ?? Date.now;
+  const tasks = new Map<string, AgentTaskRecord>();
+  const listeners = new Set<Listener>();
+  let revision = 0;
+  let lastTime: number | undefined;
+  let notifying = false;
+  let current: AgentTaskRegistrySnapshot = Object.freeze({ revision, tasks: Object.freeze([]) });
+
+  const snapshot = (): AgentTaskRegistrySnapshot =>
+    Object.freeze({ revision, tasks: Object.freeze([...tasks.values()].sort(compareTasks)) });
+  const readClock = (): number | undefined => {
+    try {
+      const value = now();
+      return isValidClock(value, lastTime) ? value : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  const notify = (): void => {
+    notifying = true;
+    try {
+      for (const listener of [...listeners]) {
+        try {
+          listener(current);
+        } catch {}
+      }
+    } finally {
+      notifying = false;
+    }
+  };
+  const commit = (task: AgentTaskRecord, time: number): AgentTaskMutationResult => {
+    const nextRevision = nextAgentTaskRevision(revision);
+    if (nextRevision === undefined) return failure("revision-exhausted");
+    revision = nextRevision;
+    lastTime = time;
+    tasks.set(task.id, task);
+    current = snapshot();
+    const result = Object.freeze({ kind: "ok" as const, task, snapshot: current });
+    notify();
+    return result;
+  };
+
+  return {
+    create(input) {
+      if (notifying) return failure("notification-in-progress");
+      const value = readExactCreateInput(input);
+      if (!value) return failure("invalid-input");
+      if (typeof value.name !== "string" || !NAME.test(value.name)) return failure("invalid-name");
+      if (tasks.size >= 1000) return failure("capacity-exceeded");
+      if (value.hasParent && (typeof value.parent_id !== "string" || !ID.test(value.parent_id) || !tasks.has(value.parent_id))) return failure("invalid-parent");
+      if (nextAgentTaskRevision(revision) === undefined) return failure("revision-exhausted");
+      let id: unknown;
+      try {
+        id = createId();
+      } catch {
+        return failure("invalid-id");
+      }
+      if (typeof id !== "string" || !ID.test(id)) return failure("invalid-id");
+      if (tasks.has(id)) return failure("duplicate-id");
+      const time = readClock();
+      if (time === undefined) return failure("invalid-clock");
+      const task: AgentTaskRecord = {
+        id,
+        name: value.name,
+        kind: "managed-task",
+        state: "queued",
+        ...(typeof value.parent_id === "string" ? { parent_id: value.parent_id } : {}),
+      };
+      return commit(Object.freeze(task), time);
+    },
+    transition(id, state) {
+      if (notifying) return failure("notification-in-progress");
+      if (typeof id !== "string" || !ID.test(id)) return failure("invalid-input");
+      if (typeof state !== "string" || !states.has(state as AgentTaskState)) return failure("invalid-input");
+      const task = tasks.get(id);
+      if (!task) return failure("unknown-task");
+      const next = state as AgentTaskState;
+      if (!transitions[task.state]?.includes(next)) return failure("invalid-transition");
+      if (nextAgentTaskRevision(revision) === undefined) return failure("revision-exhausted");
+      const time = readClock();
+      if (time === undefined) return failure("invalid-clock");
+      const updated: AgentTaskRecord = {
+        ...task,
+        state: next,
+        ...(next === "running" && task.started_at_ms === undefined ? { started_at_ms: time } : {}),
+        ...(isTerminal(next) ? { ended_at_ms: time } : {}),
+      };
+      return commit(Object.freeze(updated), time);
+    },
+    getSnapshot: () => current,
+    subscribe(listener) {
+      listeners.add(listener);
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/tests/agent-task-registry-regression.test.ts
+++ b/tests/agent-task-registry-regression.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createAgentTaskRegistry } from "../lib/agent-runtime/agent-task-registry.ts";
+
+const error = (value: unknown): void => {
+  assert.deepEqual(value, Object.freeze({ kind: "error", code: "invalid-input" }));
+  assert(Object.isFrozen(value));
+};
+
+test("create contains hostile exact-input reflection", () => {
+  let idCalls = 0;
+  let clockCalls = 0;
+  const registry = createAgentTaskRegistry({
+    createId: () => { idCalls++; return "id"; },
+    now: () => { clockCalls++; return 1; },
+  });
+  const inputs = [
+    new Proxy({ name: "agent" }, { getPrototypeOf() { throw Error("prototype"); } }),
+    new Proxy({ name: "agent" }, { ownKeys() { throw Error("keys"); } }),
+    new Proxy({ name: "agent" }, { getOwnPropertyDescriptor() { throw Error("descriptor"); } }),
+  ];
+  for (const input of inputs) error(registry.create(input));
+  assert.deepEqual([idCalls, clockCalls], [0, 0]);
+});
+
+test("terminal IDs with equal timestamps use code-unit order", () => {
+  const ids = ["a_", "a-"];
+  const registry = createAgentTaskRegistry({ createId: () => ids.shift(), now: () => 1 });
+  const underscore = registry.create({ name: "underscore" });
+  const hyphen = registry.create({ name: "hyphen" });
+  assert.equal(underscore.kind, "ok");
+  assert.equal(hyphen.kind, "ok");
+  if (underscore.kind !== "ok" || hyphen.kind !== "ok") return;
+  registry.transition(underscore.task.id, "running");
+  registry.transition(underscore.task.id, "completed");
+  registry.transition(hyphen.task.id, "running");
+  registry.transition(hyphen.task.id, "completed");
+  assert.deepEqual(registry.getSnapshot().tasks.map(task => task.id), ["a-", "a_"]);
+});

--- a/tests/agent-task-registry.test.ts
+++ b/tests/agent-task-registry.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createAgentTaskRegistry,
+  nextAgentTaskRevision,
+} from "../lib/agent-runtime/agent-task-registry.ts";
+
+type Ok = Extract<ReturnType<ReturnType<typeof createAgentTaskRegistry>["create"]>, { kind: "ok" }>;
+const ok = (value: unknown): Ok => {
+  assert.equal((value as { kind: string }).kind, "ok");
+  return value as Ok;
+};
+const error = (value: unknown, code: string): void => {
+  assert.deepEqual(value, Object.freeze({ kind: "error", code }));
+  assert(Object.isFrozen(value));
+};
+const registry = (ids = ["a", "b", "c"], clocks = [1, 2, 3, 4, 5, 6]) => {
+  let idCalls = 0;
+  let clockCalls = 0;
+  const value = createAgentTaskRegistry({
+    createId: () => {
+      idCalls++;
+      return ids.shift();
+    },
+    now: () => {
+      clockCalls++;
+      return clocks.shift();
+    },
+  });
+  return { value, calls: () => [idCalls, clockCalls] };
+};
+
+test("initial snapshot and revision helper are immutable and bounded", () => {
+  const snapshot = registry().value.getSnapshot();
+  assert.deepEqual(snapshot, { revision: 0, tasks: [] });
+  assert(Object.isFrozen(snapshot));
+  assert(Object.isFrozen(snapshot.tasks));
+  assert.equal(nextAgentTaskRevision(0), 1);
+  assert.equal(nextAgentTaskRevision(Number.MAX_SAFE_INTEGER), undefined);
+});
+
+test("create validates exact data without invoking rejected accessors", () => {
+  const { value, calls } = registry();
+  let accessorCalls = 0;
+  const accessor = Object.create(null, {
+    name: { enumerable: true, get() { accessorCalls++; throw Error("read"); } },
+  });
+  const inherited = Object.create({ name: "agent" });
+  const symbol = Object.assign(Object.create(null), { name: "agent" }, { [Symbol("x")]: "no" });
+  for (const input of [null, [], inherited, accessor, symbol, { name: "agent", extra: "no" }]) {
+    error(value.create(input), "invalid-input");
+  }
+  assert.equal(accessorCalls, 0);
+  assert.deepEqual(calls(), [0, 0]);
+  for (const name of ["", "-bad", "a!", "a".repeat(65)]) {
+    error(value.create({ name }), "invalid-name");
+  }
+  const result = ok(value.create({ name: "agent" }));
+  assert.equal(result.task.id, "a");
+  assert.equal(result.task.kind, "managed-task");
+  assert.strictEqual(result.task, result.snapshot.tasks[0]);
+  assert.strictEqual(result.snapshot, value.getSnapshot());
+  assert.deepEqual(calls(), [1, 1]);
+});
+
+test("creation validates IDs, parents, capacity, and immutable ancestry", () => {
+  const invalid = registry(["bad id"]);
+  error(invalid.value.create({ name: "agent" }), "invalid-id");
+  assert.deepEqual(invalid.calls(), [1, 0]);
+  const duplicate = registry(["a", "a"]);
+  ok(duplicate.value.create({ name: "agent" }));
+  error(duplicate.value.create({ name: "child" }), "duplicate-id");
+  const { value, calls } = registry();
+  for (const parent_id of ["missing", 1, undefined]) error(value.create({ name: "child", parent_id }), "invalid-parent");
+  assert.deepEqual(calls(), [0, 0]);
+  const parent = ok(value.create({ name: "parent" })).task;
+  const child = ok(value.create({ name: "child", parent_id: parent.id })).task;
+  assert.equal(child.parent_id, parent.id);
+  assert(Object.isFrozen(child));
+  assert.throws(() => { (child as { parent_id?: string }).parent_id = "other"; });
+  let sequence = 0;
+  const capacity = createAgentTaskRegistry({ createId: () => `x${sequence++}`, now: () => 1 });
+  for (let index = 0; index < 1000; index++) ok(capacity.create({ name: `a${index}` }));
+  error(capacity.create({ name: "overflow" }), "capacity-exceeded");
+});
+
+test("transitions retain lifecycle timestamps and reject invalid changes", () => {
+  const { value } = registry(["a"], [10, 20, 30, 40, 50]);
+  const queued = ok(value.create({ name: "agent" })).task;
+  assert.equal("started_at_ms" in queued, false);
+  assert.equal("ended_at_ms" in queued, false);
+  const running = ok(value.transition(queued.id, "running")).task;
+  assert.equal(running.started_at_ms, 20);
+  const waiting = ok(value.transition(queued.id, "waiting-for-input")).task;
+  const reentered = ok(value.transition(queued.id, "running")).task;
+  assert.equal(reentered.started_at_ms, running.started_at_ms);
+  const completed = ok(value.transition(queued.id, "completed")).task;
+  assert.equal(completed.ended_at_ms, 50);
+  error(value.transition(queued.id, "queued"), "invalid-transition");
+  error(value.transition("missing", "running"), "unknown-task");
+  error(value.transition(1, "running"), "invalid-input");
+  error(value.transition(queued.id, "no"), "invalid-input");
+  assert.equal(waiting.state, "waiting-for-input");
+});
+
+test("snapshots preserve non-terminal creation order and terminal completion order", () => {
+  const { value } = registry(["a", "b", "c"], [1, 2, 3, 4, 5, 6, 7]);
+  const a = ok(value.create({ name: "a" })).task;
+  const b = ok(value.create({ name: "b" })).task;
+  const c = ok(value.create({ name: "c" })).task;
+  ok(value.transition(c.id, "running"));
+  ok(value.transition(a.id, "running"));
+  assert.deepEqual(value.getSnapshot().tasks.map(task => task.id), [a.id, b.id, c.id]);
+  ok(value.transition(a.id, "completed"));
+  ok(value.transition(c.id, "completed"));
+  assert.deepEqual(value.getSnapshot().tasks.map(task => task.id), [b.id, c.id, a.id]);
+});
+
+test("revision advances once per success and retained values reject caller mutation", () => {
+  const { value } = registry(["a"], [1, 2]);
+  const initial = value.getSnapshot();
+  error(value.transition("missing", "running"), "unknown-task");
+  assert.equal(value.getSnapshot().revision, initial.revision);
+  const created = ok(value.create({ name: "a" }));
+  assert.equal(created.snapshot.revision, initial.revision + 1);
+  error(value.transition(created.task.id, "queued"), "invalid-transition");
+  assert.equal(value.getSnapshot().revision, created.snapshot.revision);
+  const running = ok(value.transition(created.task.id, "running"));
+  assert.equal(running.snapshot.revision, created.snapshot.revision + 1);
+  for (const valueToMutate of [running, running.task, running.snapshot, running.snapshot.tasks]) {
+    assert(Object.isFrozen(valueToMutate));
+  }
+  assert.throws(() => { (running.snapshot.tasks as unknown[]).push({}); });
+  assert.throws(() => { (running.task as { state: string }).state = "failed"; });
+  assert.equal(value.getSnapshot().tasks[0].state, "running");
+});
+
+test("clock failures, terminal ties, and subscriptions are deterministic and contained", () => {
+  const badClock = createAgentTaskRegistry({ createId: () => "a", now: () => { throw Error("no"); } });
+  error(badClock.create({ name: "a" }), "invalid-clock");
+  const nonMonotonic = registry(["a"], [2, 1]);
+  const task = ok(nonMonotonic.value.create({ name: "a" })).task;
+  error(nonMonotonic.value.transition(task.id, "running"), "invalid-clock");
+  const ties = registry(["b", "a", "next"], [1, 1, 1, 1, 1, 1, 1]);
+  const b = ok(ties.value.create({ name: "b" })).task;
+  const a = ok(ties.value.create({ name: "a" })).task;
+  ok(ties.value.transition(b.id, "running"));
+  ok(ties.value.transition(b.id, "completed"));
+  ok(ties.value.transition(a.id, "running"));
+  ok(ties.value.transition(a.id, "completed"));
+  assert.deepEqual(ties.value.getSnapshot().tasks.map(task => task.id), ["a", "b"]);
+  const observed: unknown[] = [];
+  let nested: unknown;
+  const unsubscribe = ties.value.subscribe(snapshot => {
+    observed.push(snapshot);
+    nested = ties.value.create({ name: "nested" });
+  });
+  const result = ok(ties.value.create({ name: "next" }));
+  assert.strictEqual(observed[0], result.snapshot);
+  error(nested, "notification-in-progress");
+  unsubscribe();
+});


### PR DESCRIPTION
Closes #440

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- add the first Gentle-owned authoritative identity and lifecycle registry for managed tasks
- enforce closed task metadata, transitions, timestamps, ordering, bounds, immutable snapshots, and synchronous subscriptions
- keep execution, admission wiring, activity publication, UI, persistence, and external runtime behavior unchanged

## Changes

| File | Change |
|---|---|
| `lib/agent-runtime/agent-task-registry.ts` | Add the pure process-local task registry/state machine and closed mutation contract. |
| `tests/agent-task-registry.test.ts` | Cover identity, ancestry, transitions, timing, ordering, revisions, bounds, immutability, precedence, and subscriptions. |
| `tests/agent-task-registry-regression.test.ts` | Prove hostile reflection is contained and terminal ID ties are locale-independent. |

## Review path

1. Review exact create-input validation and closed mutation results.
2. Review the transition graph, clock ownership, revision handling, and snapshot ordering.
3. Review synchronous subscription semantics and reentrant mutation rejection.
4. Review the hostile-Proxy and locale-independent ordering regressions.

## Test plan

- [x] Focused registry suites — 9/9 passed
- [x] `pnpm test` — 1,045 passed, 10 skipped
- [x] Three candidate syntax checks
- [x] `pnpm run check:runtime-modules`
- [x] `node scripts/verify-package-files.mjs`
- [x] `pnpm run test:packed-package`
- [x] `pnpm run test:cross-lane`
- [x] Direct semantic probes for all 81 state/transition combinations, Proxy reflection traps, collaborator consumption, and locale-free ordering
- [x] `git diff --check upstream/main`

## Scope

This PR is a pure internal registry. It does not construct or execute Pi `AgentSession`s, wire `subagent_run`, register an activity producer, change current external execution, add UI, persist history, poll, replay events, select providers, or create a second task store.

It can land independently and imports neither sibling:

- Activity contract: #432 / #435
- Admission seam: #436 / #439
- Parent runtime tracker: #419
- Presentation dependent: #430

Review workload: **399 changed lines / 400**.

## Contributor checklist

- [x] Linked approved issue #440
- [x] Exactly one `type:*` label (`type:feature`)
- [x] Shellcheck not applicable; no shell scripts changed
- [x] Agent/skill assets not changed
- [x] No documentation update required; no user-facing behavior is connected yet
- [x] Conventional commit used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an in-memory agent task registry for creating, tracking, and transitioning tasks through their lifecycle.
  - Added validation for task identifiers, parent relationships, capacity limits, timestamps, and state changes.
  - Added immutable snapshots with revision tracking for reliable task state access.
  - Added structured failure reporting and subscriptions for task updates.
  - Added deterministic ordering for completed tasks and safeguards against listener or notification errors.

- **Tests**
  - Added comprehensive coverage for validation, lifecycle behavior, ordering, revisions, and mutation protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->