### PR TITLE
fix(compat): project closed choices to Herdr

### DIFF
--- a/extensions/ask-user-choice.ts
+++ b/extensions/ask-user-choice.ts
@@ -4,6 +4,7 @@ import { Container, type SelectItem, SelectList, Text } from "@earendil-works/pi
 import { type Static, Type } from "typebox";
 
 const CHOICE_TOOL_NAME = "ask_user_choice";
+const ASK_USER_CHOICE_BLOCKED_EVENT = "gentle-pi:ask-user-choice:blocked";
 
 const ChoiceOptionSchema = Type.Object(
 	{
@@ -76,34 +77,40 @@ export default function askUserChoice(pi: ExtensionAPI): void {
 				label: option.label,
 				description: option.description,
 			}));
-			const selection = await ctx.ui.custom<ChoiceSelection | undefined>((tui, theme, _keybindings, done) => {
-				const container = new Container();
-				container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
-				container.addChild(new Text(theme.fg("accent", theme.bold(params.question)), 1, 0));
-				const list = new SelectList(items, items.length, {
-					selectedPrefix: (text) => theme.fg("accent", text),
-					selectedText: (text) => theme.fg("accent", text),
-					description: (text) => theme.fg("muted", text),
-					scrollInfo: (text) => theme.fg("dim", text),
-					noMatch: (text) => theme.fg("warning", text),
+			let selection: ChoiceSelection | undefined;
+			try {
+				pi.events.emit(ASK_USER_CHOICE_BLOCKED_EVENT, { active: true });
+				selection = await ctx.ui.custom<ChoiceSelection | undefined>((tui, theme, _keybindings, done) => {
+					const container = new Container();
+					container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
+					container.addChild(new Text(theme.fg("accent", theme.bold(params.question)), 1, 0));
+					const list = new SelectList(items, items.length, {
+						selectedPrefix: (text) => theme.fg("accent", text),
+						selectedText: (text) => theme.fg("accent", text),
+						description: (text) => theme.fg("muted", text),
+						scrollInfo: (text) => theme.fg("dim", text),
+						noMatch: (text) => theme.fg("warning", text),
+					});
+					list.onSelect = (item) => {
+						const index = items.indexOf(item);
+						done({ value: item.value, label: item.label, index: index + 1 });
+					};
+					list.onCancel = () => done(undefined);
+					container.addChild(list);
+					container.addChild(new Text(theme.fg("dim", "↑↓ navigate • Enter select • Esc cancel"), 1, 0));
+					container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
+					return {
+						render: (width) => container.render(width),
+						invalidate: () => container.invalidate(),
+						handleInput: (data) => {
+							list.handleInput(data);
+							tui.requestRender();
+						},
+					};
 				});
-				list.onSelect = (item) => {
-					const index = items.indexOf(item);
-					done({ value: item.value, label: item.label, index: index + 1 });
-				};
-				list.onCancel = () => done(undefined);
-				container.addChild(list);
-				container.addChild(new Text(theme.fg("dim", "↑↓ navigate • Enter select • Esc cancel"), 1, 0));
-				container.addChild(new DynamicBorder((text: string) => theme.fg("accent", text)));
-				return {
-					render: (width) => container.render(width),
-					invalidate: () => container.invalidate(),
-					handleInput: (data) => {
-						list.handleInput(data);
-						tui.requestRender();
-					},
-				};
-			});
+			} finally {
+				pi.events.emit(ASK_USER_CHOICE_BLOCKED_EVENT, { active: false });
+			}
 
 			if (selection === undefined) {
 				return {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1104,7 +1104,10 @@ function evaluateSensitivePathTool(
 	};
 }
 
+const ASK_USER_CHOICE_BLOCKED_EVENT = "gentle-pi:ask-user-choice:blocked";
+
 const HERDR_BLOCKER_LABEL = {
+	CHOICE: "Choice awaiting input",
 	GUARDED_CONFIRMATION: "Guarded command confirmation",
 	QUESTIONNAIRE: "Questionnaire awaiting input",
 } as const;
@@ -1118,19 +1121,28 @@ type HerdrConfirmationLifecycle = {
 
 function createHerdrConfirmationLifecycle(events: ExtensionAPI["events"]): HerdrConfirmationLifecycle {
 	let pending = 0;
+	let choiceActive = false;
 	let questionnaireActive = false;
 	let emittedLabel: HerdrBlockerLabel | undefined;
 	const emitEffectiveBlocker = (): void => {
-		const nextLabel = questionnaireActive
-			? HERDR_BLOCKER_LABEL.QUESTIONNAIRE
-			: pending > 0
-				? HERDR_BLOCKER_LABEL.GUARDED_CONFIRMATION
-				: undefined;
+		const nextLabel = choiceActive
+			? HERDR_BLOCKER_LABEL.CHOICE
+			: questionnaireActive
+				? HERDR_BLOCKER_LABEL.QUESTIONNAIRE
+				: pending > 0
+					? HERDR_BLOCKER_LABEL.GUARDED_CONFIRMATION
+					: undefined;
 		if (nextLabel === emittedLabel) return;
 		emittedLabel = nextLabel;
 		if (nextLabel === undefined) events.emit("herdr:blocked", { active: false });
 		else events.emit("herdr:blocked", { active: true, label: nextLabel });
 	};
+
+	events?.on?.(ASK_USER_CHOICE_BLOCKED_EVENT, (event) => {
+		if (!isRecord(event) || typeof event.active !== "boolean" || event.active === choiceActive) return;
+		choiceActive = event.active;
+		emitEffectiveBlocker();
+	});
 
 	events?.on?.("rpiv:ask-user:blocked", (event) => {
 		if (!isRecord(event) || typeof event.active !== "boolean" || event.active === questionnaireActive) return;

--- a/tests/ask-user-choice.test.ts
+++ b/tests/ask-user-choice.test.ts
@@ -30,9 +30,17 @@ interface ChoiceTool {
 	execute: (...args: unknown[]) => Promise<ChoiceResult>;
 }
 
+interface ChoiceLifecycleEvent {
+	channel: string;
+	data: { active: boolean };
+}
+
 type BeforeAgentStart = (event: unknown, ctx: { mode: string }) => void | Promise<void>;
 
-function registerChoiceTool(initialTools: string[] = []) {
+function registerChoiceTool(
+	initialTools: string[] = [],
+	onLifecycleEvent?: (event: ChoiceLifecycleEvent) => void,
+) {
 	let activeTools = initialTools;
 	let runtimeActionsAllowed = false;
 	let getActiveToolsCalls = 0;
@@ -40,6 +48,7 @@ function registerChoiceTool(initialTools: string[] = []) {
 	let tool: ChoiceTool | undefined;
 	const hooks: BeforeAgentStart[] = [];
 	const registeredToolNames: string[] = [];
+	const emittedEvents: ChoiceLifecycleEvent[] = [];
 	const pi = {
 		getActiveTools: () => {
 			getActiveToolsCalls++;
@@ -62,6 +71,13 @@ function registerChoiceTool(initialTools: string[] = []) {
 		on: (event: string, handler: BeforeAgentStart) => {
 			if (event === "before_agent_start") hooks.push(handler);
 		},
+		events: {
+			emit(channel: string, data: { active: boolean }) {
+				const event = { channel, data };
+				emittedEvents.push(event);
+				onLifecycleEvent?.(event);
+			},
+		},
 	};
 	askUserChoice(pi as never);
 	assert.ok(tool, "ask_user_choice must register");
@@ -70,6 +86,7 @@ function registerChoiceTool(initialTools: string[] = []) {
 		tool,
 		registeredToolNames,
 		activeTools: () => [...activeTools],
+		emittedEvents: () => [...emittedEvents],
 		runtimeActionCalls: () => ({ getActiveTools: getActiveToolsCalls, setActiveTools: setActiveToolsCalls }),
 		allowRuntimeActions: () => {
 			runtimeActionsAllowed = true;
@@ -146,6 +163,94 @@ test("ask_user_choice cancels without a value and remains unavailable outside th
 		() => tool.execute("call", { question: "Proceed?", options }, new AbortController().signal, undefined, { mode: "print" }),
 		/unavailable outside the interactive TUI/,
 	);
+});
+
+test("ask_user_choice emits a private balanced lifecycle around selection and cancellation", async () => {
+	const sequence: string[] = [];
+	const selectedRegistration = registerChoiceTool([], ({ data }) => {
+		sequence.push(data.active ? "active" : "inactive");
+	});
+	const selected = await selectedRegistration.tool.execute(
+		"call",
+		{ question: "private choice question", options },
+		new AbortController().signal,
+		undefined,
+		{
+			mode: "tui",
+			ui: {
+				custom: async () => {
+					sequence.push("custom");
+					return { value: "preserve_requested_hash", label: "Preserve requested hash", index: 2 };
+				},
+			},
+		},
+	);
+	assert.equal(selected.details.selection?.value, "preserve_requested_hash");
+	assert.deepEqual(sequence, ["active", "custom", "inactive"]);
+	assert.deepEqual(selectedRegistration.emittedEvents(), [
+		{ channel: "gentle-pi:ask-user-choice:blocked", data: { active: true } },
+		{ channel: "gentle-pi:ask-user-choice:blocked", data: { active: false } },
+	]);
+	assert.doesNotMatch(
+		JSON.stringify(selectedRegistration.emittedEvents()),
+		/private choice question|Authorize observed hash|Accept the baseline hash|preserve_requested_hash/,
+	);
+
+	const cancelledRegistration = registerChoiceTool();
+	const cancelled = await cancelledRegistration.tool.execute(
+		"call",
+		{ question: "Proceed?", options },
+		new AbortController().signal,
+		undefined,
+		{ mode: "tui", ui: { custom: async () => undefined } },
+	);
+	assert.equal(cancelled.details.cancelled, true);
+	assert.deepEqual(cancelledRegistration.emittedEvents(), [
+		{ channel: "gentle-pi:ask-user-choice:blocked", data: { active: true } },
+		{ channel: "gentle-pi:ask-user-choice:blocked", data: { active: false } },
+	]);
+});
+
+test("ask_user_choice settles its lifecycle after a custom UI error and emits nothing outside the TUI", async () => {
+	const failedRegistration = registerChoiceTool();
+	const customError = new Error("custom UI failed");
+	await assert.rejects(
+		failedRegistration.tool.execute(
+			"call",
+			{ question: "Proceed?", options },
+			new AbortController().signal,
+			undefined,
+			{ mode: "tui", ui: { custom: async () => { throw customError; } } },
+		),
+		(error) => error === customError,
+	);
+	assert.deepEqual(failedRegistration.emittedEvents(), [
+		{ channel: "gentle-pi:ask-user-choice:blocked", data: { active: true } },
+		{ channel: "gentle-pi:ask-user-choice:blocked", data: { active: false } },
+	]);
+
+	const nonTuiRegistration = registerChoiceTool();
+	let customCalled = false;
+	await assert.rejects(
+		nonTuiRegistration.tool.execute(
+			"call",
+			{ question: "Proceed?", options },
+			new AbortController().signal,
+			undefined,
+			{
+				mode: "print",
+				ui: {
+					custom: async () => {
+						customCalled = true;
+						return undefined;
+					},
+				},
+			},
+		),
+		/unavailable outside the interactive TUI/,
+	);
+	assert.equal(customCalled, false);
+	assert.deepEqual(nonTuiRegistration.emittedEvents(), []);
 });
 
 test("ask_user_choice is offered only for interactive TUI turns and preserves the open questionnaire", async () => {

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -764,7 +764,8 @@ test("RPIV questionnaire blockers emit only a private, balanced Herdr projection
 		registerTool() {},
 	} as unknown as ExtensionAPI;
 	createGentleAiExtension({ nativeReviewCli: null })(pi);
-	assert.equal(eventHandlers.size, 1);
+	assert.equal(eventHandlers.size, 2);
+	assert.equal(eventHandlers.has("gentle-pi:ask-user-choice:blocked"), true);
 	assert.equal(eventHandlers.has("rpiv:ask-user:blocked"), true);
 
 	const source = {
@@ -872,6 +873,73 @@ test("Herdr coordinates guarded confirmations and RPIV labels without inactive r
 	await questionnaireRequest;
 	assert.deepEqual(questionnaireFirst.herdrEvents, [
 		{ active: true, label: "Questionnaire awaiting input" },
+		{ active: true, label: "Guarded command confirmation" },
+		{ active: false },
+	]);
+});
+
+test("closed choice blockers retain the visible choice label through guarded-confirmation overlap", async () => {
+	type ToolCallHandler = (
+		event: { toolName: string; input: unknown },
+		ctx: ExtensionContext,
+	) => Promise<ToolCallEventResult | undefined>;
+	type HerdrBlockedEvent = { active: boolean; label?: string };
+	const handlers = new Map<string, ToolCallHandler>();
+	const eventHandlers = new Map<string, (data: unknown) => void>();
+	const herdrEvents: HerdrBlockedEvent[] = [];
+	const choiceEvents: Array<{ active: boolean }> = [];
+	const confirmations: Array<(approved: boolean) => void> = [];
+	const pi = {
+		on(name: string, handler: ToolCallHandler) {
+			handlers.set(name, handler);
+		},
+		events: {
+			emit(channel: string, data: unknown) {
+				if (channel === "herdr:blocked") herdrEvents.push(data as HerdrBlockedEvent);
+				if (channel === "gentle-pi:ask-user-choice:blocked") choiceEvents.push(data as { active: boolean });
+				eventHandlers.get(channel)?.(data);
+			},
+			on(channel: string, handler: (data: unknown) => void) {
+				eventHandlers.set(channel, handler);
+				return () => eventHandlers.delete(channel);
+			},
+		},
+		registerCommand() {},
+		registerTool() {},
+	} as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli: null })(pi);
+	assert.equal(eventHandlers.has("gentle-pi:ask-user-choice:blocked"), true);
+
+	pi.events.emit("gentle-pi:ask-user-choice:blocked", { active: true });
+	assert.deepEqual(choiceEvents, [{ active: true }]);
+	assert.deepEqual(herdrEvents, [{ active: true, label: "Choice awaiting input" }]);
+
+	const guardedRequest = handlers.get("tool_call")!(
+		{ toolName: "bash", input: { command: "git rebase main" } },
+		{
+			cwd: process.cwd(),
+			hasUI: true,
+			ui: {
+				confirm: async () => new Promise<boolean>((resolve) => { confirmations.push(resolve); }),
+			},
+		} as ExtensionContext,
+	);
+	await Promise.resolve();
+	assert.equal(confirmations.length, 1);
+	assert.deepEqual(herdrEvents, [{ active: true, label: "Choice awaiting input" }]);
+
+	pi.events.emit("gentle-pi:ask-user-choice:blocked", { active: false });
+	assert.deepEqual(choiceEvents, [{ active: true }, { active: false }]);
+	assert.deepEqual(herdrEvents, [
+		{ active: true, label: "Choice awaiting input" },
+		{ active: true, label: "Guarded command confirmation" },
+	]);
+	assert.equal(herdrEvents.some((event) => event.active === false), false);
+
+	confirmations[0]!(true);
+	assert.equal(await guardedRequest, undefined);
+	assert.deepEqual(herdrEvents, [
+		{ active: true, label: "Choice awaiting input" },
 		{ active: true, label: "Guarded command confirmation" },
 		{ active: false },
 	]);


### PR DESCRIPTION
## Linked Issue

Closes #472

## PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Maintenance/tooling
- [ ] `type:breaking-change` — Breaking change

## Summary

- Projects the private `ask_user_choice` wait lifecycle to Herdr with the label `Choice awaiting input`.
- Coalesces closed-choice, RPIV questionnaire, and guarded-command blockers without premature inactive events.
- Guarantees balanced cleanup after selection, cancellation, or custom UI errors without exposing choice data.

## Changes

| File | Change |
|------|--------|
| `extensions/ask-user-choice.ts` | Emits a minimal private choice-blocking lifecycle around the custom TUI in `try/finally`. |
| `extensions/gentle-ai.ts` | Projects and coalesces the choice lifecycle through the existing Herdr blocker owner. |
| `tests/ask-user-choice.test.ts` | Covers ordering, selection, cancellation, errors, non-TUI behavior, and privacy. |
| `tests/gentle-ai.test.ts` | Covers Herdr projection and guarded-confirmation overlap. |

## Test Plan

- [x] Focused tests: 24 passed, 0 failed.
- [x] Full `pnpm test`: 1102 passed, 0 failed, 1 skipped.
- [x] Provider contract mirror and runtime harness passed.
- [x] `pnpm run check:runtime-modules` passed.
- [x] `git diff --check` passed.
- [ ] Manual live-Herdr verification was not performed; mocked event-bus lifecycle coverage passed.
- [x] Shellcheck N/A — no shell files changed.

## Contributor Checklist

- [x] Linked an approved issue.
- [x] Change remains below the 400-line authored review budget.
- [x] Tests are included with the behavior change.
- [x] Documentation is not required for this internal compatibility fix.
- [x] Commit follows Conventional Commits.
- [x] Commit contains no `Co-Authored-By` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Choice prompts now clearly signal when input is awaiting selection.
  - Blocker status remains accurate when choice prompts overlap with confirmation dialogs.

- **Bug Fixes**
  - Choice prompt lifecycle indicators now settle correctly after selection, cancellation, or UI errors.
  - Non-interactive execution no longer triggers interactive UI behavior.

- **Tests**
  - Added coverage for choice prompt activation, completion, cancellation, errors, and overlapping blockers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->