### PR TITLE
fix(review): decode the review-acknowledged envelope the acknowledgement burn prints

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -128,6 +128,7 @@ import {
 	NATIVE_REVIEW_RECONCILE_ANOMALIES,
 	sanitizeForeignNativeReviewDiagnostics,
 	type NativeReviewCli,
+	type NativeReviewAcknowledgeApprovedOutcome,
 	type NativeReviewAcknowledgeApprovedRequest,
 	type NativeTargetStatusRequest,
 	type NativeReviewModeOperation,
@@ -2715,7 +2716,7 @@ interface ReviewControllerParameters {
 }
 
 type NativeReviewAcknowledgementCli = NativeReviewCli & {
-	acknowledgeApproved?: (request: NativeReviewAcknowledgeApprovedRequest) => Promise<void>;
+	acknowledgeApproved?: (request: NativeReviewAcknowledgeApprovedRequest) => Promise<NativeReviewAcknowledgeApprovedOutcome | void>;
 };
 
 interface ReviewControllerStartInput {
@@ -4782,9 +4783,15 @@ async function executeReviewControllerOperation(
 			return nativeOperationFailure(parameters.operation, error);
 		}
 		try {
-			await acknowledgementCli.acknowledgeApproved({
+			// gentle-ai #3947: the burn answers with one review-acknowledged/v1
+			// envelope bound to exactly this lineage, target, and revision, and
+			// the burn is reported from that envelope, never from a later
+			// STATUS. Every published release up to v2.5.0-rc.3 still burns in
+			// silence, and that result stays byte-identical.
+			const acknowledged = await acknowledgementCli.acknowledgeApproved({
 				argumentTokens,
 				cwd: defaultCwd,
+				binding: { lineageId: parameters.lineageId, targetIdentity: status.targetIdentity, revision: status.authority.revision },
 				...(signal === undefined ? {} : { signal }),
 			});
 			return {
@@ -4793,7 +4800,9 @@ async function executeReviewControllerOperation(
 				outcome: "native-approved-acknowledgement-completed",
 				lineage_id: parameters.lineageId,
 				target_identity: status.targetIdentity,
+				...(acknowledged === undefined ? {} : { consumed_revision: acknowledged.consumedRevision }),
 				authority: "burned",
+				...(acknowledged === undefined ? {} : { burn_evidence: acknowledged.schema }),
 				delivery: "ordinary-repository-policy",
 				mutation_performed: true,
 				mutation_outcome: "committed",

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -7,6 +7,7 @@ import { PackageLocalGentleAiBinaryMissingError, resolveGentleAiBinary } from ".
 import { GENTLE_PI_REVIEW_RELAY_CONTRACT, GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV } from "./review-relay-contract.ts";
 import {
 	REVIEW_INTEGRATION_CONTRACT,
+	decodeReviewAcknowledgedV1,
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
 	decodeReviewFailureV2,
@@ -16,6 +17,8 @@ import {
 	decodeReviewStartV3,
 	decodeReviewStartV4,
 	decodeReviewStatusV3,
+	type ReviewAcknowledgedExpectationV1,
+	type ReviewAcknowledgedV1,
 	type ReviewConsentEnvelope,
 	type ReviewFailureV2,
 	type ReviewRepairV2,
@@ -350,12 +353,19 @@ export type NativeReviewCaptureResultOutcome = NativeReviewAdmittedResultManifes
 // The one continuation that burns approved authority. Its tokens are rendered
 // by the provider in a closed order and are relayed verbatim: Pi never builds,
 // reorders, or substitutes one, because a synthesized acknowledgement would be
-// Pi deciding that a review is over.
+// Pi deciding that a review is over. `binding` is the lineage, target, and
+// revision the caller already holds from STATUS: when the provider answers the
+// burn with a review-acknowledged/v1 envelope (gentle-ai #3947), that envelope
+// must name exactly this burn.
 export interface NativeReviewAcknowledgeApprovedRequest {
 	readonly argumentTokens: readonly string[];
 	readonly cwd: string;
+	readonly binding?: ReviewAcknowledgedExpectationV1;
 	readonly signal?: AbortSignal;
 }
+
+/** `undefined` is the pinned silent burn (every release up to v2.5.0-rc.3); an envelope is the #3947 typed burn. */
+export type NativeReviewAcknowledgeApprovedOutcome = ReviewAcknowledgedV1 | undefined;
 
 export interface NativeReviewCorrectionPlanCaptureRequest {
 	readonly argumentTokens: readonly string[];
@@ -1686,6 +1696,9 @@ function decodeDeclinedConsentStart(value: unknown, expected: NativeReviewConsen
 interface NegotiatedExecution {
 	body: Record<string, unknown>;
 	exitCode: number;
+	// True only for a zero-exit bodyless operation that printed nothing: the
+	// pinned silent acknowledgement burn. A body is never synthesized for it.
+	silent?: true;
 }
 
 function decodeNativeAdmittedResultManifest(value: unknown): NativeReviewAdmittedResultManifest {
@@ -1774,10 +1787,13 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		signal: AbortSignal | undefined,
 		path: string,
 		toleratedStderr: readonly string[] = [],
-		// A successful acknowledgement burns its authority and prints nothing:
-		// there is no receipt left to describe. Only that shape opts out of the
-		// body, and only for a zero exit; a non-zero exit still has to produce
-		// its typed failure envelope like every other operation.
+		// A successful acknowledgement burns its authority and, on every
+		// published release up to v2.5.0-rc.3, prints nothing: there is no
+		// receipt left to describe. Only that shape opts out of the body, and
+		// only for a zero exit. When such an operation does print, the bytes
+		// are handed back as a body for the caller to decode against the one
+		// identity it accepts (gentle-ai #3947); a non-zero exit still has to
+		// produce its typed failure envelope like every other operation.
 		expectsBody = true,
 	): Promise<NegotiatedExecution> {
 		let result: ExecFileResult;
@@ -1791,10 +1807,9 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, operation, mutating, "native process timed out", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, operation, mutating, "native process was signalled", result);
 		const diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.NON_ZERO, result);
-		if (!expectsBody && result.exitCode === 0) {
-			if (result.stdout.trim().length > 0) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE, operation, mutating, "native bodyless operation returned output", result);
+		if (!expectsBody && result.exitCode === 0 && result.stdout.trim().length === 0) {
 			if (result.stderr.trim().length > 0 && !stderrIsTolerated(result.stderr, toleratedStderr)) throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNEXPECTED_STDERR, operation, mutating, "native process wrote stderr", result);
-			return { body: {}, exitCode: result.exitCode };
+			return { body: {}, exitCode: result.exitCode, silent: true };
 		}
 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
 		if (result.exitCode !== 0) {
@@ -2022,17 +2037,25 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 	}
 
 	// Relays the provider-issued acknowledgement exactly as rendered. A success
-	// burns the authority and its artifacts and prints nothing, so there is no
-	// body to decode and nothing survives to describe; a refusal still arrives
-	// as the ordinary typed failure envelope.
-	async acknowledgeApproved(request: NativeReviewAcknowledgeApprovedRequest): Promise<void> {
+	// burns the authority and its artifacts; a refusal still arrives as the
+	// ordinary typed failure envelope. Two success shapes exist and both are
+	// the same burn: every published release up to v2.5.0-rc.3 prints nothing
+	// (resolved as `undefined`, byte-for-byte the pinned behaviour), and
+	// gentle-ai #3947 prints one `gentle-ai.review-acknowledged/v1` envelope
+	// naming the burned lineage, target, and consumed revision. Any other
+	// output on a zero exit is schema-incompatible with the mutation outcome
+	// unknown, exactly like a malformed terminal closure: the caller
+	// reconciles through STATUS and never infers the burn from prose.
+	async acknowledgeApproved(request: NativeReviewAcknowledgeApprovedRequest): Promise<NativeReviewAcknowledgeApprovedOutcome> {
 		if (request.argumentTokens.length === 0) throw new TypeError("Native ACKNOWLEDGE_APPROVED requires the provider-issued argument tokens");
 		if (request.argumentTokens.some((token) => typeof token !== "string" || token.length === 0)) throw new TypeError("Native ACKNOWLEDGE_APPROVED argument tokens must all be non-empty strings");
 		if (request.argumentTokens.some((token) => token.includes("{{value}}"))) throw new TypeError("Native ACKNOWLEDGE_APPROVED argument tokens carry no caller-substituted value");
 		const executable = this.executablePath(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, true);
-		await this.invoke(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, request.cwd, [
+		const execution = await this.invoke(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, request.cwd, [
 			"review", "acknowledge-approved", ...request.argumentTokens,
 		], true, request.signal, executable, [], false);
+		if (execution.silent) return undefined;
+		return decode(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, true, () => decodeReviewAcknowledgedV1(execution.body, request.binding ?? {}));
 	}
 
 	async captureCorrectionPlan(request: NativeReviewCorrectionPlanCaptureRequest): Promise<ReviewLastEventClosureV1> {

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -2254,6 +2254,61 @@ export function assertReviewApprovedAcknowledgementExecuteV1(
 	if (expected.revision !== undefined && shape.revision !== expected.revision) throw new TypeError("acknowledgement.execute.revision does not match the current target"); return shape.tokens;
 }
 
+// ---------------------------------------------------------------------------
+// review-acknowledged/v1 — the answer the burn prints (gentle-ai #3947)
+// ---------------------------------------------------------------------------
+
+// Until gentle-ai #3947 a successful `review acknowledge-approved` burned its
+// authority in silence and a host could only infer the burn from a later
+// STATUS offering a fresh START. From main commit bc9f74d2 the command prints
+// exactly this envelope on success. Like result-artifact/v2 it carries no
+// `contract`: the schema constant plus the slash-form operation are its whole
+// identity, so requireIdentity (which demands the contract pair) does not
+// apply. Every published release up to v2.5.0-rc.3 still prints nothing; the
+// native client owns that distinction, this decoder only ever sees bytes.
+export const REVIEW_ACKNOWLEDGED_SCHEMA = "gentle-ai.review-acknowledged/v1" as const;
+const REVIEW_ACKNOWLEDGED_OPERATION = "review/acknowledge-approved" as const;
+
+export interface ReviewAcknowledgedV1 {
+	schema: typeof REVIEW_ACKNOWLEDGED_SCHEMA;
+	operation: typeof REVIEW_ACKNOWLEDGED_OPERATION;
+	action: "acknowledged";
+	lineageId: string;
+	targetIdentity: string;
+	consumedRevision: string;
+	authority: "burned";
+	raw: Record<string, unknown>;
+}
+
+/** The binding the caller already holds from STATUS; the envelope must name exactly that burn. */
+export interface ReviewAcknowledgedExpectationV1 {
+	lineageId?: string;
+	targetIdentity?: string;
+	revision?: string;
+}
+
+export function decodeReviewAcknowledgedV1(value: unknown, expected: ReviewAcknowledgedExpectationV1 = {}): ReviewAcknowledgedV1 {
+	if (record(value, "acknowledged").schema !== REVIEW_ACKNOWLEDGED_SCHEMA) throw new TypeError(`schema must be ${REVIEW_ACKNOWLEDGED_SCHEMA}`);
+	const body = exactRecord(value, "acknowledged", ["schema", "operation", "action", "lineage_id", "target_identity", "consumed_revision", "authority"]);
+	if (body.operation !== REVIEW_ACKNOWLEDGED_OPERATION) throw new TypeError(`acknowledged.operation must be ${REVIEW_ACKNOWLEDGED_OPERATION}`);
+	if (body.action !== "acknowledged") throw new TypeError("acknowledged.action must be acknowledged");
+	if (body.authority !== "burned") throw new TypeError("acknowledged.authority must be burned");
+	const decoded: ReviewAcknowledgedV1 = {
+		schema: REVIEW_ACKNOWLEDGED_SCHEMA,
+		operation: REVIEW_ACKNOWLEDGED_OPERATION,
+		action: "acknowledged",
+		lineageId: lineage(body.lineage_id, "acknowledged.lineage_id"),
+		targetIdentity: sha256(body.target_identity, "acknowledged.target_identity"),
+		consumedRevision: sha256(body.consumed_revision, "acknowledged.consumed_revision"),
+		authority: "burned",
+		raw: body,
+	};
+	if (expected.lineageId !== undefined && decoded.lineageId !== expected.lineageId) throw new TypeError("acknowledged.lineage_id does not name the acknowledged lineage");
+	if (expected.targetIdentity !== undefined && decoded.targetIdentity !== expected.targetIdentity) throw new TypeError("acknowledged.target_identity does not name the acknowledged target");
+	if (expected.revision !== undefined && decoded.consumedRevision !== expected.revision) throw new TypeError("acknowledged.consumed_revision does not name the consumed revision");
+	return decoded;
+}
+
 export interface ReviewLastEventClosureV1 {
 	schema: typeof REVIEW_LAST_EVENT_CLOSURE_SCHEMA;
 	operation: ReviewLastEventClosureOperation;

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -8,6 +8,7 @@ import { PackageLocalGentleAiBinaryMissingError, resolveGentleAiBinary } from ".
 import { GENTLE_PI_REVIEW_RELAY_CONTRACT, GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV } from "./review-relay-contract.mjs";
 import {
 	REVIEW_INTEGRATION_CONTRACT,
+	decodeReviewAcknowledgedV1,
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
 	decodeReviewFailureV2,
@@ -17,6 +18,8 @@ import {
 	decodeReviewStartV3,
 	decodeReviewStartV4,
 	decodeReviewStatusV3,
+
+
 
 
 
@@ -351,11 +354,18 @@ export const NATIVE_REVIEW_LEGACY_ALIAS_REPAIR = {
 // The one continuation that burns approved authority. Its tokens are rendered
 // by the provider in a closed order and are relayed verbatim: Pi never builds,
 // reorders, or substitutes one, because a synthesized acknowledgement would be
-// Pi deciding that a review is over.
+// Pi deciding that a review is over. `binding` is the lineage, target, and
+// revision the caller already holds from STATUS: when the provider answers the
+// burn with a review-acknowledged/v1 envelope (gentle-ai #3947), that envelope
+// must name exactly this burn.
 
 
 
 
+
+
+
+/** `undefined` is the pinned silent burn (every release up to v2.5.0-rc.3); an envelope is the #3947 typed burn. */
 
 
 
@@ -1689,6 +1699,9 @@ function decodeDeclinedConsentStart(value         , expected                    
 
 
 
+
+
+
 function decodeNativeAdmittedResultManifest(value         )                                     {
 	// The admission answer routes through the exact-identity forward decoder
 	// (decoder-freshness discipline): the complete live envelope — identity
@@ -1775,10 +1788,13 @@ export class NativeReviewCliV216                            {
 		signal                         ,
 		path        ,
 		toleratedStderr                    = [],
-		// A successful acknowledgement burns its authority and prints nothing:
-		// there is no receipt left to describe. Only that shape opts out of the
-		// body, and only for a zero exit; a non-zero exit still has to produce
-		// its typed failure envelope like every other operation.
+		// A successful acknowledgement burns its authority and, on every
+		// published release up to v2.5.0-rc.3, prints nothing: there is no
+		// receipt left to describe. Only that shape opts out of the body, and
+		// only for a zero exit. When such an operation does print, the bytes
+		// are handed back as a body for the caller to decode against the one
+		// identity it accepts (gentle-ai #3947); a non-zero exit still has to
+		// produce its typed failure envelope like every other operation.
 		expectsBody = true,
 	)                               {
 		let result                ;
@@ -1792,10 +1808,9 @@ export class NativeReviewCliV216                            {
 		if (result.timedOut) throw nativeError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, operation, mutating, "native process timed out", result);
 		if (result.signal) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SIGNAL, operation, mutating, "native process was signalled", result);
 		const diagnostics = nativeProcessDiagnostics(operation, NATIVE_REVIEW_ERROR_CODE.NON_ZERO, result);
-		if (!expectsBody && result.exitCode === 0) {
-			if (result.stdout.trim().length > 0) throw nativeError(NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE, operation, mutating, "native bodyless operation returned output", result);
+		if (!expectsBody && result.exitCode === 0 && result.stdout.trim().length === 0) {
 			if (result.stderr.trim().length > 0 && !stderrIsTolerated(result.stderr, toleratedStderr)) throw nativeError(NATIVE_REVIEW_ERROR_CODE.UNEXPECTED_STDERR, operation, mutating, "native process wrote stderr", result);
-			return { body: {}, exitCode: result.exitCode };
+			return { body: {}, exitCode: result.exitCode, silent: true };
 		}
 		const body = parseJson(result.stdout, operation, mutating, diagnostics);
 		if (result.exitCode !== 0) {
@@ -2023,17 +2038,25 @@ export class NativeReviewCliV216                            {
 	}
 
 	// Relays the provider-issued acknowledgement exactly as rendered. A success
-	// burns the authority and its artifacts and prints nothing, so there is no
-	// body to decode and nothing survives to describe; a refusal still arrives
-	// as the ordinary typed failure envelope.
-	async acknowledgeApproved(request                                        )                {
+	// burns the authority and its artifacts; a refusal still arrives as the
+	// ordinary typed failure envelope. Two success shapes exist and both are
+	// the same burn: every published release up to v2.5.0-rc.3 prints nothing
+	// (resolved as `undefined`, byte-for-byte the pinned behaviour), and
+	// gentle-ai #3947 prints one `gentle-ai.review-acknowledged/v1` envelope
+	// naming the burned lineage, target, and consumed revision. Any other
+	// output on a zero exit is schema-incompatible with the mutation outcome
+	// unknown, exactly like a malformed terminal closure: the caller
+	// reconciles through STATUS and never infers the burn from prose.
+	async acknowledgeApproved(request                                        )                                                  {
 		if (request.argumentTokens.length === 0) throw new TypeError("Native ACKNOWLEDGE_APPROVED requires the provider-issued argument tokens");
 		if (request.argumentTokens.some((token) => typeof token !== "string" || token.length === 0)) throw new TypeError("Native ACKNOWLEDGE_APPROVED argument tokens must all be non-empty strings");
 		if (request.argumentTokens.some((token) => token.includes("{{value}}"))) throw new TypeError("Native ACKNOWLEDGE_APPROVED argument tokens carry no caller-substituted value");
 		const executable = this.executablePath(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, true);
-		await this.invoke(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, request.cwd, [
+		const execution = await this.invoke(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, request.cwd, [
 			"review", "acknowledge-approved", ...request.argumentTokens,
 		], true, request.signal, executable, [], false);
+		if (execution.silent) return undefined;
+		return decode(NATIVE_REVIEW_OPERATION.ACKNOWLEDGE_APPROVED, true, () => decodeReviewAcknowledgedV1(execution.body, request.binding ?? {}));
 	}
 
 	async captureCorrectionPlan(request                                          )                                    {

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -2255,6 +2255,61 @@ export function assertReviewApprovedAcknowledgementExecuteV1(
 	if (expected.revision !== undefined && shape.revision !== expected.revision) throw new TypeError("acknowledgement.execute.revision does not match the current target"); return shape.tokens;
 }
 
+// ---------------------------------------------------------------------------
+// review-acknowledged/v1 — the answer the burn prints (gentle-ai #3947)
+// ---------------------------------------------------------------------------
+
+// Until gentle-ai #3947 a successful `review acknowledge-approved` burned its
+// authority in silence and a host could only infer the burn from a later
+// STATUS offering a fresh START. From main commit bc9f74d2 the command prints
+// exactly this envelope on success. Like result-artifact/v2 it carries no
+// `contract`: the schema constant plus the slash-form operation are its whole
+// identity, so requireIdentity (which demands the contract pair) does not
+// apply. Every published release up to v2.5.0-rc.3 still prints nothing; the
+// native client owns that distinction, this decoder only ever sees bytes.
+export const REVIEW_ACKNOWLEDGED_SCHEMA = "gentle-ai.review-acknowledged/v1"         ;
+const REVIEW_ACKNOWLEDGED_OPERATION = "review/acknowledge-approved"         ;
+
+
+
+
+
+
+
+
+
+
+
+
+/** The binding the caller already holds from STATUS; the envelope must name exactly that burn. */
+
+
+
+
+
+
+export function decodeReviewAcknowledgedV1(value         , expected                                  = {})                       {
+	if (record(value, "acknowledged").schema !== REVIEW_ACKNOWLEDGED_SCHEMA) throw new TypeError(`schema must be ${REVIEW_ACKNOWLEDGED_SCHEMA}`);
+	const body = exactRecord(value, "acknowledged", ["schema", "operation", "action", "lineage_id", "target_identity", "consumed_revision", "authority"]);
+	if (body.operation !== REVIEW_ACKNOWLEDGED_OPERATION) throw new TypeError(`acknowledged.operation must be ${REVIEW_ACKNOWLEDGED_OPERATION}`);
+	if (body.action !== "acknowledged") throw new TypeError("acknowledged.action must be acknowledged");
+	if (body.authority !== "burned") throw new TypeError("acknowledged.authority must be burned");
+	const decoded                       = {
+		schema: REVIEW_ACKNOWLEDGED_SCHEMA,
+		operation: REVIEW_ACKNOWLEDGED_OPERATION,
+		action: "acknowledged",
+		lineageId: lineage(body.lineage_id, "acknowledged.lineage_id"),
+		targetIdentity: sha256(body.target_identity, "acknowledged.target_identity"),
+		consumedRevision: sha256(body.consumed_revision, "acknowledged.consumed_revision"),
+		authority: "burned",
+		raw: body,
+	};
+	if (expected.lineageId !== undefined && decoded.lineageId !== expected.lineageId) throw new TypeError("acknowledged.lineage_id does not name the acknowledged lineage");
+	if (expected.targetIdentity !== undefined && decoded.targetIdentity !== expected.targetIdentity) throw new TypeError("acknowledged.target_identity does not name the acknowledged target");
+	if (expected.revision !== undefined && decoded.consumedRevision !== expected.revision) throw new TypeError("acknowledged.consumed_revision does not name the consumed revision");
+	return decoded;
+}
+
 
 
 

--- a/tests/fixtures/devbinary/review-acknowledged-v1.captured.json
+++ b/tests/fixtures/devbinary/review-acknowledged-v1.captured.json
@@ -1,0 +1,9 @@
+{
+  "schema": "gentle-ai.review-acknowledged/v1",
+  "operation": "review/acknowledge-approved",
+  "action": "acknowledged",
+  "lineage_id": "review-3ec95251db75f626",
+  "target_identity": "sha256:b505dcd8d82395c053c9786935e11e0e235cbdecca4f1f46f98c768ea6248d3d",
+  "consumed_revision": "sha256:9732b1c3526bfecd3851093239241145c970cc126acea59bfaf14133214b60ee",
+  "authority": "burned"
+}

--- a/tests/fixtures/devbinary/review-acknowledged.provenance.md
+++ b/tests/fixtures/devbinary/review-acknowledged.provenance.md
@@ -1,0 +1,31 @@
+# review-acknowledged/v1 fixture provenance
+
+`review-acknowledged-v1.captured.json` is a byte copy of the stdout that
+`gentle-ai review acknowledge-approved` printed when it burned one approved
+compact authority. gentle-ai #3947 (main commit bc9f74d2) made that command
+print this `gentle-ai.review-acknowledged/v1` envelope; every published
+release up to and including v2.5.0-rc.3 burns the same authority with EMPTY
+stdout (verified below).
+
+- Captured 2026-08-31T08:51:50Z with the installed `gentle-ai 2.5.0-main.bc9f74d2`
+  (`gentle-ai --version` banner) in a disposable Git repository under an isolated
+  `HOME`; RDD was enabled only in that isolated HOME
+  (`gentle-ai review mode enable --scope global`).
+- Candidate: one uncommitted line appended to a committed `README.md`
+  (`non_executable_only`, zero-lens, START closed `approved`).
+- Commands, each the exact vector the previous envelope returned
+  (`GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1` set for the Pi
+  transport handshake):
+  1. `gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --agent pi --next-transition`
+  2. `gentle-ai review start --cwd=<repo> --contract=gentle-ai.review-integration/v2 --target=sha256:b505dcd8… --projection=workspace --lineage=review-3ec95251db75f626 --agent=pi --consent=relay`
+  3. `gentle-ai review status … --lineage review-3ec95251db75f626 --next-transition` (offered `review.acknowledge-approved`)
+  4. `gentle-ai review acknowledge-approved --cwd=<repo> --lineage=review-3ec95251db75f626 --target=sha256:b505dcd8… --expected-revision=sha256:9732b1c3… --token=<provider-issued>` (exit 0, empty stderr; stdout is the fixture)
+- Replaying step 4 refused with exit 1, empty stdout, and the stderr line
+  `approved acknowledgement names no live compact authority; it was already acknowledged and burned, …` (unchanged refusal shape).
+- Pinned control: the same four steps against the pinned published
+  `gentle-ai 2.5.0-rc.3` binary (sha256 b69da0a51b03f326147498ae465fc1ec52eff8427d579964eefad714c3f9bd87,
+  the recorded asset digest) burned the authority with exit 0 and ZERO bytes on
+  stdout and stderr, which is the silent path `acknowledgeApproved` keeps
+  accepting byte-for-byte.
+
+The disposable repositories and HOME were removed after the captures.

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -612,3 +612,99 @@ test("current review STATUS retains compact snapshot and released-lock wire fiel
 		assert.equal((await client(canonical.adapter).reviewStatus({ cwd: alias })).repository, root);
 	}
 });
+
+// ---------------------------------------------------------------------------
+// acknowledge-approved — gentle-ai #3947 made the burn print one typed
+// `gentle-ai.review-acknowledged/v1` envelope; every published release up to
+// v2.5.0-rc.3 burns in silence. Both are a successful burn; anything else on
+// stdout is not.
+// ---------------------------------------------------------------------------
+
+const ACKNOWLEDGED_LINEAGE = "review-3ec95251db75f626";
+const ACKNOWLEDGED_TARGET = "sha256:b505dcd8d82395c053c9786935e11e0e235cbdecca4f1f46f98c768ea6248d3d";
+const ACKNOWLEDGED_REVISION = "sha256:9732b1c3526bfecd3851093239241145c970cc126acea59bfaf14133214b60ee";
+const ACKNOWLEDGEMENT_TOKENS = [`--cwd=/repo`, `--lineage=${ACKNOWLEDGED_LINEAGE}`, `--target=${ACKNOWLEDGED_TARGET}`, `--expected-revision=${ACKNOWLEDGED_REVISION}`, "--token=provider-issued-once"] as const;
+const ACKNOWLEDGED_BINDING = { lineageId: ACKNOWLEDGED_LINEAGE, targetIdentity: ACKNOWLEDGED_TARGET, revision: ACKNOWLEDGED_REVISION } as const;
+
+test("acknowledge-approved keeps accepting the pinned silent burn byte-for-byte", async () => {
+	const queue = queuedAdapter([{ stdout: "" }]);
+	const result = await client(queue.adapter).acknowledgeApproved({ argumentTokens: ACKNOWLEDGEMENT_TOKENS, cwd: "/repo", binding: ACKNOWLEDGED_BINDING });
+	assert.equal(result, undefined);
+	assert.deepEqual(queue.calls[0]?.arguments, ["review", "acknowledge-approved", ...ACKNOWLEDGEMENT_TOKENS]);
+	assert.equal(queue.calls[0]?.cwd, "/repo");
+	assert.equal(queue.calls[0]?.timeoutMs, undefined);
+	assert.equal(queue.calls.length, 1);
+});
+
+test("acknowledge-approved decodes the captured review-acknowledged/v1 burn envelope", async () => {
+	const raw = readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "review-acknowledged-v1.captured.json"), "utf8");
+	const queue = queuedAdapter([{ stdout: raw }]);
+	const result = await client(queue.adapter).acknowledgeApproved({ argumentTokens: ACKNOWLEDGEMENT_TOKENS, cwd: "/repo", binding: ACKNOWLEDGED_BINDING });
+	assert.equal(result?.schema, "gentle-ai.review-acknowledged/v1");
+	assert.deepEqual(
+		{ lineageId: result?.lineageId, targetIdentity: result?.targetIdentity, consumedRevision: result?.consumedRevision, authority: result?.authority },
+		{ lineageId: ACKNOWLEDGED_LINEAGE, targetIdentity: ACKNOWLEDGED_TARGET, consumedRevision: ACKNOWLEDGED_REVISION, authority: "burned" },
+	);
+	assert.deepEqual(queue.calls[0]?.arguments, ["review", "acknowledge-approved", ...ACKNOWLEDGEMENT_TOKENS]);
+	assert.equal(queue.calls.length, 1);
+
+	const unbound = await client(queuedAdapter([{ stdout: raw }]).adapter).acknowledgeApproved({ argumentTokens: ACKNOWLEDGEMENT_TOKENS, cwd: "/repo" });
+	assert.equal(unbound?.consumedRevision, ACKNOWLEDGED_REVISION);
+});
+
+test("acknowledge-approved fails closed on a foreign, drifted, or mismatched success body", async () => {
+	const raw = JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "review-acknowledged-v1.captured.json"), "utf8")) as Record<string, unknown>;
+	const bodies: Array<[string, string, { lineageId: string; targetIdentity: string; revision: string }]> = [
+		["a STATUS envelope", JSON.stringify(fixture("status-v5.captured.json")), ACKNOWLEDGED_BINDING],
+		["a last-event closure", JSON.stringify(fixture("last-event-capture-result-approved.captured.json")), ACKNOWLEDGED_BINDING],
+		["an envelope with an unknown field", JSON.stringify({ ...raw, receipt: {} }), ACKNOWLEDGED_BINDING],
+		["an envelope naming another lineage", JSON.stringify(raw), { ...ACKNOWLEDGED_BINDING, lineageId: "review-other" }],
+		["an envelope naming another revision", JSON.stringify(raw), { ...ACKNOWLEDGED_BINDING, revision: `sha256:${"c".repeat(64)}` }],
+		["non-JSON output", "acknowledged\n", ACKNOWLEDGED_BINDING],
+	];
+	for (const [name, stdout, binding] of bodies) {
+		const queue = queuedAdapter([{ stdout }]);
+		await assert.rejects(
+			() => client(queue.adapter).acknowledgeApproved({ argumentTokens: ACKNOWLEDGEMENT_TOKENS, cwd: "/repo", binding }),
+			(error: unknown) => error instanceof NativeReviewCliError
+				&& (error.code === NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE || error.code === NATIVE_REVIEW_ERROR_CODE.MALFORMED_JSON)
+				&& error.mutationOutcome === "unknown",
+			name,
+		);
+		assert.equal(queue.calls.length, 1, name);
+	}
+});
+
+test("acknowledge-approved keeps its fail-closed stderr and typed refusal discipline around the envelope", async () => {
+	const raw = readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "review-acknowledged-v1.captured.json"), "utf8");
+	await assert.rejects(
+		() => client(queuedAdapter([{ stdout: raw, stderr: "note: burned\n" }]).adapter).acknowledgeApproved({ argumentTokens: ACKNOWLEDGEMENT_TOKENS, cwd: "/repo", binding: ACKNOWLEDGED_BINDING }),
+		(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.UNEXPECTED_STDERR,
+	);
+	await assert.rejects(
+		() => client(queuedAdapter([{ stdout: "", stderr: "note: burned\n" }]).adapter).acknowledgeApproved({ argumentTokens: ACKNOWLEDGEMENT_TOKENS, cwd: "/repo", binding: ACKNOWLEDGED_BINDING }),
+		(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.UNEXPECTED_STDERR,
+	);
+	const failure = {
+		schema: "gentle-ai.review-integration.failure/v2",
+		contract: "gentle-ai.review-integration/v2",
+		operation: "review.capture-result",
+		phase: "pre_native",
+		code: "gate_scope_changed",
+		message: "the target scope changed since START",
+		mutation_outcome: "not_started",
+		authority_applicability: "current_target",
+		retry_safe: true,
+		replayability: "manual_action_required",
+		required_inputs: [],
+		next_action: "explicit-maintainer-action",
+	};
+	await assert.rejects(
+		() => client(queuedAdapter([{ stdout: JSON.stringify(failure), exitCode: 1 }]).adapter).acknowledgeApproved({ argumentTokens: ACKNOWLEDGEMENT_TOKENS, cwd: "/repo", binding: ACKNOWLEDGED_BINDING }),
+		(error: unknown) => error instanceof Error && error.name === "NativeReviewIntegrationError",
+	);
+	await assert.rejects(
+		() => client(queuedAdapter([{ stdout: "", stderr: "Error: approved acknowledgement names no live compact authority\n", exitCode: 1 }]).adapter).acknowledgeApproved({ argumentTokens: ACKNOWLEDGEMENT_TOKENS, cwd: "/repo", binding: ACKNOWLEDGED_BINDING }),
+		(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.EMPTY_OUTPUT,
+	);
+});

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -116,12 +116,58 @@ test("public acknowledgement relays one current provider vector and never replay
 	const completed = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, process.cwd(), native);
 	assert.deepEqual(completed, { operation: "acknowledge-approved", status: "closed", outcome: "native-approved-acknowledgement-completed", lineage_id: lineageId, target_identity: SHA, authority: "burned", delivery: "ordinary-repository-policy", mutation_performed: true, mutation_outcome: "committed" });
 	assert.deepEqual(requests, [{ cwd: process.cwd(), lineageId }]);
-	assert.deepEqual(acknowledgementRequests, [{ cwd: process.cwd(), argumentTokens: [`--cwd=${process.cwd()}`, `--lineage=${lineageId}`, `--target=${SHA}`, `--expected-revision=${SHA}`, "--token=provider-issued-once"] }]);
+	assert.deepEqual(acknowledgementRequests, [{ cwd: process.cwd(), argumentTokens: [`--cwd=${process.cwd()}`, `--lineage=${lineageId}`, `--target=${SHA}`, `--expected-revision=${SHA}`, "--token=provider-issued-once"], binding: { lineageId, targetIdentity: SHA, revision: SHA } }]);
 
 	const later = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, process.cwd(), native);
 	assert.equal(later.outcome, "native-approved-acknowledgement-not-current");
 	assert.equal(requests.length, 2);
 	assert.equal(acknowledgementRequests.length, 1);
+});
+
+test("public acknowledgement reports the burn from the review-acknowledged/v1 envelope when the provider prints one", async () => {
+	const lineageId = "acknowledge-approved-envelope";
+	let statusCalls = 0;
+	const acknowledgementRequests: Array<Record<string, unknown>> = [];
+	const native = {
+		targetStatus: async () => {
+			statusCalls += 1;
+			return statusCalls === 1 ? approvedAcknowledgementStatus(lineageId) : burnedAcknowledgementStatus(lineageId);
+		},
+		acknowledgeApproved: async (request: Record<string, unknown>) => {
+			acknowledgementRequests.push(request);
+			return {
+				schema: "gentle-ai.review-acknowledged/v1",
+				operation: "review/acknowledge-approved",
+				action: "acknowledged",
+				lineageId,
+				targetIdentity: SHA,
+				consumedRevision: SHA,
+				authority: "burned",
+				raw: { schema: "gentle-ai.review-acknowledged/v1" },
+			};
+		},
+	} as unknown as NativeReviewCli;
+
+	const completed = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, process.cwd(), native);
+	assert.deepEqual(completed, {
+		operation: "acknowledge-approved",
+		status: "closed",
+		outcome: "native-approved-acknowledgement-completed",
+		lineage_id: lineageId,
+		target_identity: SHA,
+		consumed_revision: SHA,
+		authority: "burned",
+		burn_evidence: "gentle-ai.review-acknowledged/v1",
+		delivery: "ordinary-repository-policy",
+		mutation_performed: true,
+		mutation_outcome: "committed",
+	});
+	assert.equal(statusCalls, 1, "the burn is reported from the envelope, never from a later STATUS");
+	assert.deepEqual(acknowledgementRequests, [{
+		cwd: process.cwd(),
+		argumentTokens: [`--cwd=${process.cwd()}`, `--lineage=${lineageId}`, `--target=${SHA}`, `--expected-revision=${SHA}`, "--token=provider-issued-once"],
+		binding: { lineageId, targetIdentity: SHA, revision: SHA },
+	}]);
 });
 
 test("ambiguous acknowledgement reconciles STATUS once without replaying the provider vector", async () => {

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -1,12 +1,17 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import {
+	REVIEW_ACKNOWLEDGED_SCHEMA,
+	decodeReviewAcknowledgedV1,
 	decodeReviewCapabilitiesV2,
 	decodeReviewConsentV2,
 	decodeReviewConsentV3,
+	decodeReviewFailureV2,
 	decodeReviewLastEventClosureV1,
+	decodeReviewNextTransitionV3,
+	decodeReviewRepairV2,
 	decodeReviewResultArtifactV2,
 	decodeReviewStartV3,
 	decodeReviewStartV4,
@@ -483,4 +488,82 @@ test("START/v4 closed approval keeps acknowledgement but forbids a continuation"
 
 	closed.next_transition = (reviewingStartV4().next_transition as JsonObject);
 	assert.throws(() => decodeReviewStartV4(closed), /closed approved zero-lens START cannot carry next_transition/);
+});
+
+// ---------------------------------------------------------------------------
+// review-acknowledged/v1 — gentle-ai #3947: the exact acknowledgement burn
+// prints one typed envelope instead of nothing. Provenance:
+// tests/fixtures/devbinary/review-acknowledged.provenance.md.
+// ---------------------------------------------------------------------------
+
+const ACKNOWLEDGED_FIXTURE = "review-acknowledged-v1.captured.json";
+
+function acknowledgedFixture(): JsonObject {
+	return clone(fixture(DEV_FIXTURES, ACKNOWLEDGED_FIXTURE) as JsonObject);
+}
+
+test("review-acknowledged/v1 decodes the captured burn envelope exactly", () => {
+	const raw = acknowledgedFixture();
+	const decoded = decodeReviewAcknowledgedV1(raw);
+	assert.deepEqual(decoded, {
+		schema: "gentle-ai.review-acknowledged/v1",
+		operation: "review/acknowledge-approved",
+		action: "acknowledged",
+		lineageId: "review-3ec95251db75f626",
+		targetIdentity: "sha256:b505dcd8d82395c053c9786935e11e0e235cbdecca4f1f46f98c768ea6248d3d",
+		consumedRevision: "sha256:9732b1c3526bfecd3851093239241145c970cc126acea59bfaf14133214b60ee",
+		authority: "burned",
+		raw,
+	});
+	assert.equal(decodeReviewAcknowledgedV1(raw, { lineageId: decoded.lineageId, targetIdentity: decoded.targetIdentity, revision: decoded.consumedRevision }).authority, "burned");
+	assert.equal(REVIEW_ACKNOWLEDGED_SCHEMA, "gentle-ai.review-acknowledged/v1");
+});
+
+test("review-acknowledged/v1 rejects identity drift, foreign fields, and a binding that names another burn", () => {
+	const cases: Array<[string, (body: JsonObject) => void, RegExp]> = [
+		["schema", (body) => { body.schema = "gentle-ai.review-acknowledged/v2"; }, /schema/],
+		["operation", (body) => { body.operation = "review.acknowledge-approved"; }, /operation/],
+		["action", (body) => { body.action = "replayed"; }, /action/],
+		["authority", (body) => { body.authority = "retained"; }, /authority/],
+		["unknown key", (body) => { body.receipt = { status: "created" }; }, /receipt/],
+		["missing consumed revision", (body) => { delete body.consumed_revision; }, /consumed_revision/],
+		["malformed target", (body) => { body.target_identity = "b505dcd8"; }, /target_identity/],
+		["malformed lineage", (body) => { body.lineage_id = "Review_3ec95251"; }, /lineage_id/],
+	];
+	for (const [name, mutate, pattern] of cases) {
+		const body = acknowledgedFixture();
+		mutate(body);
+		assert.throws(() => decodeReviewAcknowledgedV1(body), pattern, name);
+	}
+	const raw = acknowledgedFixture();
+	assert.throws(() => decodeReviewAcknowledgedV1(raw, { lineageId: "review-other" }), /lineage/);
+	assert.throws(() => decodeReviewAcknowledgedV1(raw, { targetIdentity: sha("b") }), /target/);
+	assert.throws(() => decodeReviewAcknowledgedV1(raw, { revision: sha("c") }), /revision/);
+	assert.throws(() => decodeReviewAcknowledgedV1(null), /object/);
+	assert.throws(() => decodeReviewAcknowledgedV1("{}"), /object/);
+});
+
+test("review-acknowledged/v1 is disjoint from every prior captured identity in both directions", () => {
+	const priorFixtures = readdirSync(DEV_FIXTURES).filter((name) => name.endsWith(".json") && name !== ACKNOWLEDGED_FIXTURE);
+	assert.ok(priorFixtures.length >= 15, "the prior captured corpus must be present");
+	for (const name of priorFixtures) {
+		assert.throws(() => decodeReviewAcknowledgedV1(fixture(DEV_FIXTURES, name)), /schema|object/, `${name} must not decode as an acknowledgement`);
+	}
+	const acknowledged = acknowledgedFixture();
+	const priorDecoders: Array<[string, (value: unknown) => unknown]> = [
+		["status/v3", decodeReviewStatusV3],
+		["start/v3", decodeReviewStartV3],
+		["start/v4", decodeReviewStartV4],
+		["capabilities/v2", decodeReviewCapabilitiesV2],
+		["consent/v2", decodeReviewConsentV2],
+		["consent/v3", decodeReviewConsentV3],
+		["last-event-closure/v1", decodeReviewLastEventClosureV1],
+		["result-artifact/v2", decodeReviewResultArtifactV2],
+		["failure/v2", decodeReviewFailureV2],
+		["next-transition/v3", decodeReviewNextTransitionV3],
+		["repair/v2", decodeReviewRepairV2],
+	];
+	for (const [name, decoder] of priorDecoders) {
+		assert.throws(() => decoder(clone(acknowledged)), `${name} must reject the acknowledged envelope`);
+	}
 });


### PR DESCRIPTION
## Parity with gentle-ai main (#3947)

gentle-ai `review acknowledge-approved` now prints one `gentle-ai.review-acknowledged/v1` envelope on success (gentle-ai #3947, main only; no published release contains it yet). Pi's bodyless invocation path threw `SCHEMA_INCOMPATIBLE: native bodyless operation returned output` on any stdout, so against a main build the burn succeeded in Go while Pi reported a failure and reconciled through STATUS.

## What changed

- `lib/review-integration-v2.ts`: `decodeReviewAcknowledgedV1` (exact identity, exact record, `action: acknowledged`, `authority: burned`, optional lineage/target/revision binding).
- `lib/native-review-cli.ts`: a zero-exit empty stdout is the pinned silent burn and resolves `undefined` (byte-identical to every published release up to v2.5.0-rc.3); printed output is decoded against the one accepted identity; anything else is `SCHEMA_INCOMPATIBLE` with `mutationOutcome: unknown` (existing STATUS-reconcile path). stderr and refusal discipline unchanged.
- `extensions/gentle-ai.ts`: passes the STATUS binding and adds `consumed_revision` / `burn_evidence` to the closed result only when the envelope is present.
- Fixture `tests/fixtures/devbinary/review-acknowledged-v1.captured.json`: byte copy of stdout from `gentle-ai 2.5.0-main.bc9f74d2` in a scratch repo (provenance in `review-acknowledged.provenance.md`); control against the pinned rc.3 binary printed 0 bytes.
- Tests: decoder exactness, drift/foreign-field/binding rejection, cross-identity in both directions (11 prior decoders reject the envelope; the new decoder rejects 19 prior captured fixtures), CLI silent/envelope/foreign/mismatch/stderr/refusal, controller path. `runtime/*.mjs` regenerated.

## Verification

`pnpm test` (override unregistered), `check:runtime-modules`, `verify-package-files` all green. Field smoke through `runtime/*.mjs` with the dev-binary override: full START to ACK lifecycle on the main binary decodes the envelope and the authority is gone; the same lifecycle on the rc.3 binary resolves the silent burn.

## Deferred

Pin bump (`GENTLE_AI_VERSION`, `INSTALLER_VERSION`, digests, `NATIVE_CLI_CONTRACTS`) waits for a published gentle-ai release that contains #3947.

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approved review acknowledgements now return structured confirmation details when provided, including consumed revision and burn evidence.
  * Added validation for acknowledgement responses and their lineage, target, and revision data.
  * Supports both structured acknowledgement responses and silent successful operations.

* **Bug Fixes**
  * Correctly handles non-empty output from successful operations instead of rejecting it prematurely.
  * Reports invalid or mismatched acknowledgement responses with appropriate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->