### PR TITLE
fix(orchestrator): end the writer surface list at its real boundary

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -457,6 +457,8 @@ const SUBAGENTS_PACKAGE_NAMES = ["pi-subagents-j0k3r", "pi-subagents"] as const;
 const SUBAGENT_RUN_TOOL = "subagent_run";
 const BOUNDED_WRITER_AGENT_NAMES = ["gentle-ai-worker", "worker"] as const;
 const ALLOWED_EDIT_SURFACES_HEADING = /^## Allowed edit surfaces[ \t]*$/gim;
+const MARKDOWN_HEADING_LINE = /^#{1,6}\s/;
+const MARKDOWN_LIST_MARKER = /^(?:[-*+]|\d+[.)])\s+/;
 const WRITER_EDIT_SURFACE_REJECTION =
 	"Parent must derive or map narrow repository-relative allowed edit surfaces from the delegated task and relaunch the writer. Do not ask the human to author paths or globs.";
 
@@ -484,6 +486,58 @@ function isTaskScopedRepositoryRelativePath(value: string): boolean {
 	return !/[?*\[\]{}]/.test(withoutCurrentDirectory.split("/")[0]);
 }
 
+/** Strips a list marker and surrounding backticks off one surface line. */
+function readSurfaceEntry(line: string): string {
+	const entry = line.replace(MARKDOWN_LIST_MARKER, "");
+	return entry.match(/^`(.+)`$/)?.[1] ?? entry;
+}
+
+/** A line still reads as a surface entry when nothing but a bare path is left. */
+function looksLikeSurfaceEntry(line: string): boolean {
+	return line.length > 0 && !MARKDOWN_HEADING_LINE.test(line) && !/\s/.test(readSurfaceEntry(line));
+}
+
+/**
+ * Reads the surface list that follows an `## Allowed edit surfaces` heading.
+ *
+ * A delegated `task` is a whole prompt: the list is normally followed by deeper
+ * headings (`### Validation commands`, `#### Return`) and by ordinary prose.
+ * Ending the section only at `#`/`##` swallowed all of that, turned prose into
+ * surface entries, and rejected valid authorizations (issue #484). A `context`
+ * value carrying just the heading and its lines had nothing following it, which
+ * is why the identical surfaces were accepted there.
+ *
+ * So the section ends at the next heading of ANY level, and prose closes the
+ * list inside it. Blank lines never close it: an entry is only ever dropped
+ * when nothing below it still reads as a surface entry. A line that a caller
+ * could pass off as a path stays under validation instead of being discarded,
+ * because discarding is what would let `/etc/passwd` sit under a blank line or
+ * a paragraph and reach an accepted dispatch.
+ */
+function readAllowedEditSurfaceEntries(following: string): string[] {
+	const lines = following.split(/\r?\n/).map((line) => line.trim());
+	const headingIndex = lines.findIndex((line) => MARKDOWN_HEADING_LINE.test(line));
+	const section = headingIndex === -1 ? lines : lines.slice(0, headingIndex);
+	const entries: string[] = [];
+
+	for (const [index, line] of section.entries()) {
+		if (line.length === 0) continue;
+		const entry = readSurfaceEntry(line);
+		if (/\s/.test(entry)) {
+			// Prose closes the list only when it is genuinely trailing. Anything
+			// below it that still reads as a path makes the section ambiguous, so
+			// every non-empty line is validated and the ambiguity is rejected.
+			if (section.slice(index + 1).some(looksLikeSurfaceEntry)) {
+				return section.filter((candidate) => candidate.length > 0).map(readSurfaceEntry);
+			}
+			break;
+		}
+		entries.push(entry);
+	}
+
+	return entries;
+}
+
 function hasTaskScopedAllowedEditSurfaces(...values: unknown[]): boolean {
 	let expectedEntries: string[] | undefined;
 	let hasSection = false;
@@ -494,17 +548,7 @@ function hasTaskScopedAllowedEditSurfaces(...values: unknown[]): boolean {
 		const headings = value.matchAll(ALLOWED_EDIT_SURFACES_HEADING);
 		for (const heading of headings) {
 			const bodyStart = (heading.index ?? 0) + heading[0].length;
-			const following = value.slice(bodyStart);
-			const nextHeading = following.search(/\n#{1,2}\s+/);
-			const section = following.slice(0, nextHeading === -1 ? undefined : nextHeading);
-			const entries = section
-				.split(/\r?\n/)
-				.map((line) => line.trim().replace(/^(?:[-*+]|\d+[.)])\s+/, ""))
-				.filter((line) => line.length > 0)
-				.map((line) => {
-					const codePath = line.match(/^`(.+)`$/);
-					return codePath?.[1] ?? line;
-				});
+			const entries = readAllowedEditSurfaceEntries(value.slice(bodyStart));
 			if (entries.length === 0 || !entries.every(isTaskScopedRepositoryRelativePath)) return false;
 
 			const uniqueEntries = [...new Set(entries)].sort();

--- a/tests/writer-edit-surface-scope.test.ts
+++ b/tests/writer-edit-surface-scope.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
+
+// ---------------------------------------------------------------------------
+// Bounded writer edit-surface scope guard (issue #484).
+//
+// The guard reads the `## Allowed edit surfaces` section out of the delegated
+// `subagent_run` prompt. A delegated task is a full prompt: the surfaces list
+// is followed by deeper headings (`### Validation`, `#### Return`) and by
+// ordinary prose. The section must end where the list ends, so that following
+// content is never parsed as a surface entry and never turned into a false
+// rejection. A `context` value carrying only the heading and its lines had
+// nothing following it, which is why the same surfaces were accepted there and
+// rejected in `task`.
+//
+// Every case below runs through the real `tool_call` hook with the exact
+// `subagent_run` input shape, because that is the boundary that rejected.
+// ---------------------------------------------------------------------------
+
+const REJECTION =
+	"Parent must derive or map narrow repository-relative allowed edit surfaces from the delegated task and relaunch the writer. Do not ask the human to author paths or globs.";
+
+type ToolCallHandler = (
+	event: { toolName: string; input: unknown },
+	ctx: ExtensionContext,
+) => Promise<{ block: true; reason: string } | undefined>;
+
+const scratchRoots: string[] = [];
+
+after(() => {
+	for (const dir of scratchRoots) rmSync(dir, { recursive: true, force: true });
+});
+
+function dispatchWriter(input: Record<string, unknown>) {
+	const handlers = new Map<string, ToolCallHandler>();
+	const pi = {
+		on(name: string, handler: ToolCallHandler) {
+			handlers.set(name, handler);
+		},
+		events: { emit() {} },
+		registerCommand() {},
+		registerTool() {},
+	} as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli: null })(pi);
+	const toolCall = handlers.get("tool_call");
+	assert.equal(typeof toolCall, "function");
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-writer-surfaces-"));
+	scratchRoots.push(cwd);
+	return toolCall!({ toolName: "subagent_run", input }, {
+		cwd,
+		hasUI: false,
+		ui: { confirm: async () => true },
+	} as ExtensionContext);
+}
+
+async function assertAccepted(input: Record<string, unknown>, message: string) {
+	assert.equal(await dispatchWriter(input), undefined, message);
+}
+
+async function assertRejected(input: Record<string, unknown>, message: string) {
+	assert.deepEqual(await dispatchWriter(input), { block: true, reason: REJECTION }, message);
+}
+
+test("task-scoped surfaces are accepted ahead of a deeper heading", async () => {
+	await assertAccepted({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: [
+			"Fix the decoder.",
+			"",
+			"## Allowed edit surfaces",
+			"- `lib/sdd-status.ts`",
+			"- `tests/sdd-status.test.ts`",
+			"",
+			"### Validation commands",
+			"- pnpm test",
+			"",
+			"#### Return",
+			"- one structured envelope",
+		].join("\n"),
+	}, "a delegated task ends its surfaces list at the next heading of any level");
+});
+
+test("task-scoped surfaces are accepted ahead of trailing prose", async () => {
+	await assertAccepted({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: [
+			"## Allowed edit surfaces",
+			"- `lib/sdd-status.ts`",
+			"",
+			"Then run the focused test file and report the outcome.",
+		].join("\n"),
+	}, "prose after the list is not a surface entry");
+});
+
+test("the documented task shape from issue #484 is accepted", async () => {
+	await assertAccepted({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: [
+			"## Allowed edit surfaces",
+			"- `lib/sdd-status.ts`",
+			"- `tests/sdd-status.test.ts`",
+			"",
+			"## Skills to load before work",
+			"- `skills/typescript/SKILL.md`",
+		].join("\n"),
+	}, "the reported repro shape stays accepted");
+});
+
+test("bullet, backtick and plain-line surfaces reach the same decision", async () => {
+	const bulleted = ["## Allowed edit surfaces", "- `lib/sdd-status.ts`", "- `tests/sdd-status.test.ts`"].join("\n");
+	const plain = ["## Allowed edit surfaces", "lib/sdd-status.ts", "tests/sdd-status.test.ts"].join("\n");
+	await assertAccepted({ agent: "gentle-ai-worker", mode: "task", task: bulleted }, "bullets in task are accepted");
+	await assertAccepted({ agent: "gentle-ai-worker", mode: "task", task: plain }, "plain lines in task are accepted");
+	await assertAccepted(
+		{ agent: "gentle-ai-worker", mode: "task", task: "Fix the decoder.", context: bulleted },
+		"bullets in context are accepted",
+	);
+	await assertAccepted(
+		{ agent: "gentle-ai-worker", mode: "task", task: "Fix the decoder.", context: plain },
+		"plain lines in context are accepted",
+	);
+	await assertAccepted(
+		{ agent: "gentle-ai-worker", mode: "task", task: bulleted, context: plain },
+		"the same surfaces in both fields are accepted",
+	);
+});
+
+test("a list broken by a blank line still validates every entry", async () => {
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "- `lib/sdd-status.ts`", "", "- `/etc/passwd`"].join("\n"),
+	}, "a loose bulleted list cannot smuggle an absolute path past the guard");
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		context: ["## Allowed edit surfaces", "lib/sdd-status.ts", "", "/etc/passwd"].join("\n"),
+	}, "a loose plain-line list cannot smuggle an absolute path past the guard");
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "lib/sdd-status.ts", "", "../other-repo/lib/a.ts"].join("\n"),
+	}, "a loose plain-line list cannot smuggle parent traversal past the guard");
+});
+
+test("an entry hidden below a paragraph is validated, not discarded", async () => {
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: [
+			"## Allowed edit surfaces",
+			"- `lib/sdd-status.ts`",
+			"",
+			"Also authorize the following path.",
+			"- `/etc/passwd`",
+		].join("\n"),
+	}, "prose does not close the list while a path still follows it");
+	await assertAccepted({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: [
+			"## Allowed edit surfaces",
+			"- `lib/sdd-status.ts`",
+			"",
+			"Then run the focused test file and report the outcome.",
+		].join("\n"),
+	}, "genuinely trailing prose still closes the list");
+});
+
+test("out-of-scope and empty surfaces stay rejected", async () => {
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: "Fix the decoder.",
+	}, "a task with no section is rejected");
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "", "## Skills to load before work", "- `skills/typescript/SKILL.md`"].join("\n"),
+	}, "an empty section is rejected");
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "- `/home/user/repo/lib/sdd-status.ts`"].join("\n"),
+	}, "an absolute path is rejected");
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "- `../other-repo/lib/sdd-status.ts`"].join("\n"),
+	}, "parent traversal is rejected");
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "- `.`"].join("\n"),
+	}, "the repository root is rejected");
+	await assertRejected({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "- `*`"].join("\n"),
+	}, "a repository-wide glob is rejected");
+	await assertRejected({
+		agent: "worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "- `~/lib/sdd-status.ts`"].join("\n"),
+	}, "a home-relative path is rejected for the configured worker too");
+});
+
+test("agents outside the bounded writer set are not scope-guarded", async () => {
+	await assertAccepted({
+		agent: "gentle-ai-explore",
+		mode: "task",
+		task: "Map the decoder call sites.",
+	}, "a read-only explorer needs no edit surfaces");
+});


### PR DESCRIPTION
Closes #484

## Problem

The bounded-writer scope guard read the `## Allowed edit surfaces` section up to the next `#` or `##` heading:

```ts
const nextHeading = following.search(/\n#{1,2}\s+/);
```

A delegated `task` is a whole prompt, so the surfaces list is normally followed by deeper headings (`### Validation commands`, `#### Return`) and by ordinary prose. `#{1,2}` never matches `###` — the greedy quantifier backtracks and `\s+` still faces a `#` — so none of that closed the section. It was parsed as surface entries, failed the repository-relative check on its whitespace, and rejected an authorization that was valid.

That is the reported `task` vs `context` asymmetry, and the field was never the cause: a `context` value carrying just the heading and its lines had nothing following it. The issue's literal repro (surfaces followed by another `##` heading) already passed before this change; a fix aimed at it would have changed nothing.

## Change

The section now ends at the next heading of **any** level, and prose closes the list inside it. Blank lines never close it, and prose only closes it when nothing below still reads as a surface entry — so a path hidden under a blank line or under a paragraph stays under validation instead of being silently discarded.

That last rule matters: a first pass at this fix closed the list on any blank line, which let

```md
## Allowed edit surfaces
lib/a.ts

/etc/passwd
```

reach an **accepted** dispatch, because the plain-line form never set the "this is a bulleted list" flag. The review caught it; both escapes are now covered by tests.

## Acceptance criteria

- A valid repository-relative surface list is accepted from `task` and from `context`.
- Bullet/backtick and plain-line representations produce the same decision.
- Absolute paths, parent traversal, home-relative paths, empty sections, and repository-root-wide surfaces remain rejected.
- Regression tests exercise the actual pre-tool-call input shape used by `subagent_run`, through the real `tool_call` hook.

## Verification

`pnpm test` — 1111 tests, 0 failures. `check:provider-contract`, `test:harness` and `check:runtime-modules` all pass.

https://claude.ai/code/session_019dKLcPy54YpxCN5rF2s2Lw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of delegated task edit-surface lists.
  * Prevented ambiguous or unsafe paths—including absolute paths, parent traversals, home-relative paths, repository roots, globs, and empty entries—from being accepted.
  * Correctly handles headings, blank lines, and trailing prose when determining edit-surface boundaries.
  * Ensured scope restrictions apply only to designated writer agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->