### PR TITLE
fix(agents): remove pi-mono path residue

### DIFF
--- a/assets/agents/sdd-design.md
+++ b/assets/agents/sdd-design.md
@@ -22,7 +22,7 @@ If skill paths are missing, explicit fallback loading is allowed only as degrade
 
 - Read proposal, specs, and relevant code before designing.
 - Document decisions, data flow, file changes, contracts, tests, and rollout.
-- Keep design centered on `packages/coding-agent` unless scope explicitly expands.
+- Keep design centered on the approved change scope unless scope explicitly expands.
 - Do NOT launch child subagents. Parent/orchestrator owns delegation.
 - Return the SDD result contract.
 ## Memory Contract

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -129,9 +129,12 @@ test("shipped prompt and agent instructions contain no pi-mono repository residu
 		for (const pattern of forbidden) assert.doesNotMatch(content, pattern, path);
 	}
 
-	assert.ok(scannedPaths.includes("assets/orchestrator.md"), "scan must cover root asset instructions");
 	assert.ok(
-		scannedPaths.includes("assets/chains/4r-review.chain.md"),
+		scannedPaths.includes(join("assets", "orchestrator.md")),
+		"scan must cover root asset instructions",
+	);
+	assert.ok(
+		scannedPaths.includes(join("assets", "chains", "4r-review.chain.md")),
 		"scan must cover nested asset instructions",
 	);
 });

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -109,6 +109,24 @@ test("package manifest has no obsolete native activation build surface", () => {
 	assert.doesNotMatch(packageJson.scripts?.prepublishOnly ?? "", /native:build/);
 });
 
+test("shipped prompt and agent instructions contain no pi-mono repository residue", () => {
+	const instructionDirectories = ["assets/agents", "prompts"] as const;
+	const forbidden = [
+		/\bpackages\//,
+		/\bAGENTS\.md\b/,
+		/github\.com\/earendil-works\/pi-mono\/(?:issues|pull)\//,
+	] as const;
+
+	for (const directory of instructionDirectories) {
+		for (const entry of readdirSync(join(PACKAGE_ROOT, directory), { withFileTypes: true })) {
+			if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+			const path = join(directory, entry.name);
+			const content = readFileSync(join(PACKAGE_ROOT, path), "utf8");
+			for (const pattern of forbidden) assert.doesNotMatch(content, pattern, path);
+		}
+	}
+});
+
 test("package verification names the native review runtime boundary and packaged fixtures", () => {
 	const verifier = readFileSync(join(PACKAGE_ROOT, "scripts", "verify-package-files.mjs"), "utf8");
 	const manifest = readPackageJson();

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -110,21 +110,30 @@ test("package manifest has no obsolete native activation build surface", () => {
 });
 
 test("shipped prompt and agent instructions contain no pi-mono repository residue", () => {
-	const instructionDirectories = ["assets/agents", "prompts"] as const;
+	const instructionDirectories = ["assets", "prompts"] as const;
 	const forbidden = [
 		/\bpackages\//,
 		/\bAGENTS\.md\b/,
 		/github\.com\/earendil-works\/pi-mono\/(?:issues|pull)\//,
 	] as const;
-
-	for (const directory of instructionDirectories) {
-		for (const entry of readdirSync(join(PACKAGE_ROOT, directory), { withFileTypes: true })) {
-			if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+	const listMarkdownPaths = (directory: string): string[] =>
+		readdirSync(join(PACKAGE_ROOT, directory), { withFileTypes: true }).flatMap((entry) => {
 			const path = join(directory, entry.name);
-			const content = readFileSync(join(PACKAGE_ROOT, path), "utf8");
-			for (const pattern of forbidden) assert.doesNotMatch(content, pattern, path);
-		}
+			if (entry.isDirectory()) return listMarkdownPaths(path);
+			return entry.isFile() && entry.name.endsWith(".md") ? [path] : [];
+		});
+	const scannedPaths = instructionDirectories.flatMap(listMarkdownPaths);
+
+	for (const path of scannedPaths) {
+		const content = readFileSync(join(PACKAGE_ROOT, path), "utf8");
+		for (const pattern of forbidden) assert.doesNotMatch(content, pattern, path);
 	}
+
+	assert.ok(scannedPaths.includes("assets/orchestrator.md"), "scan must cover root asset instructions");
+	assert.ok(
+		scannedPaths.includes("assets/chains/4r-review.chain.md"),
+		"scan must cover nested asset instructions",
+	);
 });
 
 test("package verification names the native review runtime boundary and packaged fixtures", () => {


### PR DESCRIPTION
## Summary

- replace the stale `packages/coding-agent` SDD design constraint with an approved-change-scope rule
- add regression coverage that rejects `packages/` paths, `AGENTS.md`, and old `earendil-works/pi-mono` tracker links in shipped prompt and agent instructions
- keep legitimate upstream Pi theme `$schema` URLs untouched by limiting the check to instruction Markdown

## Testing

- `node --experimental-strip-types --test tests/package-manifest.test.ts` — 34 passed, 0 failed
- `pnpm test` — 1112 passed, 0 failed, 1 skipped
- `node scripts/verify-package-files.mjs` — passed (162 files; 68 exact byte-identical contract artifacts)
- `git diff --check`

Closes #298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated design guidance to apply to the approved change scope unless explicitly expanded.

* **Tests**
  * Added validation to detect repository-specific references in agent and prompt documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->