### PR TITLE
fix(review): accept provider-issued START v4 continuation

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3304,6 +3304,7 @@ function mapNativeStartResult(result: NativeStartResult): Record<string, unknown
 		// version's capability is dark (every shipped row today).
 		...(result.riskEvidence === undefined ? {} : { risk_evidence: result.riskEvidence }),
 		...(result.hint === undefined ? {} : { hint: result.hint }),
+		...(result.nextTransition === undefined ? {} : { next_transition: result.nextTransition }),
 	};
 }
 

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -14,11 +14,15 @@ import {
 	decodeReviewRepairV2,
 	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
+	decodeReviewStartV4,
 	decodeReviewStatusV3,
 	type ReviewConsentEnvelope,
 	type ReviewFailureV2,
 	type ReviewRepairV2,
+	type ReviewNextTransitionV3,
 	type ReviewStartState,
+	type ReviewStartV3,
+	type ReviewStartV4,
 	type ReviewStatusV3,
 	type ReviewLastEventClosureV1,
 } from "./review-integration-v2.ts";
@@ -556,9 +560,9 @@ export interface NativeReviewStatusResult {
 	diagnostics: readonly NativeReviewAuthorityDiagnostic[];
 	raw: Record<string, unknown>;
 }
-export const NATIVE_START_ACTION = { CREATED: "created", RESUMED: "resumed", CLOSED: "closed", BLOCKED_SCOPE_ACTION: "blocked-scope-action" } as const;
+export const NATIVE_START_ACTION = { CREATED: "created", RESUMED: "resumed", REPLAYED: "replayed", CLOSED: "closed", BLOCKED_SCOPE_ACTION: "blocked-scope-action" } as const;
 export type NativeStartAction = (typeof NATIVE_START_ACTION)[keyof typeof NATIVE_START_ACTION];
-export interface NativeStartResult { lineageId: string; state: ReviewStartState; riskLevel: string; selectedLenses: readonly string[]; changedFiles: number; changedLines: number; correctionBudget: number; action: NativeStartAction; lensesRequired: boolean; riskReasons?: readonly Record<string, unknown>[]; raw?: Readonly<Record<string, unknown>>; riskEvidence?: readonly string[]; hint?: string; }
+export interface NativeStartResult { lineageId: string; state: ReviewStartState; riskLevel: string; selectedLenses: readonly string[]; changedFiles: number; changedLines: number; correctionBudget: number; action: NativeStartAction; lensesRequired: boolean; riskReasons?: readonly Record<string, unknown>[]; nextTransition?: ReviewNextTransitionV3; raw?: Readonly<Record<string, unknown>>; riskEvidence?: readonly string[]; hint?: string; }
 export function isCanonicalProcessString(value: unknown): value is string {
 	return typeof value === "string" && value.length > 0 && value.trim() === value && !/[\u0000-\u001f\u007f]/.test(value);
 }
@@ -927,6 +931,12 @@ function assertSupportedNextTransitionOperation(body: Record<string, unknown>): 
 }
 function decode<T>(operation: NativeReviewOperation, mutating: boolean, callback: () => T, diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE)): T {
 	try { return callback(); } catch (error) { if (error instanceof NativeReviewCliError) throw error; throw new NativeReviewCliError(NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE, operation, true, mutating, "native response is schema incompatible", { ...diagnostics, error_code: NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE }); }
+}
+function decodeReviewStartResponse(value: unknown): ReviewStartV3 | ReviewStartV4 {
+	const body = object(value);
+	return body.schema === "gentle-ai.review-integration.start/v4"
+		? decodeReviewStartV4(body)
+		: decodeReviewStartV3(body);
 }
 function decodeReleaseEvidence(value: unknown): void {
 	const release = exactObject(value, ["release_tree", "configuration_hash", "generated_artifact_hash", "provenance_hash", "publication_boundary_hash", "publication_state", "evidence_freshness_hash", "evidence_freshness_state"]);
@@ -1853,7 +1863,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			if (consent.targetIdentity !== targetIdentity || consent.projection !== projection) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent target binding mismatch");
 			throw new NativeReviewConsentRequiredError(consent);
 		}
-		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartV3(execution.body));
+		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartResponse(execution.body));
 		if (request.lineageId !== undefined && result.lineageId !== request.lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native start lineage mismatch");
 		const resultTarget = result.targetIdentity ?? result.repositoryContext?.targetIdentity;
 		if (resultTarget !== undefined && resultTarget !== targetIdentity) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native start target mismatch");
@@ -1868,6 +1878,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			action: result.action as NativeStartAction,
 			lensesRequired: result.lensesRequired,
 			riskReasons: result.riskReasons.map((reason) => ({ ...reason })),
+			...("nextTransition" in result && result.nextTransition !== undefined ? { nextTransition: result.nextTransition } : {}),
 			// Derived, not received. `risk_reasons` is a required start/v2 field
 			// already recomputed against the authoritative frozen snapshot, so
 			// these phrases describe the same candidate the lenses will review.
@@ -1891,7 +1902,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		if (request.answer === NATIVE_REVIEW_CONSENT_ANSWER.DECLINED) {
 			return decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeDeclinedConsentStart(execution.body, request));
 		}
-		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartV3(execution.body));
+		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartResponse(execution.body));
 		const answeredTarget = result.targetIdentity ?? result.repositoryContext?.targetIdentity;
 		if (answeredTarget !== request.consent.targetIdentity) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer target mismatch");
 		if (invocation.lineageId !== undefined && result.lineageId !== invocation.lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer lineage mismatch");
@@ -1906,6 +1917,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			action: result.action as NativeStartAction,
 			lensesRequired: result.lensesRequired,
 			riskReasons: result.riskReasons.map((reason) => ({ ...reason })),
+			...("nextTransition" in result && result.nextTransition !== undefined ? { nextTransition: result.nextTransition } : {}),
 			...(() => {
 				const evidence = nativeRiskEvidencePhrases(result.riskLevel, result.riskReasons);
 				return evidence.length === 0 ? {} : { riskEvidence: evidence };

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1026,7 +1026,7 @@ function decodeChangedPathEntry(value: unknown, label: string): ChangedPathEntry
 // start/v3
 // ---------------------------------------------------------------------------
 
-export function decodeReviewStartV3(value: unknown): ReviewStartV3 {
+export function decodeReviewStartV3(value: unknown, overlayIdentitySatisfiesRepositoryContext = false): ReviewStartV3 {
 	const overlayFields = ["target_mode", "target_identity", "base_tree", "candidate_tree"] as const;
 	const body = exactRecord(value, "start", [
 		"schema", "contract", "operation", "action", "lenses_required", "lineage_id", "state", "risk_level",
@@ -1060,9 +1060,12 @@ export function decodeReviewStartV3(value: unknown): ReviewStartV3 {
 		throw new TypeError("start with selected_lenses requires base_tree, candidate_tree, and changed_path_manifest");
 	}
 
-	const requiresRepositoryContext = (action === "created" || action === "resumed") && state === REVIEW_START_STATE.REVIEWING;
+	const reviewingCreatedOrResumed = (action === "created" || action === "resumed") && state === REVIEW_START_STATE.REVIEWING;
+	// START/v4 may render the frozen target as the overlay identity instead of
+	// repository_context; absence is only excused when that identity is present.
+	const requiresRepositoryContext = reviewingCreatedOrResumed && !(overlayIdentitySatisfiesRepositoryContext && targetIdentity !== undefined);
 	if (requiresRepositoryContext && body.repository_context === undefined) throw new TypeError("start.repository_context is required when action is created/resumed and state is reviewing");
-	if (!requiresRepositoryContext && body.repository_context !== undefined) throw new TypeError("start.repository_context is only valid when action is created/resumed and state is reviewing");
+	if (!reviewingCreatedOrResumed && body.repository_context !== undefined) throw new TypeError("start.repository_context is only valid when action is created/resumed and state is reviewing");
 
 	let repositoryContext: ReviewRepositoryContextV2 | undefined;
 	if (body.repository_context !== undefined) {
@@ -1116,7 +1119,7 @@ export function decodeReviewStartV3(value: unknown): ReviewStartV3 {
 }
 
 function assertReviewStartV4StatusBinding(execute: ReviewNextTransitionExecuteV3, start: ReviewStartV3): void {
-	const expectedTargetIdentity = start.repositoryContext?.targetIdentity;
+	const expectedTargetIdentity = start.repositoryContext?.targetIdentity ?? start.targetIdentity;
 	const targetIdentityConflicts = expectedTargetIdentity === undefined || execute.binding.targetIdentity !== expectedTargetIdentity
 		|| (start.targetIdentity !== undefined && start.targetIdentity !== expectedTargetIdentity)
 		|| start.artifactSubjects.some((subject) => subject.targetIdentity !== expectedTargetIdentity);
@@ -1182,7 +1185,7 @@ export function decodeReviewStartV4(value: unknown): ReviewStartV4 {
 	if (closedApprovedZeroLens && nextTransition !== undefined) throw new TypeError("closed approved zero-lens START cannot carry next_transition");
 	const v3Body = { ...body };
 	delete v3Body.next_transition;
-	const decoded = decodeReviewStartV3({ ...v3Body, schema: "gentle-ai.review-integration.start/v3", action: v3Action });
+	const decoded = decodeReviewStartV3({ ...v3Body, schema: "gentle-ai.review-integration.start/v3", action: v3Action }, true);
 	if (reviewing) assertReviewStartV4StatusBinding(nextTransition!.execute!, decoded);
 	return { ...decoded, action, ...(nextTransition === undefined ? {} : { nextTransition }), raw: body };
 }

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -117,7 +117,6 @@ const REQUIRED_SCHEMAS_COMMON = Object.freeze([
 	"gentle-ai.review-integration.operation/v2",
 	"gentle-ai.review-integration.projection/v1",
 	"gentle-ai.review-integration.repair/v2",
-	"gentle-ai.review-integration.start/v3",
 	"gentle-ai.review-receipt/v1",
 	"gentle-ai.review-receipt/v2",
 	"gentle-ai.review-result-artifact/v2",
@@ -130,15 +129,19 @@ const REQUIRED_SCHEMAS_COMMON = Object.freeze([
 const CAPABILITIES_SCHEMA_IDENTITIES: Readonly<Record<string, { protocolMinor: number; requiredSchemas: readonly string[] }>> = Object.freeze({
 	"gentle-ai.review-integration.capabilities/v2": Object.freeze({
 		protocolMinor: 0,
-		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2", "gentle-ai.review-integration.consent/v2", "gentle-ai.review-integration.status/v3"]),
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2", "gentle-ai.review-integration.consent/v2", "gentle-ai.review-integration.start/v3", "gentle-ai.review-integration.status/v3"]),
 	}),
 	"gentle-ai.review-integration.capabilities/v2.1": Object.freeze({
 		protocolMinor: 1,
-		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.1", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.status/v3"]),
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.1", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.start/v3", "gentle-ai.review-integration.status/v3"]),
 	}),
 	"gentle-ai.review-integration.capabilities/v2.2": Object.freeze({
 		protocolMinor: 2,
-		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.2", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.status/v5"]),
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.2", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.start/v3", "gentle-ai.review-integration.status/v5"]),
+	}),
+	"gentle-ai.review-integration.capabilities/v2.3": Object.freeze({
+		protocolMinor: 3,
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.3", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.start/v4", "gentle-ai.review-integration.status/v5"]),
 	}),
 });
 const OPTIONAL_FEATURE_NAMES = Object.freeze([
@@ -290,6 +293,11 @@ export interface ReviewStartV3 {
 	changedPathManifest?: readonly ChangedPathEntry[];
 	repositoryContext?: ReviewRepositoryContextV2;
 	raw: Readonly<Record<string, unknown>>;
+}
+
+export interface ReviewStartV4 extends Omit<ReviewStartV3, "action"> {
+	action: "created" | "replayed" | "closed" | "blocked-scope-action";
+	nextTransition?: ReviewNextTransitionV3;
 }
 
 export interface ReviewProjectionDescriptorV1 {
@@ -1106,6 +1114,27 @@ export function decodeReviewStartV3(value: unknown): ReviewStartV3 {
 	};
 }
 
+export function decodeReviewStartV4(value: unknown): ReviewStartV4 {
+	const overlayFields = ["target_mode", "target_identity", "base_tree", "candidate_tree"] as const;
+	const body = exactRecord(value, "start", [
+		"schema", "contract", "operation", "action", "lenses_required", "lineage_id", "state", "risk_level",
+		"selected_lenses", "projection", "changed_files", "changed_lines", "correction_budget", "risk_reasons", "artifact_subjects",
+	], [...overlayFields, "changed_path_manifest", "repository_context", "acknowledgement", "next_transition"]);
+	requireIdentity(body, "gentle-ai.review-integration.start/v4", REVIEW_INTEGRATION_OPERATION.START);
+	const action = enumeration(body.action, ["created", "replayed", "closed", "blocked-scope-action"] as const, "start.action");
+	const v3Action = action === "replayed" ? "resumed" : action;
+	const nextTransition = body.next_transition === undefined ? undefined : decodeReviewNextTransitionV3(body.next_transition);
+	const reviewing = (action === "created" || action === "replayed") && body.state === REVIEW_START_STATE.REVIEWING;
+	if (reviewing && nextTransition?.kind !== "execute") throw new TypeError("reviewing created/replayed START requires next_transition.execute");
+	if (reviewing && nextTransition.execute?.operation !== "review.status") throw new TypeError("reviewing created/replayed START next_transition.execute.operation must be review.status");
+	const closedApprovedZeroLens = action === "closed" && body.state === REVIEW_START_STATE.APPROVED && Array.isArray(body.selected_lenses) && body.selected_lenses.length === 0;
+	if (closedApprovedZeroLens && nextTransition !== undefined) throw new TypeError("closed approved zero-lens START cannot carry next_transition");
+	const v3Body = { ...body };
+	delete v3Body.next_transition;
+	const decoded = decodeReviewStartV3({ ...v3Body, schema: "gentle-ai.review-integration.start/v3", action: v3Action });
+	return { ...decoded, action, ...(nextTransition === undefined ? {} : { nextTransition }), raw: body };
+}
+
 // ---------------------------------------------------------------------------
 // projection/v1 — reused verbatim; the v2 capabilities schema still advertises
 // gentle-ai.review-integration.projection/v1, so renaming this decoder would
@@ -1209,7 +1238,7 @@ export function decodeAuthorityRepairAssessmentV1(value: unknown): AuthorityRepa
 // collect inputs and the execute binding.
 // ---------------------------------------------------------------------------
 
-const NEXT_TRANSITION_OPERATIONS = ["review.start", "review.recover", "review.repair", "review.acknowledge-approved"] as const;
+const NEXT_TRANSITION_OPERATIONS = ["review.start", "review.status", "review.recover", "review.repair", "review.acknowledge-approved"] as const;
 
 function decodeTransitionArguments(value: unknown, label: string): readonly ReviewTransitionArgumentV3[] {
 	return array(value, label, (entry, entryLabel) => {

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -347,6 +347,7 @@ export interface ReviewTransitionArgumentV3 {
 export interface ReviewNextTransitionExecuteV3 {
 	operation: string;
 	arguments: readonly ReviewTransitionArgumentV3[];
+	selectorArguments?: readonly ReviewTransitionArgumentV3[];
 	preconditions: readonly ReviewTransitionArgumentV3[];
 	binding: { targetIdentity: string; lineageId?: string; revision?: string };
 	command?: string;
@@ -1136,6 +1137,32 @@ function assertReviewStartV4StatusBinding(execute: ReviewNextTransitionExecuteV3
 		if (Object.hasOwn(optionalSelectors, argument.name) && argument.value !== optionalSelectors[argument.name]) throw new TypeError(`START/v4 status ${argument.name} binding conflicts with frozen START`);
 	}
 	if (argumentsByName.get("lineage") !== start.lineageId) throw new TypeError("START/v4 status requires exactly one lineage binding for the frozen START");
+	if (execute.arguments.find((argument) => argument.name === "lineage")?.token !== `--lineage=${start.lineageId}`) throw new TypeError("START/v4 status lineage binding conflicts with frozen START");
+	for (const [name, value] of [["contract", REVIEW_INTEGRATION_CONTRACT], ["next-transition", "true"], ["agent", "pi"]]) {
+		if (argumentsByName.get(name) !== value || execute.arguments.find((argument) => argument.name === name)?.token !== `--${name}=${value}`) throw new TypeError(`START/v4 status ${name} binding conflicts with frozen START`);
+	}
+	const selectorArguments = execute.selectorArguments;
+	if (selectorArguments === undefined || selectorArguments.length === 0) throw new TypeError("START/v4 status selector arguments are required");
+	const selectorsByName = new Map<string, ReviewTransitionArgumentV3>();
+	for (const selector of selectorArguments) {
+		const full = execute.arguments.find((argument) => argument.name === selector.name);
+		if (selectorsByName.has(selector.name) || full === undefined || full.value !== selector.value || full.token !== selector.token) throw new TypeError(`START/v4 status selector ${selector.name} binding conflicts with full arguments`);
+		selectorsByName.set(selector.name, selector);
+	}
+	const selector = (name: string, value: string): void => {
+		if (selectorsByName.get(name)?.value !== value || selectorsByName.get(name)?.token !== `--${name}=${value}` || execute.arguments.find((argument) => argument.name === name)?.token !== `--${name}=${value}`) throw new TypeError(`START/v4 status selector ${name} binding conflicts with frozen START`);
+	};
+	const baseRef = argumentsByName.get("base-ref");
+	if (start.targetMode === "base-workspace-overlay") {
+		if (baseRef !== start.baseTree || argumentsByName.has("committed-only")) throw new TypeError("START/v4 status workspace overlay binding conflicts with frozen START");
+		selector("base-ref", start.baseTree!); selector("workspace-overlay", "true");
+	} else if (baseRef !== undefined) {
+		if (baseRef !== start.baseTree || argumentsByName.has("workspace-overlay")) throw new TypeError("START/v4 status committed range binding conflicts with frozen START");
+		selector("base-ref", start.baseTree!); selector("committed-only", "true");
+	} else {
+		if (argumentsByName.has("committed-only") || argumentsByName.has("workspace-overlay")) throw new TypeError("START/v4 status current projection binding conflicts with frozen START");
+		selector("projection", start.projection);
+	}
 }
 
 export function decodeReviewStartV4(value: unknown): ReviewStartV4 {
@@ -1566,6 +1593,7 @@ export function decodeReviewNextTransitionV3(value: unknown, options: { v5?: boo
 		const execute = exactRecord(transition.execute, "next_transition.execute", ["operation", "arguments", "preconditions", "binding"], ["command", "selector_arguments", "artifacts"]);
 		const operation = enumeration(execute.operation, NEXT_TRANSITION_OPERATIONS, "next_transition.execute.operation");
 		const argumentsList = decodeTransitionArguments(execute.arguments, "next_transition.execute.arguments");
+		const selectorArguments = execute.selector_arguments === undefined ? undefined : decodeTransitionArguments(execute.selector_arguments, "next_transition.execute.selector_arguments");
 		const preconditions = decodeTransitionArguments(execute.preconditions, "next_transition.execute.preconditions");
 		// The schema gives `binding` no declared properties and no required list:
 		// it is an OPEN object. Closing it here made Pi stricter than the
@@ -1576,7 +1604,7 @@ export function decodeReviewNextTransitionV3(value: unknown, options: { v5?: boo
 		const lineageId = binding.lineage_id === undefined ? undefined : lineage(binding.lineage_id, "next_transition.execute.binding.lineage_id");
 		const revision = binding.revision === undefined ? undefined : sha256(binding.revision, "next_transition.execute.binding.revision");
 		const command = execute.command === undefined ? undefined : nonempty(execute.command, "next_transition.execute.command");
-		const decodedExecute: ReviewNextTransitionExecuteV3 = { operation, arguments: argumentsList, preconditions, binding: { targetIdentity, ...(lineageId === undefined ? {} : { lineageId }), ...(revision === undefined ? {} : { revision }) }, ...(command === undefined ? {} : { command }) };
+		const decodedExecute: ReviewNextTransitionExecuteV3 = { operation, arguments: argumentsList, ...(selectorArguments === undefined ? {} : { selectorArguments }), preconditions, binding: { targetIdentity, ...(lineageId === undefined ? {} : { lineageId }), ...(revision === undefined ? {} : { revision }) }, ...(command === undefined ? {} : { command }) };
 		if (operation === "review.acknowledge-approved") assertReviewApprovedAcknowledgementExecuteV1(decodedExecute);
 		if (transition.collect !== undefined) throw new TypeError("next_transition.collect is incompatible with execute");
 		return { kind, reasonCode, execute: decodedExecute, ...(correctionRequest === undefined ? {} : { correctionRequest }) };

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1114,6 +1114,30 @@ export function decodeReviewStartV3(value: unknown): ReviewStartV3 {
 	};
 }
 
+function assertReviewStartV4StatusBinding(execute: ReviewNextTransitionExecuteV3, start: ReviewStartV3): void {
+	const expectedTargetIdentity = start.repositoryContext?.targetIdentity;
+	const targetIdentityConflicts = expectedTargetIdentity === undefined || execute.binding.targetIdentity !== expectedTargetIdentity
+		|| (start.targetIdentity !== undefined && start.targetIdentity !== expectedTargetIdentity)
+		|| start.artifactSubjects.some((subject) => subject.targetIdentity !== expectedTargetIdentity);
+	if (targetIdentityConflicts) throw new TypeError("START/v4 status target identity binding conflicts with frozen START");
+	if (execute.binding.lineageId !== undefined && execute.binding.lineageId !== start.lineageId) {
+		throw new TypeError("START/v4 status lineage binding conflicts with frozen START");
+	}
+	const optionalSelectors: Readonly<Record<string, string | undefined>> = {
+		"base-ref": start.baseTree,
+		"base-tree": start.baseTree,
+		projection: start.projection,
+		target: expectedTargetIdentity,
+	};
+	const argumentsByName = new Map<string, string>();
+	for (const argument of execute.arguments) {
+		if (argumentsByName.has(argument.name)) throw new TypeError(`START/v4 status arguments duplicate ${argument.name} binding`);
+		argumentsByName.set(argument.name, argument.value);
+		if (Object.hasOwn(optionalSelectors, argument.name) && argument.value !== optionalSelectors[argument.name]) throw new TypeError(`START/v4 status ${argument.name} binding conflicts with frozen START`);
+	}
+	if (argumentsByName.get("lineage") !== start.lineageId) throw new TypeError("START/v4 status requires exactly one lineage binding for the frozen START");
+}
+
 export function decodeReviewStartV4(value: unknown): ReviewStartV4 {
 	const overlayFields = ["target_mode", "target_identity", "base_tree", "candidate_tree"] as const;
 	const body = exactRecord(value, "start", [
@@ -1132,6 +1156,7 @@ export function decodeReviewStartV4(value: unknown): ReviewStartV4 {
 	const v3Body = { ...body };
 	delete v3Body.next_transition;
 	const decoded = decodeReviewStartV3({ ...v3Body, schema: "gentle-ai.review-integration.start/v3", action: v3Action });
+	if (reviewing) assertReviewStartV4StatusBinding(nextTransition!.execute!, decoded);
 	return { ...decoded, action, ...(nextTransition === undefined ? {} : { nextTransition }), raw: body };
 }
 

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -15,7 +15,11 @@ import {
 	decodeReviewRepairV2,
 	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
+	decodeReviewStartV4,
 	decodeReviewStatusV3,
+
+
+
 
 
 
@@ -557,7 +561,7 @@ export const NATIVE_REVIEW_RECOVERY_DISPOSITION = {
 
 
 
-export const NATIVE_START_ACTION = { CREATED: "created", RESUMED: "resumed", CLOSED: "closed", BLOCKED_SCOPE_ACTION: "blocked-scope-action" }         ;
+export const NATIVE_START_ACTION = { CREATED: "created", RESUMED: "resumed", REPLAYED: "replayed", CLOSED: "closed", BLOCKED_SCOPE_ACTION: "blocked-scope-action" }         ;
 
 
 export function isCanonicalProcessString(value         )                  {
@@ -928,6 +932,12 @@ function assertSupportedNextTransitionOperation(body                         )  
 }
 function decode   (operation                       , mutating         , callback         , diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE))    {
 	try { return callback(); } catch (error) { if (error instanceof NativeReviewCliError) throw error; throw new NativeReviewCliError(NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE, operation, true, mutating, "native response is schema incompatible", { ...diagnostics, error_code: NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE }); }
+}
+function decodeReviewStartResponse(value         )                                {
+	const body = object(value);
+	return body.schema === "gentle-ai.review-integration.start/v4"
+		? decodeReviewStartV4(body)
+		: decodeReviewStartV3(body);
 }
 function decodeReleaseEvidence(value         )       {
 	const release = exactObject(value, ["release_tree", "configuration_hash", "generated_artifact_hash", "provenance_hash", "publication_boundary_hash", "publication_state", "evidence_freshness_hash", "evidence_freshness_state"]);
@@ -1854,7 +1864,7 @@ export class NativeReviewCliV216                            {
 			if (consent.targetIdentity !== targetIdentity || consent.projection !== projection) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent target binding mismatch");
 			throw new NativeReviewConsentRequiredError(consent);
 		}
-		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartV3(execution.body));
+		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartResponse(execution.body));
 		if (request.lineageId !== undefined && result.lineageId !== request.lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native start lineage mismatch");
 		const resultTarget = result.targetIdentity ?? result.repositoryContext?.targetIdentity;
 		if (resultTarget !== undefined && resultTarget !== targetIdentity) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native start target mismatch");
@@ -1869,6 +1879,7 @@ export class NativeReviewCliV216                            {
 			action: result.action                     ,
 			lensesRequired: result.lensesRequired,
 			riskReasons: result.riskReasons.map((reason) => ({ ...reason })),
+			...("nextTransition" in result && result.nextTransition !== undefined ? { nextTransition: result.nextTransition } : {}),
 			// Derived, not received. `risk_reasons` is a required start/v2 field
 			// already recomputed against the authoritative frozen snapshot, so
 			// these phrases describe the same candidate the lenses will review.
@@ -1892,7 +1903,7 @@ export class NativeReviewCliV216                            {
 		if (request.answer === NATIVE_REVIEW_CONSENT_ANSWER.DECLINED) {
 			return decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeDeclinedConsentStart(execution.body, request));
 		}
-		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartV3(execution.body));
+		const result = decode(NATIVE_REVIEW_OPERATION.START, true, () => decodeReviewStartResponse(execution.body));
 		const answeredTarget = result.targetIdentity ?? result.repositoryContext?.targetIdentity;
 		if (answeredTarget !== request.consent.targetIdentity) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer target mismatch");
 		if (invocation.lineageId !== undefined && result.lineageId !== invocation.lineageId) throw nativeError(NATIVE_REVIEW_ERROR_CODE.IDENTITY_MISMATCH, NATIVE_REVIEW_OPERATION.START, true, "native consent answer lineage mismatch");
@@ -1907,6 +1918,7 @@ export class NativeReviewCliV216                            {
 			action: result.action                     ,
 			lensesRequired: result.lensesRequired,
 			riskReasons: result.riskReasons.map((reason) => ({ ...reason })),
+			...("nextTransition" in result && result.nextTransition !== undefined ? { nextTransition: result.nextTransition } : {}),
 			...(() => {
 				const evidence = nativeRiskEvidencePhrases(result.riskLevel, result.riskReasons);
 				return evidence.length === 0 ? {} : { riskEvidence: evidence };

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -353,6 +353,7 @@ const REPOSITORY_CONTEXT_OUTCOMES = ["applied", "pending", "blocked_conflict", "
 
 
 
+
 // Provider-owned completing form for a host-mediated capture slot
 // (gentle-pi#311 P4). The provider issues the exact operation and argument
 // tokens that submit the captured bytes; the host substitutes only the
@@ -1137,6 +1138,32 @@ function assertReviewStartV4StatusBinding(execute                               
 		if (Object.hasOwn(optionalSelectors, argument.name) && argument.value !== optionalSelectors[argument.name]) throw new TypeError(`START/v4 status ${argument.name} binding conflicts with frozen START`);
 	}
 	if (argumentsByName.get("lineage") !== start.lineageId) throw new TypeError("START/v4 status requires exactly one lineage binding for the frozen START");
+	if (execute.arguments.find((argument) => argument.name === "lineage")?.token !== `--lineage=${start.lineageId}`) throw new TypeError("START/v4 status lineage binding conflicts with frozen START");
+	for (const [name, value] of [["contract", REVIEW_INTEGRATION_CONTRACT], ["next-transition", "true"], ["agent", "pi"]]) {
+		if (argumentsByName.get(name) !== value || execute.arguments.find((argument) => argument.name === name)?.token !== `--${name}=${value}`) throw new TypeError(`START/v4 status ${name} binding conflicts with frozen START`);
+	}
+	const selectorArguments = execute.selectorArguments;
+	if (selectorArguments === undefined || selectorArguments.length === 0) throw new TypeError("START/v4 status selector arguments are required");
+	const selectorsByName = new Map                                    ();
+	for (const selector of selectorArguments) {
+		const full = execute.arguments.find((argument) => argument.name === selector.name);
+		if (selectorsByName.has(selector.name) || full === undefined || full.value !== selector.value || full.token !== selector.token) throw new TypeError(`START/v4 status selector ${selector.name} binding conflicts with full arguments`);
+		selectorsByName.set(selector.name, selector);
+	}
+	const selector = (name        , value        )       => {
+		if (selectorsByName.get(name)?.value !== value || selectorsByName.get(name)?.token !== `--${name}=${value}` || execute.arguments.find((argument) => argument.name === name)?.token !== `--${name}=${value}`) throw new TypeError(`START/v4 status selector ${name} binding conflicts with frozen START`);
+	};
+	const baseRef = argumentsByName.get("base-ref");
+	if (start.targetMode === "base-workspace-overlay") {
+		if (baseRef !== start.baseTree || argumentsByName.has("committed-only")) throw new TypeError("START/v4 status workspace overlay binding conflicts with frozen START");
+		selector("base-ref", start.baseTree ); selector("workspace-overlay", "true");
+	} else if (baseRef !== undefined) {
+		if (baseRef !== start.baseTree || argumentsByName.has("workspace-overlay")) throw new TypeError("START/v4 status committed range binding conflicts with frozen START");
+		selector("base-ref", start.baseTree ); selector("committed-only", "true");
+	} else {
+		if (argumentsByName.has("committed-only") || argumentsByName.has("workspace-overlay")) throw new TypeError("START/v4 status current projection binding conflicts with frozen START");
+		selector("projection", start.projection);
+	}
 }
 
 export function decodeReviewStartV4(value         )                {
@@ -1567,6 +1594,7 @@ export function decodeReviewNextTransitionV3(value         , options            
 		const execute = exactRecord(transition.execute, "next_transition.execute", ["operation", "arguments", "preconditions", "binding"], ["command", "selector_arguments", "artifacts"]);
 		const operation = enumeration(execute.operation, NEXT_TRANSITION_OPERATIONS, "next_transition.execute.operation");
 		const argumentsList = decodeTransitionArguments(execute.arguments, "next_transition.execute.arguments");
+		const selectorArguments = execute.selector_arguments === undefined ? undefined : decodeTransitionArguments(execute.selector_arguments, "next_transition.execute.selector_arguments");
 		const preconditions = decodeTransitionArguments(execute.preconditions, "next_transition.execute.preconditions");
 		// The schema gives `binding` no declared properties and no required list:
 		// it is an OPEN object. Closing it here made Pi stricter than the
@@ -1577,7 +1605,7 @@ export function decodeReviewNextTransitionV3(value         , options            
 		const lineageId = binding.lineage_id === undefined ? undefined : lineage(binding.lineage_id, "next_transition.execute.binding.lineage_id");
 		const revision = binding.revision === undefined ? undefined : sha256(binding.revision, "next_transition.execute.binding.revision");
 		const command = execute.command === undefined ? undefined : nonempty(execute.command, "next_transition.execute.command");
-		const decodedExecute                                = { operation, arguments: argumentsList, preconditions, binding: { targetIdentity, ...(lineageId === undefined ? {} : { lineageId }), ...(revision === undefined ? {} : { revision }) }, ...(command === undefined ? {} : { command }) };
+		const decodedExecute                                = { operation, arguments: argumentsList, ...(selectorArguments === undefined ? {} : { selectorArguments }), preconditions, binding: { targetIdentity, ...(lineageId === undefined ? {} : { lineageId }), ...(revision === undefined ? {} : { revision }) }, ...(command === undefined ? {} : { command }) };
 		if (operation === "review.acknowledge-approved") assertReviewApprovedAcknowledgementExecuteV1(decodedExecute);
 		if (transition.collect !== undefined) throw new TypeError("next_transition.collect is incompatible with execute");
 		return { kind, reasonCode, execute: decodedExecute, ...(correctionRequest === undefined ? {} : { correctionRequest }) };

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1115,6 +1115,30 @@ export function decodeReviewStartV3(value         )                {
 	};
 }
 
+function assertReviewStartV4StatusBinding(execute                               , start               )       {
+	const expectedTargetIdentity = start.repositoryContext?.targetIdentity;
+	const targetIdentityConflicts = expectedTargetIdentity === undefined || execute.binding.targetIdentity !== expectedTargetIdentity
+		|| (start.targetIdentity !== undefined && start.targetIdentity !== expectedTargetIdentity)
+		|| start.artifactSubjects.some((subject) => subject.targetIdentity !== expectedTargetIdentity);
+	if (targetIdentityConflicts) throw new TypeError("START/v4 status target identity binding conflicts with frozen START");
+	if (execute.binding.lineageId !== undefined && execute.binding.lineageId !== start.lineageId) {
+		throw new TypeError("START/v4 status lineage binding conflicts with frozen START");
+	}
+	const optionalSelectors                                               = {
+		"base-ref": start.baseTree,
+		"base-tree": start.baseTree,
+		projection: start.projection,
+		target: expectedTargetIdentity,
+	};
+	const argumentsByName = new Map                ();
+	for (const argument of execute.arguments) {
+		if (argumentsByName.has(argument.name)) throw new TypeError(`START/v4 status arguments duplicate ${argument.name} binding`);
+		argumentsByName.set(argument.name, argument.value);
+		if (Object.hasOwn(optionalSelectors, argument.name) && argument.value !== optionalSelectors[argument.name]) throw new TypeError(`START/v4 status ${argument.name} binding conflicts with frozen START`);
+	}
+	if (argumentsByName.get("lineage") !== start.lineageId) throw new TypeError("START/v4 status requires exactly one lineage binding for the frozen START");
+}
+
 export function decodeReviewStartV4(value         )                {
 	const overlayFields = ["target_mode", "target_identity", "base_tree", "candidate_tree"]         ;
 	const body = exactRecord(value, "start", [
@@ -1133,6 +1157,7 @@ export function decodeReviewStartV4(value         )                {
 	const v3Body = { ...body };
 	delete v3Body.next_transition;
 	const decoded = decodeReviewStartV3({ ...v3Body, schema: "gentle-ai.review-integration.start/v3", action: v3Action });
+	if (reviewing) assertReviewStartV4StatusBinding(nextTransition .execute , decoded);
 	return { ...decoded, action, ...(nextTransition === undefined ? {} : { nextTransition }), raw: body };
 }
 

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -118,7 +118,6 @@ const REQUIRED_SCHEMAS_COMMON = Object.freeze([
 	"gentle-ai.review-integration.operation/v2",
 	"gentle-ai.review-integration.projection/v1",
 	"gentle-ai.review-integration.repair/v2",
-	"gentle-ai.review-integration.start/v3",
 	"gentle-ai.review-receipt/v1",
 	"gentle-ai.review-receipt/v2",
 	"gentle-ai.review-result-artifact/v2",
@@ -131,15 +130,19 @@ const REQUIRED_SCHEMAS_COMMON = Object.freeze([
 const CAPABILITIES_SCHEMA_IDENTITIES                                                                                          = Object.freeze({
 	"gentle-ai.review-integration.capabilities/v2": Object.freeze({
 		protocolMinor: 0,
-		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2", "gentle-ai.review-integration.consent/v2", "gentle-ai.review-integration.status/v3"]),
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2", "gentle-ai.review-integration.consent/v2", "gentle-ai.review-integration.start/v3", "gentle-ai.review-integration.status/v3"]),
 	}),
 	"gentle-ai.review-integration.capabilities/v2.1": Object.freeze({
 		protocolMinor: 1,
-		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.1", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.status/v3"]),
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.1", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.start/v3", "gentle-ai.review-integration.status/v3"]),
 	}),
 	"gentle-ai.review-integration.capabilities/v2.2": Object.freeze({
 		protocolMinor: 2,
-		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.2", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.status/v5"]),
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.2", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.start/v3", "gentle-ai.review-integration.status/v5"]),
+	}),
+	"gentle-ai.review-integration.capabilities/v2.3": Object.freeze({
+		protocolMinor: 3,
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON, "gentle-ai.review-integration.capabilities/v2.3", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.start/v4", "gentle-ai.review-integration.status/v5"]),
 	}),
 });
 const OPTIONAL_FEATURE_NAMES = Object.freeze([
@@ -268,6 +271,11 @@ const REQUIRED_MANDATORY_FEATURES = Object.freeze(FEATURE_NAMES.filter((name) =>
 
 
 const REPOSITORY_CONTEXT_OUTCOMES = ["applied", "pending", "blocked_conflict", "durability_limited"]         ;
+
+
+
+
+
 
 
 
@@ -1107,6 +1115,27 @@ export function decodeReviewStartV3(value         )                {
 	};
 }
 
+export function decodeReviewStartV4(value         )                {
+	const overlayFields = ["target_mode", "target_identity", "base_tree", "candidate_tree"]         ;
+	const body = exactRecord(value, "start", [
+		"schema", "contract", "operation", "action", "lenses_required", "lineage_id", "state", "risk_level",
+		"selected_lenses", "projection", "changed_files", "changed_lines", "correction_budget", "risk_reasons", "artifact_subjects",
+	], [...overlayFields, "changed_path_manifest", "repository_context", "acknowledgement", "next_transition"]);
+	requireIdentity(body, "gentle-ai.review-integration.start/v4", REVIEW_INTEGRATION_OPERATION.START);
+	const action = enumeration(body.action, ["created", "replayed", "closed", "blocked-scope-action"]         , "start.action");
+	const v3Action = action === "replayed" ? "resumed" : action;
+	const nextTransition = body.next_transition === undefined ? undefined : decodeReviewNextTransitionV3(body.next_transition);
+	const reviewing = (action === "created" || action === "replayed") && body.state === REVIEW_START_STATE.REVIEWING;
+	if (reviewing && nextTransition?.kind !== "execute") throw new TypeError("reviewing created/replayed START requires next_transition.execute");
+	if (reviewing && nextTransition.execute?.operation !== "review.status") throw new TypeError("reviewing created/replayed START next_transition.execute.operation must be review.status");
+	const closedApprovedZeroLens = action === "closed" && body.state === REVIEW_START_STATE.APPROVED && Array.isArray(body.selected_lenses) && body.selected_lenses.length === 0;
+	if (closedApprovedZeroLens && nextTransition !== undefined) throw new TypeError("closed approved zero-lens START cannot carry next_transition");
+	const v3Body = { ...body };
+	delete v3Body.next_transition;
+	const decoded = decodeReviewStartV3({ ...v3Body, schema: "gentle-ai.review-integration.start/v3", action: v3Action });
+	return { ...decoded, action, ...(nextTransition === undefined ? {} : { nextTransition }), raw: body };
+}
+
 // ---------------------------------------------------------------------------
 // projection/v1 — reused verbatim; the v2 capabilities schema still advertises
 // gentle-ai.review-integration.projection/v1, so renaming this decoder would
@@ -1210,7 +1239,7 @@ export function decodeAuthorityRepairAssessmentV1(value         )               
 // collect inputs and the execute binding.
 // ---------------------------------------------------------------------------
 
-const NEXT_TRANSITION_OPERATIONS = ["review.start", "review.recover", "review.repair", "review.acknowledge-approved"]         ;
+const NEXT_TRANSITION_OPERATIONS = ["review.start", "review.status", "review.recover", "review.repair", "review.acknowledge-approved"]         ;
 
 function decodeTransitionArguments(value         , label        )                                        {
 	return array(value, label, (entry, entryLabel) => {

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1027,7 +1027,7 @@ function decodeChangedPathEntry(value         , label        )                  
 // start/v3
 // ---------------------------------------------------------------------------
 
-export function decodeReviewStartV3(value         )                {
+export function decodeReviewStartV3(value         , overlayIdentitySatisfiesRepositoryContext = false)                {
 	const overlayFields = ["target_mode", "target_identity", "base_tree", "candidate_tree"]         ;
 	const body = exactRecord(value, "start", [
 		"schema", "contract", "operation", "action", "lenses_required", "lineage_id", "state", "risk_level",
@@ -1061,9 +1061,12 @@ export function decodeReviewStartV3(value         )                {
 		throw new TypeError("start with selected_lenses requires base_tree, candidate_tree, and changed_path_manifest");
 	}
 
-	const requiresRepositoryContext = (action === "created" || action === "resumed") && state === REVIEW_START_STATE.REVIEWING;
+	const reviewingCreatedOrResumed = (action === "created" || action === "resumed") && state === REVIEW_START_STATE.REVIEWING;
+	// START/v4 may render the frozen target as the overlay identity instead of
+	// repository_context; absence is only excused when that identity is present.
+	const requiresRepositoryContext = reviewingCreatedOrResumed && !(overlayIdentitySatisfiesRepositoryContext && targetIdentity !== undefined);
 	if (requiresRepositoryContext && body.repository_context === undefined) throw new TypeError("start.repository_context is required when action is created/resumed and state is reviewing");
-	if (!requiresRepositoryContext && body.repository_context !== undefined) throw new TypeError("start.repository_context is only valid when action is created/resumed and state is reviewing");
+	if (!reviewingCreatedOrResumed && body.repository_context !== undefined) throw new TypeError("start.repository_context is only valid when action is created/resumed and state is reviewing");
 
 	let repositoryContext                                       ;
 	if (body.repository_context !== undefined) {
@@ -1117,7 +1120,7 @@ export function decodeReviewStartV3(value         )                {
 }
 
 function assertReviewStartV4StatusBinding(execute                               , start               )       {
-	const expectedTargetIdentity = start.repositoryContext?.targetIdentity;
+	const expectedTargetIdentity = start.repositoryContext?.targetIdentity ?? start.targetIdentity;
 	const targetIdentityConflicts = expectedTargetIdentity === undefined || execute.binding.targetIdentity !== expectedTargetIdentity
 		|| (start.targetIdentity !== undefined && start.targetIdentity !== expectedTargetIdentity)
 		|| start.artifactSubjects.some((subject) => subject.targetIdentity !== expectedTargetIdentity);
@@ -1183,7 +1186,7 @@ export function decodeReviewStartV4(value         )                {
 	if (closedApprovedZeroLens && nextTransition !== undefined) throw new TypeError("closed approved zero-lens START cannot carry next_transition");
 	const v3Body = { ...body };
 	delete v3Body.next_transition;
-	const decoded = decodeReviewStartV3({ ...v3Body, schema: "gentle-ai.review-integration.start/v3", action: v3Action });
+	const decoded = decodeReviewStartV3({ ...v3Body, schema: "gentle-ai.review-integration.start/v3", action: v3Action }, true);
 	if (reviewing) assertReviewStartV4StatusBinding(nextTransition .execute , decoded);
 	return { ...decoded, action, ...(nextTransition === undefined ? {} : { nextTransition }), raw: body };
 }

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -196,6 +196,8 @@ function reviewingStartV4(targetIdentity: string): Record<string, unknown> {
 			binding: { target_identity: targetIdentity },
 		},
 	};
+	const execute = (start.next_transition as Record<string, unknown>).execute as Record<string, unknown>;
+	execute.selector_arguments = (execute.arguments as Record<string, unknown>[]).slice(-2).map((argument) => ({ ...argument }));
 	return start;
 }
 
@@ -308,6 +310,10 @@ test("native START retains the provider-owned START/v4 status transition in exac
 		"--next-transition=true",
 		`--lineage=${result.lineageId}`,
 		"--agent=pi",
+		`--base-ref=${start.base_tree}`,
+		"--committed-only=true",
+	]);
+	assert.deepEqual(result.nextTransition?.execute?.selectorArguments?.map((argument) => argument.token), [
 		`--base-ref=${start.base_tree}`,
 		"--committed-only=true",
 	]);

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+	decodeReviewConsentV3,
+} from "../lib/review-integration-v2.ts";
+import {
 	NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES,
 	NATIVE_REVIEW_ERROR_CODE,
 	NativeReviewCliError,
@@ -170,6 +173,26 @@ function negotiatedStartStatus(targetIdentity: string, tokens: readonly string[]
 const TARGET = `sha256:${"b".repeat(64)}`;
 const REPOSITORY_CONTEXT = `rctx1_${"c".repeat(64)}`;
 
+function reviewingStartV4(targetIdentity: string): Record<string, unknown> {
+	const start = fixture("start-v3-consent-granted.captured.json");
+	start.schema = "gentle-ai.review-integration.start/v4";
+	(start.repository_context as Record<string, unknown>).target_identity = targetIdentity;
+	start.next_transition = {
+		kind: "execute",
+		reason_code: "review_status_required",
+		execute: {
+			operation: "review.status",
+			arguments: [
+				{ name: "lineage", value: start.lineage_id, token: `--lineage=${start.lineage_id}` },
+				{ name: "target", value: targetIdentity, token: `--target=${targetIdentity}` },
+			],
+			preconditions: [],
+			binding: { target_identity: targetIdentity },
+		},
+	};
+	return start;
+}
+
 test("negotiated STATUS forwards its exact ordered workspace, base, lineage, and untracked selection argv", async () => {
 	const queue = queuedAdapter([{ stdout: JSON.stringify(currentStatusFixture()) }]);
 	const result = await client(queue.adapter).targetStatus({
@@ -261,6 +284,41 @@ test("native START queries STATUS then executes only the provider-rendered order
 		["review", "status", "--contract", "gentle-ai.review-integration/v2", "--cwd", "/repo", "--projection", "workspace", "--agent", "pi", "--next-transition"],
 		["review", "start", ...tokens],
 	]);
+});
+
+test("native START retains the provider-owned START/v4 status transition in exact argument order", async () => {
+	const tokens = [
+		"--contract=gentle-ai.review-integration/v2", "--cwd=/repo", `--target=${TARGET}`,
+		"--projection=workspace", "--agent=pi", "--consent=relay",
+	];
+	const start = reviewingStartV4(TARGET);
+	const queue = queuedAdapter([
+		{ stdout: JSON.stringify(negotiatedStartStatus(TARGET, tokens)) },
+		{ stdout: JSON.stringify(start) },
+	]);
+	const result = await client(queue.adapter).start({ cwd: "/repo", targetIdentity: TARGET });
+	assert.deepEqual(result.nextTransition?.execute?.arguments.map((argument) => argument.token), [
+		`--lineage=${result.lineageId}`,
+		`--target=${TARGET}`,
+	]);
+	assert.deepEqual(queue.calls[1]?.arguments, ["review", "start", ...tokens]);
+});
+
+test("native consent completion decodes START/v4 and replays its provider argv unchanged", async () => {
+	const rawConsent = fixture("consent-v3.captured.json");
+	rawConsent.agent = "pi";
+	for (const choice of rawConsent.choices as Record<string, unknown>[]) {
+		choice.invocation = String(choice.invocation)
+			.replace(/--cwd \S+ --target/, "--cwd /repo --target")
+			.replace(" --consent ", " --agent pi --consent ");
+	}
+	const consent = decodeReviewConsentV3(rawConsent, "pi");
+	const queue = queuedAdapter([{ stdout: JSON.stringify(reviewingStartV4(consent.targetIdentity)) }]);
+	const answered = await client(queue.adapter).answerConsent({ cwd: "/repo", consent, answer: "granted" });
+	assert.equal(answered.kind, "started");
+	if (answered.kind !== "started") throw new Error("expected started consent result");
+	assert.equal(answered.start.nextTransition?.execute?.operation, "review.status");
+	assert.deepEqual(queue.calls[0]?.arguments, consent.choices[0].invocation.split(" ").slice(1));
 });
 
 test("native START refuses invalid committed-range and target bindings before STATUS", async () => {

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -177,14 +177,20 @@ function reviewingStartV4(targetIdentity: string): Record<string, unknown> {
 	const start = fixture("start-v3-consent-granted.captured.json");
 	start.schema = "gentle-ai.review-integration.start/v4";
 	(start.repository_context as Record<string, unknown>).target_identity = targetIdentity;
+	for (const subject of start.artifact_subjects as Record<string, unknown>[]) subject.target_identity = targetIdentity;
+	const baseTree = start.base_tree as string;
 	start.next_transition = {
 		kind: "execute",
 		reason_code: "review_status_required",
 		execute: {
 			operation: "review.status",
 			arguments: [
+				{ name: "contract", value: "gentle-ai.review-integration/v2", token: "--contract=gentle-ai.review-integration/v2" },
+				{ name: "next-transition", value: "true", token: "--next-transition=true" },
 				{ name: "lineage", value: start.lineage_id, token: `--lineage=${start.lineage_id}` },
-				{ name: "target", value: targetIdentity, token: `--target=${targetIdentity}` },
+				{ name: "agent", value: "pi", token: "--agent=pi" },
+				{ name: "base-ref", value: baseTree, token: `--base-ref=${baseTree}` },
+				{ name: "committed-only", value: "true", token: "--committed-only=true" },
 			],
 			preconditions: [],
 			binding: { target_identity: targetIdentity },
@@ -298,8 +304,12 @@ test("native START retains the provider-owned START/v4 status transition in exac
 	]);
 	const result = await client(queue.adapter).start({ cwd: "/repo", targetIdentity: TARGET });
 	assert.deepEqual(result.nextTransition?.execute?.arguments.map((argument) => argument.token), [
+		"--contract=gentle-ai.review-integration/v2",
+		"--next-transition=true",
 		`--lineage=${result.lineageId}`,
-		`--target=${TARGET}`,
+		"--agent=pi",
+		`--base-ref=${start.base_tree}`,
+		"--committed-only=true",
 	]);
 	assert.deepEqual(queue.calls[1]?.arguments, ["review", "start", ...tokens]);
 });

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -652,6 +652,16 @@ test("pending public consent expiry is synchronous and a fresh registry never re
 
 test("native START maps only provider facts and omits absent evidence", async (t) => {
 	const cwd = repository(t);
+	const nextTransition = {
+		kind: "execute" as const,
+		reasonCode: "review_status_required",
+		execute: {
+			operation: "review.status",
+			arguments: [{ name: "lineage", value: "closed-lineage", token: "--lineage=closed-lineage" }],
+			preconditions: [],
+			binding: { targetIdentity: `sha256:${"d".repeat(64)}` },
+		},
+	};
 	const native = {
 		targetStatus: async () => startStatus(cwd),
 		start: async () => ({
@@ -665,6 +675,7 @@ test("native START maps only provider facts and omits absent evidence", async (t
 			action: "closed",
 			lensesRequired: false,
 			riskReasons: [],
+			nextTransition,
 			hint: "provider empty-candidate hint",
 		}),
 	} as unknown as NativeReviewCli;
@@ -672,6 +683,7 @@ test("native START maps only provider facts and omits absent evidence", async (t
 	const rendered = result.result as Record<string, unknown>;
 	assert.equal(rendered.hint, "provider empty-candidate hint");
 	assert.equal(rendered.risk_evidence, undefined);
+	assert.equal(rendered.next_transition, nextTransition);
 });
 
 test("consent completion stays authoritative when local latch recording fails", async (t) => {

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -364,6 +364,30 @@ test("START/v4 accepts only its reviewing status continuation and preserves v3 s
 	assert.throws(() => decodeReviewStartV4(wrongOperation), /review.status/);
 });
 
+test("START/v4 falls back to the frozen overlay target when repository_context is absent", () => {
+	// A replayed reviewing START must not carry repository_context, so the
+	// binding assert has to derive the frozen target from the overlay identity.
+	const start = reviewingStartV4("replayed");
+	const execute = (start.next_transition as JsonObject).execute as JsonObject;
+	const targetIdentity = (start.repository_context as JsonObject).target_identity as string;
+	delete start.repository_context;
+	start.target_mode = "base-workspace-overlay";
+	start.target_identity = targetIdentity;
+	const arguments_ = execute.arguments as JsonObject[];
+	const committedOnly = arguments_.find((argument) => argument.name === "committed-only")!;
+	committedOnly.name = "workspace-overlay";
+	committedOnly.token = "--workspace-overlay=true";
+	execute.selector_arguments = arguments_.slice(-2).map(clone);
+	const decoded = decodeReviewStartV4(start);
+	assert.equal(decoded.targetIdentity, targetIdentity);
+	assert.equal(decoded.repositoryContext, undefined);
+	assert.equal(decoded.nextTransition?.execute?.binding.targetIdentity, targetIdentity);
+
+	const unbound = reviewingStartV4("replayed");
+	delete unbound.repository_context;
+	assert.throws(() => decodeReviewStartV4(unbound), /repository_context is required/);
+});
+
 test("START/v4 rejects status vectors that drift from frozen bindings", () => {
 	const bindingTarget = reviewingStartV4();
 	(((bindingTarget.next_transition as JsonObject).execute as JsonObject).binding as JsonObject).target_identity = sha("d");

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -9,6 +9,7 @@ import {
 	decodeReviewLastEventClosureV1,
 	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
+	decodeReviewStartV4,
 	decodeReviewStatusV3,
 } from "../lib/review-integration-v2.ts";
 
@@ -287,4 +288,72 @@ test("a result artifact rejects unknown keys and weakened bindings", () => {
 	const foreignLocator = clone(base);
 	foreignLocator.reference = `rref1_${"b".repeat(64)}`;
 	assert.throws(() => decodeReviewResultArtifactV2(foreignLocator), /reference/);
+});
+
+function reviewingStartV4(action: "created" | "replayed" = "created"): JsonObject {
+	const body = clone(fixture(DEV_FIXTURES, "start-v3-consent-granted.captured.json") as JsonObject);
+	body.schema = "gentle-ai.review-integration.start/v4";
+	body.action = action;
+	const targetIdentity = (body.repository_context as JsonObject).target_identity as string;
+	body.next_transition = {
+		kind: "execute",
+		reason_code: "review_status_required",
+		execute: {
+			operation: "review.status",
+			arguments: [
+				{ name: "lineage", value: body.lineage_id, token: `--lineage=${body.lineage_id}` },
+				{ name: "target", value: targetIdentity, token: `--target=${targetIdentity}` },
+			],
+			preconditions: [],
+			binding: { target_identity: targetIdentity },
+		},
+	};
+	return body;
+}
+
+test("capabilities/v2.3 requires START/v4 and rejects future identities", () => {
+	const v23 = clone(fixture(DEV_FIXTURES, "capabilities-v2.2.captured.json") as JsonObject);
+	v23.schema = "gentle-ai.review-integration.capabilities/v2.3";
+	(v23.protocol as JsonObject).minor = 3;
+	v23.schemas = (v23.schemas as string[]).map((schema) => schema
+		.replace("capabilities/v2.2", "capabilities/v2.3")
+		.replace("start/v3", "start/v4"));
+	const decoded = decodeReviewCapabilitiesV2(v23, CAPTURED_DIGEST);
+	assert.equal(decoded.schemas.has("gentle-ai.review-integration.start/v4"), true);
+	assert.equal(decoded.schemas.has("gentle-ai.review-integration.start/v3"), false);
+
+	const future = clone(v23);
+	future.schema = "gentle-ai.review-integration.capabilities/v2.4";
+	(future.protocol as JsonObject).minor = 4;
+	future.schemas = (future.schemas as string[]).map((schema) => schema.replace("capabilities/v2.3", "capabilities/v2.4"));
+	assert.throws(() => decodeReviewCapabilitiesV2(future, CAPTURED_DIGEST), /schema must be one of/);
+});
+
+test("START/v4 accepts only its reviewing status continuation and preserves v3 strictness", () => {
+	for (const action of ["created", "replayed"] as const) {
+		const decoded = decodeReviewStartV4(reviewingStartV4(action));
+		assert.equal(decoded.nextTransition?.execute?.operation, "review.status");
+		assert.deepEqual(decoded.nextTransition?.execute?.arguments.map((argument) => argument.token), [
+			`--lineage=${decoded.lineageId}`,
+			`--target=${decoded.repositoryContext?.targetIdentity}`,
+		]);
+	}
+
+	const v3 = reviewingStartV4();
+	v3.schema = "gentle-ai.review-integration.start/v3";
+	assert.throws(() => decodeReviewStartV3(v3), /next_transition is not allowed/);
+
+	const wrongOperation = reviewingStartV4();
+	((wrongOperation.next_transition as JsonObject).execute as JsonObject).operation = "review.start";
+	assert.throws(() => decodeReviewStartV4(wrongOperation), /review.status/);
+});
+
+test("START/v4 closed approval keeps acknowledgement but forbids a continuation", () => {
+	const closed = clone(fixture(DEV_FIXTURES, "start-v3-zero-lens-closed.captured.json") as JsonObject);
+	closed.schema = "gentle-ai.review-integration.start/v4";
+	closed.acknowledgement = { provider_owned: true };
+	assert.deepEqual(decodeReviewStartV4(closed).raw.acknowledgement, { provider_owned: true });
+
+	closed.next_transition = (reviewingStartV4().next_transition as JsonObject);
+	assert.throws(() => decodeReviewStartV4(closed), /closed approved zero-lens START cannot carry next_transition/);
 });

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -295,14 +295,19 @@ function reviewingStartV4(action: "created" | "replayed" = "created"): JsonObjec
 	body.schema = "gentle-ai.review-integration.start/v4";
 	body.action = action;
 	const targetIdentity = (body.repository_context as JsonObject).target_identity as string;
+	const baseTree = body.base_tree as string;
 	body.next_transition = {
 		kind: "execute",
 		reason_code: "review_status_required",
 		execute: {
 			operation: "review.status",
 			arguments: [
+				{ name: "contract", value: "gentle-ai.review-integration/v2", token: "--contract=gentle-ai.review-integration/v2" },
+				{ name: "next-transition", value: "true", token: "--next-transition=true" },
 				{ name: "lineage", value: body.lineage_id, token: `--lineage=${body.lineage_id}` },
-				{ name: "target", value: targetIdentity, token: `--target=${targetIdentity}` },
+				{ name: "agent", value: "pi", token: "--agent=pi" },
+				{ name: "base-ref", value: baseTree, token: `--base-ref=${baseTree}` },
+				{ name: "committed-only", value: "true", token: "--committed-only=true" },
 			],
 			preconditions: [],
 			binding: { target_identity: targetIdentity },
@@ -331,11 +336,16 @@ test("capabilities/v2.3 requires START/v4 and rejects future identities", () => 
 
 test("START/v4 accepts only its reviewing status continuation and preserves v3 strictness", () => {
 	for (const action of ["created", "replayed"] as const) {
-		const decoded = decodeReviewStartV4(reviewingStartV4(action));
+		const start = reviewingStartV4(action);
+		const decoded = decodeReviewStartV4(start);
 		assert.equal(decoded.nextTransition?.execute?.operation, "review.status");
-		assert.deepEqual(decoded.nextTransition?.execute?.arguments.map((argument) => argument.token), [
-			`--lineage=${decoded.lineageId}`,
-			`--target=${decoded.repositoryContext?.targetIdentity}`,
+		assert.deepEqual(decoded.nextTransition?.execute?.arguments, [
+			{ name: "contract", value: "gentle-ai.review-integration/v2", token: "--contract=gentle-ai.review-integration/v2" },
+			{ name: "next-transition", value: "true", token: "--next-transition=true" },
+			{ name: "lineage", value: decoded.lineageId, token: `--lineage=${decoded.lineageId}` },
+			{ name: "agent", value: "pi", token: "--agent=pi" },
+			{ name: "base-ref", value: decoded.baseTree, token: `--base-ref=${decoded.baseTree}` },
+			{ name: "committed-only", value: "true", token: "--committed-only=true" },
 		]);
 	}
 
@@ -346,6 +356,44 @@ test("START/v4 accepts only its reviewing status continuation and preserves v3 s
 	const wrongOperation = reviewingStartV4();
 	((wrongOperation.next_transition as JsonObject).execute as JsonObject).operation = "review.start";
 	assert.throws(() => decodeReviewStartV4(wrongOperation), /review.status/);
+});
+
+test("START/v4 rejects status vectors that drift from frozen bindings", () => {
+	const bindingTarget = reviewingStartV4();
+	(((bindingTarget.next_transition as JsonObject).execute as JsonObject).binding as JsonObject).target_identity = sha("d");
+	assert.throws(() => decodeReviewStartV4(bindingTarget), /binding/);
+
+	for (const [name, value] of [["lineage", "review-other"], ["base-ref", "a".repeat(40)]] as const) {
+		const start = reviewingStartV4();
+		const arguments_ = ((start.next_transition as JsonObject).execute as JsonObject).arguments as JsonObject[];
+		arguments_.find((argument) => argument.name === name)!.value = value;
+		assert.throws(() => decodeReviewStartV4(start), /binding/);
+	}
+
+	for (const [name, value, token] of [["projection", "staged", "--projection=staged"], ["target", sha("d"), `--target=${sha("d")}`]] as const) {
+		const start = reviewingStartV4();
+		const arguments_ = ((start.next_transition as JsonObject).execute as JsonObject).arguments as JsonObject[];
+		arguments_.push({ name, value, token });
+		assert.throws(() => decodeReviewStartV4(start), /binding/);
+	}
+
+	const bindingLineage = reviewingStartV4();
+	(((bindingLineage.next_transition as JsonObject).execute as JsonObject).binding as JsonObject).lineage_id = "review-other";
+	assert.throws(() => decodeReviewStartV4(bindingLineage), /binding/);
+
+	const outerTarget = reviewingStartV4();
+	outerTarget.target_mode = "base-workspace-overlay";
+	outerTarget.target_identity = sha("d");
+	assert.throws(() => decodeReviewStartV4(outerTarget), /binding/);
+
+	const artifactTarget = reviewingStartV4();
+	(artifactTarget.artifact_subjects as JsonObject[])[0]!.target_identity = sha("d");
+	assert.throws(() => decodeReviewStartV4(artifactTarget), /binding/);
+
+	const duplicate = reviewingStartV4();
+	const arguments_ = ((duplicate.next_transition as JsonObject).execute as JsonObject).arguments as JsonObject[];
+	arguments_.push(clone(arguments_.find((argument) => argument.name === "lineage")!));
+	assert.throws(() => decodeReviewStartV4(duplicate), /binding/);
 });
 
 test("START/v4 closed approval keeps acknowledgement but forbids a continuation", () => {

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -313,6 +313,8 @@ function reviewingStartV4(action: "created" | "replayed" = "created"): JsonObjec
 			binding: { target_identity: targetIdentity },
 		},
 	};
+	const execute = (body.next_transition as JsonObject).execute as JsonObject;
+	execute.selector_arguments = (execute.arguments as JsonObject[]).slice(-2).map(clone);
 	return body;
 }
 
@@ -344,6 +346,10 @@ test("START/v4 accepts only its reviewing status continuation and preserves v3 s
 			{ name: "next-transition", value: "true", token: "--next-transition=true" },
 			{ name: "lineage", value: decoded.lineageId, token: `--lineage=${decoded.lineageId}` },
 			{ name: "agent", value: "pi", token: "--agent=pi" },
+			{ name: "base-ref", value: decoded.baseTree, token: `--base-ref=${decoded.baseTree}` },
+			{ name: "committed-only", value: "true", token: "--committed-only=true" },
+		]);
+		assert.deepEqual(decoded.nextTransition?.execute?.selectorArguments, [
 			{ name: "base-ref", value: decoded.baseTree, token: `--base-ref=${decoded.baseTree}` },
 			{ name: "committed-only", value: "true", token: "--committed-only=true" },
 		]);
@@ -394,6 +400,33 @@ test("START/v4 rejects status vectors that drift from frozen bindings", () => {
 	const arguments_ = ((duplicate.next_transition as JsonObject).execute as JsonObject).arguments as JsonObject[];
 	arguments_.push(clone(arguments_.find((argument) => argument.name === "lineage")!));
 	assert.throws(() => decodeReviewStartV4(duplicate), /binding/);
+});
+
+test("START/v4 rejects incomplete or incoherent provider-owned status selectors", () => {
+	const execute = (start: JsonObject) => (start.next_transition as JsonObject).execute as JsonObject;
+	const rows = (start: JsonObject, field: "arguments" | "selector_arguments") => execute(start)[field] as JsonObject[];
+	for (const change of [
+		(start: JsonObject) => delete execute(start).selector_arguments,
+		(start: JsonObject) => rows(start, "selector_arguments").splice(1, 1),
+		(start: JsonObject) => {
+			for (const field of ["arguments", "selector_arguments"] as const) rows(start, field).find((row) => row.name === "committed-only")!.value = "false";
+		},
+		(start: JsonObject) => rows(start, "selector_arguments")[1]!.token = "--committed-only",
+	]) {
+		const start = reviewingStartV4();
+		change(start);
+		assert.throws(() => decodeReviewStartV4(start), /selector|binding/);
+	}
+	for (const [name, value] of [["contract", "other"], ["next-transition", "false"], ["lineage", "review-other"], ["agent", "other"]] as const) {
+		const missing = reviewingStartV4();
+		rows(missing, "arguments").splice(rows(missing, "arguments").findIndex((row) => row.name === name), 1);
+		assert.throws(() => decodeReviewStartV4(missing), /binding/);
+		const wrong = reviewingStartV4();
+		rows(wrong, "arguments").find((row) => row.name === name)!.value = value;
+		assert.throws(() => decodeReviewStartV4(wrong), /binding/);
+	}
+	const controlToken = reviewingStartV4(); rows(controlToken, "arguments")[0]!.token = "--contract=other";
+	assert.throws(() => decodeReviewStartV4(controlToken), /binding/);
 });
 
 test("START/v4 closed approval keeps acknowledgement but forbids a continuation", () => {


### PR DESCRIPTION
Closes #499

## Summary

- Accepts the negotiated capabilities v2.3 minor and the `start/v4` identity while preserving exact START v3 behavior; v4 decodes its reviewing `next_transition.execute(review.status)` continuation through the existing generic transition decoder and surfaces the provider-issued operation and ordered tokens unchanged.
- Fail-closed binding checks: exactly one lineage row, frozen target/base-tree/projection agreement, byte-exact selector echo, duplicate-argument rejection, and closed approved zero-lens rejection.
- Correction from the native RDD review: a replayed reviewing START/v4 must not carry `repository_context`, so the binding assert now derives the frozen target from the overlay identity when that block is absent — the optional field is no longer effectively mandatory, and the no-identity case still fails closed.

## Test Plan

- [x] Full suite 1125 pass / 0 fail (includes new forward tests for v4 decode, drift rejection, and the replayed-overlay fallback); runtime mirror regenerated and convergent
- [x] Existing START v3 fixtures and rejection tests unchanged and passing
- [x] Native RDD review of the exact candidate: approved (lineage `review-273b81393b25439a`), one bounded correction applied and validated, acknowledgement burned

## Rollout ordering

This consumer parity lands before the provider advertises capabilities v2.3 (Gentleman-Programming/gentle-ai#3914).

https://claude.ai/code/session_01TBmouNwxG3gPfNKFmKXPMb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the negotiated START/v4 review protocol.
  * Added replayed review-start handling and provider-supplied status transitions.
  * Preserved transition details, including selector arguments, in review results.
  * Added capabilities support for protocol version 2.3.

* **Bug Fixes**
  * Improved validation of review status transitions and frozen start bindings.
  * Relaxed repository context requirements when a valid overlay identity is provided.

* **Tests**
  * Added coverage for START/v4 decoding, consent flows, replayed starts, transition integrity, and invalid payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->