### PR TITLE
fix(review): relay approved acknowledgement

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -128,6 +128,7 @@ import {
 	NATIVE_REVIEW_RECONCILE_ANOMALIES,
 	sanitizeForeignNativeReviewDiagnostics,
 	type NativeReviewCli,
+	type NativeReviewAcknowledgeApprovedRequest,
 	type NativeTargetStatusRequest,
 	type NativeReviewModeOperation,
 	type NativeReviewModeSource,
@@ -135,6 +136,7 @@ import {
 	type NativeStartResult,
 } from "../lib/native-review-cli.ts";
 import {
+	assertReviewApprovedAcknowledgementExecuteV1,
 	decodeReviewLastEventClosureV1,
 	type ReviewCollectInputV3,
 	type ReviewConsentEnvelope,
@@ -2571,6 +2573,7 @@ const REVIEW_CONTROLLER_OPERATION = {
 	START: "start",
 	ANSWER_CONSENT: "answer-consent",
 	ADVANCE: "advance",
+	ACKNOWLEDGE_APPROVED: "acknowledge-approved",
 	STATUS: "status",
 	EXPORT: "export",
 	IMPORT: "import",
@@ -2710,6 +2713,10 @@ interface ReviewControllerParameters {
 	acknowledgeUntrustedBundleSource?: string;
 	workspaceRoot?: string;
 }
+
+type NativeReviewAcknowledgementCli = NativeReviewCli & {
+	acknowledgeApproved?: (request: NativeReviewAcknowledgeApprovedRequest) => Promise<void>;
+};
 
 interface ReviewControllerStartInput {
 	mode: ReviewMode;
@@ -4702,6 +4709,98 @@ async function executeReviewControllerOperation(
 		const store = ReviewTransactionStore.forRepository(defaultCwd);
 		store.repairCurrentAuthority();
 		return { operation: parameters.operation, repaired: true };
+	}
+	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.ACKNOWLEDGE_APPROVED) {
+		const controllerOnlyInput = ["changeName", "idempotencyKey", "transition", "input", "outputPath", "inputPath", "operationId", "lineageIds", "acknowledgeUntrustedBundleSource"]
+			.find((key) => parameters[key as keyof ReviewControllerParameters] !== undefined);
+		if (controllerOnlyInput !== undefined || !isCanonicalProcessString(parameters.lineageId)) {
+			return {
+				operation: parameters.operation,
+				status: "blocked",
+				outcome: "native-approved-acknowledgement-input-invalid",
+				reason: controllerOnlyInput === undefined ? "lineage-invalid" : "controller-only-input",
+				...(controllerOnlyInput === undefined ? {} : { field: controllerOnlyInput }),
+				mutation_performed: false,
+				mutation_outcome: "none",
+				next_action: "resubmit-the-exact-lineage-without-controller-only-input",
+			};
+		}
+		const acknowledgementCli = nativeReviewCli as NativeReviewAcknowledgementCli | null;
+		if (acknowledgementCli?.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
+		if (acknowledgementCli.acknowledgeApproved === undefined) {
+			return {
+				operation: parameters.operation,
+				status: "blocked",
+				outcome: "native-approved-acknowledgement-unsupported",
+				mutation_performed: false,
+				mutation_outcome: "none",
+				next_action: "install-native-acknowledge-approved-support",
+			};
+		}
+		const frozenTarget = candidateViews?.hasProjection(parameters.lineageId, defaultCwd)
+			? candidateViews.resolveProjection(parameters.lineageId, defaultCwd)
+			: undefined;
+		const target = {
+			cwd: defaultCwd,
+			lineageId: parameters.lineageId,
+			...(frozenTarget?.committedOnly === true ? { baseRef: frozenTarget.baseCommit, committedOnly: true } : {}),
+			...(signal === undefined ? {} : { signal }),
+		};
+		let status: ReviewStatusV3;
+		try {
+			status = await acknowledgementCli.targetStatus(target);
+		} catch (error) {
+			return nativeStatusFailed(parameters.operation, error);
+		}
+		const execute = status.nextTransition?.kind === "execute" ? status.nextTransition.execute : undefined;
+		if (
+			status.applicability !== "current_target" ||
+			status.authority?.lineageId !== parameters.lineageId ||
+			status.authority.state !== "approved" ||
+			execute?.operation !== "review.acknowledge-approved"
+		) {
+			return {
+				operation: parameters.operation,
+				status: "blocked",
+				outcome: "native-approved-acknowledgement-not-current",
+				result: status.raw,
+				mutation_performed: false,
+				mutation_outcome: "none",
+				next_action: "follow-provider-target-status",
+			};
+		}
+		let argumentTokens: readonly string[];
+		try {
+			argumentTokens = assertReviewApprovedAcknowledgementExecuteV1(execute, {
+				cwd: defaultCwd,
+				lineageId: parameters.lineageId,
+				targetIdentity: status.targetIdentity,
+				revision: status.authority.revision,
+			});
+		} catch (error) {
+			return nativeOperationFailure(parameters.operation, error);
+		}
+		try {
+			await acknowledgementCli.acknowledgeApproved({
+				argumentTokens,
+				cwd: defaultCwd,
+				...(signal === undefined ? {} : { signal }),
+			});
+			return {
+				operation: parameters.operation,
+				status: "closed",
+				outcome: "native-approved-acknowledgement-completed",
+				lineage_id: parameters.lineageId,
+				target_identity: status.targetIdentity,
+				authority: "burned",
+				delivery: "ordinary-repository-policy",
+				mutation_performed: true,
+				mutation_outcome: "committed",
+			};
+		} catch (error) {
+			if (!nativeMutationRequiresStatus(error)) return nativeOperationFailure(parameters.operation, error);
+			return await reconcileNativeMutationFailure(parameters.operation, error, acknowledgementCli, target, retainedUntrackedSelections);
+		}
 	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.ANSWER_CONSENT) {
 		const input = parseControllerJson(requiredControllerString(parameters, "input"), parameters.operation);

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1513,8 +1513,10 @@ export function decodeReviewNextTransitionV3(value: unknown, options: { v5?: boo
 		const lineageId = binding.lineage_id === undefined ? undefined : lineage(binding.lineage_id, "next_transition.execute.binding.lineage_id");
 		const revision = binding.revision === undefined ? undefined : sha256(binding.revision, "next_transition.execute.binding.revision");
 		const command = execute.command === undefined ? undefined : nonempty(execute.command, "next_transition.execute.command");
+		const decodedExecute: ReviewNextTransitionExecuteV3 = { operation, arguments: argumentsList, preconditions, binding: { targetIdentity, ...(lineageId === undefined ? {} : { lineageId }), ...(revision === undefined ? {} : { revision }) }, ...(command === undefined ? {} : { command }) };
+		if (operation === "review.acknowledge-approved") assertReviewApprovedAcknowledgementExecuteV1(decodedExecute);
 		if (transition.collect !== undefined) throw new TypeError("next_transition.collect is incompatible with execute");
-		return { kind, reasonCode, execute: { operation, arguments: argumentsList, preconditions, binding: { targetIdentity, ...(lineageId === undefined ? {} : { lineageId }), ...(revision === undefined ? {} : { revision }) }, ...(command === undefined ? {} : { command }) }, ...(correctionRequest === undefined ? {} : { correctionRequest }) };
+		return { kind, reasonCode, execute: decodedExecute, ...(correctionRequest === undefined ? {} : { correctionRequest }) };
 	}
 	if (kind === "collect") {
 		const collect = exactRecord(transition.collect, "next_transition.collect", ["inputs"]);
@@ -2076,6 +2078,41 @@ export interface ReviewApprovedAcknowledgementV1 {
 	raw: Record<string, unknown>;
 }
 
+export interface ReviewApprovedAcknowledgementExecuteExpectationV1 { cwd?: string; lineageId?: string; targetIdentity?: string; revision?: string; }
+
+export type ReviewApprovedAcknowledgementExecuteTokensV1 = readonly [string, string, string, string, string];
+
+interface ReviewApprovedAcknowledgementExecuteShapeV1 { tokens: ReviewApprovedAcknowledgementExecuteTokensV1; values: readonly [string, string, string, string, string]; lineageId: string; targetIdentity: string; revision: string; }
+
+function assertReviewApprovedAcknowledgementExecuteShapeV1(execute: ReviewNextTransitionExecuteV3): ReviewApprovedAcknowledgementExecuteShapeV1 {
+	if (execute.operation !== REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION) throw new TypeError(`acknowledgement.execute.operation must be ${REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION}`);
+	if (execute.command === undefined) throw new TypeError("acknowledgement.execute.command is required");
+	text(execute.command, "acknowledgement.execute.command", { minimum: 1, pattern: /^gentle-ai review acknowledge-approved(?: |$)/ });
+	if (execute.arguments.length !== REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length) throw new TypeError(`acknowledgement.execute.arguments must carry exactly ${REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length} provider-issued arguments`);
+	const values = execute.arguments.map((argument, index) => { const name = REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS[index]!; if (argument.name !== name) throw new TypeError(`acknowledgement.execute.arguments[${index}].name must be ${name}`); const value = nonempty(argument.value, `acknowledgement.execute.arguments[${index}].value`); if (nonempty(argument.token, `acknowledgement.execute.arguments[${index}].token`) !== `--${name}=${value}`) throw new TypeError(`acknowledgement.execute.arguments[${index}].token must exactly match ${name}`); return value; });
+	if (execute.preconditions.length !== 1 || execute.preconditions[0]?.name !== "state" || execute.preconditions[0]?.value !== "approved") throw new TypeError("acknowledgement.execute.preconditions must be the single approved state precondition");
+	return { tokens: execute.arguments.map((argument) => argument.token!) as ReviewApprovedAcknowledgementExecuteTokensV1, values: values as readonly [string, string, string, string, string], lineageId: lineage(execute.binding.lineageId, "acknowledgement.execute.binding.lineage_id"), targetIdentity: sha256(execute.binding.targetIdentity, "acknowledgement.execute.binding.target_identity"), revision: sha256(execute.binding.revision, "acknowledgement.execute.binding.revision") };
+}
+
+/**
+ * Proves that an approved-acknowledgement execute vector is the exact closed,
+ * provider-issued burn invocation. Callers can additionally bind its values to
+ * their own current STATUS before invoking the returned tokens.
+ */
+export function assertReviewApprovedAcknowledgementExecuteV1(
+	execute: ReviewNextTransitionExecuteV3,
+	expected: ReviewApprovedAcknowledgementExecuteExpectationV1 = {},
+): ReviewApprovedAcknowledgementExecuteTokensV1 {
+	const shape = assertReviewApprovedAcknowledgementExecuteShapeV1(execute);
+	if (shape.values[1] !== shape.lineageId) throw new TypeError("acknowledgement lineage argument does not match its binding");
+	if (shape.values[2] !== shape.targetIdentity) throw new TypeError("acknowledgement target argument does not match its binding");
+	if (shape.values[3] !== shape.revision) throw new TypeError("acknowledgement revision argument does not match its binding");
+	if (expected.cwd !== undefined && shape.values[0] !== expected.cwd) throw new TypeError("acknowledgement.execute.cwd does not match the current target");
+	if (expected.lineageId !== undefined && shape.lineageId !== expected.lineageId) throw new TypeError("acknowledgement.execute.lineage does not match the current target");
+	if (expected.targetIdentity !== undefined && shape.targetIdentity !== expected.targetIdentity) throw new TypeError("acknowledgement.execute.target does not match the current target");
+	if (expected.revision !== undefined && shape.revision !== expected.revision) throw new TypeError("acknowledgement.execute.revision does not match the current target"); return shape.tokens;
+}
+
 export interface ReviewLastEventClosureV1 {
 	schema: typeof REVIEW_LAST_EVENT_CLOSURE_SCHEMA;
 	operation: ReviewLastEventClosureOperation;
@@ -2120,42 +2157,39 @@ function decodeReviewStatusContinuationArtifactV1(value: unknown, label: string)
 	};
 }
 
-// decodeReviewApprovedAcknowledgementV1 decodes the one continuation that burns
-// approved authority. Only this exact invocation ends the lifecycle, so every
-// field is pinned: the closed positional argument list, the single approved
-// precondition, and the fully-bound lineage/revision/target it commits to.
+// decodeReviewApprovedAcknowledgementV1 retains the closure-specific wire
+// boundary with the shared shape validator; its semantic binding stays outside
+// the defensive closure catch in the exported assertion.
 function decodeReviewApprovedAcknowledgementV1(value: unknown, label: string): ReviewApprovedAcknowledgementV1 {
 	const body = exactRecord(value, label, ["operation", "command", "arguments", "preconditions", "binding"]);
-	if (body.operation !== REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION) {
-		throw new TypeError(`${label}.operation must be ${REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION}`);
-	}
-	const command = text(body.command, `${label}.command`, { minimum: 1, pattern: /^gentle-ai review acknowledge-approved(?: |$)/ });
 	const argumentsList = decodeTransitionArguments(body.arguments, `${label}.arguments`);
-	if (argumentsList.length !== REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length) {
-		throw new TypeError(`${label}.arguments must carry exactly ${REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length} provider-issued arguments`);
-	}
-	argumentsList.forEach((argument, index) => {
-		const expected = REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS[index];
-		if (argument.name !== expected) throw new TypeError(`${label}.arguments[${index}].name must be ${expected}`);
-		if (argument.token === undefined) throw new TypeError(`${label}.arguments[${index}] requires its exact token`);
-	});
 	const preconditions = decodeTransitionArguments(body.preconditions, `${label}.preconditions`);
-	if (preconditions.length !== 1 || preconditions[0].name !== "state" || preconditions[0].value !== "approved") {
-		throw new TypeError(`${label}.preconditions must be the single approved state precondition`);
-	}
 	const sourceBinding = exactRecord(body.binding, `${label}.binding`, ["lineage_id", "revision", "target_identity"], ["repository_context"]);
 	const repositoryContext = sourceBinding.repository_context === undefined
 		? undefined
 		: text(sourceBinding.repository_context, `${label}.binding.repository_context`, { pattern: /^rctx[12]_[0-9a-f]{64}$/ });
-	return {
-		operation: REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION,
-		command,
+	const acknowledgement = {
+		operation: body.operation,
+		command: body.command,
 		arguments: argumentsList,
 		preconditions,
 		binding: {
-			lineageId: lineage(sourceBinding.lineage_id, `${label}.binding.lineage_id`),
-			revision: sha256(sourceBinding.revision, `${label}.binding.revision`),
-			targetIdentity: sha256(sourceBinding.target_identity, `${label}.binding.target_identity`),
+			lineageId: sourceBinding.lineage_id,
+			revision: sourceBinding.revision,
+			targetIdentity: sourceBinding.target_identity,
+			...(repositoryContext === undefined ? {} : { repositoryContext }),
+		},
+	} as unknown as ReviewNextTransitionExecuteV3;
+	const shape = assertReviewApprovedAcknowledgementExecuteShapeV1(acknowledgement);
+	return {
+		operation: REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION,
+		command: acknowledgement.command!,
+		arguments: argumentsList,
+		preconditions,
+		binding: {
+			lineageId: shape.lineageId,
+			revision: shape.revision,
+			targetIdentity: shape.targetIdentity,
 			...(repositoryContext === undefined ? {} : { repositoryContext }),
 		},
 		raw: body,
@@ -2274,26 +2308,7 @@ export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventC
 	}
 	if (acknowledgement !== undefined) {
 		if (state !== "approved") throw new TypeError("last_event_closure acknowledgement requires approved state");
-		if (acknowledgement.binding.lineageId !== shared.lineageId) {
-			throw new TypeError("last_event_closure acknowledgement lineage does not match its enclosing closure");
-		}
-		if (acknowledgement.binding.revision !== shared.storeRevision) {
-			throw new TypeError("last_event_closure acknowledgement revision does not match its enclosing closure");
-		}
-		const lineageArguments = acknowledgement.arguments.filter((argument) => argument.name === "lineage");
-		if (lineageArguments.length !== 1 || lineageArguments[0]?.value !== shared.lineageId || lineageArguments[0]?.token !== `--lineage=${shared.lineageId}`) {
-			throw new TypeError("last_event_closure acknowledgement lineage argument does not match its enclosing closure");
-		}
-		// The target is the other half of what this invocation burns, and it is
-		// relayed verbatim. A terminal closure carries no target of its own, so
-		// the acknowledgement's binding is the only statement of which candidate
-		// is being burned: pinning lineage and revision while leaving the
-		// relayed target token free of it proves nothing about what runs.
-		const targetArguments = acknowledgement.arguments.filter((argument) => argument.name === "target");
-		if (targetArguments.length !== 1 || targetArguments[0]?.value !== acknowledgement.binding.targetIdentity
-			|| targetArguments[0]?.token !== `--target=${acknowledgement.binding.targetIdentity}`) {
-			throw new TypeError("last_event_closure acknowledgement target argument does not match its binding");
-		}
+		assertReviewApprovedAcknowledgementExecuteV1(acknowledgement, { lineageId: shared.lineageId, revision: shared.storeRevision });
 	}
 	const action = nonempty(body.action, "last_event_closure.action");
 	const advisoryFindings = body.advisory_findings === undefined

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1514,8 +1514,10 @@ export function decodeReviewNextTransitionV3(value         , options            
 		const lineageId = binding.lineage_id === undefined ? undefined : lineage(binding.lineage_id, "next_transition.execute.binding.lineage_id");
 		const revision = binding.revision === undefined ? undefined : sha256(binding.revision, "next_transition.execute.binding.revision");
 		const command = execute.command === undefined ? undefined : nonempty(execute.command, "next_transition.execute.command");
+		const decodedExecute                                = { operation, arguments: argumentsList, preconditions, binding: { targetIdentity, ...(lineageId === undefined ? {} : { lineageId }), ...(revision === undefined ? {} : { revision }) }, ...(command === undefined ? {} : { command }) };
+		if (operation === "review.acknowledge-approved") assertReviewApprovedAcknowledgementExecuteV1(decodedExecute);
 		if (transition.collect !== undefined) throw new TypeError("next_transition.collect is incompatible with execute");
-		return { kind, reasonCode, execute: { operation, arguments: argumentsList, preconditions, binding: { targetIdentity, ...(lineageId === undefined ? {} : { lineageId }), ...(revision === undefined ? {} : { revision }) }, ...(command === undefined ? {} : { command }) }, ...(correctionRequest === undefined ? {} : { correctionRequest }) };
+		return { kind, reasonCode, execute: decodedExecute, ...(correctionRequest === undefined ? {} : { correctionRequest }) };
 	}
 	if (kind === "collect") {
 		const collect = exactRecord(transition.collect, "next_transition.collect", ["inputs"]);
@@ -2083,6 +2085,41 @@ const REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS = ["cwd", "lineage", "target", "
 
 
 
+function assertReviewApprovedAcknowledgementExecuteShapeV1(execute                               )                                              {
+	if (execute.operation !== REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION) throw new TypeError(`acknowledgement.execute.operation must be ${REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION}`);
+	if (execute.command === undefined) throw new TypeError("acknowledgement.execute.command is required");
+	text(execute.command, "acknowledgement.execute.command", { minimum: 1, pattern: /^gentle-ai review acknowledge-approved(?: |$)/ });
+	if (execute.arguments.length !== REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length) throw new TypeError(`acknowledgement.execute.arguments must carry exactly ${REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length} provider-issued arguments`);
+	const values = execute.arguments.map((argument, index) => { const name = REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS[index] ; if (argument.name !== name) throw new TypeError(`acknowledgement.execute.arguments[${index}].name must be ${name}`); const value = nonempty(argument.value, `acknowledgement.execute.arguments[${index}].value`); if (nonempty(argument.token, `acknowledgement.execute.arguments[${index}].token`) !== `--${name}=${value}`) throw new TypeError(`acknowledgement.execute.arguments[${index}].token must exactly match ${name}`); return value; });
+	if (execute.preconditions.length !== 1 || execute.preconditions[0]?.name !== "state" || execute.preconditions[0]?.value !== "approved") throw new TypeError("acknowledgement.execute.preconditions must be the single approved state precondition");
+	return { tokens: execute.arguments.map((argument) => argument.token )                                                , values: values                                                     , lineageId: lineage(execute.binding.lineageId, "acknowledgement.execute.binding.lineage_id"), targetIdentity: sha256(execute.binding.targetIdentity, "acknowledgement.execute.binding.target_identity"), revision: sha256(execute.binding.revision, "acknowledgement.execute.binding.revision") };
+}
+
+/**
+ * Proves that an approved-acknowledgement execute vector is the exact closed,
+ * provider-issued burn invocation. Callers can additionally bind its values to
+ * their own current STATUS before invoking the returned tokens.
+ */
+export function assertReviewApprovedAcknowledgementExecuteV1(
+	execute                               ,
+	expected                                                    = {},
+)                                               {
+	const shape = assertReviewApprovedAcknowledgementExecuteShapeV1(execute);
+	if (shape.values[1] !== shape.lineageId) throw new TypeError("acknowledgement lineage argument does not match its binding");
+	if (shape.values[2] !== shape.targetIdentity) throw new TypeError("acknowledgement target argument does not match its binding");
+	if (shape.values[3] !== shape.revision) throw new TypeError("acknowledgement revision argument does not match its binding");
+	if (expected.cwd !== undefined && shape.values[0] !== expected.cwd) throw new TypeError("acknowledgement.execute.cwd does not match the current target");
+	if (expected.lineageId !== undefined && shape.lineageId !== expected.lineageId) throw new TypeError("acknowledgement.execute.lineage does not match the current target");
+	if (expected.targetIdentity !== undefined && shape.targetIdentity !== expected.targetIdentity) throw new TypeError("acknowledgement.execute.target does not match the current target");
+	if (expected.revision !== undefined && shape.revision !== expected.revision) throw new TypeError("acknowledgement.execute.revision does not match the current target"); return shape.tokens;
+}
+
+
+
+
+
+
+
 
 
 
@@ -2121,42 +2158,39 @@ function decodeReviewStatusContinuationArtifactV1(value         , label        )
 	};
 }
 
-// decodeReviewApprovedAcknowledgementV1 decodes the one continuation that burns
-// approved authority. Only this exact invocation ends the lifecycle, so every
-// field is pinned: the closed positional argument list, the single approved
-// precondition, and the fully-bound lineage/revision/target it commits to.
+// decodeReviewApprovedAcknowledgementV1 retains the closure-specific wire
+// boundary with the shared shape validator; its semantic binding stays outside
+// the defensive closure catch in the exported assertion.
 function decodeReviewApprovedAcknowledgementV1(value         , label        )                                  {
 	const body = exactRecord(value, label, ["operation", "command", "arguments", "preconditions", "binding"]);
-	if (body.operation !== REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION) {
-		throw new TypeError(`${label}.operation must be ${REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION}`);
-	}
-	const command = text(body.command, `${label}.command`, { minimum: 1, pattern: /^gentle-ai review acknowledge-approved(?: |$)/ });
 	const argumentsList = decodeTransitionArguments(body.arguments, `${label}.arguments`);
-	if (argumentsList.length !== REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length) {
-		throw new TypeError(`${label}.arguments must carry exactly ${REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS.length} provider-issued arguments`);
-	}
-	argumentsList.forEach((argument, index) => {
-		const expected = REVIEW_APPROVED_ACKNOWLEDGEMENT_ARGUMENTS[index];
-		if (argument.name !== expected) throw new TypeError(`${label}.arguments[${index}].name must be ${expected}`);
-		if (argument.token === undefined) throw new TypeError(`${label}.arguments[${index}] requires its exact token`);
-	});
 	const preconditions = decodeTransitionArguments(body.preconditions, `${label}.preconditions`);
-	if (preconditions.length !== 1 || preconditions[0].name !== "state" || preconditions[0].value !== "approved") {
-		throw new TypeError(`${label}.preconditions must be the single approved state precondition`);
-	}
 	const sourceBinding = exactRecord(body.binding, `${label}.binding`, ["lineage_id", "revision", "target_identity"], ["repository_context"]);
 	const repositoryContext = sourceBinding.repository_context === undefined
 		? undefined
 		: text(sourceBinding.repository_context, `${label}.binding.repository_context`, { pattern: /^rctx[12]_[0-9a-f]{64}$/ });
-	return {
-		operation: REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION,
-		command,
+	const acknowledgement = {
+		operation: body.operation,
+		command: body.command,
 		arguments: argumentsList,
 		preconditions,
 		binding: {
-			lineageId: lineage(sourceBinding.lineage_id, `${label}.binding.lineage_id`),
-			revision: sha256(sourceBinding.revision, `${label}.binding.revision`),
-			targetIdentity: sha256(sourceBinding.target_identity, `${label}.binding.target_identity`),
+			lineageId: sourceBinding.lineage_id,
+			revision: sourceBinding.revision,
+			targetIdentity: sourceBinding.target_identity,
+			...(repositoryContext === undefined ? {} : { repositoryContext }),
+		},
+	}                                            ;
+	const shape = assertReviewApprovedAcknowledgementExecuteShapeV1(acknowledgement);
+	return {
+		operation: REVIEW_APPROVED_ACKNOWLEDGEMENT_OPERATION,
+		command: acknowledgement.command ,
+		arguments: argumentsList,
+		preconditions,
+		binding: {
+			lineageId: shape.lineageId,
+			revision: shape.revision,
+			targetIdentity: shape.targetIdentity,
 			...(repositoryContext === undefined ? {} : { repositoryContext }),
 		},
 		raw: body,
@@ -2275,26 +2309,7 @@ export function decodeReviewLastEventClosureV1(value         )                  
 	}
 	if (acknowledgement !== undefined) {
 		if (state !== "approved") throw new TypeError("last_event_closure acknowledgement requires approved state");
-		if (acknowledgement.binding.lineageId !== shared.lineageId) {
-			throw new TypeError("last_event_closure acknowledgement lineage does not match its enclosing closure");
-		}
-		if (acknowledgement.binding.revision !== shared.storeRevision) {
-			throw new TypeError("last_event_closure acknowledgement revision does not match its enclosing closure");
-		}
-		const lineageArguments = acknowledgement.arguments.filter((argument) => argument.name === "lineage");
-		if (lineageArguments.length !== 1 || lineageArguments[0]?.value !== shared.lineageId || lineageArguments[0]?.token !== `--lineage=${shared.lineageId}`) {
-			throw new TypeError("last_event_closure acknowledgement lineage argument does not match its enclosing closure");
-		}
-		// The target is the other half of what this invocation burns, and it is
-		// relayed verbatim. A terminal closure carries no target of its own, so
-		// the acknowledgement's binding is the only statement of which candidate
-		// is being burned: pinning lineage and revision while leaving the
-		// relayed target token free of it proves nothing about what runs.
-		const targetArguments = acknowledgement.arguments.filter((argument) => argument.name === "target");
-		if (targetArguments.length !== 1 || targetArguments[0]?.value !== acknowledgement.binding.targetIdentity
-			|| targetArguments[0]?.token !== `--target=${acknowledgement.binding.targetIdentity}`) {
-			throw new TypeError("last_event_closure acknowledgement target argument does not match its binding");
-		}
+		assertReviewApprovedAcknowledgementExecuteV1(acknowledgement, { lineageId: shared.lineageId, revision: shared.storeRevision });
 	}
 	const action = nonempty(body.action, "last_event_closure.action");
 	const advisoryFindings = body.advisory_findings === undefined

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -82,6 +82,116 @@ function status(
 	} as unknown as ReviewStatusV3;
 }
 
+function approvedAcknowledgementStatus(lineageId: string, cwd = process.cwd()): ReviewStatusV3 {
+	const arguments_ = [{ name: "cwd", value: cwd, token: `--cwd=${cwd}` }, { name: "lineage", value: lineageId, token: `--lineage=${lineageId}` }, { name: "target", value: SHA, token: `--target=${SHA}` }, { name: "expected-revision", value: SHA, token: `--expected-revision=${SHA}` }, { name: "token", value: "provider-issued-once", token: "--token=provider-issued-once" }];
+	const approved = status(lineageId, [], "approved");
+	approved.nextTransition = { kind: "execute", reasonCode: "approved_acknowledgement_required", execute: { operation: "review.acknowledge-approved", command: "gentle-ai review acknowledge-approved --provider-vector", arguments: arguments_, preconditions: [{ name: "state", value: "approved", token: "--state=approved" }], binding: { lineageId, targetIdentity: SHA, revision: SHA } } };
+	return approved;
+}
+
+function burnedAcknowledgementStatus(lineageId: string): ReviewStatusV3 {
+	const burned = status(lineageId, [], "approved");
+	burned.nextTransition = { kind: "stop", reasonCode: "approved_acknowledged" };
+	return burned;
+}
+
+test("public acknowledgement relays one current provider vector and never replays after authority burn", async () => {
+	const lineageId = "acknowledge-approved";
+	const requests: Array<Record<string, unknown>> = [];
+	const acknowledgementRequests: Array<{ argumentTokens: readonly string[]; cwd: string }> = [];
+	const native = {
+		targetStatus: async (request: Record<string, unknown>) => {
+			requests.push(request);
+			return requests.length === 1
+				? approvedAcknowledgementStatus(lineageId)
+				: burnedAcknowledgementStatus(lineageId);
+		},
+		acknowledgeApproved: async (request: { argumentTokens: readonly string[]; cwd: string }) => {
+			acknowledgementRequests.push(request);
+		},
+	} as unknown as NativeReviewCli;
+
+	const rejected = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId, input: "{}" }, process.cwd(), native);
+	assert.deepEqual({ outcome: rejected.outcome, calls: requests.length }, { outcome: "native-approved-acknowledgement-input-invalid", calls: 0 });
+	const completed = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, process.cwd(), native);
+	assert.deepEqual(completed, { operation: "acknowledge-approved", status: "closed", outcome: "native-approved-acknowledgement-completed", lineage_id: lineageId, target_identity: SHA, authority: "burned", delivery: "ordinary-repository-policy", mutation_performed: true, mutation_outcome: "committed" });
+	assert.deepEqual(requests, [{ cwd: process.cwd(), lineageId }]);
+	assert.deepEqual(acknowledgementRequests, [{ cwd: process.cwd(), argumentTokens: [`--cwd=${process.cwd()}`, `--lineage=${lineageId}`, `--target=${SHA}`, `--expected-revision=${SHA}`, "--token=provider-issued-once"] }]);
+
+	const later = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, process.cwd(), native);
+	assert.equal(later.outcome, "native-approved-acknowledgement-not-current");
+	assert.equal(requests.length, 2);
+	assert.equal(acknowledgementRequests.length, 1);
+});
+
+test("ambiguous acknowledgement reconciles STATUS once without replaying the provider vector", async () => {
+	const lineageId = "ambiguous-acknowledgement";
+	let statusCalls = 0;
+	let acknowledgementCalls = 0;
+	const native = {
+		targetStatus: async () => {
+			statusCalls += 1;
+			return statusCalls === 1
+				? approvedAcknowledgementStatus(lineageId)
+				: burnedAcknowledgementStatus(lineageId);
+		},
+		acknowledgeApproved: async () => { acknowledgementCalls += 1; throw new NativeReviewCliError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, "review/acknowledge-approved", true, true, "acknowledgement outcome unknown"); },
+	} as unknown as NativeReviewCli;
+
+	const result = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, process.cwd(), native);
+	assert.equal(result.outcome, "native-mutation-status-reconciled");
+	assert.equal(result.mutation_outcome, "unknown");
+	assert.equal((result.diagnostics as { error_code?: string }).error_code, NATIVE_REVIEW_ERROR_CODE.NON_ZERO);
+	assert.deepEqual(result.reconciliation, { schema: "gentle-ai.review-integration.status/v5" });
+	assert.equal(statusCalls, 2);
+	assert.equal(acknowledgementCalls, 1);
+});
+
+test("public acknowledgement rejects a typed decoy provider vector before invocation", async () => {
+	const lineageId = "decoy-acknowledgement";
+	const decoy = approvedAcknowledgementStatus(lineageId);
+	const target = decoy.nextTransition!.execute!.arguments[2]!;
+	target.value = `sha256:${"b".repeat(64)}`;
+	target.token = `--target=${target.value}`;
+	let statusCalls = 0;
+	let acknowledgementCalls = 0;
+	const native = {
+		targetStatus: async () => { statusCalls += 1; return decoy; },
+		acknowledgeApproved: async () => { acknowledgementCalls += 1; },
+	} as unknown as NativeReviewCli;
+
+	const result = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, process.cwd(), native);
+	assert.equal(result.outcome, "native-operation-failed");
+	assert.equal(result.mutation_outcome, "none");
+	assert.equal(statusCalls, 1);
+	assert.equal(acknowledgementCalls, 0);
+});
+
+test("public acknowledgement rejects a mismatched provider cwd before invocation", async () => {
+	let invoked = false;
+	const result = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId: "mismatched-cwd" }, process.cwd(), {
+		targetStatus: async () => approvedAcknowledgementStatus("mismatched-cwd", "/provider/mismatch"),
+		acknowledgeApproved: async () => { invoked = true; },
+	} as unknown as NativeReviewCli);
+	assert.deepEqual({ outcome: result.outcome, invoked }, { outcome: "native-operation-failed", invoked: false });
+});
+
+test("local acknowledgement failure remains pre-launch and does not reconcile STATUS", async () => {
+	const lineageId = "local-acknowledgement-failure";
+	let statusCalls = 0;
+	let acknowledgementCalls = 0;
+	const native = {
+		targetStatus: async () => { statusCalls += 1; return approvedAcknowledgementStatus(lineageId); },
+		acknowledgeApproved: async () => { acknowledgementCalls += 1; throw new TypeError("local acknowledgement validation failed"); },
+	} as unknown as NativeReviewCli;
+
+	const result = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, process.cwd(), native);
+	assert.equal(result.outcome, "native-operation-failed");
+	assert.equal(result.mutation_outcome, "none");
+	assert.equal(statusCalls, 1);
+	assert.equal(acknowledgementCalls, 1);
+});
+
 function correctionPlanInput(lineageId: string): ReviewCollectInputV3 {
 	const arguments_ = [{ name: "lineage", value: lineageId, token: `--lineage=${lineageId}` }, { name: "target", value: SHA, token: `--target=${SHA}` }];
 	return { name: "correction_plan", schema: "https://gentle-ai.dev/schema/review/correction-plan/v1", captureOperation: "review.capture-correction-plan", arguments: arguments_, submission: { operationToken: "capture-correction-plan", argumentTokens: [`--lineage=${lineageId}`, "--correction-lines={{value}}"], values: [{ slot: "correction_lines", domain: "integer", substitutionLocation: 1, minimum: 1, maximum: 200 }] } } as unknown as ReviewCollectInputV3;

--- a/tests/review-integration-v2.test.ts
+++ b/tests/review-integration-v2.test.ts
@@ -405,6 +405,44 @@ test("next_transition decodes an execute variant and rejects a stop that carries
 	assert.throws(() => decodeReviewNextTransitionV3(stopWithExecute), /stop cannot carry/);
 });
 
+function approvedAcknowledgementTransition(): JsonObject {
+	return {
+		kind: "execute",
+		reason_code: "approved_acknowledgement_required",
+		execute: {
+			operation: "review.acknowledge-approved",
+			command: "gentle-ai review acknowledge-approved --provider-vector",
+			arguments: [
+				{ name: "cwd", value: "/provider/repository", token: "--cwd=/provider/repository" },
+				{ name: "lineage", value: "review-fixture", token: "--lineage=review-fixture" },
+				{ name: "target", value: digest, token: `--target=${digest}` },
+				{ name: "expected-revision", value: digest, token: `--expected-revision=${digest}` },
+				{ name: "token", value: "provider-issued-once", token: "--token=provider-issued-once" },
+			],
+			preconditions: [{ name: "state", value: "approved", token: "--state=approved" }],
+			binding: { lineage_id: "review-fixture", target_identity: digest, revision: digest },
+		},
+	};
+}
+
+test("acknowledgement execute rejects decoy bindings, closed-vector drift, and malformed approval", () => {
+	const valid = approvedAcknowledgementTransition();
+	assert.equal(decodeReviewNextTransitionV3(valid).execute?.operation, "review.acknowledge-approved");
+	const cases: Array<[string, (candidate: JsonObject) => void]> = [
+		["decoy target", (candidate) => { const argument = ((candidate.execute as JsonObject).arguments as JsonObject[])[2]!; argument.value = `sha256:${"b".repeat(64)}`; argument.token = `--target=${argument.value}`; }],
+		["mismatched expected revision", (candidate) => { const argument = ((candidate.execute as JsonObject).arguments as JsonObject[])[3]!; argument.value = `sha256:${"c".repeat(64)}`; argument.token = `--expected-revision=${argument.value}`; }],
+		["wrong argument order", (candidate) => { ((candidate.execute as JsonObject).arguments as JsonObject[]).reverse(); }],
+		["wrong argument name", (candidate) => { const argument = ((candidate.execute as JsonObject).arguments as JsonObject[])[0]!; argument.name = "repository"; argument.token = `--repository=${argument.value}`; }],
+		["malformed approved precondition", (candidate) => { ((candidate.execute as JsonObject).preconditions as JsonObject[])[0]!.value = "burned"; }],
+		["token value mismatch", (candidate) => { ((candidate.execute as JsonObject).arguments as JsonObject[])[4]!.token = "--token=other"; }],
+	];
+	for (const [name, mutate] of cases) {
+		const candidate = clone(valid);
+		mutate(candidate);
+		assert.throws(() => decodeReviewNextTransitionV3(candidate), /acknowledgement|arguments|preconditions|binding/, name);
+	}
+});
+
 test("repair decodes a committed execute result and rejects a non-eligible preflight carrying provider_inputs", () => {
 	const executed: JsonObject = {
 		schema: "gentle-ai.review-integration.repair/v2",


### PR DESCRIPTION
## Summary

- expose `review.acknowledge-approved` as a first-class public controller operation
- bind the provider-issued acknowledgement vector to fresh STATUS lineage, target, revision, and repository cwd before invocation
- relay the exact provider tokens once, reconcile only ambiguous launched failures, and never replay after authority burn
- centralize acknowledgement-vector validation and keep the generated runtime mirror in parity
- add controller and integration regression coverage, including cross-repository cwd rejection

## Review evidence

- native RDD lineage: `review-b830af45cb817c71`
- four high-risk lenses completed
- deterministic cross-repository authority-burn finding corrected within 16/20 planned lines
- targeted correction validator approved
- exact acknowledgement completed once; authority burned and STATUS reported zero remaining lineages

## Testing

- `pnpm test`: 1117 passed, 1 skipped
- `pnpm run check:runtime-modules`: passed
- `pnpm run check:provider-contract`: passed
- `pnpm run test:harness`: passed
- `git diff --check origin/main...HEAD`: passed

## Review size

- 365 additions + 88 deletions = 453 changed lines
- explicit maintainer size exception authorized for this corrected work unit
- consent diagnostics were delivered separately in #489

Closes #486


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `acknowledge-approved` operation to the review controller.
  - Approved review acknowledgements can now be relayed through the native CLI with single-use authority handling.
  - Added validation to ensure acknowledgement requests match the approved review, target, revision, working directory, and provider-issued arguments.

- **Bug Fixes**
  - Ambiguous acknowledgement outcomes are reconciled using status information.
  - Invalid or mismatched acknowledgement requests are rejected before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->