### PR TITLE
fix(guard): emit guarded command permission lifecycle

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1069,11 +1069,17 @@ async function confirmCommand(
 			toolName: "bash",
 		});
 	};
+	const emitHerdrBlocked = (active: boolean): void => {
+		events.emit("herdr:blocked", active
+			? { active: true, label: "Guarded command confirmation" }
+			: { active: false });
+	};
 
 	let approved = false;
 	let confirmationFailed = false;
 	let confirmationError: unknown;
 	emitPermissionRequest("waiting");
+	emitHerdrBlocked(true);
 	try {
 		approved = await ctx.ui.confirm("Allow guarded command?", preview);
 	} catch (error) {
@@ -1081,6 +1087,7 @@ async function confirmCommand(
 		confirmationError = error;
 	} finally {
 		emitPermissionRequest(confirmationFailed || !approved ? "denied" : "approved");
+		emitHerdrBlocked(false);
 	}
 	if (confirmationFailed) throw confirmationError;
 	if (approved) return undefined;

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1023,10 +1023,32 @@ function evaluateSensitivePathTool(
 	};
 }
 
+type HerdrConfirmationLifecycle = {
+	begin(): void;
+	settle(): void;
+};
+
+function createHerdrConfirmationLifecycle(events: ExtensionAPI["events"]): HerdrConfirmationLifecycle {
+	let pending = 0;
+	return {
+		begin() {
+			const wasIdle = pending === 0;
+			pending += 1;
+			if (wasIdle) events.emit("herdr:blocked", { active: true, label: "Guarded command confirmation" });
+		},
+		settle() {
+			if (pending === 0) return;
+			pending -= 1;
+			if (pending === 0) events.emit("herdr:blocked", { active: false });
+		},
+	};
+}
+
 async function confirmCommand(
 	command: string,
 	ctx: ExtensionContext,
 	events: ExtensionAPI["events"],
+	herdrLifecycle: HerdrConfirmationLifecycle,
 ): Promise<ToolCallEventResult | undefined> {
 	const guardrailsConfig = loadRuntimeGuardrailsConfig(ctx.cwd);
 	const classification = classifyGuardedCommand(command, guardrailsConfig);
@@ -1069,25 +1091,22 @@ async function confirmCommand(
 			toolName: "bash",
 		});
 	};
-	const emitHerdrBlocked = (active: boolean): void => {
-		events.emit("herdr:blocked", active
-			? { active: true, label: "Guarded command confirmation" }
-			: { active: false });
-	};
-
 	let approved = false;
 	let confirmationFailed = false;
 	let confirmationError: unknown;
 	emitPermissionRequest("waiting");
-	emitHerdrBlocked(true);
+	herdrLifecycle.begin();
 	try {
 		approved = await ctx.ui.confirm("Allow guarded command?", preview);
 	} catch (error) {
 		confirmationFailed = true;
 		confirmationError = error;
 	} finally {
-		emitPermissionRequest(confirmationFailed || !approved ? "denied" : "approved");
-		emitHerdrBlocked(false);
+		try {
+			emitPermissionRequest(confirmationFailed || !approved ? "denied" : "approved");
+		} finally {
+			herdrLifecycle.settle();
+		}
 	}
 	if (confirmationFailed) throw confirmationError;
 	if (approved) return undefined;
@@ -4980,6 +4999,7 @@ function createGentleAiExtensionForTesting(
 	return function gentleAi(pi: ExtensionAPI): void {
 	const pendingReviewConsentFallbackKey = Symbol("pending-review-consent-fallback");
 	const candidateViews = dependencies.candidateViews === undefined ? new CandidateViewRegistry() : dependencies.candidateViews;
+	const herdrLifecycle = createHerdrConfirmationLifecycle(pi.events);
 
 	pi.on("session_shutdown", (_event, context) => {
 		const sessionKey = pendingReviewConsentSessionKey(context, pendingReviewConsentFallbackKey);
@@ -5202,7 +5222,7 @@ function createGentleAiExtensionForTesting(
 		if (!isRecord(event.input) || typeof event.input.command !== "string") {
 			return undefined;
 		}
-		return await confirmCommand(event.input.command, ctx, pi.events);
+		return await confirmCommand(event.input.command, ctx, pi.events, herdrLifecycle);
 	});
 
 	pi.registerCommand("gentle:install-sdd", {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1026,6 +1026,7 @@ function evaluateSensitivePathTool(
 async function confirmCommand(
 	command: string,
 	ctx: ExtensionContext,
+	events: ExtensionAPI["events"],
 ): Promise<ToolCallEventResult | undefined> {
 	const guardrailsConfig = loadRuntimeGuardrailsConfig(ctx.cwd);
 	const classification = classifyGuardedCommand(command, guardrailsConfig);
@@ -1056,7 +1057,32 @@ async function confirmCommand(
 		180,
 		"…",
 	);
-	const approved = await ctx.ui.confirm("Allow guarded command?", preview);
+	const requestId = randomUUID();
+	const emitPermissionRequest = (
+		state: "waiting" | "approved" | "denied",
+	): void => {
+		events.emit("pi-permission-system:permission-request", {
+			requestId,
+			state,
+			source: "tool_call",
+			message: "Gentle AI safety policy requires confirmation for this tool call.",
+			toolName: "bash",
+		});
+	};
+
+	let approved = false;
+	let confirmationFailed = false;
+	let confirmationError: unknown;
+	emitPermissionRequest("waiting");
+	try {
+		approved = await ctx.ui.confirm("Allow guarded command?", preview);
+	} catch (error) {
+		confirmationFailed = true;
+		confirmationError = error;
+	} finally {
+		emitPermissionRequest(confirmationFailed || !approved ? "denied" : "approved");
+	}
+	if (confirmationFailed) throw confirmationError;
 	if (approved) return undefined;
 	return {
 		block: true,
@@ -5169,7 +5195,7 @@ function createGentleAiExtensionForTesting(
 		if (!isRecord(event.input) || typeof event.input.command !== "string") {
 			return undefined;
 		}
-		return await confirmCommand(event.input.command, ctx);
+		return await confirmCommand(event.input.command, ctx, pi.events);
 	});
 
 	pi.registerCommand("gentle:install-sdd", {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -484,6 +484,7 @@ test("delivery commands bypass RDD under every mode outcome while command safety
 			on(name: string, handler: ToolCallHandler) {
 				handlers.set(name, handler);
 			},
+			events: { emit() {} },
 			registerCommand() {},
 			registerTool() {},
 		} as unknown as ExtensionAPI;
@@ -500,5 +501,165 @@ test("delivery commands bypass RDD under every mode outcome while command safety
 			const result = await toolCall!({ toolName: "bash", input: { command } }, ctx);
 			assert.equal(result, undefined, `${mode.label}: ${command}`);
 		}
+	}
+});
+
+test("guarded command confirmation emits a generic correlated permission lifecycle", async () => {
+	type ToolCallHandler = (
+		event: { toolName: string; input: unknown },
+		ctx: ExtensionContext,
+	) => Promise<ToolCallEventResult | undefined>;
+	type PermissionEvent = {
+		channel: string;
+		data: {
+			requestId: string;
+			state: "waiting" | "approved" | "denied";
+			source: "tool_call";
+			message: string;
+			toolName: "bash";
+		};
+	};
+	const handlers = new Map<string, ToolCallHandler>();
+	const emitted: PermissionEvent[] = [];
+	const sequence: string[] = [];
+	let confirm!: () => Promise<boolean>;
+	const pi = {
+		on(name: string, handler: ToolCallHandler) {
+			handlers.set(name, handler);
+		},
+		events: {
+			emit(channel: string, data: PermissionEvent["data"]) {
+				sequence.push(`event:${data.state}`);
+				emitted.push({ channel, data });
+			},
+		},
+		registerCommand() {},
+		registerTool() {},
+	} as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli: null })(pi);
+	const toolCall = handlers.get("tool_call");
+	assert.equal(typeof toolCall, "function");
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-permission-request-"));
+	try {
+		const ctx = {
+			cwd,
+			hasUI: true,
+			ui: {
+				confirm: async () => {
+					sequence.push("confirm");
+					return confirm();
+				},
+			},
+		} as ExtensionContext;
+		let resolveConfirmation!: (approved: boolean) => void;
+		confirm = () => new Promise<boolean>((resolve) => { resolveConfirmation = resolve; });
+		const denied = toolCall!({
+			toolName: "bash",
+			input: { command: "git rebase main --secret-command-content" },
+		}, ctx);
+
+		await Promise.resolve();
+		assert.equal(emitted[0].channel, "pi-permission-system:permission-request");
+		assert.equal(emitted[0].data.state, "waiting");
+		assert.deepEqual(sequence, ["event:waiting", "confirm"]);
+		const deniedRequestId = emitted[0].data.requestId;
+		assert.match(deniedRequestId, /^[0-9a-f-]{36}$/);
+		assert.deepEqual(emitted[0].data, {
+			requestId: deniedRequestId,
+			state: "waiting",
+			source: "tool_call",
+			message: "Gentle AI safety policy requires confirmation for this tool call.",
+			toolName: "bash",
+		});
+		assert.equal(Object.keys(emitted[0].data).includes("command"), false);
+		assert.equal(Object.keys(emitted[0].data).includes("preview"), false);
+		assert.doesNotMatch(JSON.stringify(emitted), /secret-command-content|git rebase/);
+
+		resolveConfirmation(false);
+		assert.deepEqual(await denied, {
+			block: true,
+			reason: "Gentle AI safety policy blocked the command because it was not confirmed.",
+		});
+		assert.deepEqual(emitted[1], {
+			channel: "pi-permission-system:permission-request",
+			data: {
+				requestId: deniedRequestId,
+				state: "denied",
+				source: "tool_call",
+				message: "Gentle AI safety policy requires confirmation for this tool call.",
+				toolName: "bash",
+			},
+		});
+
+		emitted.length = 0;
+		sequence.length = 0;
+		confirm = async () => true;
+		assert.equal(await toolCall!({ toolName: "bash", input: { command: "git rebase main" } }, ctx), undefined);
+		assert.equal(emitted.length, 2);
+		assert.equal(emitted[0].data.state, "waiting");
+		assert.equal(emitted[1].data.state, "approved");
+		assert.equal(emitted[0].data.requestId, emitted[1].data.requestId);
+		assert.notEqual(emitted[0].data.requestId, deniedRequestId);
+		assert.deepEqual(sequence, ["event:waiting", "confirm", "event:approved"]);
+
+		emitted.length = 0;
+		sequence.length = 0;
+		confirm = async () => { throw new Error("confirmation unavailable"); };
+		await assert.rejects(
+			toolCall!({ toolName: "bash", input: { command: "git rebase main" } }, ctx),
+			/confirmation unavailable/,
+		);
+		assert.equal(emitted.length, 2);
+		assert.equal(emitted[0].data.state, "waiting");
+		assert.equal(emitted[1].data.state, "denied");
+		assert.equal(emitted[0].data.requestId, emitted[1].data.requestId);
+		assert.deepEqual(sequence, ["event:waiting", "confirm", "event:denied"]);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("permission lifecycle is inactive for unguarded and headless commands", async () => {
+	type ToolCallHandler = (
+		event: { toolName: string; input: unknown },
+		ctx: ExtensionContext,
+	) => Promise<ToolCallEventResult | undefined>;
+	const handlers = new Map<string, ToolCallHandler>();
+	const emitted: unknown[] = [];
+	let confirmations = 0;
+	const pi = {
+		on(name: string, handler: ToolCallHandler) {
+			handlers.set(name, handler);
+		},
+		events: { emit(_channel: string, data: unknown) { emitted.push(data); } },
+		registerCommand() {},
+		registerTool() {},
+	} as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli: null })(pi);
+	const toolCall = handlers.get("tool_call");
+	assert.equal(typeof toolCall, "function");
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-permission-headless-"));
+	try {
+		const confirm = async () => {
+			confirmations += 1;
+			return true;
+		};
+		assert.equal(await toolCall!({ toolName: "bash", input: { command: "echo safe --secret-command-content" } }, {
+			cwd,
+			hasUI: false,
+			ui: { confirm },
+		} as ExtensionContext), undefined);
+		assert.deepEqual(await toolCall!({ toolName: "bash", input: { command: "git rebase main" } }, {
+			cwd,
+			hasUI: false,
+			ui: { confirm },
+		} as ExtensionContext), {
+			block: true,
+			reason: "Gentle AI safety policy requires interactive confirmation before this command.",
+		});
+		assert.equal(confirmations, 0);
+		assert.deepEqual(emitted, []);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
 	}
 });

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -519,8 +519,13 @@ test("guarded command confirmation emits a generic correlated permission lifecyc
 			toolName: "bash";
 		};
 	};
+	type HerdrBlockedEvent = {
+		channel: "herdr:blocked";
+		data: { active: boolean; label?: string };
+	};
+	type EmittedEvent = PermissionEvent | HerdrBlockedEvent;
 	const handlers = new Map<string, ToolCallHandler>();
-	const emitted: PermissionEvent[] = [];
+	const emitted: EmittedEvent[] = [];
 	const sequence: string[] = [];
 	let confirm!: () => Promise<boolean>;
 	const pi = {
@@ -528,9 +533,13 @@ test("guarded command confirmation emits a generic correlated permission lifecyc
 			handlers.set(name, handler);
 		},
 		events: {
-			emit(channel: string, data: PermissionEvent["data"]) {
-				sequence.push(`event:${data.state}`);
-				emitted.push({ channel, data });
+			emit(channel: string, data: EmittedEvent["data"]) {
+				sequence.push(
+					channel === "herdr:blocked"
+						? `herdr:${"active" in data && data.active ? "active" : "inactive"}`
+						: `event:${data.state}`,
+				);
+				emitted.push({ channel, data } as EmittedEvent);
 			},
 		},
 		registerCommand() {},
@@ -561,7 +570,11 @@ test("guarded command confirmation emits a generic correlated permission lifecyc
 		await Promise.resolve();
 		assert.equal(emitted[0].channel, "pi-permission-system:permission-request");
 		assert.equal(emitted[0].data.state, "waiting");
-		assert.deepEqual(sequence, ["event:waiting", "confirm"]);
+		assert.deepEqual(emitted[1], {
+			channel: "herdr:blocked",
+			data: { active: true, label: "Guarded command confirmation" },
+		});
+		assert.deepEqual(sequence, ["event:waiting", "herdr:active", "confirm"]);
 		const deniedRequestId = emitted[0].data.requestId;
 		assert.match(deniedRequestId, /^[0-9a-f-]{36}$/);
 		assert.deepEqual(emitted[0].data, {
@@ -580,7 +593,7 @@ test("guarded command confirmation emits a generic correlated permission lifecyc
 			block: true,
 			reason: "Gentle AI safety policy blocked the command because it was not confirmed.",
 		});
-		assert.deepEqual(emitted[1], {
+		assert.deepEqual(emitted[2], {
 			channel: "pi-permission-system:permission-request",
 			data: {
 				requestId: deniedRequestId,
@@ -590,30 +603,52 @@ test("guarded command confirmation emits a generic correlated permission lifecyc
 				toolName: "bash",
 			},
 		});
+		assert.deepEqual(emitted[3], {
+			channel: "herdr:blocked",
+			data: { active: false },
+		});
+		assert.deepEqual(sequence, ["event:waiting", "herdr:active", "confirm", "event:denied", "herdr:inactive"]);
 
 		emitted.length = 0;
 		sequence.length = 0;
 		confirm = async () => true;
 		assert.equal(await toolCall!({ toolName: "bash", input: { command: "git rebase main" } }, ctx), undefined);
-		assert.equal(emitted.length, 2);
+		assert.equal(emitted.length, 4);
 		assert.equal(emitted[0].data.state, "waiting");
-		assert.equal(emitted[1].data.state, "approved");
-		assert.equal(emitted[0].data.requestId, emitted[1].data.requestId);
+		assert.deepEqual(emitted[1], {
+			channel: "herdr:blocked",
+			data: { active: true, label: "Guarded command confirmation" },
+		});
+		assert.equal(emitted[2].data.state, "approved");
+		assert.equal(emitted[0].data.requestId, emitted[2].data.requestId);
 		assert.notEqual(emitted[0].data.requestId, deniedRequestId);
-		assert.deepEqual(sequence, ["event:waiting", "confirm", "event:approved"]);
+		assert.deepEqual(emitted[3], {
+			channel: "herdr:blocked",
+			data: { active: false },
+		});
+		assert.deepEqual(sequence, ["event:waiting", "herdr:active", "confirm", "event:approved", "herdr:inactive"]);
 
 		emitted.length = 0;
 		sequence.length = 0;
-		confirm = async () => { throw new Error("confirmation unavailable"); };
+		const confirmationError = new Error("confirmation unavailable");
+		confirm = async () => { throw confirmationError; };
 		await assert.rejects(
 			toolCall!({ toolName: "bash", input: { command: "git rebase main" } }, ctx),
-			/confirmation unavailable/,
+			(error) => error === confirmationError,
 		);
-		assert.equal(emitted.length, 2);
+		assert.equal(emitted.length, 4);
 		assert.equal(emitted[0].data.state, "waiting");
-		assert.equal(emitted[1].data.state, "denied");
-		assert.equal(emitted[0].data.requestId, emitted[1].data.requestId);
-		assert.deepEqual(sequence, ["event:waiting", "confirm", "event:denied"]);
+		assert.deepEqual(emitted[1], {
+			channel: "herdr:blocked",
+			data: { active: true, label: "Guarded command confirmation" },
+		});
+		assert.equal(emitted[2].data.state, "denied");
+		assert.equal(emitted[0].data.requestId, emitted[2].data.requestId);
+		assert.deepEqual(emitted[3], {
+			channel: "herdr:blocked",
+			data: { active: false },
+		});
+		assert.deepEqual(sequence, ["event:waiting", "herdr:active", "confirm", "event:denied", "herdr:inactive"]);
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -654,6 +654,93 @@ test("guarded command confirmation emits a generic correlated permission lifecyc
 	}
 });
 
+test("concurrent guarded confirmations coalesce the Herdr lifecycle per extension instance", async () => {
+	type ToolCallHandler = (
+		event: { toolName: string; input: unknown },
+		ctx: ExtensionContext,
+	) => Promise<ToolCallEventResult | undefined>;
+	type EmittedEvent = {
+		channel: string;
+		data: {
+			requestId?: string;
+			state?: "waiting" | "approved" | "denied";
+			active?: boolean;
+			label?: string;
+		};
+	};
+	const createHarness = () => {
+		const handlers = new Map<string, ToolCallHandler>();
+		const emitted: EmittedEvent[] = [];
+		const confirmations: Array<(approved: boolean) => void> = [];
+		const pi = {
+			on(name: string, handler: ToolCallHandler) {
+				handlers.set(name, handler);
+			},
+			events: { emit(channel: string, data: EmittedEvent["data"]) { emitted.push({ channel, data }); } },
+			registerCommand() {},
+			registerTool() {},
+		} as unknown as ExtensionAPI;
+		createGentleAiExtension({ nativeReviewCli: null })(pi);
+		return { handlers, emitted, confirmations };
+	};
+	const first = createHarness();
+	const second = createHarness();
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-permission-concurrent-"));
+	try {
+		const context = (confirmations: Array<(approved: boolean) => void>) => ({
+			cwd,
+			hasUI: true,
+			ui: {
+				confirm: async () => new Promise<boolean>((resolve) => { confirmations.push(resolve); }),
+			},
+		} as ExtensionContext);
+		const firstRequest = first.handlers.get("tool_call")!({ toolName: "bash", input: { command: "git rebase main" } }, context(first.confirmations));
+		const secondRequest = first.handlers.get("tool_call")!({ toolName: "bash", input: { command: "git rebase main --another-command" } }, context(first.confirmations));
+		await Promise.resolve();
+		assert.deepEqual(first.emitted.map(({ channel, data }) => ({ channel, state: data.state, active: data.active })), [
+			{ channel: "pi-permission-system:permission-request", state: "waiting", active: undefined },
+			{ channel: "herdr:blocked", state: undefined, active: true },
+			{ channel: "pi-permission-system:permission-request", state: "waiting", active: undefined },
+		]);
+		assert.equal(first.confirmations.length, 2);
+		const waitingEvents = first.emitted.filter(({ channel, data }) => channel === "pi-permission-system:permission-request" && data.state === "waiting");
+		assert.notEqual(waitingEvents[0]?.data.requestId, waitingEvents[1]?.data.requestId);
+
+		first.confirmations[0]!(false);
+		assert.deepEqual(await firstRequest, {
+			block: true,
+			reason: "Gentle AI safety policy blocked the command because it was not confirmed.",
+		});
+		assert.deepEqual(first.emitted.map(({ channel, data }) => ({ channel, state: data.state, active: data.active })), [
+			{ channel: "pi-permission-system:permission-request", state: "waiting", active: undefined },
+			{ channel: "herdr:blocked", state: undefined, active: true },
+			{ channel: "pi-permission-system:permission-request", state: "waiting", active: undefined },
+			{ channel: "pi-permission-system:permission-request", state: "denied", active: undefined },
+		]);
+
+		const independentRequest = second.handlers.get("tool_call")!({ toolName: "bash", input: { command: "git rebase main --independent-command" } }, context(second.confirmations));
+		await Promise.resolve();
+		assert.equal(second.emitted.filter(({ channel }) => channel === "herdr:blocked").length, 1);
+		assert.equal(second.emitted.find(({ channel }) => channel === "herdr:blocked")?.data.active, true);
+		assert.equal(second.confirmations.length, 1);
+
+		first.confirmations[1]!(true);
+		assert.equal(await secondRequest, undefined);
+		assert.equal(first.emitted.filter(({ channel, data }) => channel === "herdr:blocked" && data.active === false).length, 1);
+		second.confirmations[0]!(true);
+		assert.equal(await independentRequest, undefined);
+		assert.deepEqual(second.emitted.map(({ channel, data }) => ({ channel, state: data.state, active: data.active })), [
+			{ channel: "pi-permission-system:permission-request", state: "waiting", active: undefined },
+			{ channel: "herdr:blocked", state: undefined, active: true },
+			{ channel: "pi-permission-system:permission-request", state: "approved", active: undefined },
+			{ channel: "herdr:blocked", state: undefined, active: false },
+		]);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+
 test("permission lifecycle is inactive for unguarded and headless commands", async () => {
 	type ToolCallHandler = (
 		event: { toolName: string; input: unknown },

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -64,10 +64,28 @@ function createPi() {
 	const commands = new Map();
 	const flags = new Map();
 	const tools = new Map();
+	const eventHandlers = new Map();
+	const emittedEvents = [];
 	const flagValues = new Map([["no-skill-registry", true]]);
+	const events = {
+		emit(channel, data) {
+			emittedEvents.push({ channel, data });
+			for (const handler of eventHandlers.get(channel) ?? []) handler(data);
+		},
+		on(channel, handler) {
+			const handlers = eventHandlers.get(channel) ?? new Set();
+			handlers.add(handler);
+			eventHandlers.set(channel, handlers);
+			return () => {
+				handlers.delete(handler);
+				if (handlers.size === 0) eventHandlers.delete(channel);
+			};
+		},
+	};
 	let activeTools = ["read", "bash", "edit", "write"];
 
 	const pi = {
+		events,
 		on(name, handler) {
 			const list = hooks.get(name) ?? [];
 			list.push(handler);
@@ -108,7 +126,7 @@ function createPi() {
 		},
 	};
 
-	return { pi, hooks, commands, flags, tools };
+	return { pi, hooks, commands, flags, tools, emittedEvents };
 }
 
 function createUi() {
@@ -206,7 +224,7 @@ async function run() {
 	process.env.GENTLE_PI_TEST_ASSETS_DIR = ambientTestAssetsDir;
 	const globalModelsPath = join(globalConfigHome, "models.json");
 	const globalSubagentsPath = join(globalAgentHome, "subagents.json");
-	const { pi, hooks, commands, flags, tools } = createPi();
+	const { pi, hooks, commands, flags, tools, emittedEvents } = createPi();
 	await loadExtensions(pi);
 
 	// gentle-pi#404: a collect binding that returns the native last-event
@@ -524,6 +542,43 @@ async function run() {
 		);
 		assert.equal(needsConfirm.block, true);
 		assert.match(needsConfirm.reason, /not confirmed/);
+		assert.deepEqual(
+			emittedEvents.map(({ channel, data }) => ({
+				channel,
+				state: data.state,
+				active: data.active,
+				label: data.label,
+			})),
+			[
+				{
+					channel: "pi-permission-system:permission-request",
+					state: "waiting",
+					active: undefined,
+					label: undefined,
+				},
+				{
+					channel: "herdr:blocked",
+					state: undefined,
+					active: true,
+					label: "Guarded command confirmation",
+				},
+				{
+					channel: "pi-permission-system:permission-request",
+					state: "denied",
+					active: undefined,
+					label: undefined,
+				},
+				{
+					channel: "herdr:blocked",
+					state: undefined,
+					active: false,
+					label: undefined,
+				},
+			],
+			"guarded confirmation emits both lifecycle channels in order",
+		);
+		assert.equal(emittedEvents[0].data.requestId, emittedEvents[2].data.requestId);
+		emittedEvents.length = 0;
 		assert.equal(
 			dangerousReviewCtx.ui.notifications.length,
 			0,


### PR DESCRIPTION
Closes #394

## Summary

- emit a correlated permission lifecycle around guarded command confirmations
- publish privacy-safe `waiting`, `approved`, and `denied` states through the existing extension event bus
- preserve `herdr:blocked` active/inactive compatibility for existing Herdr integrations
- preserve fail-closed behavior when the confirmation UI rejects

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Emits generic permission events and Herdr compatibility events without exposing command contents. |
| `tests/gentle-ai.test.ts` | Covers ordering, correlation, approval, denial, failures, privacy, and inactive paths. |
| `tests/runtime-harness.mjs` | Models the extension event bus and verifies both lifecycle contracts end to end. |

## Test plan

- [x] `pnpm test` (1068 passed, 10 skipped, 0 failed)
- [x] `pnpm run check:runtime-modules`
- [x] Syntax checks for changed TypeScript and JavaScript files
- [x] `git diff --check`
- [x] Manually verified Herdr enters blocked state during a guarded confirmation on Linux


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added permission request lifecycle events for guarded command confirmations, including waiting, approved, and denied states.
  - Permission requests now use correlated identifiers while protecting command details.
  - Added blocked-command notifications when confirmation is rejected or fails.
  - Concurrent confirmations now share a consistent blocked-state lifecycle while retaining individual request tracking.

- **Bug Fixes**
  - Rejected or failed confirmations now correctly block command execution and report denial.
  - Headless and unguarded commands avoid unnecessary confirmation prompts and events.
  - Confirmation errors are handled consistently while preserving the original error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
