### PR TITLE
test(review): compare the sandbox common directory against its own repository

### DIFF
--- a/tests/devbinary/pi-host-relay.devtest.ts
+++ b/tests/devbinary/pi-host-relay.devtest.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, join } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { __testing, createGentleAiExtension } from "../../extensions/gentle-ai.ts";
@@ -452,8 +452,13 @@ test("dev-binary: Pi controller keeps an explicit B root and selected-untracked 
 
 	const canonicalB = realpathSync(targetB);
 	assert.equal(realpathSync(git(nestedTarget, "rev-parse", "--show-toplevel")), canonicalB, "B/nested must canonicalize to B before controller routing");
-	const activeProjectCommonDir = realpathSync(git(process.cwd(), "rev-parse", "--git-common-dir"));
-	const sandboxCommonDir = realpathSync(git(canonicalB, "rev-parse", "--git-common-dir"));
+	// --git-common-dir answers relative to the repository it was asked about, so
+	// resolving it against the process cwd compared the active project with
+	// itself: the assertion held in a linked worktree and failed in a primary
+	// checkout, and in neither case measured what it names. lib/review-candidate-view.ts
+	// resolves it against the repository root, which is the convention here too.
+	const activeProjectCommonDir = realpathSync(resolve(process.cwd(), git(process.cwd(), "rev-parse", "--git-common-dir")));
+	const sandboxCommonDir = realpathSync(resolve(canonicalB, git(canonicalB, "rev-parse", "--git-common-dir")));
 	assert.notEqual(sandboxCommonDir, activeProjectCommonDir, "the B sandbox must not share the active project's Git common directory");
 	const isolatedHome = join(sessionA, "home");
 	mkdirSync(isolatedHome);


### PR DESCRIPTION
The host-relay devtest asserts the B sandbox does not share the active project's Git common directory. It never measured that.

`git rev-parse --git-common-dir` answers relative to the repository it was asked about, and both reads were passed to `realpathSync` without resolving them against that repository. The sandbox's `.git` therefore resolved against the process cwd, so the assertion compared the active project with itself.

That made the result depend on where the lane was run rather than on what it claims:

- from a linked worktree, `--git-common-dir` answers with an absolute path for the active project and a relative one for the sandbox, so the two differed and the assertion passed for the wrong reason;
- from a primary checkout, both resolve to the same `.git` and the assertion failed although the sandbox is a fresh `mkdtemp` repository that shares nothing.

Each read now resolves against the repository it came from, which is what `lib/review-candidate-view.ts` already does for the same command.

## Verification

- `pnpm run test:dev-binary` from a primary checkout: 7 of 7, where it previously failed 1. Run against a gentle-ai built from `main`, with `GENTLE_AI_DEV_BINARY`, `GENTLE_PI_GENTLE_AI_DEV_BINARY` and `GENTLE_PI_REQUIRE_DEV_BINARY=1`.
- Decoy: pointing the sandbox read back at the active project makes the assertion refuse, which it could not do before. That is the check the fix restores.
- `pnpm test` — 0 failures. `pnpm run check:runtime-modules` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved development test path resolution for repositories with shared Git directories.
  * Tests now consistently handle relative Git metadata paths across active projects and sandbox environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->