### PR TITLE
fix(review): validate consent choice agent bindings

### DIFF
--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -1592,6 +1592,19 @@ function exactConsentOption(arguments_: readonly string[], name: string): string
 	return values[0]!;
 }
 
+// A Pi consent envelope is bound to Pi only when every exact provider replay
+// path carries exactly one `--agent pi` option. The outer envelope agent alone
+// cannot bind an omitted, embedded, duplicated, or conflicting invocation.
+function validatePiConsentChoiceAgentBindings(consent: ReviewConsentEnvelope): void {
+	if (!("agent" in consent) || consent.agent !== "pi") return;
+	for (const choice of consent.choices) {
+		const arguments_ = splitNativeConsentInvocation(choice.invocation).slice(1);
+		if (exactConsentOption(arguments_, "--agent") !== "pi") {
+			throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
+		}
+	}
+}
+
 function optionalConsentLineageOption(arguments_: readonly string[]): string | undefined {
 	const values: string[] = [];
 	for (let index = 0; index < arguments_.length; index += 1) {
@@ -1616,6 +1629,7 @@ interface ConsentInvocation {
 }
 
 function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): ConsentInvocation {
+	validatePiConsentChoiceAgentBindings(request.consent);
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
 	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
@@ -1830,11 +1844,12 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		// v2.1+) emits consent/v3, and any other identity fails closed inside
 		// the v3 decoder's exact identity gate.
 		if (execution.body.action === "consent_required") {
-			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => (
-				execution.body.schema === "gentle-ai.review-integration.consent/v2"
-					? decodeReviewConsentV2(execution.body)
-					: decodeReviewConsentV3(execution.body, "pi")
-			));
+			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => {
+				if (execution.body.schema === "gentle-ai.review-integration.consent/v2") return decodeReviewConsentV2(execution.body);
+				const decoded = decodeReviewConsentV3(execution.body, "pi");
+				validatePiConsentChoiceAgentBindings(decoded);
+				return decoded;
+			});
 			if (consent.targetIdentity !== targetIdentity || consent.projection !== projection) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent target binding mismatch");
 			throw new NativeReviewConsentRequiredError(consent);
 		}

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -1593,6 +1593,19 @@ function exactConsentOption(arguments_                   , name        )        
 	return values[0] ;
 }
 
+// A Pi consent envelope is bound to Pi only when every exact provider replay
+// path carries exactly one `--agent pi` option. The outer envelope agent alone
+// cannot bind an omitted, embedded, duplicated, or conflicting invocation.
+function validatePiConsentChoiceAgentBindings(consent                       )       {
+	if (!("agent" in consent) || consent.agent !== "pi") return;
+	for (const choice of consent.choices) {
+		const arguments_ = splitNativeConsentInvocation(choice.invocation).slice(1);
+		if (exactConsentOption(arguments_, "--agent") !== "pi") {
+			throw new NativeReviewConsentBindingError("consent-invocation-agent-changed", "Native Pi consent invocation agent binding changed");
+		}
+	}
+}
+
 function optionalConsentLineageOption(arguments_                   )                     {
 	const values           = [];
 	for (let index = 0; index < arguments_.length; index += 1) {
@@ -1617,6 +1630,7 @@ function optionalConsentLineageOption(arguments_                   )            
 
 
 function consentInvocationArguments(request                                  )                    {
+	validatePiConsentChoiceAgentBindings(request.consent);
 	const choice = request.consent.choices.find((candidate) => candidate.answer === request.answer);
 	if (choice === undefined) throw new NativeReviewConsentBindingError("consent-answer-unknown", "Native consent answer must be granted or declined");
 	const words = splitNativeConsentInvocation(choice.invocation);
@@ -1831,11 +1845,12 @@ export class NativeReviewCliV216                            {
 		// v2.1+) emits consent/v3, and any other identity fails closed inside
 		// the v3 decoder's exact identity gate.
 		if (execution.body.action === "consent_required") {
-			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => (
-				execution.body.schema === "gentle-ai.review-integration.consent/v2"
-					? decodeReviewConsentV2(execution.body)
-					: decodeReviewConsentV3(execution.body, "pi")
-			));
+			const consent = decode(NATIVE_REVIEW_OPERATION.START, true, () => {
+				if (execution.body.schema === "gentle-ai.review-integration.consent/v2") return decodeReviewConsentV2(execution.body);
+				const decoded = decodeReviewConsentV3(execution.body, "pi");
+				validatePiConsentChoiceAgentBindings(decoded);
+				return decoded;
+			});
 			if (consent.targetIdentity !== targetIdentity || consent.projection !== projection) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent target binding mismatch");
 			throw new NativeReviewConsentRequiredError(consent);
 		}

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -334,7 +334,51 @@ test("declined consent decodes the provider's explicit empty authority fields wi
 const devbinaryFixtureRoot = join(process.cwd(), "tests", "fixtures", "devbinary");
 const devbinaryFixture = <T = Record<string, unknown>>(name: string): T => JSON.parse(readFileSync(join(devbinaryFixtureRoot, name), "utf8")) as T;
 
-test("Pi START rejects a foreign consent/v3 envelope and only relays a Pi-bound clone", async () => {
+function piConsent(rewriteInvocation: (invocation: string) => string = (invocation) => invocation): Record<string, unknown> {
+	const consent = devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json");
+	consent.agent = "pi";
+	for (const choice of consent.choices as Array<Record<string, unknown>>) {
+		choice.invocation = rewriteInvocation(String(choice.invocation));
+	}
+	return consent;
+}
+
+function piBoundConsent(): Record<string, unknown> {
+	return piConsent((invocation) => invocation.replace(" --consent ", " --agent pi --consent "));
+}
+
+test("Pi START rejects a Pi-bound consent/v3 envelope when any provider choice omits or misbinds the Pi agent", async () => {
+	const target = String(devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json").target_identity);
+	const tokens = startTransitionTokens(target);
+	const invalidUnselectedChoice = (replace: (invocation: string) => string): Record<string, unknown> => {
+		const consent = piBoundConsent();
+		const choice = (consent.choices as Array<Record<string, unknown>>).find((candidate) => candidate.answer === "declined")!;
+		choice.invocation = replace(String(choice.invocation));
+		return consent;
+	};
+	const cases = [
+		["missing", piConsent()],
+		["embedded", piConsent((invocation) => invocation.replace(" --consent ", " --note=--agent\\ pi --consent "))],
+		["duplicate", invalidUnselectedChoice((invocation) => invocation.replace("--agent pi", "--agent pi --agent pi"))],
+		["conflicting", invalidUnselectedChoice((invocation) => invocation.replace("--agent pi", "--agent pi --agent claude-code"))],
+	] as const;
+	for (const [label, consent] of cases) {
+		for (const createClient of [client, runtimeClient]) {
+			const queue = queuedAdapter([capabilities(), executableStartStatus(target), structuredClone(consent)]);
+			await assert.rejects(
+				() => createClient(queue.adapter).start({ cwd: "/repo" }),
+				(error: unknown) => {
+					assert.equal((error as { name?: string }).name, "NativeReviewCliError", `${label} binding must fail closed before consent presentation`);
+					assert.equal((error as { code?: string }).code, "schema-incompatible");
+					return true;
+				},
+			);
+			assert.deepEqual(queue.calls.at(-1), ["review", "start", ...tokens]);
+		}
+	}
+});
+
+test("Pi START rejects a foreign consent/v3 envelope and only relays exact Pi-bound choice invocations", async () => {
 	const consent = devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json");
 	const target = String(consent.target_identity);
 	const tokens = startTransitionTokens(target);
@@ -349,26 +393,30 @@ test("Pi START rejects a foreign consent/v3 envelope and only relays a Pi-bound 
 			},
 		);
 		assert.deepEqual(foreignQueue.calls.at(-1), ["review", "start", ...tokens]);
-		const piConsent = { ...structuredClone(consent), agent: "pi" };
-		const piQueue = queuedAdapter([capabilities(), executableStartStatus(target), piConsent]);
-		await assert.rejects(
-			() => createClient(piQueue.adapter).start({ cwd: "/repo" }),
-			(error: unknown) => {
-				assert.equal((error as { name?: string }).name, "NativeReviewConsentRequiredError");
-				const required = error as { consent: { raw: Record<string, unknown>; schema: string; targetIdentity: string; agent?: string } };
-				assert.deepEqual(required.consent.raw, piConsent);
-				assert.equal(required.consent.schema, "gentle-ai.review-integration.consent/v3");
-				assert.equal(required.consent.targetIdentity, target);
-				assert.equal(required.consent.agent, "pi");
-				return true;
-			},
-		);
-		assert.deepEqual(piQueue.calls.at(-1), ["review", "start", ...tokens]);
+		for (const piBound of [
+			piBoundConsent(),
+			piConsent((invocation) => invocation.replace(" --consent ", " --agent=pi --consent ")),
+		]) {
+			const piQueue = queuedAdapter([capabilities(), executableStartStatus(target), piBound]);
+			await assert.rejects(
+				() => createClient(piQueue.adapter).start({ cwd: "/repo" }),
+				(error: unknown) => {
+					assert.equal((error as { name?: string }).name, "NativeReviewConsentRequiredError");
+					const required = error as { consent: { raw: Record<string, unknown>; schema: string; targetIdentity: string; agent?: string } };
+					assert.deepEqual(required.consent.raw, piBound);
+					assert.equal(required.consent.schema, "gentle-ai.review-integration.consent/v3");
+					assert.equal(required.consent.targetIdentity, target);
+					assert.equal(required.consent.agent, "pi");
+					return true;
+				},
+			);
+			assert.deepEqual(piQueue.calls.at(-1), ["review", "start", ...tokens]);
+		}
 	}
 });
 
-test("a granted consent/v3 answer decodes the captured start/v3 result with its event binding", async () => {
-	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json"));
+test("a granted Pi consent/v3 answer replays the captured exact agent-bound invocation", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(piBoundConsent(), "pi");
 	const cwd = decoded.choices[0].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
 	const started = devbinaryFixture<Record<string, unknown>>("start-v3-consent-granted.captured.json");
 	const queue = queuedAdapter([capabilities(), started]);
@@ -379,6 +427,7 @@ test("a granted consent/v3 answer decodes the captured start/v3 result with its 
 	assert.equal(result.start.selectedLenses.length, 4);
 	// The follow-up runs the provider-owned invocation verbatim, exactly once.
 	assert.deepEqual(queue.calls.at(-1), decoded.choices[0].invocation.split(" ").slice(1));
+	assert.equal(queue.calls.filter((arguments_) => arguments_.includes("--agent") && arguments_.includes("pi")).length, 1);
 	assert.equal(queue.calls.filter((arguments_) => arguments_.includes("granted")).length, 1);
 
 	const runtimeQueue = queuedAdapter([capabilities(), structuredClone(started)]);
@@ -386,8 +435,8 @@ test("a granted consent/v3 answer decodes the captured start/v3 result with its 
 	assert.equal(runtimeResult.kind, "started");
 });
 
-test("a declined consent/v3 answer accepts the captured declined result and creates no authority", async () => {
-	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(devbinaryFixture<Record<string, unknown>>("consent-v3.captured.json"));
+test("a declined Pi consent/v3 answer replays the captured exact agent-bound invocation and creates no authority", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV3(piBoundConsent(), "pi");
 	const cwd = decoded.choices[1].invocation.split(" --cwd ")[1]!.split(" ")[0]!;
 	const declined = devbinaryFixture<Record<string, unknown>>("start-v3-consent-declined.captured.json");
 	const queue = queuedAdapter([capabilities(), declined]);
@@ -396,4 +445,6 @@ test("a declined consent/v3 answer accepts the captured declined result and crea
 	assert.ok(result.kind === "declined");
 	assert.equal(result.consent, "declined_this_candidate");
 	assert.equal(result.targetIdentity, decoded.targetIdentity);
+	assert.deepEqual(queue.calls.at(-1), decoded.choices[1].invocation.split(" ").slice(1));
+	assert.equal(queue.calls.filter((arguments_) => arguments_.includes("--agent") && arguments_.includes("pi")).length, 1);
 });


### PR DESCRIPTION
Closes #377

## Summary

- Validate every Pi consent/v3 choice invocation before consent is presented or replayed.
- Reject missing, embedded, duplicate, conflicting, and invalid unselected agent bindings while preserving exact valid replay.
- Replace the broad, stale direction in #378 with one current-main-native fail-closed invariant.

## Changes

| File | Change |
|------|--------|
| `lib/native-review-cli.ts` | Validate all Pi consent choice invocations with the existing token and exact-option parser. |
| `runtime/native-review-cli.mjs` | Regenerated runtime mirror. |
| `tests/native-review-consent.test.ts` | Add RED regression, sibling malformed cases, valid forms, and granted/declined replay coverage. |

## Test plan

- [x] RED on current main: 11 passed, 1 failed because missing choice binding still exposed consent.
- [x] Focused consent and transport suite: 19 passed.
- [x] Full `pnpm test`: 1,117 passed, 1 platform skip, 0 failed.
- [x] Generated runtime parity and package-file verification passed.
- [x] Packed-package E2E passed with the required native binary.
- [x] Candidate-specific high-risk RDD approved exact tree `912f914620081ac7bfc1d900d2e692f2412caf90`.

## Contributor checklist

- [x] Linked approved issue #377.
- [x] One `type:bug` label.
- [x] Conventional commit.
- [x] No `Co-Authored-By` trailers.
- [x] No fallback, controller plumbing, compatibility layer, or new runtime state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Pi consent validation to require exactly one matching `--agent pi` binding.
  * Consent requests now fail safely when the agent binding is missing, duplicated, embedded, or conflicting.
  * Granted and declined consent responses now consistently verify the original agent-bound invocation before continuing.
  * Applied the same protections across native and runtime clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->