### PR TITLE
feat(runtime): add isolated Pi AgentSession adapter

### DIFF
--- a/lib/agent-runtime/pi-agent-session-adapter.ts
+++ b/lib/agent-runtime/pi-agent-session-adapter.ts
@@ -23,9 +23,9 @@ const TOOL_NAMES = new Set(["read", "bash", "powershell", "edit", "write", "grep
 type Specification = {
 	ownerCwd: string;
 	systemPrompt: string;
-	model: object;
-	modelRegistry: object;
-	thinkingLevel: string;
+	model: NonNullable<CreateAgentSessionOptions["model"]>;
+	modelRegistry: NonNullable<CreateAgentSessionOptions["modelRegistry"]>;
+	thinkingLevel: NonNullable<CreateAgentSessionOptions["thinkingLevel"]>;
 	tools: string[];
 };
 type CreateSession = (options: CreateAgentSessionOptions) => Promise<unknown>;
@@ -91,7 +91,14 @@ function readSpecification(value: unknown): Specification | undefined {
 		if (typeof thinkingLevel !== "string" || !THINKING_LEVELS.has(thinkingLevel)) return undefined;
 		const tools = readTools(suppliedTools);
 		if (tools === undefined) return undefined;
-		return { ownerCwd, systemPrompt, model, modelRegistry, thinkingLevel, tools };
+		return {
+			ownerCwd,
+			systemPrompt,
+			model: model as Specification["model"],
+			modelRegistry: modelRegistry as Specification["modelRegistry"],
+			thinkingLevel: thinkingLevel as Specification["thinkingLevel"],
+			tools,
+		};
 	} catch {
 		return undefined;
 	}

--- a/lib/agent-runtime/pi-agent-session-adapter.ts
+++ b/lib/agent-runtime/pi-agent-session-adapter.ts
@@ -1,0 +1,204 @@
+import {
+	createAgentSession,
+	createExtensionRuntime,
+	SessionManager,
+	SettingsManager,
+	type AgentSession,
+	type CreateAgentSessionOptions,
+	type ResourceLoader,
+} from "@earendil-works/pi-coding-agent";
+import { posix, win32 } from "node:path";
+
+const SPECIFICATION_KEYS = [
+	"ownerCwd",
+	"systemPrompt",
+	"model",
+	"modelRegistry",
+	"thinkingLevel",
+	"tools",
+] as const;
+const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh"]);
+const TOOL_NAMES = new Set(["read", "bash", "powershell", "edit", "write", "grep", "find", "ls"]);
+
+type Specification = {
+	ownerCwd: string;
+	systemPrompt: string;
+	model: object;
+	modelRegistry: object;
+	thinkingLevel: string;
+	tools: string[];
+};
+type CreateSession = (options: CreateAgentSessionOptions) => Promise<unknown>;
+type FailureCode = "invalid-spec" | "session-creation-failed" | "session-contract-failed" | "cleanup-failed";
+export type PiAgentSessionPreparationResult =
+	| Readonly<{ kind: "ready"; session: AgentSession }>
+	| Readonly<{ kind: "failed"; code: FailureCode }>;
+
+function failed(code: FailureCode): PiAgentSessionPreparationResult {
+	return Object.freeze({ kind: "failed", code });
+}
+
+function isObject(value: unknown): value is object {
+	return typeof value === "object" && value !== null;
+}
+
+function isPlainObject(value: unknown): value is object {
+	if (!isObject(value)) return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function isNonArrayObject(value: unknown): value is object {
+	return isObject(value) && !Array.isArray(value);
+}
+
+function isAbsolutePath(value: string): boolean {
+	return posix.isAbsolute(value) || win32.isAbsolute(value);
+}
+
+function hasExactKeys(value: object): boolean {
+	const keys = Reflect.ownKeys(value);
+	if (keys.length !== SPECIFICATION_KEYS.length) return false;
+	return keys.every((key) => typeof key === "string" && SPECIFICATION_KEYS.includes(key as typeof SPECIFICATION_KEYS[number]));
+}
+
+function readDataValues(value: object, keys: readonly string[]): unknown[] | undefined {
+	const descriptors = keys.map((key) => Object.getOwnPropertyDescriptor(value, key));
+	if (descriptors.some((descriptor) => descriptor === undefined || !("value" in descriptor))) return undefined;
+	return descriptors.map((descriptor) => descriptor.value);
+}
+
+function readTools(value: unknown): string[] | undefined {
+	if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) return undefined;
+	const keys = Reflect.ownKeys(value);
+	if (keys.length !== value.length + 1) return undefined;
+	if (keys.some((key, index) => key !== "length" && key !== String(index))) return undefined;
+	const tools = readDataValues(value, Array.from({ length: value.length }, (_, index) => String(index)));
+	if (tools === undefined || tools.some((tool) => typeof tool !== "string" || !TOOL_NAMES.has(tool))) return undefined;
+	if (new Set(tools).size !== tools.length) return undefined;
+	return tools as string[];
+}
+
+function readSpecification(value: unknown): Specification | undefined {
+	try {
+		if (!isPlainObject(value) || !hasExactKeys(value)) return undefined;
+		const values = readDataValues(value, SPECIFICATION_KEYS);
+		if (values === undefined) return undefined;
+		const [ownerCwd, systemPrompt, model, modelRegistry, thinkingLevel, suppliedTools] = values;
+		if (typeof ownerCwd !== "string" || !isAbsolutePath(ownerCwd) || ownerCwd.includes("\0")) return undefined;
+		if (typeof systemPrompt !== "string" || systemPrompt.trim() === "") return undefined;
+		if (!isNonArrayObject(model) || !isNonArrayObject(modelRegistry)) return undefined;
+		if (typeof thinkingLevel !== "string" || !THINKING_LEVELS.has(thinkingLevel)) return undefined;
+		const tools = readTools(suppliedTools);
+		if (tools === undefined) return undefined;
+		return { ownerCwd, systemPrompt, model, modelRegistry, thinkingLevel, tools };
+	} catch {
+		return undefined;
+	}
+}
+
+function createResourceLoader(systemPrompt: string): ResourceLoader {
+	const runtime = createExtensionRuntime();
+	return {
+		getExtensions: () => ({ extensions: [], errors: [], runtime }),
+		getSkills: () => ({ skills: [], diagnostics: [] }),
+		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getThemes: () => ({ themes: [], diagnostics: [] }),
+		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getSystemPrompt: () => systemPrompt,
+		getAppendSystemPrompt: () => [],
+		extendResources: () => {},
+		reload: async () => {},
+	};
+}
+
+function createOptions(specification: Specification): CreateAgentSessionOptions {
+	const tools = Object.freeze([...specification.tools]);
+	return Object.freeze({
+		cwd: specification.ownerCwd,
+		model: specification.model,
+		modelRegistry: specification.modelRegistry,
+		thinkingLevel: specification.thinkingLevel,
+		tools,
+		...(tools.length === 0 ? { noTools: "all" as const } : {}),
+		customTools: Object.freeze([]),
+		resourceLoader: createResourceLoader(specification.systemPrompt),
+		sessionManager: SessionManager.inMemory(specification.ownerCwd),
+		settingsManager: SettingsManager.inMemory(),
+	});
+}
+
+function acquireSession(result: unknown): object | undefined {
+	try {
+		if (!isObject(result)) return undefined;
+		const descriptor = Object.getOwnPropertyDescriptor(result, "session");
+		if (descriptor === undefined || !("value" in descriptor) || !isObject(descriptor.value)) return undefined;
+		return descriptor.value;
+	} catch {
+		return undefined;
+	}
+}
+
+function acquireDispose(session: object): (() => unknown) | undefined {
+	try {
+		const dispose = (session as { dispose?: unknown }).dispose;
+		return typeof dispose === "function" ? dispose : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function sessionMatchesContract(session: object, tools: readonly string[]): boolean {
+	try {
+		const prompt = (session as { prompt?: unknown }).prompt;
+		const getActiveToolNames = (session as { getActiveToolNames?: unknown }).getActiveToolNames;
+		const agent = (session as { agent?: unknown }).agent;
+		const sessionFile = (session as { sessionFile?: unknown }).sessionFile;
+		if (typeof prompt !== "function" || typeof getActiveToolNames !== "function") return false;
+		if (!isObject(agent) || typeof (agent as { subscribe?: unknown }).subscribe !== "function") return false;
+		if (sessionFile !== undefined) return false;
+		const activeTools = getActiveToolNames.call(session);
+		if (!Array.isArray(activeTools) || activeTools.length !== tools.length) return false;
+		if (new Set(activeTools).size !== activeTools.length) return false;
+		return activeTools.every((tool) => typeof tool === "string" && tools.includes(tool));
+	} catch {
+		return false;
+	}
+}
+
+function cleanUp(session: object, dispose: () => unknown): boolean {
+	try {
+		dispose.call(session);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function preparePiAgentSession(
+	input: unknown,
+	injectedCreateSession?: CreateSession,
+): Promise<PiAgentSessionPreparationResult> {
+	const specification = readSpecification(input);
+	if (specification === undefined) return failed("invalid-spec");
+
+	let options: CreateAgentSessionOptions;
+	let result: unknown;
+	try {
+		options = createOptions(specification);
+		result = await (injectedCreateSession ?? createAgentSession)(options);
+	} catch {
+		return failed("session-creation-failed");
+	}
+
+	const session = acquireSession(result);
+	if (session === undefined) return failed("session-creation-failed");
+
+	const dispose = acquireDispose(session);
+	if (dispose === undefined) return failed("cleanup-failed");
+	if (!sessionMatchesContract(session, options.tools ?? [])) {
+		return cleanUp(session, dispose) ? failed("session-contract-failed") : failed("cleanup-failed");
+	}
+
+	return Object.freeze({ kind: "ready", session: session as AgentSession });
+}

--- a/tests/pi-agent-session-adapter.test.ts
+++ b/tests/pi-agent-session-adapter.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { preparePiAgentSession } from "../lib/agent-runtime/pi-agent-session-adapter.ts";
+
+const validSpecification = () => ({
+	ownerCwd: "/synthetic/owner",
+	systemPrompt: "SYNTHETIC_PROMPT",
+	model: {},
+	modelRegistry: {},
+	thinkingLevel: "high",
+	tools: ["read", "grep"],
+});
+
+type Calls = {
+	factory: number;
+	dispose: number;
+	prompt: number;
+	subscribe: number;
+	options?: Record<string, unknown>;
+};
+
+function createSession(calls: Calls, changes: Record<string, unknown> = {}) {
+	return Object.assign({
+		dispose: () => calls.dispose++,
+		prompt: () => calls.prompt++,
+		getActiveToolNames: () => ["grep", "read"],
+		agent: { subscribe: () => calls.subscribe++ },
+		sessionFile: undefined,
+	}, changes);
+}
+
+function createFactory(calls: Calls, value: unknown) {
+	return async (options: Record<string, unknown>) => {
+		calls.factory++;
+		calls.options = options;
+		return value;
+	};
+}
+
+const DEFAULT_FACTORY_RESULT = Symbol("default-factory-result");
+
+async function prepare(input: unknown = validSpecification(), ...factoryResults: unknown[]) {
+	const calls: Calls = { factory: 0, dispose: 0, prompt: 0, subscribe: 0 };
+	const session = createSession(calls);
+	const value = factoryResults.length === 0 ? DEFAULT_FACTORY_RESULT : factoryResults[0];
+	const result = await preparePiAgentSession(input, createFactory(calls, value === DEFAULT_FACTORY_RESULT ? { session } : value) as never);
+	return { calls, result, session };
+}
+
+test("rejects exact plain specifications without reading accessors or calling Pi", async () => {
+	const accessor = { ...validSpecification() };
+	Object.defineProperty(accessor, "ownerCwd", { enumerable: true, get: () => { throw new Error("read"); } });
+	const rejected: unknown[] = [
+		null,
+		[],
+		Object.create(validSpecification()),
+		{ ...validSpecification(), extra: "not-read" },
+		{ ...validSpecification(), [Symbol("extra")]: true },
+		accessor,
+		{ ...validSpecification(), ownerCwd: "relative" },
+		{ ...validSpecification(), ownerCwd: "/nul\0" },
+		{ ...validSpecification(), systemPrompt: " " },
+		{ ...validSpecification(), model: [] },
+		{ ...validSpecification(), modelRegistry: [] },
+		{ ...validSpecification(), thinkingLevel: "maximum" },
+		{ ...validSpecification(), tools: ["read", "read"] },
+		{ ...validSpecification(), tools: ["unknown"] },
+	];
+	for (const input of rejected) {
+		const { calls, result } = await prepare(input);
+		assert.deepEqual(result, { kind: "failed", code: "invalid-spec" });
+		assert.equal(calls.factory, 0);
+		assert.ok(Object.isFrozen(result));
+	}
+	const nullPrototype = Object.assign(Object.create(null), validSpecification());
+	assert.equal((await prepare(nullPrototype)).result.kind, "ready");
+	assert.equal((await prepare({ ...validSpecification(), ownerCwd: "C:\\owner" })).result.kind, "ready");
+	assert.equal((await prepare({ ...validSpecification(), ownerCwd: "\\\\server\\owner" })).result.kind, "ready");
+	assert.equal((await prepare(new Proxy(validSpecification(), { ownKeys: () => { throw new Error("hostile"); } }))).result.code, "invalid-spec");
+	const revoked = Proxy.revocable(validSpecification(), {});
+	revoked.revoke();
+	assert.equal((await prepare(revoked.proxy)).result.code, "invalid-spec");
+});
+
+test("uses isolated local Pi 0.74 options and an empty resource loader", async () => {
+	const input = validSpecification();
+	const { calls, result } = await prepare(input);
+	assert.equal(result.kind, "ready");
+	assert.equal(calls.factory, 1);
+	const options = calls.options!;
+	assert.deepEqual(Object.keys(options).sort(), ["customTools", "cwd", "model", "modelRegistry", "resourceLoader", "sessionManager", "settingsManager", "thinkingLevel", "tools"]);
+	assert.equal(options.cwd, input.ownerCwd);
+	assert.equal(options.model, input.model);
+	assert.equal(options.modelRegistry, input.modelRegistry);
+	assert.deepEqual(options.tools, ["read", "grep"]);
+	assert.notEqual(options.tools, input.tools);
+	assert.deepEqual(options.customTools, []);
+	assert.ok(Object.isFrozen(options));
+	assert.ok(Object.isFrozen(options.tools));
+	const loader = options.resourceLoader as Record<string, () => unknown>;
+	assert.deepEqual(loader.getExtensions().extensions, []);
+	assert.deepEqual(loader.getSkills(), { skills: [], diagnostics: [] });
+	assert.deepEqual(loader.getPrompts(), { prompts: [], diagnostics: [] });
+	assert.deepEqual(loader.getThemes(), { themes: [], diagnostics: [] });
+	assert.deepEqual(loader.getAgentsFiles(), { agentsFiles: [] });
+	assert.equal(loader.getSystemPrompt(), input.systemPrompt);
+	assert.deepEqual(loader.getAppendSystemPrompt(), []);
+	assert.equal(loader.extendResources(), undefined);
+	await loader.reload();
+	const empty = await prepare({ ...validSpecification(), tools: [] });
+	assert.equal(empty.calls.options!.noTools, "all");
+});
+
+test("classifies factory and manager failures without cleanup or private output", async () => {
+	const throwingSessionGetter = Object.defineProperty({}, "session", { get: () => { throw new Error("hostile"); } });
+	for (const result of [null, undefined, 1, {}, { session: null }, { session: 1 }, throwingSessionGetter, new Proxy({}, { getOwnPropertyDescriptor: () => { throw new Error("hostile"); } })]) {
+		const { calls, result: prepared } = await prepare(validSpecification(), result);
+		assert.deepEqual(prepared, { kind: "failed", code: "session-creation-failed" });
+		assert.equal(calls.factory, 1);
+		assert.equal(calls.dispose, 0);
+	}
+	const calls: Calls = { factory: 0, dispose: 0, prompt: 0, subscribe: 0 };
+	const factory = async () => { calls.factory++; throw new Error("private detail"); };
+	assert.equal((await preparePiAgentSession(validSpecification(), factory as never)).code, "session-creation-failed");
+	assert.equal(calls.dispose, 0);
+});
+
+test("acquires each capability once, cleans invalid sessions, and preserves exact ready identity", async () => {
+	for (const changes of [{ dispose: undefined }, { dispose: 1 }]) {
+		const calls: Calls = { factory: 0, dispose: 0, prompt: 0, subscribe: 0 };
+		const result = await preparePiAgentSession(validSpecification(), createFactory(calls, { session: createSession(calls, changes) }) as never);
+		assert.equal(result.code, "cleanup-failed");
+		assert.equal(calls.dispose, 0);
+	}
+	for (const changes of [{ prompt: undefined }, { getActiveToolNames: () => ["read"] }, { agent: null }, { sessionFile: "/persisted" }]) {
+		const calls: Calls = { factory: 0, dispose: 0, prompt: 0, subscribe: 0 };
+		const result = await preparePiAgentSession(validSpecification(), createFactory(calls, { session: createSession(calls, changes) }) as never);
+		assert.equal(result.code, "session-contract-failed");
+		assert.equal(calls.dispose, 1);
+	}
+	const calls: Calls = { factory: 0, dispose: 0, prompt: 0, subscribe: 0 };
+	const reads = { dispose: 0, prompt: 0, active: 0, agent: 0, subscribe: 0, file: 0 };
+	const session = {} as Record<string, unknown>;
+	Object.defineProperties(session, {
+		dispose: { get: () => { reads.dispose++; return () => calls.dispose++; } },
+		prompt: { get: () => { reads.prompt++; return () => calls.prompt++; } },
+		getActiveToolNames: { get: () => { reads.active++; return () => ["read", "grep"]; } },
+		agent: { get: () => { reads.agent++; return { get subscribe() { reads.subscribe++; return () => calls.subscribe++; } }; } },
+		sessionFile: { get: () => { reads.file++; return undefined; } },
+	});
+	const result = await preparePiAgentSession(validSpecification(), createFactory(calls, { session }) as never);
+	assert.equal(result.kind, "ready");
+	assert.equal(result.session, session);
+	assert.ok(Object.isFrozen(result));
+	assert.deepEqual(reads, { dispose: 1, prompt: 1, active: 1, agent: 1, subscribe: 1, file: 1 });
+	assert.deepEqual(calls, { factory: 1, dispose: 0, prompt: 0, subscribe: 0, options: calls.options });
+	const broken = createSession(calls, { getActiveToolNames: () => { throw new Error("private"); }, dispose: () => { calls.dispose++; throw new Error("private"); } });
+	assert.equal((await preparePiAgentSession(validSpecification(), createFactory(calls, { session: broken }) as never)).code, "cleanup-failed");
+});
+
+test("uses only public Pi imports and never starts a ready lifecycle", () => {
+	const source = readFileSync(fileURLToPath(new URL("../lib/agent-runtime/pi-agent-session-adapter.ts", import.meta.url)), "utf8");
+	assert.match(source, /from "@earendil-works\/pi-coding-agent"/);
+	assert.match(source, /let options: CreateAgentSessionOptions;\s+let result: unknown;\s+try \{\s+options = createOptions\(specification\);\s+result = await \(injectedCreateSession \?\? createAgentSession\)\(options\);/s);
+	assert.doesNotMatch(source, /console\.|agent-runtime\.ts|subagent_run|\.prompt\(|\.subscribe\(/i);
+});


### PR DESCRIPTION
Closes #444

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- add a real public-SDK adapter for constructing one isolated Pi 0.74 `AgentSession`
- enforce exact owner context, system prompt, model registry, thinking level, tools, in-memory managers, and empty ambient resources
- return only a closed ready/failure result without prompting, task lifecycle, persistence, or production wiring

## Changes

| File | Change |
|---|---|
| `lib/agent-runtime/pi-agent-session-adapter.ts` | Add exact input validation, Pi 0.74 ResourceLoader isolation, in-memory construction, capability checks, and cleanup precedence. |
| `tests/pi-agent-session-adapter.test.ts` | Cover hostile inputs, exact SDK options/loader shape, in-memory managers, malformed sessions, cleanup, privacy, and ready-session identity. |

## Review path

1. Review exact specification validation and closed failure envelopes.
2. Review the nine-method repository-local Pi 0.74 ResourceLoader and construction options.
3. Review acquired-session capability checks and cleanup precedence.
4. Confirm the ready path returns the exact session without prompting, subscribing, aborting, or disposing it.

## Pi compatibility

The repository-local locked Pi **0.74.0** declarations/source are authoritative. The global development installation is 0.84.3, so this adapter intentionally excludes newer ResourceLoader source-introspection methods.

## Test plan

- [x] Focused adapter suite — 5/5 passed
- [x] `pnpm test` — 1,067 passed, 10 skipped
- [x] Candidate syntax checks
- [x] `pnpm run check:runtime-modules`
- [x] `node scripts/verify-package-files.mjs`
- [x] `pnpm run test:packed-package`
- [x] `pnpm run test:cross-lane`
- [x] Direct semantic probes for hostile input, POSIX/drive/UNC paths, exact loader/options, tool contracts, receiver binding, cleanup, privacy, and ready identity
- [x] `git diff --check upstream/main`

## Scope

This PR constructs a session capability only. It does not send a prompt, subscribe to run events, create or transition a managed task, add `extensions/agent-runtime.ts`, wire `subagent_run`, change current execution, persist state, publish activity, or add UI.

```text
#419
├── #440 / #441: lifecycle authority
├── 📍 #444: isolated Pi session adapter
└── next: foreground executor combining both
```

Review workload: **372 changed lines / 400**.

## Contributor checklist

- [x] Linked approved issue #444
- [x] Exactly one `type:*` label (`type:feature`)
- [x] Shellcheck not applicable; no shell scripts changed
- [x] Agent/skill assets not changed
- [x] No documentation update required; no user-facing behavior is connected
- [x] Conventional commit used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preparation support for Pi agent sessions with strict input validation.
  * Valid sessions now provide isolated configuration and verified active tools.
  * Invalid or failed sessions return categorized results and are safely cleaned up.

* **Reliability**
  * Added safeguards for invalid session contracts, creation failures, and cleanup errors.
  * Improved validation of session capabilities and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->