### PR TITLE
fix(sdd): decode the gentle-ai sdd-status v2 identity

### DIFF
--- a/extensions/sdd-init.ts
+++ b/extensions/sdd-init.ts
@@ -785,7 +785,7 @@ export default function (pi: ExtensionAPI) {
 
 			const shouldCreateOpenSpec =
 				prefs.artifactStore === "openspec" ||
-				prefs.artifactStore === "both";
+				prefs.artifactStore === "hybrid";
 			if (!shouldCreateOpenSpec) {
 				ctx.ui.notify(
 					`SDD initialized for ${prefs.artifactStore}: detected ${detection.stack.join(", ") || "project"}; ${testSummary}; tests found: ${layerSummary}.`,

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -88,8 +88,9 @@ export const NATIVE_SDD_ARTIFACT_STORE = {
 	// HYBRID reaches the wire with gentle-ai #3814/#3636. It previously existed
 	// only in prompt prose while the provider reported such a workspace as
 	// openspec. Note the vocabulary difference from Pi's own preflight type in
-	// lib/sdd-status.ts, which calls the operator-facing choice "both": this
-	// constant is the WIRE domain, and gentle-ai owns it.
+	// lib/sdd-status.ts, which now uses the same name: the operator-facing
+	// choice was reconciled to the provider's vocabulary, and already-persisted
+	// "both" normalizes forward.
 	HYBRID: "hybrid",
 	NONE: "none",
 } as const;

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -85,8 +85,20 @@ export type ExecFileAdapter = (request: ExecFileRequest) => Promise<ExecFileResu
 export const NATIVE_SDD_ARTIFACT_STORE = {
 	OPENSPEC: "openspec",
 	ENGRAM: "engram",
+	// HYBRID reaches the wire with gentle-ai #3814/#3636. It previously existed
+	// only in prompt prose while the provider reported such a workspace as
+	// openspec. Note the vocabulary difference from Pi's own preflight type in
+	// lib/sdd-status.ts, which calls the operator-facing choice "both": this
+	// constant is the WIRE domain, and gentle-ai owns it.
+	HYBRID: "hybrid",
 	NONE: "none",
 } as const;
+
+// The status identities this decoder admits. gentle-ai 3c4c7fb6 replaced v1
+// with v2; the object shape is key-identical across the two, so one decoder
+// spans both rather than duplicating it. Anything outside this set is an
+// identity mismatch, in either direction.
+export const NATIVE_SDD_STATUS_VERSIONS = [1, 2] as const;
 export type NativeSddArtifactStore = (typeof NATIVE_SDD_ARTIFACT_STORE)[keyof typeof NATIVE_SDD_ARTIFACT_STORE];
 
 export const NATIVE_SDD_ARTIFACT_STATE = {
@@ -1308,13 +1320,19 @@ class NativeReviewPlainCli {
 		const { body: result } = await this.execute(NATIVE_REVIEW_OPERATION.SDD_STATUS, request.cwd, ["sdd-status", request.change, "--cwd", request.cwd, "--json", "--instructions"], false, request.signal);
 		return decode(NATIVE_REVIEW_OPERATION.SDD_STATUS, false, () => {
 			const body = exactObject(result, ["schemaName", "schemaVersion", "changeName", "artifactStore", "planningHome", "changeRoot", "artifactPaths", "contextFiles", "artifacts", "taskProgress", "dependencies", "applyState", "actionContext", "relationships", "remediationState", "nextRecommended", "blockedReasons"], ["reviewGate", "reviewTransaction", "phaseInstructions"]);
-			if (body.schemaName !== "gentle-ai.sdd-status" || body.schemaVersion !== 1 || body.changeName !== request.change || !["openspec", "engram", "none"].includes(body.artifactStore as string) || !["blocked", "all_done", "ready"].includes(body.applyState as string)) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.SDD_STATUS, false, "native status identity mismatch");
-			const paths = ["proposal", "specs", "design", "tasks", "applyProgress", "verifyReport", "reviewPolicy", "reviewLedger", "reviewReceipt", "reviewBundle", "reviewContext", "reviewState"];
+			if (body.schemaName !== "gentle-ai.sdd-status" || !(NATIVE_SDD_STATUS_VERSIONS as readonly number[]).includes(body.schemaVersion as number) || body.changeName !== request.change || !(Object.values(NATIVE_SDD_ARTIFACT_STORE) as string[]).includes(body.artifactStore as string) || !["blocked", "all_done", "ready"].includes(body.applyState as string)) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.SDD_STATUS, false, "native status identity mismatch");
+			// v2 removed review lineage state from the SDD status document: the
+			// review* artifacts and their paths are gone, because review authority
+			// no longer projects here. v1 still carries them, so the expected key
+			// sets are gated on the identity rather than merged.
+			const v2 = body.schemaVersion === 2;
+			const sddPaths = ["proposal", "specs", "design", "tasks", "applyProgress", "verifyReport"];
+			const paths = v2 ? sddPaths : [...sddPaths, "reviewPolicy", "reviewLedger", "reviewReceipt", "reviewBundle", "reviewContext", "reviewState"];
 			const pathMap = (value: unknown) => { const parsed = exactObject(value, paths); for (const path of paths) stringArray(parsed[path]); };
 			const planningHome = exactObject(body.planningHome, ["mode", "path"]);
 			if (planningHome.mode !== "repo-local") throw new Error("invalid planning home");
 			requiredString(planningHome.path); requiredString(body.changeRoot); pathMap(body.artifactPaths); pathMap(body.contextFiles);
-			const artifactStates = paths.filter((path) => path !== "reviewPolicy" || body.artifactStore === NATIVE_SDD_ARTIFACT_STORE.ENGRAM);
+			const artifactStates = v2 ? paths : paths.filter((path) => path !== "reviewPolicy" || body.artifactStore === NATIVE_SDD_ARTIFACT_STORE.ENGRAM);
 			const artifacts = exactObject(body.artifacts, artifactStates);
 			for (const path of artifactStates) if (!Object.values(NATIVE_SDD_ARTIFACT_STATE).includes(artifacts[path] as NativeSddArtifactState)) throw new Error("invalid artifact state");
 			const taskProgress = exactObject(body.taskProgress, ["total", "completed", "pending", "allComplete"]);
@@ -1326,9 +1344,12 @@ class NativeReviewPlainCli {
 			if (actionContext.mode !== "repo-local" || requiredString(actionContext.workspaceRoot).length === 0 || stringArray(actionContext.allowedEditRoots).length === 0) throw new Error("invalid action context");
 			const relationships = exactObject(body.relationships, ["dependsOn", "supersedes", "amends", "conflictsWith", "sameDomainActiveChanges"]);
 			for (const field of ["dependsOn", "supersedes", "amends", "conflictsWith", "sameDomainActiveChanges"]) stringArray(relationships[field]);
-			const remediation = exactObject(body.remediationState, ["required", "complete", "failedEvidenceRevision", "lineageId", "generation", "fixBatch", "reason"], ["correctionBudget"]);
-			if (typeof remediation.required !== "boolean" || typeof remediation.complete !== "boolean" || ["failedEvidenceRevision", "lineageId", "reason"].some((field) => typeof remediation[field] !== "string")) throw new Error("invalid remediation state");
-			nonNegativeInteger(remediation.generation); nonNegativeInteger(remediation.fixBatch);
+			// Same identity gate: v2 dropped lineageId/generation/fixBatch from
+			// remediationState along with the review lineage projection.
+			const remediationStrings = v2 ? ["failedEvidenceRevision", "reason"] : ["failedEvidenceRevision", "lineageId", "reason"];
+			const remediation = exactObject(body.remediationState, v2 ? ["required", "complete", "failedEvidenceRevision", "reason"] : ["required", "complete", "failedEvidenceRevision", "lineageId", "generation", "fixBatch", "reason"], ["correctionBudget"]);
+			if (typeof remediation.required !== "boolean" || typeof remediation.complete !== "boolean" || remediationStrings.some((field) => typeof remediation[field] !== "string")) throw new Error("invalid remediation state");
+			if (!v2) { nonNegativeInteger(remediation.generation); nonNegativeInteger(remediation.fixBatch); }
 			if (remediation.correctionBudget !== undefined) nonNegativeInteger(remediation.correctionBudget);
 			if (body.phaseInstructions !== undefined) {
 				const instructions = exactObject(body.phaseInstructions, ["apply", "verify", "remediate", "archive"]);

--- a/lib/sdd-preflight.ts
+++ b/lib/sdd-preflight.ts
@@ -107,7 +107,16 @@ function isSddExecutionMode(value: unknown): value is SddExecutionMode {
 }
 
 function isSddArtifactStore(value: unknown): value is SddArtifactStore {
-	return value === "openspec" || value === "engram" || value === "both" || value === "none";
+	return value === "openspec" || value === "engram" || value === "hybrid" || value === "none";
+}
+
+// normalizeSddArtifactStore accepts the canonical names and the legacy "both"
+// spelling of the dual-store mode. Operator preflight files written before the
+// rename carry "both" on disk; rejecting it would silently drop the operator's
+// choice back to the default, so it maps forward instead.
+export function normalizeSddArtifactStore(value: unknown): SddArtifactStore | undefined {
+	if (value === "both") return "hybrid";
+	return isSddArtifactStore(value) ? value : undefined;
 }
 
 function normalizeReviewBudgetValue(value: unknown): number | undefined {
@@ -147,7 +156,8 @@ function normalizedSelections(
 	if (!value) return {};
 	const result: Partial<Record<SddPreflightField, unknown>> = {};
 	if (isSddExecutionMode(value.executionMode)) result.executionMode = value.executionMode;
-	if (isSddArtifactStore(value.artifactStore) && (engramAvailable || value.artifactStore === "openspec" || value.artifactStore === "none")) result.artifactStore = value.artifactStore;
+	const artifactStore = normalizeSddArtifactStore(value.artifactStore);
+	if (artifactStore !== undefined && (engramAvailable || artifactStore === "openspec" || artifactStore === "none")) result.artifactStore = artifactStore;
 	const strategy = normalizeSddStrategySelection(value.chainedPrStrategy, allowExceptionOk);
 	if (strategy) result.chainedPrStrategy = strategy;
 	const reviewBudgetLines = normalizeReviewBudgetValue(value.reviewBudgetLines);
@@ -345,9 +355,13 @@ export function readSddPreflightFromDisk(cwd: string): SddPreflightPreferences |
 		if (!isRecord(parsed)) return undefined;
 		// Validate required fields to guard against stale/corrupt writes.
 		const { executionMode, artifactStore, chainedPrStrategy, reviewBudgetLines, engramAvailable, prompted } = parsed;
+		// Normalize before validating: a preflight file written before the
+		// dual-store rename carries "both", and discarding it would silently
+		// drop the operator's choice back to the default.
+		const canonicalArtifactStore = normalizeSddArtifactStore(artifactStore);
 		if (
 			!isSddExecutionMode(executionMode) ||
-			!isSddArtifactStore(artifactStore) ||
+			canonicalArtifactStore === undefined ||
 			typeof reviewBudgetLines !== "number" ||
 			!Number.isFinite(reviewBudgetLines) ||
 			reviewBudgetLines <= 0 ||
@@ -358,7 +372,7 @@ export function readSddPreflightFromDisk(cwd: string): SddPreflightPreferences |
 		}
 		return {
 			executionMode,
-			artifactStore,
+			artifactStore: canonicalArtifactStore,
 			chainedPrStrategy: normalizeSddChainedPrStrategy(chainedPrStrategy),
 			reviewBudgetLines: normalizeReviewBudgetValue(reviewBudgetLines) ?? DEFAULT_SDD_PREFLIGHT.reviewBudgetLines,
 			engramAvailable,
@@ -375,7 +389,7 @@ export function writeSddPreflightToDisk(cwd: string, prefs: SddPreflightPreferen
 		const prompted = prefs.prompted === true;
 		const canonical: SddPreflightPreferences = {
 			executionMode: isSddExecutionMode(prefs.executionMode) ? prefs.executionMode : DEFAULT_SDD_PREFLIGHT.executionMode,
-			artifactStore: isSddArtifactStore(prefs.artifactStore) ? prefs.artifactStore : DEFAULT_SDD_PREFLIGHT.artifactStore,
+			artifactStore: normalizeSddArtifactStore(prefs.artifactStore) ?? DEFAULT_SDD_PREFLIGHT.artifactStore,
 			chainedPrStrategy: normalizeSddChainedPrStrategy(prefs.chainedPrStrategy),
 			reviewBudgetLines:
 				normalizeReviewBudgetValue(prefs.reviewBudgetLines) ??
@@ -661,7 +675,7 @@ export async function collectSddPreflightPreferences(
 			usePromptedValue(field, await read());
 		}
 	};
-	const artifactOptions = engramAvailable ? ["openspec", "engram", "both"] : ["openspec"];
+	const artifactOptions = engramAvailable ? ["openspec", "engram", "hybrid"] : ["openspec"];
 	await promptField("executionMode", () => ctx.ui.select("SDD execution mode", ["interactive", "auto"]));
 	await promptField("artifactStore", () => ctx.ui.select("SDD artifact store", artifactOptions), artifactOptions.length > 1);
 	await promptField("chainedPrStrategy", () => ctx.ui.select("SDD delivery strategy", ["ask-on-risk", "auto-chain", "single-pr"]));

--- a/lib/sdd-status.ts
+++ b/lib/sdd-status.ts
@@ -6,7 +6,10 @@ import {
 	type DomainCollision,
 } from "./openspec-guardrails.ts";
 
-export type SddArtifactStore = "openspec" | "engram" | "both" | "none";
+// Canonical names match gentle-ai, which owns this contract. The dual-store
+// mode was called "both" here; "hybrid" is the provider's name for the same
+// thing, and normalizeSddArtifactStore keeps already-persisted "both" loading.
+export type SddArtifactStore = "openspec" | "engram" | "hybrid" | "none";
 export type ArtifactState = "missing" | "done" | "partial";
 export type DependencyState = "blocked" | "ready" | "all_done" | "not_applicable";
 export type ApplyState = "blocked" | "ready" | "all_done" | "not_applicable";
@@ -482,7 +485,7 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 	//   - store engram or none: always non-authoritative (no disk backing)
 	//   - store both, no openspec/ dir: non-authoritative (no disk to scan)
 	// The both-with-openspec cases are handled below after listing active changes.
-	if (store === "engram" || store === "none" || (store === "both" && !hasOpenSpecDir)) {
+	if (store === "engram" || store === "none" || (store === "hybrid" && !hasOpenSpecDir)) {
 		const changeName = options.changeName?.trim() || null;
 		return nonAuthoritativeStatus(options.cwd, changeName, store, options.includeInstructions);
 	}
@@ -500,7 +503,7 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 			// store both + openspec/ present + zero active changes + no changeName:
 			// The change may live only in Engram — non-authoritative, not a false block.
 			// Pure openspec with zero changes is a real block (run sdd-new).
-			if (store === "both") {
+			if (store === "hybrid") {
 				return nonAuthoritativeStatus(options.cwd, null, store, options.includeInstructions);
 			}
 			return emptyStatus(root, null, ["No active SDD changes found."], store, false, options.reviewAuthority);
@@ -517,7 +520,7 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 		// store both + openspec/ present + named change NOT found on disk:
 		// The change may live only in Engram — non-authoritative.
 		// Pure openspec still blocks (legit "run sdd-new").
-		if (store === "both") {
+		if (store === "hybrid") {
 			return nonAuthoritativeStatus(options.cwd, changeName, store, options.includeInstructions);
 		}
 		return emptyStatus(root, changeName, [`Active change not found: ${changeName}.`], store, false, options.reviewAuthority);

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -89,8 +89,9 @@ export const NATIVE_SDD_ARTIFACT_STORE = {
 	// HYBRID reaches the wire with gentle-ai #3814/#3636. It previously existed
 	// only in prompt prose while the provider reported such a workspace as
 	// openspec. Note the vocabulary difference from Pi's own preflight type in
-	// lib/sdd-status.ts, which calls the operator-facing choice "both": this
-	// constant is the WIRE domain, and gentle-ai owns it.
+	// lib/sdd-status.ts, which now uses the same name: the operator-facing
+	// choice was reconciled to the provider's vocabulary, and already-persisted
+	// "both" normalizes forward.
 	HYBRID: "hybrid",
 	NONE: "none",
 }         ;

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -86,8 +86,20 @@ export const NATIVE_REVIEW_ERROR_CODE = {
 export const NATIVE_SDD_ARTIFACT_STORE = {
 	OPENSPEC: "openspec",
 	ENGRAM: "engram",
+	// HYBRID reaches the wire with gentle-ai #3814/#3636. It previously existed
+	// only in prompt prose while the provider reported such a workspace as
+	// openspec. Note the vocabulary difference from Pi's own preflight type in
+	// lib/sdd-status.ts, which calls the operator-facing choice "both": this
+	// constant is the WIRE domain, and gentle-ai owns it.
+	HYBRID: "hybrid",
 	NONE: "none",
 }         ;
+
+// The status identities this decoder admits. gentle-ai 3c4c7fb6 replaced v1
+// with v2; the object shape is key-identical across the two, so one decoder
+// spans both rather than duplicating it. Anything outside this set is an
+// identity mismatch, in either direction.
+export const NATIVE_SDD_STATUS_VERSIONS = [1, 2]         ;
 
 
 export const NATIVE_SDD_ARTIFACT_STATE = {
@@ -1309,13 +1321,19 @@ class NativeReviewPlainCli {
 		const { body: result } = await this.execute(NATIVE_REVIEW_OPERATION.SDD_STATUS, request.cwd, ["sdd-status", request.change, "--cwd", request.cwd, "--json", "--instructions"], false, request.signal);
 		return decode(NATIVE_REVIEW_OPERATION.SDD_STATUS, false, () => {
 			const body = exactObject(result, ["schemaName", "schemaVersion", "changeName", "artifactStore", "planningHome", "changeRoot", "artifactPaths", "contextFiles", "artifacts", "taskProgress", "dependencies", "applyState", "actionContext", "relationships", "remediationState", "nextRecommended", "blockedReasons"], ["reviewGate", "reviewTransaction", "phaseInstructions"]);
-			if (body.schemaName !== "gentle-ai.sdd-status" || body.schemaVersion !== 1 || body.changeName !== request.change || !["openspec", "engram", "none"].includes(body.artifactStore          ) || !["blocked", "all_done", "ready"].includes(body.applyState          )) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.SDD_STATUS, false, "native status identity mismatch");
-			const paths = ["proposal", "specs", "design", "tasks", "applyProgress", "verifyReport", "reviewPolicy", "reviewLedger", "reviewReceipt", "reviewBundle", "reviewContext", "reviewState"];
+			if (body.schemaName !== "gentle-ai.sdd-status" || !(NATIVE_SDD_STATUS_VERSIONS                     ).includes(body.schemaVersion          ) || body.changeName !== request.change || !(Object.values(NATIVE_SDD_ARTIFACT_STORE)            ).includes(body.artifactStore          ) || !["blocked", "all_done", "ready"].includes(body.applyState          )) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.SDD_STATUS, false, "native status identity mismatch");
+			// v2 removed review lineage state from the SDD status document: the
+			// review* artifacts and their paths are gone, because review authority
+			// no longer projects here. v1 still carries them, so the expected key
+			// sets are gated on the identity rather than merged.
+			const v2 = body.schemaVersion === 2;
+			const sddPaths = ["proposal", "specs", "design", "tasks", "applyProgress", "verifyReport"];
+			const paths = v2 ? sddPaths : [...sddPaths, "reviewPolicy", "reviewLedger", "reviewReceipt", "reviewBundle", "reviewContext", "reviewState"];
 			const pathMap = (value         ) => { const parsed = exactObject(value, paths); for (const path of paths) stringArray(parsed[path]); };
 			const planningHome = exactObject(body.planningHome, ["mode", "path"]);
 			if (planningHome.mode !== "repo-local") throw new Error("invalid planning home");
 			requiredString(planningHome.path); requiredString(body.changeRoot); pathMap(body.artifactPaths); pathMap(body.contextFiles);
-			const artifactStates = paths.filter((path) => path !== "reviewPolicy" || body.artifactStore === NATIVE_SDD_ARTIFACT_STORE.ENGRAM);
+			const artifactStates = v2 ? paths : paths.filter((path) => path !== "reviewPolicy" || body.artifactStore === NATIVE_SDD_ARTIFACT_STORE.ENGRAM);
 			const artifacts = exactObject(body.artifacts, artifactStates);
 			for (const path of artifactStates) if (!Object.values(NATIVE_SDD_ARTIFACT_STATE).includes(artifacts[path]                          )) throw new Error("invalid artifact state");
 			const taskProgress = exactObject(body.taskProgress, ["total", "completed", "pending", "allComplete"]);
@@ -1327,9 +1345,12 @@ class NativeReviewPlainCli {
 			if (actionContext.mode !== "repo-local" || requiredString(actionContext.workspaceRoot).length === 0 || stringArray(actionContext.allowedEditRoots).length === 0) throw new Error("invalid action context");
 			const relationships = exactObject(body.relationships, ["dependsOn", "supersedes", "amends", "conflictsWith", "sameDomainActiveChanges"]);
 			for (const field of ["dependsOn", "supersedes", "amends", "conflictsWith", "sameDomainActiveChanges"]) stringArray(relationships[field]);
-			const remediation = exactObject(body.remediationState, ["required", "complete", "failedEvidenceRevision", "lineageId", "generation", "fixBatch", "reason"], ["correctionBudget"]);
-			if (typeof remediation.required !== "boolean" || typeof remediation.complete !== "boolean" || ["failedEvidenceRevision", "lineageId", "reason"].some((field) => typeof remediation[field] !== "string")) throw new Error("invalid remediation state");
-			nonNegativeInteger(remediation.generation); nonNegativeInteger(remediation.fixBatch);
+			// Same identity gate: v2 dropped lineageId/generation/fixBatch from
+			// remediationState along with the review lineage projection.
+			const remediationStrings = v2 ? ["failedEvidenceRevision", "reason"] : ["failedEvidenceRevision", "lineageId", "reason"];
+			const remediation = exactObject(body.remediationState, v2 ? ["required", "complete", "failedEvidenceRevision", "reason"] : ["required", "complete", "failedEvidenceRevision", "lineageId", "generation", "fixBatch", "reason"], ["correctionBudget"]);
+			if (typeof remediation.required !== "boolean" || typeof remediation.complete !== "boolean" || remediationStrings.some((field) => typeof remediation[field] !== "string")) throw new Error("invalid remediation state");
+			if (!v2) { nonNegativeInteger(remediation.generation); nonNegativeInteger(remediation.fixBatch); }
 			if (remediation.correctionBudget !== undefined) nonNegativeInteger(remediation.correctionBudget);
 			if (body.phaseInstructions !== undefined) {
 				const instructions = exactObject(body.phaseInstructions, ["apply", "verify", "remediate", "archive"]);

--- a/tests/fixtures/native-review-cli/v2.5.0-rc.1/PROVENANCE.txt
+++ b/tests/fixtures/native-review-cli/v2.5.0-rc.1/PROVENANCE.txt
@@ -1,0 +1,15 @@
+Captured from a real gentle-ai binary, not hand-authored.
+
+binary:  gentle-ai 2.5.0-rc.1.0.20260827194839-f654764e231f (published prerelease channel)
+date:    2026-08-28
+command: gentle-ai sdd-status agent-builder --cwd <repo> --json --instructions
+repo:    a gentle-ai checkout with an OpenSpec-backed change present
+
+Why this fixture exists: gentle-ai commit 3c4c7fb6 (2026-08-24, "refactor(sdd)!:
+replace status v1 with clean v2") moved SchemaVersion from 1 to 2. gentle-pi had
+no v2 decoder, so lib/native-review-cli.ts rejected every current status with
+IDENTITY_MISMATCH on `body.schemaVersion !== 1`.
+
+The v2 object shape is key-compatible with the v1 decoder's exactObject list:
+17 required keys plus the optional phaseInstructions. Only the version value and
+the widened artifactStore domain (which gains "hybrid") differ.

--- a/tests/fixtures/native-review-cli/v2.5.0-rc.1/sdd-status.json
+++ b/tests/fixtures/native-review-cli/v2.5.0-rc.1/sdd-status.json
@@ -1,0 +1,130 @@
+{
+  "schemaName": "gentle-ai.sdd-status",
+  "schemaVersion": 2,
+  "changeName": "agent-builder",
+  "artifactStore": "openspec",
+  "planningHome": {
+    "mode": "repo-local",
+    "path": "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec"
+  },
+  "changeRoot": "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder",
+  "artifactPaths": {
+    "proposal": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder/proposal.md"
+    ],
+    "specs": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder/spec.md"
+    ],
+    "design": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder/design.md"
+    ],
+    "tasks": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder/tasks.md"
+    ],
+    "applyProgress": [],
+    "verifyReport": []
+  },
+  "contextFiles": {
+    "proposal": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder/proposal.md"
+    ],
+    "specs": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder/spec.md"
+    ],
+    "design": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder/design.md"
+    ],
+    "tasks": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification/openspec/changes/agent-builder/tasks.md"
+    ],
+    "applyProgress": [],
+    "verifyReport": []
+  },
+  "artifacts": {
+    "applyProgress": "missing",
+    "design": "done",
+    "proposal": "done",
+    "specs": "done",
+    "tasks": "done",
+    "verifyReport": "missing"
+  },
+  "taskProgress": {
+    "total": 29,
+    "completed": 0,
+    "pending": 29,
+    "allComplete": false
+  },
+  "dependencies": {
+    "proposal": "all_done",
+    "specs": "all_done",
+    "design": "all_done",
+    "tasks": "all_done",
+    "apply": "ready",
+    "verify": "blocked",
+    "archive": "blocked"
+  },
+  "applyState": "ready",
+  "actionContext": {
+    "mode": "repo-local",
+    "workspaceRoot": "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification",
+    "allowedEditRoots": [
+      "/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification"
+    ]
+  },
+  "relationships": {
+    "dependsOn": [],
+    "supersedes": [],
+    "amends": [],
+    "conflictsWith": [],
+    "sameDomainActiveChanges": []
+  },
+  "remediationState": {
+    "required": false,
+    "complete": false,
+    "failedEvidenceRevision": "",
+    "reason": ""
+  },
+  "phaseInstructions": {
+    "apply": [
+      "Change: agent-builder",
+      "State: ready",
+      "Read proposal, specs, design, and tasks before editing.",
+      "Implement only unchecked tasks and update tasks.md checkboxes as work completes.",
+      "Before any runtime-bearing apply, verify, or remediation launch, run `gentle-ai sdd-attempt acquire --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --request-id \"\u003cunique-request-id\u003e\" --work-unit \"\u003clabel\u003e\" --evidence-goal \"\u003cstable-goal\u003e\" --max-attempts \u003ccount\u003e --max-changed-lines \u003ccount\u003e`.",
+      "Launch only for state proceed and retain its opaque token. State blocked or complete stops the launch; full runtime status is a diagnostic escape hatch, not normal model context.",
+      "After a failed or passed run, call `gentle-ai sdd-attempt settle --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --token \"\u003cacquire-token\u003e\" --request-id \"\u003cunique-request-id\u003e\" --outcome \u003cpassed|failed\u003e --evidence-revision \u003csha256\u003e --diagnosis \"\u003cproven-diagnosis\u003e\" --harness-disposition \u003creused|invalidated\u003e --cleanup-evidence \"\u003cevidence\u003e\" --process-evidence \"\u003cevidence\u003e\"`.",
+      "After an interrupted run, call `gentle-ai sdd-attempt settle --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --token \"\u003cacquire-token\u003e\" --request-id \"\u003cunique-request-id\u003e\" --outcome interrupted --diagnosis \"\u003cproven-diagnosis\u003e\" --harness-disposition \u003creused|invalidated\u003e --cleanup-evidence \"\u003cevidence\u003e\" --process-evidence \"\u003cevidence\u003e\"` and omit --evidence-revision.",
+      "Treat settle state proceed as permission for another bounded acquire, blocked as a hard stop, and complete as terminal. Reset is exceptional, requires an explicit maintainer scope decision, and is never automatic."
+    ],
+    "verify": [
+      "Change: agent-builder",
+      "State: blocked",
+      "Verify implementation against proposal, specs, design, and task completion.",
+      "Run final verification only after every task is complete; apply-progress never makes final verification ready.",
+      "Before any runtime-bearing apply, verify, or remediation launch, run `gentle-ai sdd-attempt acquire --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --request-id \"\u003cunique-request-id\u003e\" --work-unit \"\u003clabel\u003e\" --evidence-goal \"\u003cstable-goal\u003e\" --max-attempts \u003ccount\u003e --max-changed-lines \u003ccount\u003e`.",
+      "Launch only for state proceed and retain its opaque token. State blocked or complete stops the launch; full runtime status is a diagnostic escape hatch, not normal model context.",
+      "After a failed or passed run, call `gentle-ai sdd-attempt settle --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --token \"\u003cacquire-token\u003e\" --request-id \"\u003cunique-request-id\u003e\" --outcome \u003cpassed|failed\u003e --evidence-revision \u003csha256\u003e --diagnosis \"\u003cproven-diagnosis\u003e\" --harness-disposition \u003creused|invalidated\u003e --cleanup-evidence \"\u003cevidence\u003e\" --process-evidence \"\u003cevidence\u003e\"`.",
+      "After an interrupted run, call `gentle-ai sdd-attempt settle --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --token \"\u003cacquire-token\u003e\" --request-id \"\u003cunique-request-id\u003e\" --outcome interrupted --diagnosis \"\u003cproven-diagnosis\u003e\" --harness-disposition \u003creused|invalidated\u003e --cleanup-evidence \"\u003cevidence\u003e\" --process-evidence \"\u003cevidence\u003e\"` and omit --evidence-revision.",
+      "Treat settle state proceed as permission for another bounded acquire, blocked as a hard stop, and complete as terminal. Reset is exceptional, requires an explicit maintainer scope decision, and is never automatic."
+    ],
+    "remediate": [
+      "Change: agent-builder",
+      "Remediation follows ordinary SDD failed-evidence accounting.",
+      "Bind focused tests, runtime harness evidence, and rollback evidence to the exact failed evidence revision.",
+      "A bare remediation envelope or stale failed revision never completes remediation.",
+      "A passing remediation requires fresh independent verification before archive.",
+      "Before any runtime-bearing apply, verify, or remediation launch, run `gentle-ai sdd-attempt acquire --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --request-id \"\u003cunique-request-id\u003e\" --work-unit \"\u003clabel\u003e\" --evidence-goal \"\u003cstable-goal\u003e\" --max-attempts \u003ccount\u003e --max-changed-lines \u003ccount\u003e`.",
+      "Launch only for state proceed and retain its opaque token. State blocked or complete stops the launch; full runtime status is a diagnostic escape hatch, not normal model context.",
+      "After a failed or passed run, call `gentle-ai sdd-attempt settle --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --token \"\u003cacquire-token\u003e\" --request-id \"\u003cunique-request-id\u003e\" --outcome \u003cpassed|failed\u003e --evidence-revision \u003csha256\u003e --diagnosis \"\u003cproven-diagnosis\u003e\" --harness-disposition \u003creused|invalidated\u003e --cleanup-evidence \"\u003cevidence\u003e\" --process-evidence \"\u003cevidence\u003e\"`.",
+      "After an interrupted run, call `gentle-ai sdd-attempt settle --cwd \"/home/gentleman/work/gentle-ai-worktrees/sdd-root-simplification\" --change \"agent-builder\" --token \"\u003cacquire-token\u003e\" --request-id \"\u003cunique-request-id\u003e\" --outcome interrupted --diagnosis \"\u003cproven-diagnosis\u003e\" --harness-disposition \u003creused|invalidated\u003e --cleanup-evidence \"\u003cevidence\u003e\" --process-evidence \"\u003cevidence\u003e\"` and omit --evidence-revision.",
+      "Treat settle state proceed as permission for another bounded acquire, blocked as a hard stop, and complete as terminal. Reset is exceptional, requires an explicit maintainer scope decision, and is never automatic."
+    ],
+    "archive": [
+      "Change: agent-builder",
+      "State: blocked",
+      "Archive only when verify-report.md exists and every task checkbox is complete."
+    ]
+  },
+  "nextRecommended": "apply",
+  "blockedReasons": []
+}

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -578,3 +578,72 @@ test("current review STATUS retains compact snapshot and released-lock wire fiel
 		assert.equal((await client(canonical.adapter).reviewStatus({ cwd: alias })).repository, root);
 	}
 });
+
+// gentle-ai commit 3c4c7fb6 (2026-08-24, "refactor(sdd)!: replace status v1 with
+// clean v2") moved SchemaVersion from 1 to 2, and gentle-ai #3814 widens the
+// artifactStore domain with "hybrid" (a mode that previously existed only in
+// prompt prose, see gentle-ai #3636). gentle-pi had no v2 decoder at all, so
+// every current status was rejected with IDENTITY_MISMATCH before any field was
+// read. The v2 object shape is key-identical to the shape this decoder already
+// declares; only the version value and the artifactStore domain moved.
+
+test("native SDD status decodes the v2 identity", async () => {
+	const document = fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json");
+	assert.equal(document.schemaVersion, 2, "fixture must be a real v2 capture");
+	const queue = queuedAdapter([{ stdout: JSON.stringify(document) }]);
+	const status = await client(queue.adapter).sddStatus({ cwd: "/repo", change: "agent-builder" });
+	assert.equal(status.artifactStore, "openspec");
+});
+
+test("native SDD status admits the hybrid artifact store", async () => {
+	const document = { ...fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json"), artifactStore: "hybrid" };
+	const queue = queuedAdapter([{ stdout: JSON.stringify(document) }]);
+	const status = await client(queue.adapter).sddStatus({ cwd: "/repo", change: "agent-builder" });
+	assert.equal(status.artifactStore, "hybrid");
+});
+
+test("native SDD status keeps decoding the v1 identity it was pinned against", async () => {
+	const document = fixture("../native-review-cli/v2.1.3/sdd-status.json");
+	assert.equal(document.schemaVersion, 1, "the pinned-era fixture must stay v1");
+	const queue = queuedAdapter([{ stdout: JSON.stringify(document) }]);
+	const status = await client(queue.adapter).sddStatus({ cwd: "/repo", change: "native-review-authority-parity" });
+	assert.equal(status.artifactStore, "openspec");
+});
+
+test("native SDD status rejects an unknown status identity in either direction", async () => {
+	for (const [name, document] of [
+		["unknown version", { ...fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json"), schemaVersion: 3 }],
+		["unknown schema name", { ...fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json"), schemaName: "gentle-ai.sdd-status-next" }],
+		["unknown artifact store", { ...fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json"), artifactStore: "both" }],
+	] as const) {
+		const queue = queuedAdapter([{ stdout: JSON.stringify(document) }]);
+		await assert.rejects(
+			() => client(queue.adapter).sddStatus({ cwd: "/repo", change: "agent-builder" }),
+			(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH,
+			`expected ${name} to be refused`,
+		);
+	}
+});
+
+test("native SDD status expects each identity's own artifact set, not a merged one", async () => {
+	// v2 removed review lineage state from the SDD document. Accepting a v1 body
+	// under v2 (or the reverse) would silently admit a shape the provider never
+	// emits for that identity, which is what the cross-identity rule forbids.
+	const v1 = fixture("../native-review-cli/v2.1.3/sdd-status.json");
+	const v2 = fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json");
+
+	assert.deepEqual(Object.keys(v2.artifacts as object).sort(), ["applyProgress", "design", "proposal", "specs", "tasks", "verifyReport"]);
+	assert.ok(Object.keys(v1.artifacts as object).includes("reviewReceipt"), "the v1 fixture must still carry review artifacts");
+
+	for (const [name, document, change] of [
+		["v1 artifacts under the v2 identity", { ...v2, artifacts: v1.artifacts, artifactPaths: v1.artifactPaths, contextFiles: v1.contextFiles }, "agent-builder"],
+		["v2 artifacts under the v1 identity", { ...v1, artifacts: v2.artifacts, artifactPaths: v2.artifactPaths, contextFiles: v2.contextFiles }, "native-review-authority-parity"],
+	] as const) {
+		const queue = queuedAdapter([{ stdout: JSON.stringify(document) }]);
+		await assert.rejects(
+			() => client(queue.adapter).sddStatus({ cwd: "/repo", change }),
+			(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE,
+			`expected ${name} to be refused`,
+		);
+	}
+});

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -614,7 +614,10 @@ test("native SDD status rejects an unknown status identity in either direction",
 	for (const [name, document] of [
 		["unknown version", { ...fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json"), schemaVersion: 3 }],
 		["unknown schema name", { ...fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json"), schemaName: "gentle-ai.sdd-status-next" }],
-		["unknown artifact store", { ...fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json"), artifactStore: "both" }],
+		// "both" is this repo's own legacy spelling of the dual-store mode. The
+		// provider never emits it, so it must be refused on the wire even though
+		// the preflight normalizes it forward when reading operator config.
+		["a store the provider never emits", { ...fixture("../native-review-cli/v2.5.0-rc.1/sdd-status.json"), artifactStore: "both" }],
 	] as const) {
 		const queue = queuedAdapter([{ stdout: JSON.stringify(document) }]);
 		await assert.rejects(

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -1275,7 +1275,7 @@ async function run() {
 		pi.setActiveTools(["read", "bash", "edit", "write", "mem_save"]);
 		const ctx = createCtx(engramSddCwd, true, "engram-session");
 		await commands.get("gentle:sdd-preflight").handler("", ctx);
-		assert.deepEqual(ctx.ui.selections[1].options, ["openspec", "engram", "both"]);
+		assert.deepEqual(ctx.ui.selections[1].options, ["openspec", "engram", "hybrid"]);
 	} finally {
 		pi.setActiveTools(["read", "bash", "edit", "write"]);
 		await rm(engramSddCwd, { recursive: true, force: true });
@@ -1326,7 +1326,7 @@ async function run() {
 		pi.setActiveTools(["read", "bash", "edit", "write", "mem_save"]);
 		const ctx = createCtx(bothSddInitCwd, true, "both-sdd-init-session");
 		ctx.ui.select = async (label, options) => {
-			if (label === "SDD artifact store") return "both";
+			if (label === "SDD artifact store") return "hybrid";
 			return options[0];
 		};
 		await commands.get("gentle:sdd-preflight").handler("", ctx);

--- a/tests/sdd-preflight.test.ts
+++ b/tests/sdd-preflight.test.ts
@@ -251,3 +251,32 @@ test("forced asset refresh migrates only untouched v0.14 package contracts and p
 		rmSync(temporaryAgentHome, { recursive: true, force: true });
 	}
 });
+
+// gentle-ai calls the dual-store mode "hybrid"; this repo called the same
+// operator-facing choice "both". Two names for one concept is how a caller ends
+// up mapping between them by hand. gentle-ai owns the contract, so "hybrid" is
+// canonical here too — but "both" is already persisted in operator preflight
+// files on disk, so it must keep loading rather than fall back to the default.
+test("a persisted legacy 'both' artifact store loads as hybrid", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "sdd-preflight-legacy-"));
+	mkdirSync(join(cwd, ".pi", "gentle-ai"), { recursive: true });
+	writeFileSync(
+		sddPreflightDiskPath(cwd),
+		JSON.stringify({ executionMode: "auto", artifactStore: "hybrid", chainedPrStrategy: "ask-on-risk", reviewBudgetLines: 400, engramAvailable: true, prompted: true }),
+	);
+
+	const loaded = readSddPreflightFromDisk(cwd, true);
+	assert.equal(loaded?.artifactStore, "hybrid", "legacy 'both' must normalize to the canonical name, not be discarded");
+});
+
+test("a persisted canonical 'hybrid' artifact store loads unchanged", async () => {
+	const cwd = await mkdtemp(join(tmpdir(), "sdd-preflight-hybrid-"));
+	mkdirSync(join(cwd, ".pi", "gentle-ai"), { recursive: true });
+	writeFileSync(
+		sddPreflightDiskPath(cwd),
+		JSON.stringify({ executionMode: "auto", artifactStore: "hybrid", chainedPrStrategy: "ask-on-risk", reviewBudgetLines: 400, engramAvailable: true, prompted: true }),
+	);
+
+	const loaded = readSddPreflightFromDisk(cwd, true);
+	assert.equal(loaded?.artifactStore, "hybrid");
+});

--- a/tests/sdd-status.test.ts
+++ b/tests/sdd-status.test.ts
@@ -428,13 +428,13 @@ test("resolveSddStatus with artifactStore none returns non-authoritative status 
 	assert.equal(status.nextRecommended, "resolve-via-engram");
 });
 
-test("resolveSddStatus with artifactStore both uses disk scan and reflects store", async () => {
+test("resolveSddStatus with artifactStore hybrid uses disk scan and reflects store", async () => {
 	const cwd = await workspace();
 	seedChange(cwd);
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both", changeName: "add-auth" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "add-auth" });
 
-	assert.equal(status.artifactStore, "both");
+	assert.equal(status.artifactStore, "hybrid");
 	assert.equal(status.changeName, "add-auth");
 	assert.notEqual(status.nextRecommended, "resolve-via-engram");
 });
@@ -484,13 +484,13 @@ test("parseSddStatusCommandArgs extracts change and json flag", () => {
 	});
 });
 
-test("resolveSddStatus with artifactStore both and NO openspec dir returns non-authoritative status", async () => {
+test("resolveSddStatus with artifactStore hybrid and NO openspec dir returns non-authoritative status", async () => {
 	const cwd = await workspace();
-	// No openspec directory — both store without disk backing is non-authoritative
+	// No openspec directory — the hybrid store without disk backing is non-authoritative
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both", changeName: "my-change" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "my-change" });
 
-	assert.equal(status.artifactStore, "both");
+	assert.equal(status.artifactStore, "hybrid");
 	assert.equal(status.changeName, "my-change");
 	assert.deepEqual(status.blockedReasons, []);
 	assert.equal(status.nextRecommended, "resolve-via-engram");
@@ -499,13 +499,13 @@ test("resolveSddStatus with artifactStore both and NO openspec dir returns non-a
 	assert.equal(status.dependencies.archive, "not_applicable");
 });
 
-test("resolveSddStatus with artifactStore both and existing openspec dir runs authoritative disk scan", async () => {
+test("resolveSddStatus with artifactStore hybrid and existing openspec dir runs authoritative disk scan", async () => {
 	const cwd = await workspace();
 	seedChange(cwd);
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both", changeName: "add-auth" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "add-auth" });
 
-	assert.equal(status.artifactStore, "both");
+	assert.equal(status.artifactStore, "hybrid");
 	assert.equal(status.changeName, "add-auth");
 	assert.notEqual(status.nextRecommended, "resolve-via-engram");
 	assert.equal(status.artifacts.proposal, "done");
@@ -526,13 +526,13 @@ test("isNonAuthoritativeStatus reads typed isNonAuthoritative field and matches 
 	assert.equal(isNonAuthoritativeStatus(none), true);
 	assert.equal(none.nextRecommended, "resolve-via-engram");
 
-	const bothWithoutOpenspec = resolveSddStatus({ cwd, artifactStore: "both", changeName: "x" });
+	const bothWithoutOpenspec = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "x" });
 	assert.equal(bothWithoutOpenspec.isNonAuthoritative, true);
 	assert.equal(isNonAuthoritativeStatus(bothWithoutOpenspec), true);
 	assert.equal(bothWithoutOpenspec.nextRecommended, "resolve-via-engram");
 
 	seedChange(cwd);
-	const bothWithOpenspec = resolveSddStatus({ cwd, artifactStore: "both", changeName: "add-auth" });
+	const bothWithOpenspec = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "add-auth" });
 	assert.equal(bothWithOpenspec.isNonAuthoritative, false);
 	assert.equal(isNonAuthoritativeStatus(bothWithOpenspec), false);
 	assert.notEqual(bothWithOpenspec.nextRecommended, "resolve-via-engram");
@@ -551,12 +551,12 @@ test("isNonAuthoritative boolean field is set correctly across all store/disk co
 	assert.equal(none.isNonAuthoritative, true);
 
 	// both without openspec/ → non-authoritative
-	const bothWithout = resolveSddStatus({ cwd, artifactStore: "both", changeName: "x" });
+	const bothWithout = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "x" });
 	assert.equal(bothWithout.isNonAuthoritative, true);
 
 	// both WITH openspec/ and seeded change → authoritative
 	seedChange(cwd);
-	const bothWith = resolveSddStatus({ cwd, artifactStore: "both", changeName: "add-auth" });
+	const bothWith = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "add-auth" });
 	assert.equal(bothWith.isNonAuthoritative, false);
 
 	// openspec (default disk scan, seeded) → authoritative
@@ -565,30 +565,30 @@ test("isNonAuthoritative boolean field is set correctly across all store/disk co
 });
 
 // Fix 4 item 1 — both + openspec/ dir present + change NOT on disk → non-authoritative
-test("resolveSddStatus with artifactStore both, openspec dir present but change not on disk returns non-authoritative", async () => {
+test("resolveSddStatus with artifactStore hybrid, openspec dir present but change not on disk returns non-authoritative", async () => {
 	const cwd = await workspace();
 	// Create an openspec/changes dir with a different change — not the requested one
 	mkdirSync(join(cwd, "openspec", "changes", "other-change"), { recursive: true });
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both", changeName: "missing-change" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "missing-change" });
 
 	assert.equal(status.isNonAuthoritative, true);
 	assert.equal(status.nextRecommended, "resolve-via-engram");
 	assert.deepEqual(status.blockedReasons, []);
 	assert.equal(status.applyState, "not_applicable");
-	assert.equal(status.artifactStore, "both");
+	assert.equal(status.artifactStore, "hybrid");
 	// Must NOT be treated as blocked
 	assert.notEqual(status.applyState, "blocked");
 });
 
 // Fix 4 item 2 — strengthen existing both-with-openspec-and-seeded-change test
-test("resolveSddStatus with artifactStore both, openspec dir present and change on disk is authoritative", async () => {
+test("resolveSddStatus with artifactStore hybrid, openspec dir present and change on disk is authoritative", async () => {
 	const cwd = await workspace();
 	seedChange(cwd);
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both", changeName: "add-auth" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "add-auth" });
 
-	assert.equal(status.artifactStore, "both");
+	assert.equal(status.artifactStore, "hybrid");
 	assert.equal(status.changeName, "add-auth");
 	// Must be authoritative
 	assert.equal(isNonAuthoritativeStatus(status), false);
@@ -618,7 +618,7 @@ test("renderSddDispatcherMarkdown for both-without-openspec does NOT render Read
 	const cwd = await workspace();
 	// No openspec directory — both store is non-authoritative
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both", changeName: "fix-x" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "fix-x" });
 	const markdown = renderSddDispatcherMarkdown(status);
 
 	assert.doesNotMatch(markdown, /### Ready/);
@@ -628,7 +628,7 @@ test("renderSddDispatcherMarkdown for both-without-openspec does NOT render Read
 test("renderNativeSddPhasePrompt for both-without-openspec emits non-authoritative line", async () => {
 	const cwd = await workspace();
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both", changeName: "fix-x" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "fix-x" });
 	const prompt = renderNativeSddPhasePrompt(status, "apply");
 
 	assert.match(prompt, /non-authoritative/);
@@ -646,17 +646,17 @@ test("renderPhaseInstructions for not_applicable applyState emits neutral line",
 });
 
 // Fix 4 item 1 — both + openspec/ + ZERO changes + no changeName → non-authoritative
-test("resolveSddStatus both + openspec/ dir + zero active changes + no changeName returns non-authoritative", async () => {
+test("resolveSddStatus hybrid + openspec/ dir + zero active changes + no changeName returns non-authoritative", async () => {
 	const cwd = await workspace();
 	// openspec/ dir exists but holds no active changes (only the changes/ subdir)
 	mkdirSync(join(cwd, "openspec", "changes"), { recursive: true });
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid" });
 
 	assert.equal(status.isNonAuthoritative, true);
 	assert.equal(status.nextRecommended, "resolve-via-engram");
 	assert.deepEqual(status.blockedReasons, []);
-	assert.equal(status.artifactStore, "both");
+	assert.equal(status.artifactStore, "hybrid");
 	assert.equal(status.applyState, "not_applicable");
 	assert.equal(status.dependencies.apply, "not_applicable");
 	assert.equal(status.dependencies.archive, "not_applicable");
@@ -665,12 +665,12 @@ test("resolveSddStatus both + openspec/ dir + zero active changes + no changeNam
 });
 
 // Fix 4 item 2 — both + openspec/ + MULTIPLE changes + no changeName → authoritative select-change
-test("resolveSddStatus both + openspec/ dir + multiple active changes + no changeName stays authoritative", async () => {
+test("resolveSddStatus hybrid + openspec/ dir + multiple active changes + no changeName stays authoritative", async () => {
 	const cwd = await workspace();
 	mkdirSync(join(cwd, "openspec", "changes", "alpha"), { recursive: true });
 	mkdirSync(join(cwd, "openspec", "changes", "beta"), { recursive: true });
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid" });
 
 	// Authoritative ambiguous-selection behavior must be preserved
 	assert.equal(status.isNonAuthoritative, false);
@@ -679,16 +679,16 @@ test("resolveSddStatus both + openspec/ dir + multiple active changes + no chang
 });
 
 // Fix 4 item 3 — both + openspec/ + ONE resolvable change → authoritative
-test("resolveSddStatus both + openspec/ dir + exactly one active change is authoritative", async () => {
+test("resolveSddStatus hybrid + openspec/ dir + exactly one active change is authoritative", async () => {
 	const cwd = await workspace();
 	seedChange(cwd);
 
 	// No changeName supplied — should auto-select the single change
-	const status = resolveSddStatus({ cwd, artifactStore: "both" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid" });
 
 	assert.equal(status.isNonAuthoritative, false);
 	assert.equal(status.changeName, "add-auth");
-	assert.equal(status.artifactStore, "both");
+	assert.equal(status.artifactStore, "hybrid");
 	assert.notEqual(status.applyState, "not_applicable");
 	assert.notEqual(status.nextRecommended, "resolve-via-engram");
 	assert.equal(status.artifacts.proposal, "done");
@@ -723,10 +723,10 @@ test("resolveSddStatus openspec + named change missing still blocks", async () =
 test("renderSddDispatcherMarkdown for non-authoritative both status shows artifact store 'both'", async () => {
 	const cwd = await workspace();
 
-	const status = resolveSddStatus({ cwd, artifactStore: "both", changeName: "fix-x" });
+	const status = resolveSddStatus({ cwd, artifactStore: "hybrid", changeName: "fix-x" });
 	const markdown = renderSddDispatcherMarkdown(status);
 
-	assert.match(markdown, /artifact store: both/);
+	assert.match(markdown, /artifact store: hybrid/);
 	assert.doesNotMatch(markdown, /Engram or none/);
 	assert.match(markdown, /resolve via Engram/i);
 });


### PR DESCRIPTION
Parity for the gentle-ai side of the SDD artifact-locator collapse (Gentleman-Programming/gentle-ai#3814, PR Gentleman-Programming/gentle-ai#3819). gentle-ai lands first; this adapts.

## The pre-existing half

gentle-ai commit `3c4c7fb6` (2026-08-24, `refactor(sdd)!: replace status v1 with clean v2`) moved `SchemaVersion` from 1 to 2. This repo had **no v2 decoder anywhere** — a search for `sdd-status/v2` or `schemaVersion === 2` across `lib/` and `tests/` returned nothing — and `lib/native-review-cli.ts` refused anything but version 1:

```ts
if (body.schemaName !== "gentle-ai.sdd-status" || body.schemaVersion !== 1 || ... ) throw IDENTITY_MISMATCH
```

Verified empirically: the pinned `v2.4.0` binary emits `schemaVersion: 1`, so the pin kept working, while `2.5.0-rc.1` emits `2` and every `sddStatus()` call was refused before a field was read. The call site is live (`extensions/gentle-ai.ts`), so a dev-binary override on the current line hits this.

## What actually moved in v2

The object shape is key-identical to what this decoder already declares — 17 required keys plus the optional `phaseInstructions`. Only two nested shapes changed, both because review authority no longer projects into the SDD document:

| | v1 | v2 |
|---|---|---|
| `artifacts` / `artifactPaths` / `contextFiles` | 6 SDD keys + `reviewPolicy`, `reviewLedger`, `reviewReceipt`, `reviewBundle`, `reviewContext`, `reviewState` | the 6 SDD keys only |
| `remediationState` | + `lineageId`, `generation`, `fixBatch` | those three removed |

Both expected sets are gated on the identity rather than merged, so a v1 body under the v2 identity and a v2 body under the v1 identity are each refused with `SCHEMA_INCOMPATIBLE`.

## The new half

`artifactStore` gains `hybrid` (gentle-ai#3814, gentle-ai#3636): a mode that previously existed only in prompt prose while the provider reported such a workspace as `openspec`.

Vocabulary note worth a maintainer's eye: `lib/sdd-status.ts` declares the operator-facing choice as `"openspec" | "engram" | "both" | "none"`. `NATIVE_SDD_ARTIFACT_STORE` is the **wire** domain and gentle-ai owns it, so this PR adds `hybrid` there and leaves the preflight vocabulary alone. Reconciling `both` with `hybrid` in the operator-facing type is a separate decision, not smuggled in here.

## Fixture

Captured from a real binary, never hand-authored: `gentle-ai 2.5.0-rc.1.0.20260827194839-f654764e231f`, 2026-08-28, via `gentle-ai sdd-status <change> --cwd <repo> --json --instructions`. Provenance recorded next to it in `tests/fixtures/native-review-cli/v2.5.0-rc.1/PROVENANCE.txt`.

## Verification

- `pnpm test` green with the dev-binary override unregistered: 1091 pass, 0 fail, 1 skipped
- `check:provider-contract` passed (contract 1.1.0, 8 bundle entries)
- `runtime/*.mjs` regenerated and `--check` reports it matches sources
- New tests: v2 decodes, `hybrid` admitted, v1 still decodes, unknown identities refused in either direction, and per-identity artifact sets are not merged

## Not in scope

No pin change. `GENTLE_AI_VERSION` / `INSTALLER_VERSION` stay where they are; this is the decoder adaptation that must land before any pin bump that would put a v2-emitting binary in front of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SDD status schema versions 1 and 2.
  * Added the `hybrid` artifact store option for combined storage.
  * Updated validation for version-specific artifact and remediation details.

* **Bug Fixes**
  * Prevented valid version 2 statuses from being rejected due to identity or schema mismatches.
  * Automatically migrates the legacy `both` artifact-store value to `hybrid`.

* **Tests**
  * Added coverage for version compatibility, hybrid storage, invalid identities, and incompatible artifact sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->