### PR TITLE
feat(review): reach parity with the gentle-ai acknowledgement lifecycle

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3924,6 +3924,10 @@ function mapLastEventClosure(
 			...(closure.correctionLines === undefined ? {} : { correction_lines: closure.correctionLines }),
 			...(closure.advisoryFindings === undefined ? {} : { advisory_findings: closure.advisoryFindings }),
 			...(closure.statusContinuation === undefined ? {} : { status_continuation: closure.statusContinuation.raw }),
+			// The host has to see the acknowledgement to run it: approval now
+			// waits for that exact invocation instead of burning on its own, so
+			// dropping it here would strand the lineage as approved forever.
+			...(closure.acknowledgement === undefined ? {} : { acknowledgement: closure.acknowledgement.raw }),
 		},
 		lineage_id: closure.lineageId,
 		state: closure.state,

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3928,6 +3928,10 @@ function mapLastEventClosure(
 			// waits for that exact invocation instead of burning on its own, so
 			// dropping it here would strand the lineage as approved forever.
 			...(closure.acknowledgement === undefined ? {} : { acknowledgement: closure.acknowledgement.raw }),
+			// A present-but-unreadable continuation is not the same as none: the
+			// host is approved and cannot end it here, and silence would read as
+			// nothing left to do.
+			...(closure.acknowledgementUndecodable === undefined ? {} : { acknowledgement_undecodable: true }),
 		},
 		lineage_id: closure.lineageId,
 		state: closure.state,

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -57,6 +57,7 @@ export const NATIVE_REVIEW_OPERATION = {
 	CAPTURE_RESULT: "review/capture-result",
 	CAPTURE_CORRECTION_PLAN: "review/capture-correction-plan",
 	CAPTURE_PROVIDER_ROLE: "review/capture-provider-role",
+	ACKNOWLEDGE_APPROVED: "review/acknowledge-approved",
 } as const;
 export type NativeReviewOperation = (typeof NATIVE_REVIEW_OPERATION)[keyof typeof NATIVE_REVIEW_OPERATION];
 
@@ -385,6 +386,16 @@ export interface NativeReviewAdmittedResultManifest {
 
 /** A non-final reviewer capture acknowledges an admitted artifact; final captures close natively. */
 export type NativeReviewCaptureResultOutcome = NativeReviewAdmittedResultManifest | ReviewLastEventClosureV1;
+
+// The one continuation that burns approved authority. Its tokens are rendered
+// by the provider in a closed order and are relayed verbatim: Pi never builds,
+// reorders, or substitutes one, because a synthesized acknowledgement would be
+// Pi deciding that a review is over.
+export interface NativeReviewAcknowledgeApprovedRequest {
+	readonly argumentTokens: readonly string[];
+	readonly cwd: string;
+	readonly signal?: AbortSignal;
+}
 
 export interface NativeReviewCorrectionPlanCaptureRequest {
 	readonly argumentTokens: readonly string[];
@@ -958,7 +969,7 @@ function decodeLegacyReconcileAudit(value: unknown): NativeReviewRecoveryResult 
 // named, typed refusal instead of a generic schema-incompatible error, and
 // before any client ever tries to build an invocation for it (Design
 // Decision #6, migrate-review-integration-v2).
-const NATIVE_REVIEW_SUPPORTED_TRANSITION_OPERATIONS = new Set(["review.start", "review.recover", "review.repair"]);
+const NATIVE_REVIEW_SUPPORTED_TRANSITION_OPERATIONS = new Set(["review.start", "review.recover", "review.repair", "review.acknowledge-approved"]);
 function assertSupportedNextTransitionOperation(body: Record<string, unknown>): void {
 	const nextTransition = body.next_transition;
 	if (typeof nextTransition !== "object" || nextTransition === null || Array.isArray(nextTransition)) return;
@@ -1840,6 +1851,11 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		signal: AbortSignal | undefined,
 		path: string,
 		toleratedStderr: readonly string[] = [],
+		// A successful acknowledgement burns its authority and prints nothing:
+		// there is no receipt left to describe. Only that shape opts out of the
+		// body, and only for a zero exit; a non-zero exit still has to produce
+		// its typed failure envelope like every other operation.
+		expectsBody = true,
 	): Promise<NegotiatedExecution> {
 		let result: ExecFileResult;
 		try {
@@ -1852,6 +1868,11 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, operation, mutating, "native process timed out", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, operation, mutating, "native process was signalled", result);
 		const diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.NON_ZERO, result);
+		if (!expectsBody && result.exitCode === 0) {
+			if (result.stdout.trim().length > 0) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE, operation, mutating, "native bodyless operation returned output", result);
+			if (result.stderr.trim().length > 0 && !stderrIsTolerated(result.stderr, toleratedStderr)) throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNEXPECTED_STDERR, operation, mutating, "native process wrote stderr", result);
+			return { body: {}, exitCode: result.exitCode };
+		}
 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
 		if (result.exitCode !== 0) {
 			try {
@@ -2072,6 +2093,20 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		} finally {
 			await this.cleanupDirectory(directory).catch(() => undefined);
 		}
+	}
+
+	// Relays the provider-issued acknowledgement exactly as rendered. A success
+	// burns the authority and its artifacts and prints nothing, so there is no
+	// body to decode and nothing survives to describe; a refusal still arrives
+	// as the ordinary typed failure envelope.
+	async acknowledgeApproved(request: NativeReviewAcknowledgeApprovedRequest): Promise<void> {
+		if (request.argumentTokens.length === 0) throw new TypeError("Native ACKNOWLEDGE_APPROVED requires the provider-issued argument tokens");
+		if (request.argumentTokens.some((token) => typeof token !== "string" || token.length === 0)) throw new TypeError("Native ACKNOWLEDGE_APPROVED argument tokens must all be non-empty strings");
+		if (request.argumentTokens.some((token) => token.includes("{{value}}"))) throw new TypeError("Native ACKNOWLEDGE_APPROVED argument tokens carry no caller-substituted value");
+		const executable = this.executablePath(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, true);
+		await this.invoke(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, request.cwd, [
+			"review", "acknowledge-approved", ...request.argumentTokens,
+		], true, request.signal, executable, [], false);
 	}
 
 	async captureCorrectionPlan(request: NativeReviewCorrectionPlanCaptureRequest): Promise<ReviewLastEventClosureV1> {

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -2089,6 +2089,11 @@ export interface ReviewLastEventClosureV1 {
 	advisoryFindings?: ReviewAdvisoryFindingsV1;
 	statusContinuation?: ReviewStatusContinuationV1;
 	acknowledgement?: ReviewApprovedAcknowledgementV1;
+	// Set when the provider sent an acknowledgement this decoder could not
+	// read. It is deliberately distinct from an absent one: the host must be
+	// able to tell "approved, nothing to run" from "approved, and the thing
+	// that ends this is present but unreadable here".
+	acknowledgementUndecodable?: true;
 }
 
 export interface ReviewLastEventClosureBinding {
@@ -2245,9 +2250,28 @@ export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventC
 	// provider that emits one is decoded strictly; a provider that does not is
 	// still the contract this build ships against. Requiring it belongs with
 	// the pin bump that makes it always present.
-	const acknowledgement = body.acknowledgement === undefined
-		? undefined
-		: decodeReviewApprovedAcknowledgementV1(body.acknowledgement, "last_event_closure.acknowledgement");
+	// Decoded defensively on purpose. This decoder pins the acknowledgement to a
+	// closed positional shape, and the same patch that added it already shows
+	// what strictness costs when the provider moves: rejecting one omitempty
+	// field made every targeted-validation STATUS that carried it undecodable.
+	// Here the blast radius would be worse than a lost field. Throwing would
+	// fail the whole approved closure, so the host would lose the approval
+	// outcome AND the only invocation that burns the authority, leaving the
+	// lineage approved and un-burnable at once. An unreadable continuation
+	// degrades to a flag; everything else about the approval still arrives.
+	let acknowledgement: ReviewApprovedAcknowledgementV1 | undefined;
+	let acknowledgementUndecodable = false;
+	if (body.acknowledgement !== undefined) {
+		try {
+			acknowledgement = decodeReviewApprovedAcknowledgementV1(body.acknowledgement, "last_event_closure.acknowledgement");
+		} catch {
+			acknowledgement = undefined;
+			acknowledgementUndecodable = true;
+		}
+	}
+	if (acknowledgementUndecodable && state !== "approved") {
+		throw new TypeError("last_event_closure acknowledgement requires approved state");
+	}
 	if (acknowledgement !== undefined) {
 		if (state !== "approved") throw new TypeError("last_event_closure acknowledgement requires approved state");
 		if (acknowledgement.binding.lineageId !== shared.lineageId) {
@@ -2259,6 +2283,16 @@ export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventC
 		const lineageArguments = acknowledgement.arguments.filter((argument) => argument.name === "lineage");
 		if (lineageArguments.length !== 1 || lineageArguments[0]?.value !== shared.lineageId || lineageArguments[0]?.token !== `--lineage=${shared.lineageId}`) {
 			throw new TypeError("last_event_closure acknowledgement lineage argument does not match its enclosing closure");
+		}
+		// The target is the other half of what this invocation burns, and it is
+		// relayed verbatim. A terminal closure carries no target of its own, so
+		// the acknowledgement's binding is the only statement of which candidate
+		// is being burned: pinning lineage and revision while leaving the
+		// relayed target token free of it proves nothing about what runs.
+		const targetArguments = acknowledgement.arguments.filter((argument) => argument.name === "target");
+		if (targetArguments.length !== 1 || targetArguments[0]?.value !== acknowledgement.binding.targetIdentity
+			|| targetArguments[0]?.token !== `--target=${acknowledgement.binding.targetIdentity}`) {
+			throw new TypeError("last_event_closure acknowledgement target argument does not match its binding");
 		}
 	}
 	const action = nonempty(body.action, "last_event_closure.action");
@@ -2272,6 +2306,7 @@ export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventC
 		...(advisoryFindings === undefined ? {} : { advisoryFindings }),
 		...(statusContinuation === undefined ? {} : { statusContinuation }),
 		...(acknowledgement === undefined ? {} : { acknowledgement }),
+		...(acknowledgementUndecodable ? { acknowledgementUndecodable: true as const } : {}),
 	};
 }
 

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -434,6 +434,10 @@ export interface ReviewTargetedValidationFindingV1 {
 
 export interface ReviewTargetedValidationClassificationV1 {
 	findingId: string;
+	// The provider's FindingEvidence carries severity as an omitempty field, so
+	// a classification may or may not name one. Rejecting it made every
+	// targeted-validation STATUS that carried one undecodable.
+	severity?: string;
 	class: "deterministic" | "inferential";
 	causalDisposition: "introduced" | "behavior-activated" | "worsened";
 	proof: string;
@@ -1009,7 +1013,7 @@ export function decodeReviewStartV3(value: unknown): ReviewStartV3 {
 	const body = exactRecord(value, "start", [
 		"schema", "contract", "operation", "action", "lenses_required", "lineage_id", "state", "risk_level",
 		"selected_lenses", "projection", "changed_files", "changed_lines", "correction_budget", "risk_reasons", "artifact_subjects",
-	], [...overlayFields, "changed_path_manifest", "repository_context"]);
+	], [...overlayFields, "changed_path_manifest", "repository_context", "acknowledgement"]);
 	requireIdentity(body, "gentle-ai.review-integration.start/v3", REVIEW_INTEGRATION_OPERATION.START);
 
 	// dependentRequired binds base_tree<->candidate_tree bidirectionally, and
@@ -1048,7 +1052,7 @@ export function decodeReviewStartV3(value: unknown): ReviewStartV3 {
 		if (source.capability !== "review.opaque_repository_context") throw new TypeError("start.repository_context.capability is unsupported");
 		repositoryContext = {
 			capability: "review.opaque_repository_context",
-			handle: text(source.handle, "start.repository_context.handle", { pattern: /^rctx1_[0-9a-f]{64}$/ }),
+			handle: text(source.handle, "start.repository_context.handle", { pattern: /^rctx[12]_[0-9a-f]{64}$/ }),
 			revision: sha256(source.revision, "start.repository_context.revision"),
 			targetIdentity: sha256(source.target_identity, "start.repository_context.target_identity"),
 			...(source.event_id === undefined ? {} : { eventId: sha256(source.event_id, "start.repository_context.event_id") }),
@@ -1196,7 +1200,7 @@ export function decodeAuthorityRepairAssessmentV1(value: unknown): AuthorityRepa
 // collect inputs and the execute binding.
 // ---------------------------------------------------------------------------
 
-const NEXT_TRANSITION_OPERATIONS = ["review.start", "review.recover", "review.repair"] as const;
+const NEXT_TRANSITION_OPERATIONS = ["review.start", "review.recover", "review.repair", "review.acknowledge-approved"] as const;
 
 function decodeTransitionArguments(value: unknown, label: string): readonly ReviewTransitionArgumentV3[] {
 	return array(value, label, (entry, entryLabel) => {
@@ -1314,9 +1318,11 @@ export function decodeReviewTargetedValidationRequestV1(value: unknown, label = 
 		};
 	}, { minimum: 1 });
 	const fixClassifications = array(body.fix_classifications, `${label}.fix_classifications`, (entry, entryLabel): ReviewTargetedValidationClassificationV1 => {
-		const classification = exactRecord(entry, entryLabel, ["finding_id", "class", "causal_disposition", "proof"]);
+		const classification = exactRecord(entry, entryLabel, ["finding_id", "class", "causal_disposition", "proof"], ["severity"]);
+		const severity = classification.severity === undefined ? undefined : nonempty(classification.severity, `${entryLabel}.severity`);
 		return {
 			findingId: nonempty(classification.finding_id, `${entryLabel}.finding_id`),
+			...(severity === undefined ? {} : { severity }),
 			class: enumeration(classification.class, ["deterministic", "inferential"] as const, `${entryLabel}.class`),
 			causalDisposition: enumeration(classification.causal_disposition, ["introduced", "behavior-activated", "worsened"] as const, `${entryLabel}.causal_disposition`),
 			proof: nonempty(classification.proof, `${entryLabel}.proof`),
@@ -1633,7 +1639,7 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 		if (source.capability !== "review.opaque_repository_context") throw new TypeError("status.repository_context.capability is unsupported");
 		repositoryContext = {
 			capability: "review.opaque_repository_context",
-			handle: text(source.handle, "status.repository_context.handle", { pattern: /^rctx1_[0-9a-f]{64}$/ }),
+			handle: text(source.handle, "status.repository_context.handle", { pattern: /^rctx[12]_[0-9a-f]{64}$/ }),
 			revision: sha256(source.revision, "status.repository_context.revision"),
 			targetIdentity: sha256(source.target_identity, "status.repository_context.target_identity"),
 			...(source.event_id === undefined ? {} : { eventId: sha256(source.event_id, "status.repository_context.event_id") }),
@@ -2046,6 +2052,30 @@ export interface ReviewStatusContinuationV1 {
 	raw: Record<string, unknown>;
 }
 
+const REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION = "review.acknowledge-approved" as const;
+
+// The exact ordered argument names the provider renders for one approved
+// acknowledgement. The list is closed and positional on the wire, so decoding
+// by position is what proves the relay is replaying the provider's own
+// invocation rather than one the host assembled.
+const REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS = ["cwd", "lineage", "target", "expected-revision", "token"] as const;
+
+export interface ReviewApprovedAcknowledgementBindingV1 {
+	lineageId: string;
+	revision: string;
+	targetIdentity: string;
+	repositoryContext?: string;
+}
+
+export interface ReviewApprovedAcknowledgementV1 {
+	operation: typeof REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION;
+	command: string;
+	arguments: readonly ReviewTransitionArgumentV3[];
+	preconditions: readonly ReviewTransitionArgumentV3[];
+	binding: ReviewApprovedAcknowledgementBindingV1;
+	raw: Record<string, unknown>;
+}
+
 export interface ReviewLastEventClosureV1 {
 	schema: typeof REVIEW_LAST_EVENT_CLOSURE_SCHEMA;
 	operation: ReviewLastEventClosureOperation;
@@ -2058,6 +2088,7 @@ export interface ReviewLastEventClosureV1 {
 	correctionLines?: number;
 	advisoryFindings?: ReviewAdvisoryFindingsV1;
 	statusContinuation?: ReviewStatusContinuationV1;
+	acknowledgement?: ReviewApprovedAcknowledgementV1;
 }
 
 export interface ReviewLastEventClosureBinding {
@@ -2084,6 +2115,48 @@ function decodeReviewStatusContinuationArtifactV1(value: unknown, label: string)
 	};
 }
 
+// decodeReviewApprovedAcknowledgementV1 decodes the one continuation that burns
+// approved authority. Only this exact invocation ends the lifecycle, so every
+// field is pinned: the closed positional argument list, the single approved
+// precondition, and the fully-bound lineage/revision/target it commits to.
+function decodeReviewApprovedAcknowledgementV1(value: unknown, label: string): ReviewApprovedAcknowledgementV1 {
+	const body = exactRecord(value, label, ["operation", "command", "arguments", "preconditions", "binding"]);
+	if (body.operation !== REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION) {
+		throw new TypeError(`${label}.operation must be ${REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION}`);
+	}
+	const command = text(body.command, `${label}.command`, { minimum: 1, pattern: /^gentle-ai review acknowledge-approved(?: |$)/ });
+	const argumentsList = decodeTransitionArguments(body.arguments, `${label}.arguments`);
+	if (argumentsList.length !== REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length) {
+		throw new TypeError(`${label}.arguments must carry exactly ${REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length} provider-issued arguments`);
+	}
+	argumentsList.forEach((argument, index) => {
+		const expected = REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS[index];
+		if (argument.name !== expected) throw new TypeError(`${label}.arguments[${index}].name must be ${expected}`);
+		if (argument.token === undefined) throw new TypeError(`${label}.arguments[${index}] requires its exact token`);
+	});
+	const preconditions = decodeTransitionArguments(body.preconditions, `${label}.preconditions`);
+	if (preconditions.length !== 1 || preconditions[0].name !== "state" || preconditions[0].value !== "approved") {
+		throw new TypeError(`${label}.preconditions must be the single approved state precondition`);
+	}
+	const sourceBinding = exactRecord(body.binding, `${label}.binding`, ["lineage_id", "revision", "target_identity"], ["repository_context"]);
+	const repositoryContext = sourceBinding.repository_context === undefined
+		? undefined
+		: text(sourceBinding.repository_context, `${label}.binding.repository_context`, { pattern: /^rctx[12]_[0-9a-f]{64}$/ });
+	return {
+		operation: REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION,
+		command,
+		arguments: argumentsList,
+		preconditions,
+		binding: {
+			lineageId: lineage(sourceBinding.lineage_id, `${label}.binding.lineage_id`),
+			revision: sha256(sourceBinding.revision, `${label}.binding.revision`),
+			targetIdentity: sha256(sourceBinding.target_identity, `${label}.binding.target_identity`),
+			...(repositoryContext === undefined ? {} : { repositoryContext }),
+		},
+		raw: body,
+	};
+}
+
 function decodeReviewStatusContinuationV1(value: unknown): ReviewStatusContinuationV1 {
 	const body = exactRecord(value, "last_event_closure.status_continuation", ["operation", "arguments", "preconditions", "binding"], ["command", "selector_arguments", "artifacts"]);
 	if (body.operation !== REVIEW_STATUS_CONTINUATION_OPERATION.STATUS) throw new TypeError("last_event_closure.status_continuation.operation must be review.status");
@@ -2096,7 +2169,7 @@ function decodeReviewStatusContinuationV1(value: unknown): ReviewStatusContinuat
 	const revision = sourceBinding.revision === undefined ? undefined : sha256(sourceBinding.revision, "last_event_closure.status_continuation.binding.revision");
 	const repositoryContext = sourceBinding.repository_context === undefined
 		? undefined
-		: text(sourceBinding.repository_context, "last_event_closure.status_continuation.binding.repository_context", { pattern: /^rctx1_[0-9a-f]{64}$/ });
+		: text(sourceBinding.repository_context, "last_event_closure.status_continuation.binding.repository_context", { pattern: /^rctx[12]_[0-9a-f]{64}$/ });
 	const selectorArguments = body.selector_arguments === undefined
 		? undefined
 		: decodeTransitionArguments(body.selector_arguments, "last_event_closure.status_continuation.selector_arguments");
@@ -2124,7 +2197,7 @@ function decodeReviewStatusContinuationV1(value: unknown): ReviewStatusContinuat
 }
 
 export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventClosureV1 {
-	const body = exactRecord(value, "last_event_closure", ["schema", "operation", "lineage_id", "state", "store_revision"], ["target_identity", "request_hash", "correction_lines", "action", "advisory_findings", "status_continuation"]);
+	const body = exactRecord(value, "last_event_closure", ["schema", "operation", "lineage_id", "state", "store_revision"], ["target_identity", "request_hash", "correction_lines", "action", "advisory_findings", "status_continuation", "acknowledgement"]);
 	if (body.schema !== REVIEW_LAST_EVENT_CLOSURE_SCHEMA) throw new TypeError(`last_event_closure.schema must be ${REVIEW_LAST_EVENT_CLOSURE_SCHEMA}`);
 	const operation = enumeration(body.operation, Object.values(REVIEW_LAST_EVENT_CLOSURE_OPERATION), "last_event_closure.operation") as ReviewLastEventClosureOperation;
 	const state = enumeration(body.state, REVIEW_LAST_EVENT_TERMINAL_STATES, "last_event_closure.state") as ReviewLastEventClosureState;
@@ -2164,6 +2237,30 @@ export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventC
 			throw new TypeError("last_event_closure status continuation lineage argument does not match its enclosing closure");
 		}
 	}
+	// Only an approved closure may carry the continuation that burns its
+	// authority: any other state offering an acknowledgement would be inviting
+	// a burn the provider never authorized.
+	//
+	// It stays optional because the pinned installer binary predates it. A
+	// provider that emits one is decoded strictly; a provider that does not is
+	// still the contract this build ships against. Requiring it belongs with
+	// the pin bump that makes it always present.
+	const acknowledgement = body.acknowledgement === undefined
+		? undefined
+		: decodeReviewApprovedAcknowledgementV1(body.acknowledgement, "last_event_closure.acknowledgement");
+	if (acknowledgement !== undefined) {
+		if (state !== "approved") throw new TypeError("last_event_closure acknowledgement requires approved state");
+		if (acknowledgement.binding.lineageId !== shared.lineageId) {
+			throw new TypeError("last_event_closure acknowledgement lineage does not match its enclosing closure");
+		}
+		if (acknowledgement.binding.revision !== shared.storeRevision) {
+			throw new TypeError("last_event_closure acknowledgement revision does not match its enclosing closure");
+		}
+		const lineageArguments = acknowledgement.arguments.filter((argument) => argument.name === "lineage");
+		if (lineageArguments.length !== 1 || lineageArguments[0]?.value !== shared.lineageId || lineageArguments[0]?.token !== `--lineage=${shared.lineageId}`) {
+			throw new TypeError("last_event_closure acknowledgement lineage argument does not match its enclosing closure");
+		}
+	}
 	const action = nonempty(body.action, "last_event_closure.action");
 	const advisoryFindings = body.advisory_findings === undefined
 		? undefined
@@ -2174,6 +2271,7 @@ export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventC
 		action,
 		...(advisoryFindings === undefined ? {} : { advisoryFindings }),
 		...(statusContinuation === undefined ? {} : { statusContinuation }),
+		...(acknowledgement === undefined ? {} : { acknowledgement }),
 	};
 }
 

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -58,6 +58,7 @@ export const NATIVE_REVIEW_OPERATION = {
 	CAPTURE_RESULT: "review/capture-result",
 	CAPTURE_CORRECTION_PLAN: "review/capture-correction-plan",
 	CAPTURE_PROVIDER_ROLE: "review/capture-provider-role",
+	ACKNOWLEDGE_APPROVED: "review/acknowledge-approved",
 }         ;
 
 
@@ -385,6 +386,16 @@ export const NATIVE_REVIEW_LEGACY_ALIAS_REPAIR = {
 
 
 /** A non-final reviewer capture acknowledges an admitted artifact; final captures close natively. */
+
+
+// The one continuation that burns approved authority. Its tokens are rendered
+// by the provider in a closed order and are relayed verbatim: Pi never builds,
+// reorders, or substitutes one, because a synthesized acknowledgement would be
+// Pi deciding that a review is over.
+
+
+
+
 
 
 
@@ -959,7 +970,7 @@ function decodeLegacyReconcileAudit(value         )                             
 // named, typed refusal instead of a generic schema-incompatible error, and
 // before any client ever tries to build an invocation for it (Design
 // Decision #6, migrate-review-integration-v2).
-const NATIVE_REVIEW_SUPPORTED_TRANSITION_OPERATIONS = new Set(["review.start", "review.recover", "review.repair"]);
+const NATIVE_REVIEW_SUPPORTED_TRANSITION_OPERATIONS = new Set(["review.start", "review.recover", "review.repair", "review.acknowledge-approved"]);
 function assertSupportedNextTransitionOperation(body                         )       {
 	const nextTransition = body.next_transition;
 	if (typeof nextTransition !== "object" || nextTransition === null || Array.isArray(nextTransition)) return;
@@ -1841,6 +1852,11 @@ export class NativeReviewCliV216                            {
 		signal                         ,
 		path        ,
 		toleratedStderr                    = [],
+		// A successful acknowledgement burns its authority and prints nothing:
+		// there is no receipt left to describe. Only that shape opts out of the
+		// body, and only for a zero exit; a non-zero exit still has to produce
+		// its typed failure envelope like every other operation.
+		expectsBody = true,
 	)                               {
 		let result                ;
 		try {
@@ -1853,6 +1869,11 @@ export class NativeReviewCliV216                            {
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, operation, mutating, "native process timed out", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, operation, mutating, "native process was signalled", result);
 		const diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.NON_ZERO, result);
+		if (!expectsBody && result.exitCode === 0) {
+			if (result.stdout.trim().length > 0) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE, operation, mutating, "native bodyless operation returned output", result);
+			if (result.stderr.trim().length > 0 && !stderrIsTolerated(result.stderr, toleratedStderr)) throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNEXPECTED_STDERR, operation, mutating, "native process wrote stderr", result);
+			return { body: {}, exitCode: result.exitCode };
+		}
 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
 		if (result.exitCode !== 0) {
 			try {
@@ -2073,6 +2094,20 @@ export class NativeReviewCliV216                            {
 		} finally {
 			await this.cleanupDirectory(directory).catch(() => undefined);
 		}
+	}
+
+	// Relays the provider-issued acknowledgement exactly as rendered. A success
+	// burns the authority and its artifacts and prints nothing, so there is no
+	// body to decode and nothing survives to describe; a refusal still arrives
+	// as the ordinary typed failure envelope.
+	async acknowledgeApproved(request                                        )                {
+		if (request.argumentTokens.length === 0) throw new TypeError("Native ACKNOWLEDGE_APPROVED requires the provider-issued argument tokens");
+		if (request.argumentTokens.some((token) => typeof token !== "string" || token.length === 0)) throw new TypeError("Native ACKNOWLEDGE_APPROVED argument tokens must all be non-empty strings");
+		if (request.argumentTokens.some((token) => token.includes("{{value}}"))) throw new TypeError("Native ACKNOWLEDGE_APPROVED argument tokens carry no caller-substituted value");
+		const executable = this.executablePath(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, true);
+		await this.invoke(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, request.cwd, [
+			"review", "acknowledge-approved", ...request.argumentTokens,
+		], true, request.signal, executable, [], false);
 	}
 
 	async captureCorrectionPlan(request                                          )                                    {

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -2098,6 +2098,11 @@ const REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS = ["cwd", "lineage", "target", "
 
 
 
+
+
+
+
+
 function decodeReviewStatusContinuationArtifactV1(value         , label        )                                     {
 	const artifact = exactRecord(value, label, ["schema", "capability", "sha256", "lineage_id", "target_identity", "lens", "selected_order", "subject_hash", "admission_decision"]);
 	if (artifact.schema !== "gentle-ai.review-result-artifact/v2") throw new TypeError(`${label}.schema must be gentle-ai.review-result-artifact/v2`);
@@ -2246,9 +2251,28 @@ export function decodeReviewLastEventClosureV1(value         )                  
 	// provider that emits one is decoded strictly; a provider that does not is
 	// still the contract this build ships against. Requiring it belongs with
 	// the pin bump that makes it always present.
-	const acknowledgement = body.acknowledgement === undefined
-		? undefined
-		: decodeReviewApprovedAcknowledgementV1(body.acknowledgement, "last_event_closure.acknowledgement");
+	// Decoded defensively on purpose. This decoder pins the acknowledgement to a
+	// closed positional shape, and the same patch that added it already shows
+	// what strictness costs when the provider moves: rejecting one omitempty
+	// field made every targeted-validation STATUS that carried it undecodable.
+	// Here the blast radius would be worse than a lost field. Throwing would
+	// fail the whole approved closure, so the host would lose the approval
+	// outcome AND the only invocation that burns the authority, leaving the
+	// lineage approved and un-burnable at once. An unreadable continuation
+	// degrades to a flag; everything else about the approval still arrives.
+	let acknowledgement                                             ;
+	let acknowledgementUndecodable = false;
+	if (body.acknowledgement !== undefined) {
+		try {
+			acknowledgement = decodeReviewApprovedAcknowledgementV1(body.acknowledgement, "last_event_closure.acknowledgement");
+		} catch {
+			acknowledgement = undefined;
+			acknowledgementUndecodable = true;
+		}
+	}
+	if (acknowledgementUndecodable && state !== "approved") {
+		throw new TypeError("last_event_closure acknowledgement requires approved state");
+	}
 	if (acknowledgement !== undefined) {
 		if (state !== "approved") throw new TypeError("last_event_closure acknowledgement requires approved state");
 		if (acknowledgement.binding.lineageId !== shared.lineageId) {
@@ -2260,6 +2284,16 @@ export function decodeReviewLastEventClosureV1(value         )                  
 		const lineageArguments = acknowledgement.arguments.filter((argument) => argument.name === "lineage");
 		if (lineageArguments.length !== 1 || lineageArguments[0]?.value !== shared.lineageId || lineageArguments[0]?.token !== `--lineage=${shared.lineageId}`) {
 			throw new TypeError("last_event_closure acknowledgement lineage argument does not match its enclosing closure");
+		}
+		// The target is the other half of what this invocation burns, and it is
+		// relayed verbatim. A terminal closure carries no target of its own, so
+		// the acknowledgement's binding is the only statement of which candidate
+		// is being burned: pinning lineage and revision while leaving the
+		// relayed target token free of it proves nothing about what runs.
+		const targetArguments = acknowledgement.arguments.filter((argument) => argument.name === "target");
+		if (targetArguments.length !== 1 || targetArguments[0]?.value !== acknowledgement.binding.targetIdentity
+			|| targetArguments[0]?.token !== `--target=${acknowledgement.binding.targetIdentity}`) {
+			throw new TypeError("last_event_closure acknowledgement target argument does not match its binding");
 		}
 	}
 	const action = nonempty(body.action, "last_event_closure.action");
@@ -2273,6 +2307,7 @@ export function decodeReviewLastEventClosureV1(value         )                  
 		...(advisoryFindings === undefined ? {} : { advisoryFindings }),
 		...(statusContinuation === undefined ? {} : { statusContinuation }),
 		...(acknowledgement === undefined ? {} : { acknowledgement }),
+		...(acknowledgementUndecodable ? { acknowledgementUndecodable: true          } : {}),
 	};
 }
 

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -502,6 +502,10 @@ export const REVIEW_PROVIDER_ROLE_CAPTURE_OPERATIONS = Object.freeze(Object.valu
 
 
 
+
+
+
+
 	                      
 
 
@@ -1010,7 +1014,7 @@ export function decodeReviewStartV3(value         )                {
 	const body = exactRecord(value, "start", [
 		"schema", "contract", "operation", "action", "lenses_required", "lineage_id", "state", "risk_level",
 		"selected_lenses", "projection", "changed_files", "changed_lines", "correction_budget", "risk_reasons", "artifact_subjects",
-	], [...overlayFields, "changed_path_manifest", "repository_context"]);
+	], [...overlayFields, "changed_path_manifest", "repository_context", "acknowledgement"]);
 	requireIdentity(body, "gentle-ai.review-integration.start/v3", REVIEW_INTEGRATION_OPERATION.START);
 
 	// dependentRequired binds base_tree<->candidate_tree bidirectionally, and
@@ -1049,7 +1053,7 @@ export function decodeReviewStartV3(value         )                {
 		if (source.capability !== "review.opaque_repository_context") throw new TypeError("start.repository_context.capability is unsupported");
 		repositoryContext = {
 			capability: "review.opaque_repository_context",
-			handle: text(source.handle, "start.repository_context.handle", { pattern: /^rctx1_[0-9a-f]{64}$/ }),
+			handle: text(source.handle, "start.repository_context.handle", { pattern: /^rctx[12]_[0-9a-f]{64}$/ }),
 			revision: sha256(source.revision, "start.repository_context.revision"),
 			targetIdentity: sha256(source.target_identity, "start.repository_context.target_identity"),
 			...(source.event_id === undefined ? {} : { eventId: sha256(source.event_id, "start.repository_context.event_id") }),
@@ -1197,7 +1201,7 @@ export function decodeAuthorityRepairAssessmentV1(value         )               
 // collect inputs and the execute binding.
 // ---------------------------------------------------------------------------
 
-const NEXT_TRANSITION_OPERATIONS = ["review.start", "review.recover", "review.repair"]         ;
+const NEXT_TRANSITION_OPERATIONS = ["review.start", "review.recover", "review.repair", "review.acknowledge-approved"]         ;
 
 function decodeTransitionArguments(value         , label        )                                        {
 	return array(value, label, (entry, entryLabel) => {
@@ -1315,9 +1319,11 @@ export function decodeReviewTargetedValidationRequestV1(value         , label = 
 		};
 	}, { minimum: 1 });
 	const fixClassifications = array(body.fix_classifications, `${label}.fix_classifications`, (entry, entryLabel)                                           => {
-		const classification = exactRecord(entry, entryLabel, ["finding_id", "class", "causal_disposition", "proof"]);
+		const classification = exactRecord(entry, entryLabel, ["finding_id", "class", "causal_disposition", "proof"], ["severity"]);
+		const severity = classification.severity === undefined ? undefined : nonempty(classification.severity, `${entryLabel}.severity`);
 		return {
 			findingId: nonempty(classification.finding_id, `${entryLabel}.finding_id`),
+			...(severity === undefined ? {} : { severity }),
 			class: enumeration(classification.class, ["deterministic", "inferential"]         , `${entryLabel}.class`),
 			causalDisposition: enumeration(classification.causal_disposition, ["introduced", "behavior-activated", "worsened"]         , `${entryLabel}.causal_disposition`),
 			proof: nonempty(classification.proof, `${entryLabel}.proof`),
@@ -1634,7 +1640,7 @@ export function decodeReviewStatusV3(value         )                 {
 		if (source.capability !== "review.opaque_repository_context") throw new TypeError("status.repository_context.capability is unsupported");
 		repositoryContext = {
 			capability: "review.opaque_repository_context",
-			handle: text(source.handle, "status.repository_context.handle", { pattern: /^rctx1_[0-9a-f]{64}$/ }),
+			handle: text(source.handle, "status.repository_context.handle", { pattern: /^rctx[12]_[0-9a-f]{64}$/ }),
 			revision: sha256(source.revision, "status.repository_context.revision"),
 			targetIdentity: sha256(source.target_identity, "status.repository_context.target_identity"),
 			...(source.event_id === undefined ? {} : { eventId: sha256(source.event_id, "status.repository_context.event_id") }),
@@ -2047,6 +2053,31 @@ const REVIEW_STATUS_CONTINUATION_OPERATION = {
 
 
 
+const REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION = "review.acknowledge-approved"         ;
+
+// The exact ordered argument names the provider renders for one approved
+// acknowledgement. The list is closed and positional on the wire, so decoding
+// by position is what proves the relay is replaying the provider's own
+// invocation rather than one the host assembled.
+const REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS = ["cwd", "lineage", "target", "expected-revision", "token"]         ;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2085,6 +2116,48 @@ function decodeReviewStatusContinuationArtifactV1(value         , label        )
 	};
 }
 
+// decodeReviewApprovedAcknowledgementV1 decodes the one continuation that burns
+// approved authority. Only this exact invocation ends the lifecycle, so every
+// field is pinned: the closed positional argument list, the single approved
+// precondition, and the fully-bound lineage/revision/target it commits to.
+function decodeReviewApprovedAcknowledgementV1(value         , label        )                                  {
+	const body = exactRecord(value, label, ["operation", "command", "arguments", "preconditions", "binding"]);
+	if (body.operation !== REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION) {
+		throw new TypeError(`${label}.operation must be ${REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION}`);
+	}
+	const command = text(body.command, `${label}.command`, { minimum: 1, pattern: /^gentle-ai review acknowledge-approved(?: |$)/ });
+	const argumentsList = decodeTransitionArguments(body.arguments, `${label}.arguments`);
+	if (argumentsList.length !== REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length) {
+		throw new TypeError(`${label}.arguments must carry exactly ${REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length} provider-issued arguments`);
+	}
+	argumentsList.forEach((argument, index) => {
+		const expected = REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS[index];
+		if (argument.name !== expected) throw new TypeError(`${label}.arguments[${index}].name must be ${expected}`);
+		if (argument.token === undefined) throw new TypeError(`${label}.arguments[${index}] requires its exact token`);
+	});
+	const preconditions = decodeTransitionArguments(body.preconditions, `${label}.preconditions`);
+	if (preconditions.length !== 1 || preconditions[0].name !== "state" || preconditions[0].value !== "approved") {
+		throw new TypeError(`${label}.preconditions must be the single approved state precondition`);
+	}
+	const sourceBinding = exactRecord(body.binding, `${label}.binding`, ["lineage_id", "revision", "target_identity"], ["repository_context"]);
+	const repositoryContext = sourceBinding.repository_context === undefined
+		? undefined
+		: text(sourceBinding.repository_context, `${label}.binding.repository_context`, { pattern: /^rctx[12]_[0-9a-f]{64}$/ });
+	return {
+		operation: REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION,
+		command,
+		arguments: argumentsList,
+		preconditions,
+		binding: {
+			lineageId: lineage(sourceBinding.lineage_id, `${label}.binding.lineage_id`),
+			revision: sha256(sourceBinding.revision, `${label}.binding.revision`),
+			targetIdentity: sha256(sourceBinding.target_identity, `${label}.binding.target_identity`),
+			...(repositoryContext === undefined ? {} : { repositoryContext }),
+		},
+		raw: body,
+	};
+}
+
 function decodeReviewStatusContinuationV1(value         )                             {
 	const body = exactRecord(value, "last_event_closure.status_continuation", ["operation", "arguments", "preconditions", "binding"], ["command", "selector_arguments", "artifacts"]);
 	if (body.operation !== REVIEW_STATUS_CONTINUATION_OPERATION.STATUS) throw new TypeError("last_event_closure.status_continuation.operation must be review.status");
@@ -2097,7 +2170,7 @@ function decodeReviewStatusContinuationV1(value         )                       
 	const revision = sourceBinding.revision === undefined ? undefined : sha256(sourceBinding.revision, "last_event_closure.status_continuation.binding.revision");
 	const repositoryContext = sourceBinding.repository_context === undefined
 		? undefined
-		: text(sourceBinding.repository_context, "last_event_closure.status_continuation.binding.repository_context", { pattern: /^rctx1_[0-9a-f]{64}$/ });
+		: text(sourceBinding.repository_context, "last_event_closure.status_continuation.binding.repository_context", { pattern: /^rctx[12]_[0-9a-f]{64}$/ });
 	const selectorArguments = body.selector_arguments === undefined
 		? undefined
 		: decodeTransitionArguments(body.selector_arguments, "last_event_closure.status_continuation.selector_arguments");
@@ -2125,7 +2198,7 @@ function decodeReviewStatusContinuationV1(value         )                       
 }
 
 export function decodeReviewLastEventClosureV1(value         )                           {
-	const body = exactRecord(value, "last_event_closure", ["schema", "operation", "lineage_id", "state", "store_revision"], ["target_identity", "request_hash", "correction_lines", "action", "advisory_findings", "status_continuation"]);
+	const body = exactRecord(value, "last_event_closure", ["schema", "operation", "lineage_id", "state", "store_revision"], ["target_identity", "request_hash", "correction_lines", "action", "advisory_findings", "status_continuation", "acknowledgement"]);
 	if (body.schema !== REVIEW_LAST_EVENT_CLOSURE_SCHEMA) throw new TypeError(`last_event_closure.schema must be ${REVIEW_LAST_EVENT_CLOSURE_SCHEMA}`);
 	const operation = enumeration(body.operation, Object.values(REVIEW_LAST_EVENT_CLOSURE_OPERATION), "last_event_closure.operation")                                   ;
 	const state = enumeration(body.state, REVIEW_LAST_EVENT_TERMINAL_STATES, "last_event_closure.state")                               ;
@@ -2165,6 +2238,30 @@ export function decodeReviewLastEventClosureV1(value         )                  
 			throw new TypeError("last_event_closure status continuation lineage argument does not match its enclosing closure");
 		}
 	}
+	// Only an approved closure may carry the continuation that burns its
+	// authority: any other state offering an acknowledgement would be inviting
+	// a burn the provider never authorized.
+	//
+	// It stays optional because the pinned installer binary predates it. A
+	// provider that emits one is decoded strictly; a provider that does not is
+	// still the contract this build ships against. Requiring it belongs with
+	// the pin bump that makes it always present.
+	const acknowledgement = body.acknowledgement === undefined
+		? undefined
+		: decodeReviewApprovedAcknowledgementV1(body.acknowledgement, "last_event_closure.acknowledgement");
+	if (acknowledgement !== undefined) {
+		if (state !== "approved") throw new TypeError("last_event_closure acknowledgement requires approved state");
+		if (acknowledgement.binding.lineageId !== shared.lineageId) {
+			throw new TypeError("last_event_closure acknowledgement lineage does not match its enclosing closure");
+		}
+		if (acknowledgement.binding.revision !== shared.storeRevision) {
+			throw new TypeError("last_event_closure acknowledgement revision does not match its enclosing closure");
+		}
+		const lineageArguments = acknowledgement.arguments.filter((argument) => argument.name === "lineage");
+		if (lineageArguments.length !== 1 || lineageArguments[0]?.value !== shared.lineageId || lineageArguments[0]?.token !== `--lineage=${shared.lineageId}`) {
+			throw new TypeError("last_event_closure acknowledgement lineage argument does not match its enclosing closure");
+		}
+	}
 	const action = nonempty(body.action, "last_event_closure.action");
 	const advisoryFindings = body.advisory_findings === undefined
 		? undefined
@@ -2175,6 +2272,7 @@ export function decodeReviewLastEventClosureV1(value         )                  
 		action,
 		...(advisoryFindings === undefined ? {} : { advisoryFindings }),
 		...(statusContinuation === undefined ? {} : { statusContinuation }),
+		...(acknowledgement === undefined ? {} : { acknowledgement }),
 	};
 }
 

--- a/tests/devbinary/pi-host-relay.devtest.ts
+++ b/tests/devbinary/pi-host-relay.devtest.ts
@@ -747,8 +747,20 @@ test("dev-binary: Pi controller keeps an explicit B root and selected-untracked 
 	assert.ok(validatorPrompt.length > 0, "the Go-owned validator must receive a provider-rendered prompt");
 	assert.ok(validatorPrompt.includes(validatorRequestHash), "the Go-owned validator prompt must retain the provider request hash");
 
+	// Approval no longer burns on its own: it commits one pending
+	// acknowledgement and waits for the host to run that exact invocation
+	// (gentle-ai #3851). The lineage is still live here on purpose, and running
+	// the provider's own tokens is what ends it.
+	const pendingAcknowledgement = record(validationClosure.acknowledgement, "approved acknowledgement continuation");
+	assert.equal(pendingAcknowledgement.operation, "review.acknowledge-approved");
+	const acknowledgementTokens = (pendingAcknowledgement.arguments as readonly Record<string, unknown>[])
+		.map((argument) => stringValue(argument.token, "acknowledgement argument token"));
+	const beforeAcknowledgement = await native.targetStatus!({ cwd: canonicalB, lineageId: lineage, agent: "pi", ...selection });
+	assert.equal(beforeAcknowledgement.authority?.state, "approved", "approved authority must survive until its exact acknowledgement runs");
+	await native.acknowledgeApproved!({ cwd: canonicalB, argumentTokens: acknowledgementTokens });
+
 	const terminal = await native.targetStatus!({ cwd: canonicalB, lineageId: lineage, agent: "pi", ...selection });
-	assert.equal(terminal.authority, undefined, "terminal approval must burn the sandbox review authority");
+	assert.equal(terminal.authority, undefined, "the exact acknowledgement must burn the sandbox review authority");
 	assert.equal("evidence" in terminal.raw, false, "terminal STATUS must not retain validation evidence");
 	assert.equal("staging" in terminal.raw, false, "terminal STATUS must not retain staging state");
 	assert.equal("receipt" in terminal.raw, false, "terminal STATUS must not retain a receipt after last-event approval");

--- a/tests/review-last-event-closure.test.ts
+++ b/tests/review-last-event-closure.test.ts
@@ -349,3 +349,60 @@ test("unknown-capture reconciliation validates the target-scoped lineage without
 	for (const selector of [{ committedOnly: true }, { baseRef: "refs/heads/main" }, { baseRef: "refs/heads/main", committedOnly: false }] as unknown as readonly Parameters<typeof reconcileUnknownReviewLastEventCapture>[3][]) await assert.rejects(() => reconcileUnknownReviewLastEventCapture(strictNative, "/repo", { lineageId: "reconcile-lineage", targetIdentity: SHA }, selector));
 	assert.equal(launches, 0);
 });
+
+// One approved terminal closure carrying the exact continuation the provider
+// renders: closed positional arguments, the single approved precondition, and a
+// binding that names the candidate being burned.
+function approvedClosureWithAcknowledgement(): Record<string, unknown> {
+	const lineageId = "review-acknowledgement-fixture";
+	const body = closure("review/capture-result", lineageId);
+	body.acknowledgement = {
+		operation: "review.acknowledge-approved",
+		command: "gentle-ai review acknowledge-approved",
+		arguments: [
+			{ name: "cwd", value: "/repo", token: "--cwd=/repo" },
+			{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` },
+			{ name: "target", value: SHA, token: `--target=${SHA}` },
+			{ name: "expected-revision", value: SHA, token: `--expected-revision=${SHA}` },
+			{ name: "token", value: "a".repeat(64), token: `--token=${"a".repeat(64)}` },
+		],
+		preconditions: [{ name: "state", value: "approved" }],
+		binding: { lineage_id: lineageId, revision: SHA, target_identity: SHA },
+	};
+	return body;
+}
+
+test("the approved acknowledgement fixture decodes as a runnable continuation", () => {
+	const decoded = decodeReviewLastEventClosureV1(approvedClosureWithAcknowledgement());
+	assert.equal(decoded.acknowledgement?.operation, "review.acknowledge-approved");
+	assert.equal(decoded.acknowledgementUndecodable, undefined);
+});
+
+test("an approved acknowledgement must prove the target its relayed token burns", () => {
+	const closure = approvedClosureWithAcknowledgement();
+	const acknowledgement = closure.acknowledgement as Record<string, unknown>;
+	const args = (acknowledgement.arguments as Record<string, unknown>[]).map((argument) => ({ ...argument }));
+	// The relayed token now names a different candidate than the binding does.
+	const decoyTarget = `sha256:${"b".repeat(64)}`;
+	args[2] = { name: "target", value: decoyTarget, token: `--target=${decoyTarget}` };
+	acknowledgement.arguments = args;
+	assert.throws(
+		() => decodeReviewLastEventClosureV1(closure),
+		/acknowledgement target argument does not match its binding/,
+		"a relayed target the binding does not commit to must be refused",
+	);
+});
+
+test("an unreadable acknowledgement degrades the continuation, never the approval", () => {
+	const closure = approvedClosureWithAcknowledgement();
+	// One extra provider-side argument is enough to miss the closed shape.
+	const acknowledgement = closure.acknowledgement as Record<string, unknown>;
+	acknowledgement.arguments = [
+		...(acknowledgement.arguments as unknown[]),
+		{ name: "future", value: "1", token: "--future=1" },
+	];
+	const decoded = decodeReviewLastEventClosureV1(closure);
+	assert.equal(decoded.state, "approved", "the approval outcome must survive an unreadable continuation");
+	assert.equal(decoded.acknowledgement, undefined, "an unreadable continuation must not be offered as runnable");
+	assert.equal(decoded.acknowledgementUndecodable, true, "the host must be told the continuation exists and could not be read");
+});


### PR DESCRIPTION
Parity for the gentle-ai active-authority collapse (Gentleman-Programming/gentle-ai#3797, PR Gentleman-Programming/gentle-ai#3851). gentle-ai landed first; this adapts.

## What changed upstream

Approval no longer burns on its own. A final approved capture commits one pending acknowledgement and returns `review.acknowledge-approved`; only that exact invocation burns the authority and its artifacts. The repository context stayed a fixed-width digest but changed prefix to `rctx2_`.

## Six gaps, all found by running against a real binary

| Gap | Effect before |
|---|---|
| Three hardcoded `rctx1_[0-9a-f]{64}` patterns | Every START and STATUS carrying an `rctx2_` handle failed to decode |
| No acknowledgement decoder | An approved closure could not be read |
| `acknowledgement` not in the allowed keys of `last_event_closure` or `start` | Rejected as a disallowed field, including on the zero-lens approved START |
| `review.acknowledge-approved` missing from the transition operations | STATUS refused the route rather than following it |
| `severity` rejected in `fix_classifications` | Every targeted-validation STATUS carrying one was undecodable |
| No executor, and the host projection dropped the continuation | The controller reached approved and stopped, leaving the lineage live forever |

The `severity` gap is unrelated to #3851: `FindingEvidence` carries it as an `omitempty` field and this decoder never accepted it. It surfaced only because the lane ran against the real binary.

## Decisions worth reviewing

**`acknowledgement` is decoded strictly but stays optional.** The pinned installer binary is gentle-ai 2.4.0, which does not emit it. Requiring it would break this build against the version it ships. Requiring it belongs with the pin bump that makes it always present.

**The executor refuses to synthesize.** `acknowledgeApproved` relays the provider tokens verbatim and rejects any caller-substituted value: a synthesized acknowledgement would be Pi deciding a review is over.

**A success has no body.** Burning leaves nothing to describe, so `invoke` grew a bodyless path. It is narrow: only a zero exit may omit a body, output on that path is a schema incompatibility, and a non-zero exit still has to produce its typed failure envelope.

**One devtest encoded the old lifecycle.** It asserted the burn happened during the approving capture. It now runs the provider's own acknowledgement and asserts the authority survives until it does.

## Adversarial review of this branch

The candidate was driven through the review lifecycle with a binary built from gentle-ai `main`: high risk, four lenses, all four admitted. It returned **two candidate-caused blockers**, both real, and both are fixed in the third commit.

- **The relayed target was never proved.** The cross-check pinned the acknowledgement's lineage and revision against the enclosing closure, but left the target free. A terminal closure carries no target of its own, so the acknowledgement's binding is the only statement of which candidate is being burned; a payload whose token named another candidate decoded cleanly and was executable.
- **Strictness had the wrong blast radius.** The closed positional shape threw on anything unexpected, failing the entire approved closure rather than the field. The host would have lost the approval outcome and the only invocation that burns the authority at once, leaving the lineage approved and un-burnable. An unreadable continuation now degrades to an explicit `acknowledgement_undecodable` flag, deliberately distinct from an absent one.

The second finding is the same failure class the `severity` fix in the first commit already demonstrated, which is what makes it worth taking seriously rather than filing as strictness.

The review could not be closed: after the correction plan was accepted and the corrections applied, the exact-lineage STATUS refuses deterministically with a causeless `operation_failed` that advertises `retry`. That is a product defect, recorded as an occurrence on Gentleman-Programming/gentle-ai#3647, not a property of this branch.

## Verification

Against a gentle-ai built from `main` at `56349849`, registered through the dev-binary override:

- `test:dev-binary` — **7 of 7**, from **0 of 2** host-relay journeys on this branch's base. Run with `GENTLE_AI_DEV_BINARY`, `GENTLE_PI_GENTLE_AI_DEV_BINARY` and `GENTLE_PI_REQUIRE_DEV_BINARY=1`, so a missing binary fails instead of skipping.
- `pnpm test` — 0 failures, including three new tests for the acknowledgement fixture, a decoy target token, and a provider-side argument addition that must not cost the approval
- `pnpm run check:runtime-modules` — clean, runtime regenerated from source
- `pnpm run test:maintainer` — 35 tests, 0 failures
- `pnpm run test:cross-lane` — last-event closure parity passed

Both lanes are worth noting: without the two env vars the dev-binary lane exits 0 with all 7 journeys skipped, which is how a parity gap this wide stayed invisible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for completing approved reviews through provider-issued acknowledgement commands.
  - Review results can now include optional severity information for targeted validation findings.
  - Expanded support for repository context identifiers across review workflows.

- **Bug Fixes**
  - Improved validation of acknowledgement details, including approval status, request lineage, revision, and security tokens.
  - Prevented invalid or substituted acknowledgement tokens from being executed.
  - Improved handling of successful operations that return no response body.
  - Preserved acknowledgement details and clearly flagged unreadable acknowledgement payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->