### PR TITLE
fix(review): preserve consent binding continuity

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3379,10 +3379,16 @@ interface PendingReviewConsent {
 	expiry?: ReturnType<typeof setTimeout>;
 }
 
+interface PendingReviewConsentClaim {
+	sessionKey: PendingReviewConsentSessionKey;
+	pending: PendingReviewConsent;
+}
+
 /**
  * Process-memory-only pending consent partitions. A loaded extension module
- * shares this registry across registrations, while exact Pi session IDs remain
- * the only continuity boundary. It intentionally has no persistence surface.
+ * shares this registry across registrations. Session buckets own cleanup, while
+ * an opaque binding can be claimed once by any active session. It intentionally
+ * has no persistence surface.
  */
 export class PendingReviewConsentRegistry {
 	private readonly sessions = new Map<PendingReviewConsentSessionKey, Map<string, PendingReviewConsent>>();
@@ -3405,6 +3411,16 @@ export class PendingReviewConsentRegistry {
 		if (session?.get(pending.id) !== pending) return;
 		session.delete(pending.id);
 		if (session.size === 0) this.sessions.delete(sessionKey);
+	}
+
+	claim(id: string): PendingReviewConsentClaim | undefined {
+		for (const [sessionKey, session] of this.sessions) {
+			const pending = session.get(id);
+			if (pending === undefined) continue;
+			consumePendingReviewConsent(pending, this, sessionKey);
+			return { sessionKey, pending };
+		}
+		return undefined;
 	}
 
 	take(sessionKey: PendingReviewConsentSessionKey): PendingReviewConsent[] {
@@ -4564,9 +4580,11 @@ async function executeReviewControllerOperation(
 		if (Object.keys(input).some((key) => key !== "consentBinding" && key !== "answer") || Object.keys(input).length !== 2) throw new Error("Review controller answer-consent input must contain exactly consentBinding and answer");
 		if (typeof input.consentBinding !== "string" || input.consentBinding.length === 0) throw new Error("Review controller answer-consent requires an opaque consentBinding");
 		if (input.answer !== "granted" && input.answer !== "declined") throw new Error("Review controller answer-consent answer must be granted or declined");
-		const pending = pendingReviewConsentRegistry.get(pendingReviewConsentSession)?.get(input.consentBinding);
+		const pendingClaim = pendingReviewConsentRegistry.claim(input.consentBinding);
+		const pending = pendingClaim?.pending;
+		const pendingSession = pendingClaim?.sessionKey;
 		if (pending === undefined || pending.expiresAt <= reviewConsentNow()) {
-			if (pending !== undefined) cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession);
+			if (pending !== undefined && pendingSession !== undefined) cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, pendingSession);
 			if (nativeReviewCli?.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
 			try {
 				const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, {
@@ -4586,7 +4604,7 @@ async function executeReviewControllerOperation(
 		try {
 			const gated = await resolveReviewModeGate(nativeReviewCli, parameters.operation, defaultCwd, signal);
 			if (gated !== undefined) {
-				cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession);
+				cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, pendingSession!);
 				return gated;
 			}
 		} catch (error) {
@@ -4594,7 +4612,6 @@ async function executeReviewControllerOperation(
 		}
 		// The one-shot binding is consumed before the provider mutation. Any
 		// ambiguous result reconciles through STATUS and can never be replayed.
-		consumePendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession);
 		let completed: Record<string, unknown>;
 		try {
 			const answered = await nativeReviewCli.answerConsent({

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -383,7 +383,7 @@ test("public gentle:review-mode handler reports current operations, global-off w
 	assert.deepEqual(unavailableNotices, [{ message: "Gentle AI review mode is not available with the currently negotiated native version.", type: "info" }]);
 });
 
-test("public consent relay is session-bound, one-shot, and candidate-scoped", async (t) => {
+test("public consent relay is one-shot and candidate-scoped across active sessions", async (t) => {
 	const cwd = repository(t);
 	const sharedRegistry = new PendingReviewConsentRegistry();
 	const fixture = consentNative(cwd);
@@ -395,10 +395,9 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 
 	const blockedA = await beginConsent(first, cwd, "session-a");
 	assert.deepEqual(blockedA.consent, decodeReviewConsentV3(captured("consent-v3.captured.json")).raw);
-	const staleOtherSession = await answerConsent(second, cwd, blockedA.consent_binding, "declined", "session-b");
-	assert.equal(staleOtherSession.operation, "answer-consent");
-	assert.equal(staleOtherSession.status, "ready");
-	assert.deepEqual(fixture.answers, ["declined"]);
+	const crossSessionDeclined = await answerConsent(second, cwd, blockedA.consent_binding, "declined", "session-b");
+	assert.equal(crossSessionDeclined.outcome, "consent-declined-this-candidate");
+	assert.deepEqual(fixture.answers, ["declined", "declined"]);
 	const blockedB = await beginConsent(second, cwd, "session-b");
 	const declined = await answerConsent(second, cwd, blockedB.consent_binding, "declined", "session-b");
 	assert.equal(declined.outcome, "consent-declined-this-candidate");
@@ -406,7 +405,7 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	const staleConsumed = await answerConsent(second, cwd, blockedB.consent_binding, "declined", "session-b");
 	assert.equal(staleConsumed.operation, "answer-consent");
 	assert.equal(staleConsumed.status, "ready");
-	assert.deepEqual(fixture.answers, ["declined", "declined"]);
+	assert.deepEqual(fixture.answers, ["declined", "declined", "declined"]);
 
 	const shutdown = first.events.get("session_shutdown");
 	assert.ok(shutdown);
@@ -431,6 +430,51 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	assert.equal(staleModeCleared.operation, "answer-consent");
 	assert.equal(staleModeCleared.status, "ready");
 	assert.equal(fixture.starts.count, 4);
+});
+
+test("active shared consent bindings continue across session boundaries exactly once", async (t) => {
+	const cwd = repository(t);
+	const candidateViews = new CandidateViewRegistry();
+	const sharedRegistry = new PendingReviewConsentRegistry();
+	const fixture = consentNative(cwd);
+	const answer = fixture.native.answerConsent!;
+	fixture.native.answerConsent = async (request) => {
+		const result = await answer(request);
+		return { ...result, start: { ...result.start!, state: "reviewing", action: "created", lensesRequired: true, selectedLenses: ["review-risk"] } };
+	};
+	const expiry = { registered: 0, fired: 0 };
+	const sessionA = parityRuntime(fixture.native, {
+		candidateViews,
+		pendingReviewConsentRegistry: sharedRegistry,
+		scheduleTimer: (callback) => {
+			expiry.registered += 1;
+			return setTimeout(() => {
+				expiry.fired += 1;
+				callback();
+			}, 0);
+		},
+	});
+	const sessionB = parityRuntime(fixture.native, { pendingReviewConsentRegistry: sharedRegistry });
+	const blocked = await beginConsent(sessionA, cwd, "session-a");
+	const completed = await answerConsent(sessionB, cwd, blocked.consent_binding, "granted", "session-b");
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	assert.deepEqual(expiry, { registered: 1, fired: 0 });
+
+	assert.deepEqual(
+		{
+			answers: fixture.answers,
+			lineageId: (completed.result as { lineage_id?: string }).lineage_id,
+			activeLineageId: candidateViews.currentLineageId(cwd),
+			status: completed.status,
+		},
+		{
+			answers: ["granted"],
+			lineageId: "consent-lineage",
+			activeLineageId: "consent-lineage",
+			status: undefined,
+		},
+	);
+	candidateViews.cleanupAll();
 });
 
 test("stale local consent bindings reconcile exactly once with the native status transition", async (t) => {


### PR DESCRIPTION
Closes #455

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Claim pending review-consent bindings across active Pi sessions exactly once.
- Cancel the binding expiration timer during claim so it cannot delete the granted candidate view later.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Adds cross-session consent claim and consumes the binding before provider mutation. |
| `tests/native-review-parity.test.ts` | Covers cross-session one-shot grant and expiration-timer cancellation. |

## Test plan

- [x] `pnpm test` — 1083 tests, 1082 passed, 1 skipped.
- [x] `pnpm run check:runtime-modules`
- [x] `pnpm run test:packed-package`
- [x] Candidate-scoped RDD review completed and approved after rebasing onto current `origin/main`.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] Runtime behavior is covered through the Pi parity suite.
- [x] Documentation is not required for this internal lifecycle fix.
- [x] Commit uses conventional commit format.
- [x] No `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consent requests can now be answered from a different active session.
  * Cross-session consent responses are securely consumed once and cannot be replayed.
* **Bug Fixes**
  * Fixed valid cross-session consent declines being incorrectly treated as stale.
  * Improved handling of granted consent, including lineage creation and expiration tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->