### PR TITLE
fix(review): preserve consent start diagnostics

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3691,11 +3691,12 @@ function nativeOperationFailure(operation: ReviewControllerOperation | "gentle_r
 	// Preserve either already-sanitized diagnostic on every controller route rather
 	// than relabeling an actionable failure as an opaque controller failure.
 	const preservesNativeTargetStatusDiagnostic = nativeDiagnostics?.operation === NATIVE_REVIEW_OPERATION.VERSION || nativeDiagnostics?.operation === NATIVE_REVIEW_OPERATION.STATUS;
+	const preservesAnswerConsentStartDiagnostic = operation === REVIEW_CONTROLLER_OPERATION.ANSWER_CONSENT && nativeDiagnostics?.operation === NATIVE_REVIEW_OPERATION.START;
 	const diagnostics = operation === REVIEW_CONTROLLER_OPERATION.START && error instanceof CandidateViewError && value.candidateViewPreNative === true
 		? error.diagnostics ?? { code: error.reason, message: "candidate view rejected before native START" }
 		: error instanceof CandidateViewError
 			? { code: error.reason, message: error.message }
-			: nativeDiagnostics?.operation === `review/${operation}` || preservesNativeTargetStatusDiagnostic
+			: nativeDiagnostics?.operation === `review/${operation}` || preservesNativeTargetStatusDiagnostic || preservesAnswerConsentStartDiagnostic
 		? nativeDiagnostics
 		: undefined;
 	return {

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -465,6 +465,52 @@ test("stale local consent bindings reconcile exactly once with the native status
 	assert.deepEqual(fixture.answers, ["declined"], "stale binding recovery must not replay answer-consent");
 });
 
+test("launched answer-consent failures remain blocked after fresh-target STATUS reconciliation", async (t) => {
+	const cwd = repository(t);
+	const fixture = consentNative(cwd);
+	const statusRequests: Array<{ agent?: string }> = [];
+	const freshTargetStatus = {
+		...startStatus(cwd),
+		raw: { schema: "gentle-ai.review-integration.status/v5", next_transition: { kind: "execute", reason_code: "fresh_start_available" } },
+	} as ReviewStatusV3;
+	fixture.native.targetStatus = async (request) => {
+		statusRequests.push(request);
+		return freshTargetStatus;
+	};
+	let answerCalls = 0;
+	fixture.native.answerConsent = async () => {
+		answerCalls += 1;
+		throw new NativeReviewCliError(
+			NATIVE_REVIEW_ERROR_CODE.NON_ZERO,
+			NATIVE_REVIEW_OPERATION.START,
+			true,
+			true,
+			"native review/start failed after launch",
+		);
+	};
+	const runtime = parityRuntime(fixture.native);
+	const blocked = await beginConsent(runtime, cwd);
+
+	const first = await answerConsent(runtime, cwd, blocked.consent_binding, "granted");
+	assert.equal(first.operation, "answer-consent");
+	assert.equal(first.status, "blocked");
+	assert.equal(first.outcome, "native-mutation-status-reconciled");
+	assert.deepEqual(first.diagnostics, {
+		operation: NATIVE_REVIEW_OPERATION.START,
+		error_code: NATIVE_REVIEW_ERROR_CODE.NON_ZERO,
+		timed_out: false,
+		output_limit_exceeded: false,
+	});
+	assert.deepEqual(first.reconciliation, freshTargetStatus.raw);
+	assert.equal(statusRequests.length, 2, "the launched failure reconciles exactly once after the initial START status");
+	assert.equal(answerCalls, 1, "reconciliation must not replay answer-consent");
+
+	const stale = await answerConsent(runtime, cwd, blocked.consent_binding, "granted");
+	assert.equal(stale.status, "ready");
+	assert.equal(statusRequests.length, 3, "a later stale binding performs one current STATUS read");
+	assert.equal(answerCalls, 1, "the stale binding must not replay answer-consent");
+});
+
 test("stale local consent bindings preserve a typed native STATUS failure", async (t) => {
 	const cwd = repository(t);
 	const fixture = consentNative(cwd);


### PR DESCRIPTION
## Summary

- preserve the original native `review/start` diagnostics when granted consent reconciles through fresh STATUS
- keep consent bindings one-shot with one reconciliation and no automatic replay
- add regression coverage for launched and pre-launch failure boundaries

## Testing

- focused native review consent/parity tests: 31 passed
- full test suite: 1111 passed, 1 skipped

Part of #486


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved native START diagnostics when consent failures occur, ensuring errors display accurate details instead of generic controller messages.
  - Prevented failed consent actions from being retried after status reconciliation, avoiding duplicate reviews and repeated error messages.

- **Tests**
  - Added coverage confirming diagnostic errors are surfaced once and stale consent states remain blocked after reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->