### PR TITLE
fix(review): restore reopened untracked selector

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5133,13 +5133,16 @@ async function executeReviewControllerOperation(
 			(untrackedSelection.reason !== undefined || (baseRef === undefined && untrackedSelection.untrackedScope === undefined))
 		) return nativeStatusInputRejection(untrackedSelection.reason ?? "untracked-selection-invalid");
 		const retainedUntrackedSelection = cloneRetainedNativeUntrackedSelection(untrackedSelection);
+		const effectiveUntrackedSelection = rawStatus === undefined && parameters.lineageId !== undefined
+			? readRetainedNativeUntrackedSelection(retainedUntrackedSelections, defaultCwd, parameters.lineageId)
+			: untrackedSelection;
 		if (nativeReviewCli?.targetStatus !== undefined) {
 			try {
 				const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, {
 					cwd: defaultCwd,
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 					...(baseRef === undefined ? {} : { baseRef, committedOnly: true }),
-					...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
+					...(effectiveUntrackedSelection.untrackedScope === undefined ? {} : effectiveUntrackedSelection),
 					...(signal === undefined ? {} : { signal }),
 				}, retainedUntrackedSelections, defaultCwd);
 				if (negotiated.transport !== undefined) {

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -283,6 +283,109 @@ test("REPAIR retains frozen committed collect selectors and leaves workspace rou
 	assert.deepEqual(workspaceRequests, [{ cwd, lineageId: workspaceLineage }]);
 });
 
+test("STATUS preserves retained intended-untracked selection through selectorless same-lineage replacement collection", async () => {
+	const cwd = process.cwd();
+	const lineageId = "selectorless-replacement";
+	const selectedUntracked = {
+		untrackedScope: "select",
+		expectedUntrackedInventory: "inventory-sha256",
+		intendedUntracked: ["generated/report.json"],
+	};
+	const initial = correctionPlanInput(lineageId);
+	const replacement: ReviewCollectInputV3 = {
+		...correctionPlanInput(lineageId),
+		arguments: [
+			...correctionPlanInput(lineageId).arguments,
+			{ name: "replacement", value: "b", token: "--replacement=b" },
+		],
+	};
+	const selections = new Map();
+	const requests: Array<Record<string, unknown>> = [];
+	let captures = 0;
+	const native = {
+		targetStatus: async (request: Record<string, unknown>) => {
+			requests.push(request);
+			return "baseRef" in request
+				? status(lineageId, [])
+				: status(lineageId, [requests.length === 1 ? initial : replacement]);
+		},
+		captureCorrectionPlan: async ({ correctionLines, cwd: captureCwd }: { correctionLines: number; cwd: string }) => {
+			captures += 1;
+			assert.deepEqual({ correctionLines, cwd: captureCwd }, { correctionLines: 1, cwd });
+			return { schema: "gentle-ai.review-last-event-closure/v1", operation: "review.capture-correction-plan", lineageId, state: "correction_required", storeRevision: SHA };
+		},
+	} as unknown as NativeReviewCli;
+
+	const initialStatus = await __testing.executeReviewControllerOperation(
+		{ operation: "status", lineageId, input: JSON.stringify(selectedUntracked) },
+		cwd,
+		native,
+		undefined,
+		undefined,
+		undefined,
+		selections,
+	);
+	assert.equal(selections.size, 2);
+	await __testing.executeReviewControllerOperation(
+		{ operation: "status", lineageId, input: JSON.stringify({ baseRef: "main", committedOnly: true }) },
+		cwd,
+		native,
+		undefined,
+		undefined,
+		undefined,
+		selections,
+	);
+	assert.deepEqual(requests[1], { cwd, lineageId, agent: "pi", baseRef: "main", committedOnly: true });
+	assert.equal(selections.size, 1);
+	const replacementStatus = await __testing.executeReviewControllerOperation(
+		{ operation: "status", lineageId },
+		cwd,
+		native,
+		undefined,
+		undefined,
+		undefined,
+		selections,
+	);
+	assert.equal(selections.size, 2);
+	const bindingA = bindingOf(initialStatus);
+	const bindingB = bindingOf(replacementStatus);
+	assert.notEqual(bindingA, bindingB);
+
+	const stale = await __testing.executeReviewCaptureOperation(
+		{ lineageId, collectBinding: bindingA, correctionLines: 1 },
+		cwd,
+		native,
+		undefined,
+		undefined,
+		selections,
+		true,
+	);
+	assert.deepEqual({ outcome: stale.outcome, requests: requests.length, captures }, { outcome: "capture-binding-rejected", requests: 3, captures: 0 });
+
+	const captured = await __testing.executeReviewCaptureOperation(
+		{ lineageId, collectBinding: bindingB, correctionLines: 1 },
+		cwd,
+		native,
+		undefined,
+		undefined,
+		selections,
+		true,
+	);
+	assert.equal(captured.outcome, "native-last-event-closure");
+	assert.deepEqual(requests, [
+		{ cwd, lineageId, agent: "pi", ...selectedUntracked },
+		{ cwd, lineageId, agent: "pi", baseRef: "main", committedOnly: true },
+		{ cwd, lineageId, agent: "pi", ...selectedUntracked },
+		{ cwd, lineageId, agent: "pi", ...selectedUntracked },
+	]);
+	assert.equal(captures, 1);
+
+	const override = { ...selectedUntracked, expectedUntrackedInventory: "override-inventory", intendedUntracked: ["generated/override.json"] };
+	await __testing.executeReviewControllerOperation({ operation: "status", lineageId, input: JSON.stringify(override) }, cwd, native, undefined, undefined, undefined, selections);
+	await __testing.executeReviewControllerOperation({ operation: "status", lineageId }, cwd, native, undefined, undefined, undefined, selections);
+	assert.deepEqual(requests.slice(-2), Array.from({ length: 2 }, () => ({ cwd, lineageId, agent: "pi", ...override })));
+});
+
 test("route retention caps, rejects collisions and invalid selectors, and clears every terminal state", async () => {
 	const native = { targetStatus: async (request: Record<string, unknown>) => status(String(request.lineageId)) } as unknown as NativeReviewCli;
 	const selections = new Map();


### PR DESCRIPTION
## Summary

- restore retained intended-untracked selection for selectorless same-lineage STATUS after reviewer-result reopen
- keep explicit committed and intended-untracked selectors authoritative without cross-product leakage
- register only the fresh replacement collect route, reject the stale binding, and capture the replacement exactly once

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Reuse retained untracked selection only when STATUS omits its selector entirely. |
| `tests/review-controller-native-routing.test.ts` | Cover replacement binding registration, stale binding rejection, exact capture, explicit override, and committed-selector isolation. |

## Test plan

- [x] Focused regression: 1 passed
- [x] Native routing suite: 34 passed
- [x] Full suite: 1111 passed, 1 skipped
- [x] Runtime modules: 4 matched
- [x] Provider contract: version 1.1.0, 8 bundle entries, 2 generated baselines
- [x] Runtime harness: passed
- [x] `git diff --check`: passed

## Review evidence

- Native RDD lineage: `review-55efb187c8f53f83`
- Frozen target: `sha256:8e69ce521cd067960e76de8f3897b1401e51b32251b66a60b82e5f3a18dd66bf`
- Reliability review: approved without correction
- Exact acknowledgement completed once; authority burned
- Delivery follows ordinary repository policy

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Included tests with the behavior change
- [x] Used a conventional commit
- [x] No `Co-Authored-By` trailers

Closes #491


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved untracked selection settings during status checks when no selector is explicitly provided.
  * Improved handling of replacement collection inputs so the active collection binding remains accurate.
  * Prevented capture attempts using stale bindings while allowing capture with the current binding.

* **Tests**
  * Added coverage for retained selections, selectorless status checks, replacement collections, and binding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->