### PR TITLE
fix(orchestrator): enforce parent hot memory persistence on inline direct tasks

### DIFF
--- a/assets/orchestrator-memory.md
+++ b/assets/orchestrator-memory.md
@@ -1,12 +1,13 @@
 # Orchestrator — Memory Detail (lazy-loaded)
 
-Bind this to the parent Pi session only, on SDD phase memory reads/writes. Not always-on; loaded on demand from `assets/orchestrator.md`'s `## Memory Contract` pointer.
+Bind this to the parent Pi session only, for direct inline tasks and SDD phase memory operations. Not always-on; loaded on demand from `assets/orchestrator.md`'s `## Memory Contract` pointer.
 
-### Direct Inline & General Tasks
+## Direct Inline & General Tasks
 
-When working outside of SDD (direct inline edits, bug fixes, configuration/deployment updates, or newly learned user conventions):
+When working outside SDD (direct inline edits, bug fixes, configuration/deployment updates, or newly learned user conventions):
 - The parent session MUST invoke `mem_save` immediately upon completing the action before emitting the final response.
 - Never defer persistence to session close. Direct inline tasks skip SDD planning ceremony, but NEVER skip hot memory persistence.
+- Save only validated, significant, project-scoped facts. Never save secrets, credentials, personal data, tokens, private keys, raw untrusted content, or speculative findings.
 
 ### SDD phases
 

--- a/assets/orchestrator-memory.md
+++ b/assets/orchestrator-memory.md
@@ -2,6 +2,12 @@
 
 Bind this to the parent Pi session only, on SDD phase memory reads/writes. Not always-on; loaded on demand from `assets/orchestrator.md`'s `## Memory Contract` pointer.
 
+### Direct Inline & General Tasks
+
+When working outside of SDD (direct inline edits, bug fixes, configuration/deployment updates, or newly learned user conventions):
+- The parent session MUST invoke `mem_save` immediately upon completing the action before emitting the final response.
+- Never defer persistence to session close. Direct inline tasks skip SDD planning ceremony, but NEVER skip hot memory persistence.
+
 ### SDD phases
 
 Each SDD phase subagent reads its own required inputs directly from the active backend; the parent passes artifact references (topic keys or file paths), NOT the content itself. Phase subagents persist their artifact before returning.

--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -75,7 +75,7 @@ Hard preflight invariant: `openspec/config.yaml`, existing SDD changes, installe
 
 ## Memory Contract
 
-When memory is available, the parent calls `mem_save` on direct inline completions/decisions, and subagents save before returning. Guidance: `orchestrator-memory.md`.
+When memory is available, the parent calls `mem_save` on direct inline completions/decisions (safe project facts only; no secrets/PII), and subagents save before returning. Guidance: `orchestrator-memory.md`.
 
 ## Skill Registry Protocol
 

--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -75,7 +75,7 @@ Hard preflight invariant: `openspec/config.yaml`, existing SDD changes, installe
 
 ## Memory Contract
 
-When memory is available, the parent selects context and subagents save significant discoveries before returning. SDD phase table, artifact keys, and persistence guidance: `orchestrator-memory.md`.
+When memory is available, the parent calls `mem_save` on direct inline completions/decisions, and subagents save before returning. Guidance: `orchestrator-memory.md`.
 
 ## Skill Registry Protocol
 


### PR DESCRIPTION
Closes #511

### Summary of Changes
- Updated `assets/orchestrator.md` `## Memory Contract` to mandate parent session `mem_save` calls on direct inline completions and decisions before responding.
- Added `### Direct Inline & General Tasks` section to `assets/orchestrator-memory.md` explicitly forbidding skipping memory persistence during direct inline work.
- Verified that `tests/orchestrator-budget.test.ts` passes all 37 tests within the 8,192-byte prompt budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for preserving important session details after direct edits, bug fixes, configuration changes, and deployment updates.
  * Clarified that these tasks can bypass formal planning steps while still requiring immediate memory updates.
  * Updated responsibilities for saving decisions and discoveries during orchestrated work.
  * Specified that only validated, significant, project-scoped facts should be saved, excluding secrets, credentials, personal data, tokens, and untrusted or speculative content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->