### PR TITLE
fix(review): accept status v5 receipt

### DIFF
--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -80,6 +80,8 @@ const REVIEW_LENSES = ["review-risk", "review-resilience", "review-readability",
 const RISK_REASON_CODES = ["configuration_change", "empty_content", "executable_change", "executable_mode", "hot_path", "large_change", "non_executable_only", "process_boundary", "process_scan_limit", "service_token", "shell_source"] as const;
 const RISK_SIGNALS = ["auth", "update", "security", "payments", "permissions", "shell_process"] as const;
 const STATUS_ACTIONS = ["start", "recover", "maintainer_action", "select_lineage", "repair_authority", "stop"] as const;
+const RECEIPT_STATUSES = ["expected_missing", "present", "publication_pending", "not_applicable"] as const;
+type ReviewReceiptStatus = (typeof RECEIPT_STATUSES)[number];
 export const REVIEW_STATUS_ACTION_DISPOSITION = {
 	SCOPE_CHANGED: "scope_changed",
 	INVALIDATED: "invalidated",
@@ -313,6 +315,11 @@ export interface ReviewStatusAuthorityV1 {
 	revision: string;
 }
 
+export interface ReviewStatusReceiptV1 {
+	status: ReviewReceiptStatus;
+	identity?: string;
+}
+
 export interface ReviewStatusFrozenV1 {
 	tier: RiskLevel;
 	originalChangedLines: number;
@@ -489,6 +496,8 @@ export interface ReviewStatusV3 {
 	contract: typeof REVIEW_INTEGRATION_CONTRACT;
 	applicability: Exclude<ReviewAuthorityApplicability, "not_evaluated">;
 	authority?: ReviewStatusAuthorityV1;
+	/** status/v5 compatibility metadata; it is decoded but never used as routing authority. */
+	receipt?: ReviewStatusReceiptV1;
 	action: ReviewStatusAction;
 	actionDisposition?: ReviewStatusActionDisposition;
 	replayability: ReviewReplayability;
@@ -1575,10 +1584,18 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 	const v5 = typeof value === "object" && value !== null && (value as Record<string, unknown>).schema === "gentle-ai.review-integration.status/v5";
 	const body = exactRecord(value, "status", [
 		"schema", "contract", "operation", "applicability", "action", "replayability", "target_identity", "projection", "repair", "candidates",
-	], ["authority", "frozen", "action_disposition", "eligibility", "next_transition", "authority_target_identity", ...(v5 ? ["forecast", "repository_context", "validation_request"] : [])]);
+	], ["authority", "frozen", "action_disposition", "eligibility", "next_transition", "authority_target_identity", ...(v5 ? ["receipt", "forecast", "repository_context", "validation_request"] : [])]);
 	requireIdentity(body, v5 ? "gentle-ai.review-integration.status/v5" : "gentle-ai.review-integration.status/v3", REVIEW_INTEGRATION_OPERATION.STATUS);
 
 	const applicability = enumeration(body.applicability, ["current_target", "unrelated", "ambiguous", "corrupted"] as const, "status.applicability");
+	let receipt: ReviewStatusReceiptV1 | undefined;
+	if (body.receipt !== undefined) {
+		const source = exactRecord(body.receipt, "status.receipt", ["status"], ["identity"]);
+		receipt = {
+			status: enumeration(source.status, RECEIPT_STATUSES, "status.receipt.status"),
+			...(source.identity === undefined ? {} : { identity: sha256(source.identity, "status.receipt.identity") }),
+		};
+	}
 	let authority: ReviewStatusAuthorityV1 | undefined;
 	if (body.authority !== undefined) {
 		const source = exactRecord(body.authority, "status.authority", ["version", "lineage_id", "state", "generation", "revision"]);
@@ -1606,6 +1623,9 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 	}
 	if (authority?.version === REVIEW_AUTHORITY_VERSION.COMPACT_V2 && frozen === undefined) throw new TypeError("compact-v2 status requires frozen metadata");
 	if (authority?.version === REVIEW_AUTHORITY_VERSION.LEGACY_V1 && (frozen !== undefined || body.authority_target_identity !== undefined)) throw new TypeError("legacy status cannot expose frozen metadata or authority_target_identity");
+	if (authority?.version === REVIEW_AUTHORITY_VERSION.LEGACY_V1 && receipt !== undefined && receipt.status !== "expected_missing" && receipt.status !== "present") {
+		throw new TypeError("legacy status receipt is incompatible");
+	}
 
 	const action = enumeration(body.action, STATUS_ACTIONS, "status.action");
 	const actionDisposition = body.action_disposition === undefined ? undefined : enumeration(body.action_disposition, Object.values(REVIEW_STATUS_ACTION_DISPOSITION), "status.action_disposition");
@@ -1651,6 +1671,7 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 		contract: REVIEW_INTEGRATION_CONTRACT,
 		applicability,
 		...(authority === undefined ? {} : { authority }),
+		...(receipt === undefined ? {} : { receipt }),
 		action,
 		...(actionDisposition === undefined ? {} : { actionDisposition }),
 		replayability,

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -81,6 +81,8 @@ const REVIEW_LENSES = ["review-risk", "review-resilience", "review-readability",
 const RISK_REASON_CODES = ["configuration_change", "empty_content", "executable_change", "executable_mode", "hot_path", "large_change", "non_executable_only", "process_boundary", "process_scan_limit", "service_token", "shell_source"]         ;
 const RISK_SIGNALS = ["auth", "update", "security", "payments", "permissions", "shell_process"]         ;
 const STATUS_ACTIONS = ["start", "recover", "maintainer_action", "select_lineage", "repair_authority", "stop"]         ;
+const RECEIPT_STATUSES = ["expected_missing", "present", "publication_pending", "not_applicable"]         ;
+
 export const REVIEW_STATUS_ACTION_DISPOSITION = {
 	SCOPE_CHANGED: "scope_changed",
 	INVALIDATED: "invalidated",
@@ -338,6 +340,11 @@ const REPOSITORY_CONTEXT_OUTCOMES = ["applied", "pending", "blocked_conflict", "
 
 
 
+
+
+
+
+
 // Provider-owned completing form for a host-mediated capture slot
 // (gentle-pi#311 P4). The provider issues the exact operation and argument
 // tokens that submit the captured bytes; the host substitutes only the
@@ -381,6 +388,8 @@ export const REVIEW_PROVIDER_ROLE_CAPTURE_OPERATIONS = Object.freeze(Object.valu
 // decoded strictly (exact key sets per the vendored status-v5.schema.json and
 // correction-plan-request.schema.json on gentle-ai main) and carried through
 // so a v5 provider payload is never rejected for being newer than v3.
+
+
 
 
 
@@ -1576,10 +1585,18 @@ export function decodeReviewStatusV3(value         )                 {
 	const v5 = typeof value === "object" && value !== null && (value                           ).schema === "gentle-ai.review-integration.status/v5";
 	const body = exactRecord(value, "status", [
 		"schema", "contract", "operation", "applicability", "action", "replayability", "target_identity", "projection", "repair", "candidates",
-	], ["authority", "frozen", "action_disposition", "eligibility", "next_transition", "authority_target_identity", ...(v5 ? ["forecast", "repository_context", "validation_request"] : [])]);
+	], ["authority", "frozen", "action_disposition", "eligibility", "next_transition", "authority_target_identity", ...(v5 ? ["receipt", "forecast", "repository_context", "validation_request"] : [])]);
 	requireIdentity(body, v5 ? "gentle-ai.review-integration.status/v5" : "gentle-ai.review-integration.status/v3", REVIEW_INTEGRATION_OPERATION.STATUS);
 
 	const applicability = enumeration(body.applicability, ["current_target", "unrelated", "ambiguous", "corrupted"]         , "status.applicability");
+	let receipt                                   ;
+	if (body.receipt !== undefined) {
+		const source = exactRecord(body.receipt, "status.receipt", ["status"], ["identity"]);
+		receipt = {
+			status: enumeration(source.status, RECEIPT_STATUSES, "status.receipt.status"),
+			...(source.identity === undefined ? {} : { identity: sha256(source.identity, "status.receipt.identity") }),
+		};
+	}
 	let authority                                     ;
 	if (body.authority !== undefined) {
 		const source = exactRecord(body.authority, "status.authority", ["version", "lineage_id", "state", "generation", "revision"]);
@@ -1607,6 +1624,9 @@ export function decodeReviewStatusV3(value         )                 {
 	}
 	if (authority?.version === REVIEW_AUTHORITY_VERSION.COMPACT_V2 && frozen === undefined) throw new TypeError("compact-v2 status requires frozen metadata");
 	if (authority?.version === REVIEW_AUTHORITY_VERSION.LEGACY_V1 && (frozen !== undefined || body.authority_target_identity !== undefined)) throw new TypeError("legacy status cannot expose frozen metadata or authority_target_identity");
+	if (authority?.version === REVIEW_AUTHORITY_VERSION.LEGACY_V1 && receipt !== undefined && receipt.status !== "expected_missing" && receipt.status !== "present") {
+		throw new TypeError("legacy status receipt is incompatible");
+	}
 
 	const action = enumeration(body.action, STATUS_ACTIONS, "status.action");
 	const actionDisposition = body.action_disposition === undefined ? undefined : enumeration(body.action_disposition, Object.values(REVIEW_STATUS_ACTION_DISPOSITION), "status.action_disposition");
@@ -1652,6 +1672,7 @@ export function decodeReviewStatusV3(value         )                 {
 		contract: REVIEW_INTEGRATION_CONTRACT,
 		applicability,
 		...(authority === undefined ? {} : { authority }),
+		...(receipt === undefined ? {} : { receipt }),
 		action,
 		...(actionDisposition === undefined ? {} : { actionDisposition }),
 		replayability,

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -53,16 +53,12 @@ function client(adapter: ExecFileAdapter): NativeReviewCliV216 {
 	return new NativeReviewCliV216(adapter, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024);
 }
 
-test("negotiated STATUS rejects the retired receipt payload before any lifecycle advance", async () => {
-	// The pinned historical status fixture intentionally retains the retired
-	// receipt surface. Keep its bytes unchanged and require an explicit decoder
-	// refusal rather than treating it as a current lifecycle authority.
-	const status = readFileSync(join(process.cwd(), "contracts", "review-integration", "v2", "fixtures", "status.fixture.json"), "utf8");
-	const queue = queuedAdapter([{ stdout: status }]);
-	await assert.rejects(
-		() => client(queue.adapter).targetStatus({ cwd: "/repo", lineageId: "review-status-fixture", agent: "pi" }),
-		(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE,
-	);
+test("negotiated STATUS accepts the pinned v5 receipt before routing its transition", async () => {
+	const status = fixture("status-v5.captured.json");
+	const queue = queuedAdapter([{ stdout: JSON.stringify(status) }]);
+	const result = await client(queue.adapter).targetStatus({ cwd: "/repo", lineageId: "review-status-fixture", agent: "pi" });
+	assert.deepEqual(result.receipt, { status: "not_applicable" });
+	assert.equal(result.nextTransition?.kind, "collect");
 	assert.deepEqual(queue.calls[0]?.arguments, [
 		"review", "status", "--contract", "gentle-ai.review-integration/v2", "--cwd", "/repo",
 		"--projection", "workspace", "--lineage", "review-status-fixture", "--agent", "pi", "--next-transition",
@@ -146,11 +142,7 @@ test("malformed closure output remains a typed schema failure and never authoriz
 });
 
 function currentStatusFixture(): Record<string, unknown> {
-	const status = fixture("status-v5.captured.json");
-	// Preserve the captured historical bytes on disk while excluding the receipt
-	// field that #404 explicitly retired from the current STATUS decoder.
-	delete status.receipt;
-	return status;
+	return fixture("status-v5.captured.json");
 }
 
 function negotiatedStartStatus(targetIdentity: string, tokens: readonly string[]): Record<string, unknown> {

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -26,11 +26,6 @@ function fixture(root: string, name: string): unknown {
 
 function currentStatusFixture(name: string): Record<string, unknown> {
 	const body = structuredClone(fixture(DEV_FIXTURES, name)) as Record<string, unknown>;
-	// The real capture retains the historical receipt field byte-for-byte; the
-	// current decoder correctly refuses that retired surface. Remove only that
-	// retired field from the in-memory assertion subject to preserve coverage of
-	// the still-supported v5 status fields.
-	delete body.receipt;
 	if (body.action === "finalize") {
 		body.action = "stop";
 		const transition = body.next_transition as Record<string, unknown> | undefined;
@@ -51,11 +46,34 @@ test("captured capabilities retain their exact schema identity", () => {
 	assert.equal(capabilities.schemas.has("gentle-ai.review-integration.status/v5"), true);
 });
 
-test("historical published status with a retired receipt is rejected without rewriting fixture bytes", () => {
+test("historical v3 FINALIZE status remains rejected without rewriting fixture bytes", () => {
 	assert.throws(
 		() => decodeReviewStatusV3(fixture(V2_FIXTURES, "status.fixture.json")),
-		/receipt|schema|status/i,
+		/receipt|finalize|status/i,
 	);
+});
+
+test("captured v5 STATUS preserves its strict receipt while routing intended-untracked selection", () => {
+	const body = currentStatusFixture("status-v5.captured.json");
+	(body.next_transition as JsonObject).reason_code = "intended_untracked_selection_required";
+	const decoded = decodeReviewStatusV3(body);
+	assert.deepEqual(decoded.receipt, { status: "not_applicable" });
+	assert.equal(decoded.nextTransition?.kind, "collect");
+	assert.equal(decoded.nextTransition?.reasonCode, "intended_untracked_selection_required");
+});
+
+test("v5 STATUS rejects malformed receipt status, identity, and extra fields", () => {
+	const unsupported = currentStatusFixture("status-v5.captured.json");
+	(unsupported.receipt as JsonObject).status = "retired";
+	assert.throws(() => decodeReviewStatusV3(unsupported), /status\.receipt\.status/);
+
+	const invalidIdentity = currentStatusFixture("status-v5.captured.json");
+	(invalidIdentity.receipt as JsonObject).identity = "not-a-sha256";
+	assert.throws(() => decodeReviewStatusV3(invalidIdentity), /status\.receipt\.identity/);
+
+	const extra = currentStatusFixture("status-v5.captured.json");
+	(extra.receipt as JsonObject).unexpected = true;
+	assert.throws(() => decodeReviewStatusV3(extra), /status\.receipt\.unexpected is not allowed/);
 });
 
 test("captured terminal closure decodes without a compatibility status projection", () => {
@@ -90,6 +108,7 @@ test("captured v5 STATUS preserves its provider forecast and collect binding", (
 test("v3 status identity rejects v5-only forecast fields", () => {
 	const body = currentStatusFixture("status-v5.captured.json");
 	body.schema = "gentle-ai.review-integration.status/v3";
+	delete body.receipt;
 	assert.throws(() => decodeReviewStatusV3(body), /forecast/);
 });
 
@@ -164,6 +183,7 @@ test("the derived capabilities/v2.1 payload decodes with protocol minor 1", () =
 test("a status/v3 payload never carries a top-level repository context", () => {
 	const body = currentStatusFixture("status-v5-repository-context.captured.json");
 	body.schema = "gentle-ai.review-integration.status/v3";
+	delete body.receipt;
 	delete body.forecast;
 	assert.throws(() => decodeReviewStatusV3(body), /repository_context/);
 });
@@ -198,6 +218,7 @@ test("a v5 provider role task input decodes and is confined to external.run_prov
 test("the v3 identity keeps rejecting the singular capture-result value form", () => {
 	const body = currentStatusFixture("status-v5-capture-result-submission.captured.json");
 	body.schema = "gentle-ai.review-integration.status/v3";
+	delete body.receipt;
 	delete body.forecast;
 	delete body.repository_context;
 	assert.throws(() => decodeReviewStatusV3(body), /values is required/);
@@ -206,6 +227,7 @@ test("the v3 identity keeps rejecting the singular capture-result value form", (
 test("the v3 next transition keeps rejecting every v5-only surface", () => {
 	const v5 = currentStatusFixture("status-v5.captured.json");
 	v5.schema = "gentle-ai.review-integration.status/v3";
+	delete v5.receipt;
 	delete v5.forecast;
 	const transition = v5.next_transition as JsonObject;
 	transition.correction_request = { schema: "gentle-ai.review-correction-plan-request/v1", request_hash: sha("a") };

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -76,6 +76,23 @@ test("v5 STATUS rejects malformed receipt status, identity, and extra fields", (
 	assert.throws(() => decodeReviewStatusV3(extra), /status\.receipt\.unexpected is not allowed/);
 });
 
+test("legacy-v1 v5 STATUS accepts only its two compatible receipt states", () => {
+	const legacyStatus = (status: string, identity?: string): JsonObject => {
+		const body = currentStatusFixture("status-v5-capture-result-submission.captured.json");
+		(body.authority as JsonObject).version = "legacy-v1";
+		body.receipt = { status, ...(identity === undefined ? {} : { identity }) };
+		delete body.frozen;
+		delete body.authority_target_identity;
+		return body;
+	};
+
+	assert.deepEqual(decodeReviewStatusV3(legacyStatus("expected_missing")).receipt, { status: "expected_missing" });
+	assert.deepEqual(decodeReviewStatusV3(legacyStatus("present", sha("a"))).receipt, { status: "present", identity: sha("a") });
+	for (const status of ["publication_pending", "not_applicable"]) {
+		assert.throws(() => decodeReviewStatusV3(legacyStatus(status)), /legacy status receipt is incompatible/);
+	}
+});
+
 test("captured terminal closure decodes without a compatibility status projection", () => {
 	const closure = decodeReviewLastEventClosureV1(
 		fixture(DEV_FIXTURES, "last-event-capture-result-approved.captured.json"),


### PR DESCRIPTION
Closes #475

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Accept and strictly decode the `receipt` compatibility metadata emitted by the pinned Gentle AI 2.4.0 `status/v5` runtime.
- Preserve exact unknown-key rejection, SHA-256 identity validation, legacy-v1 receipt constraints, and receipt-free newer `status/v5` compatibility.
- Keep `next_transition` as the sole routing authority while retaining the retired receipt rejection on `status/v3`.

## Changes

| File | Change |
|------|--------|
| `lib/review-integration-v2.ts` | Adds the bounded v5 receipt type, decoder, and legacy compatibility guard. |
| `runtime/review-integration-v2.mjs` | Regenerates the runtime mirror from the TypeScript source. |
| `tests/review-integration-v2-forward.test.ts` | Exercises valid, malformed, and cross-version receipt behavior. |
| `tests/native-review-cli.test.ts` | Verifies negotiated STATUS accepts the pinned v5 capture and routes its collect transition. |

## Test Plan

- [x] RED reproduced: `status.receipt is not allowed` in both focused suites.
- [x] `node --experimental-strip-types --test tests/review-integration-v2-forward.test.ts` — 28 passed.
- [x] `node --experimental-strip-types --test tests/native-review-cli.test.ts` — 33 passed.
- [x] `pnpm test` — 1112 passed, 1 Windows-only skip, 0 failed; provider contract and runtime harness passed.
- [x] Latest GitHub `verify` check passed after the review follow-up commit.
- [x] `pnpm run check:runtime-modules`.
- [x] `node scripts/verify-package-files.mjs`.
- [x] `git diff --check`.
- [x] Independent read-only verification: PASS.

## Contributor Checklist

- [x] Linked approved issue #475.
- [x] Added exactly one `type:*` label.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] No skills changed; skill-agent validation is not applicable.
- [x] No user-facing documentation change is required for this compatibility fix.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.

## Review Workload

One bounded decoder work unit: 4 files, 97 insertions, 24 deletions. The generated runtime mirror accounts for 23 insertions and 1 deletion; the review follow-up adds only focused legacy-receipt coverage.
