### PR TITLE
fix(commands): rename the SDD slash commands to the gentle-sdd prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ pi
 /gentle:status          Check package, SDD assets, OpenSpec, and global model config.
 /gentle:doctor          Run read-only diagnostics for SDD assets, config, tools, and guards.
 /gentle:sdd-preflight   Run or reuse the session SDD preflight explicitly.
-/sdd-init                  Create or refresh openspec/config.yaml (openspec/both stores only).
+/gentle-sdd-init           Create or refresh openspec/config.yaml (openspec/both stores only).
 /gentle:models             Assign global model/effort routing to SDD/custom agents.
 /gentle:persona            Switch between gentleman and neutral persona modes.
 /gentle:background-subagents  Show or set the managed background-subagents policy, with its deciding source.
@@ -122,7 +122,7 @@ Typical flow:
 
 1. Open Pi in your repo.
 2. Run `/gentle:status`.
-3. Run `/sdd-init` once per project, or when test/project capabilities change. This also runs the session SDD preflight.
+3. Run `/gentle-sdd-init` once per project, or when test/project capabilities change. This also runs the session SDD preflight.
 4. For a substantial change, ask Pi to use SDD. Natural-language requests are classified by the parent agent, not by brittle runtime regexes.
 5. Review the phase artifacts instead of trusting floating chat context.
 
@@ -390,7 +390,7 @@ Engram-only mode is different by design: Engram is working memory and does not m
 
 ## SDD preflight and project files
 
-`gentle-pi` does not require SDD agents to be copied into every project. The package ensures global Pi SDD assets exist under the Pi agent home and treats project-local files only as overrides/debug copies. Slash SDD flows such as `/sdd-*`, `/sdd-init`, and the explicit `/gentle:sdd-preflight` command run a lazy preflight and resolve session-scoped SDD preferences. For natural-language requests, the parent agent decides whether the work should use SDD and must run/reuse `/gentle:sdd-preflight` before continuing.
+`gentle-pi` does not require SDD agents to be copied into every project. The package ensures global Pi SDD assets exist under the Pi agent home and treats project-local files only as overrides/debug copies. Slash SDD flows such as `/sdd-*`, `/gentle-sdd-init`, and the explicit `/gentle:sdd-preflight` command run a lazy preflight and resolve session-scoped SDD preferences. For natural-language requests, the parent agent decides whether the work should use SDD and must run/reuse `/gentle:sdd-preflight` before continuing.
 
 ```text
 ~/.pi/agent/agents/sdd-*.md
@@ -571,7 +571,7 @@ Legacy string entries are still accepted and treated as `model`-only config.
 | `/gentle:toggle-rose`            | Toggles the startup rose.                                           |
 | `/gentle:toggle-text-logo`       | Toggles the startup text logo.                                      |
 | `/gentle:banner-color`           | Selects a startup banner color preset.                              |
-| `/sdd-init`                      | Initializes or refreshes `openspec/config.yaml` (openspec/both stores only). |
+| `/gentle-sdd-init`               | Initializes or refreshes `openspec/config.yaml` (openspec/both stores only). |
 | `/gentle:install-sdd`         | Repairs missing global SDD runtime assets without overwriting files. |
 | `/gentle:install-sdd --force` | Force-refreshes installed global SDD assets.                         |
 | `/skill-registry:refresh`        | Regenerates `.atl/skill-registry.md`.                               |
@@ -659,7 +659,7 @@ Memory contract for SDD delegation:
 | `contracts/review-integration/v1/` | Byte-identical provider schemas and conformance fixtures for contract `review-integration/v1`, hash-checked before packaging; retained on disk permanently because `/v2`'s schemas `$ref` into these fragments. |
 | `contracts/review-integration/v2/` | Byte-identical provider schemas and conformance fixtures for contract `review-integration/v2` (immutable `base_tree`/`candidate_tree`, ordered `changed_path_manifest`, no inline candidate diff), hash-checked before packaging. |
 | `extensions/startup-banner.ts` | Shows and configures the startup intro, color presets, compact runtime panel, and collaboration credit.     |
-| `extensions/sdd-init.ts`       | Registers `/sdd-init` for OpenSpec initialization.                                                         |
+| `extensions/sdd-init.ts`       | Registers `/gentle-sdd-init` for OpenSpec initialization.                                                         |
 | `extensions/skill-registry.ts` | Maintains `.atl/skill-registry.md` from project/user skills and closes file watchers on shutdown.          |
 | `assets/orchestrator.md`       | Parent-session orchestration contract (always-on core).                                                    |
 | `assets/orchestrator-delegation.md` | Lazy-loaded delegation/routing/review detail, including the mirrored gentle-ai canon.                 |

--- a/assets/orchestrator-delegation.md
+++ b/assets/orchestrator-delegation.md
@@ -190,7 +190,7 @@ Do not make every task SDD. Do make non-trivial tasks multi-agent at the narrowe
 
 SDD is never selected by size, file count, or risk alone. Suggest it organically when durable proposal/spec/design/tasks would materially reduce substantial ambiguity (unclear requirements or acceptance criteria, architectural or product decisions, cross-cutting behavior changes), and let the user decide.
 
-Select SDD only when the user explicitly asks to use SDD, invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue`, or accepts an SDD proposal. Once selected, do not jump directly to implementation. Calibrate context, create artifacts, and ask for approval at the appropriate gates.
+Select SDD only when the user explicitly asks to use SDD, invokes `/gentle-sdd-new`, `/gentle-sdd-ff`, or `/gentle-sdd-continue`, or accepts an SDD proposal. Once selected, do not jump directly to implementation. Calibrate context, create artifacts, and ask for approval at the appropriate gates.
 
 ## Pi Delegation Bindings
 

--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -41,7 +41,7 @@ Route work through the smallest harness that is safe. Three tiers:
 
 1. **Inline Direct** — small, mechanical, parent has context (typo, one-file edit, read-only check of 1-3 known files, bash for state). No SDD ceremony; stop when it is no longer small.
 2. **Simple Delegation** — generic non-SDD exploration → `gentle-ai-explore`; bounded implementation → `gentle-ai-worker`; command-running generic non-SDD verification → `gentle-ai-verify`. Try its package role; if missing/unusable, use native `Agent` under the same read-only mapping/verification constraints and report fallback. SDD roles stay inside SDD.
-3. **SDD (optional)** — selected only by an explicit request (`/sdd-new`/`/sdd-ff`/`/sdd-continue` or a direct ask) or an accepted proposal; size, file count, or risk alone never selects SDD. Suggest it organically when durable proposal/spec/design/tasks would materially reduce substantial ambiguity. Once selected, do not jump to implementation; create artifacts and gate for approval.
+3. **SDD (optional)** — selected only by an explicit request (`/gentle-sdd-new`/`/gentle-sdd-ff`/`/gentle-sdd-continue` or a direct ask) or an accepted proposal; size, file count, or risk alone never selects SDD. Suggest it organically when durable proposal/spec/design/tasks would materially reduce substantial ambiguity. Once selected, do not jump to implementation; create artifacts and gate for approval.
 
 ## Delegation Rules
 

--- a/assets/sdd-orchestrator-workflow.md
+++ b/assets/sdd-orchestrator-workflow.md
@@ -18,11 +18,11 @@ proposal → spec ─┬→ tasks → apply → verify → sync → archive
 proposal → design ┘
 ```
 
-`/sdd-status [change]` is the read-only status action for resolving the active change, artifact paths, task progress, dependency readiness, and action context before apply/verify/sync/archive.
+`/gentle-sdd-status [change]` is the read-only status action for resolving the active change, artifact paths, task progress, dependency readiness, and action context before apply/verify/sync/archive.
 
 ## Native SDD Dispatcher
 
-The user expresses intent; they should not have to administer phases manually. For natural-language SDD requests and `/sdd-continue`, the parent/orchestrator must use the native status engine as the state authority, decide the next phase, and delegate only the phase that status marks ready.
+The user expresses intent; they should not have to administer phases manually. For natural-language SDD requests and `/gentle-sdd-continue`, the parent/orchestrator must use the native status engine as the state authority, decide the next phase, and delegate only the phase that status marks ready.
 
 Flow:
 
@@ -32,8 +32,8 @@ user intent → preflight/init guard → native status engine → phase decision
 
 Rules:
 
-- `/sdd-status` is a debug/status command, not the main UX.
-- `/sdd-continue` is the native dispatcher command: resolve status, choose the next ready phase, and carry status/instructions into the subagent prompt.
+- `/gentle-sdd-status` is a debug/status command, not the main UX.
+- `/gentle-sdd-continue` is the native dispatcher command: resolve status, choose the next ready phase, and carry status/instructions into the subagent prompt.
 - `sdd-apply`, `sdd-verify`, `sdd-sync`, and `sdd-archive` must obey parent-provided native status; they must not reconstruct readiness from prompt inference when status JSON is present.
 - Do not launch a phase when native status marks that dependency `blocked`.
 - `sdd-archive` cannot proceed unless native status says `dependencies.archive` is `ready` or `all_done` — UNLESS the store carve-out is active (`nextRecommended: "resolve-via-engram"`), in which case resolve archive readiness from Engram instead of treating `not_applicable` as a gate failure.
@@ -41,7 +41,7 @@ Rules:
 
 ## SDD Status Contract
 
-Before `/sdd-continue`, `sdd-apply`, `sdd-verify`, `sdd-sync`, or `sdd-archive`, resolve and carry structured status. Lookup order: parent-provided status, then project override `.pi/gentle-ai/support/sdd-status-contract.md`, then globally installed `~/.pi/agent/gentle-ai/support/sdd-status-contract.md`, then the embedded `sdd-status` prompt contract. Do not use `assets/support/...` as a runtime path; that is only the package source path before installation.
+Before `/gentle-sdd-continue`, `sdd-apply`, `sdd-verify`, `sdd-sync`, or `sdd-archive`, resolve and carry structured status. Lookup order: parent-provided status, then project override `.pi/gentle-ai/support/sdd-status-contract.md`, then globally installed `~/.pi/agent/gentle-ai/support/sdd-status-contract.md`, then the embedded `sdd-status` prompt contract. Do not use `assets/support/...` as a runtime path; that is only the package source path before installation.
 
 Status must include:
 
@@ -56,7 +56,7 @@ Do not guess the active change. If change selection is ambiguous, ask the user a
 
 ## Lazy SDD Preflight
 
-Do not ask SDD setup questions on session start. The first time the user initiates an SDD process in a Pi session, run the SDD preflight once and keep those choices for the rest of that session. Runtime trigger detection is intentionally deterministic: slash SDD flows and `/sdd-init` run preflight automatically; for natural-language requests, the parent/orchestrator decides semantically whether SDD is needed and must run/reuse `/gentle:sdd-preflight` before continuing.
+Do not ask SDD setup questions on session start. The first time the user initiates an SDD process in a Pi session, run the SDD preflight once and keep those choices for the rest of that session. Runtime trigger detection is intentionally deterministic: slash SDD flows and `/gentle-sdd-init` run preflight automatically; for natural-language requests, the parent/orchestrator decides semantically whether SDD is needed and must run/reuse `/gentle:sdd-preflight` before continuing.
 
 **Hard gate:** `openspec/config.yaml`, existing SDD changes, installed `.pi`/global SDD assets, or a todo named "preflight" are not session preflight. They are project context only. Do not mark SDD preflight complete, start `sdd-init`, launch SDD subagents/chains, or move to explore/proposal/spec/design/tasks until this session has an injected `## SDD Session Preflight` block or an equivalent resolution from the canonical authority order below.
 
@@ -87,9 +87,9 @@ When the store is `openspec` or `both`, the local artifact is:
 openspec/config.yaml
 ```
 
-If it is missing, ask the user for the minimal information needed or run `/sdd-init` if available.
+If it is missing, ask the user for the minimal information needed or run `/gentle-sdd-init` if available.
 
-When the store is `engram` or `none`, `/sdd-init` never writes that file, so its absence is expected and is not a missing init. Never re-trigger `/sdd-init` over it. Resolve project context from the Engram `sdd-init/{project}` topic for `engram`, or inline from the session for `none`, and ask the user only when that context is genuinely absent.
+When the store is `engram` or `none`, `/gentle-sdd-init` never writes that file, so its absence is expected and is not a missing init. Never re-trigger `/gentle-sdd-init` over it. Resolve project context from the Engram `sdd-init/{project}` topic for `engram`, or inline from the session for `none`, and ask the user only when that context is genuinely absent.
 
 This init guard runs after the session preflight gate above; project config presence or absence never substitutes for session preflight choices. Do not proceed with a substantial SDD flow while pretending project context, testing capability, or session preflight choices are known.
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5520,7 +5520,7 @@ function createGentleAiExtensionForTesting(
 		);
 	};
 
-	pi.registerCommand("sdd-status", {
+	pi.registerCommand("gentle-sdd-status", {
 		description: "Show deterministic SDD change status and instructions.",
 		handler: async (args, ctx) => {
 			await handleSddStatusCommand(args, ctx);
@@ -5541,7 +5541,7 @@ function createGentleAiExtensionForTesting(
 		);
 	};
 
-	pi.registerCommand("sdd-continue", {
+	pi.registerCommand("gentle-sdd-continue", {
 		description: "Resolve SDD status and route the next phase deterministically.",
 		handler: async (args, ctx) => {
 			await handleSddContinueCommand(args, ctx);

--- a/extensions/sdd-init.ts
+++ b/extensions/sdd-init.ts
@@ -771,7 +771,7 @@ function ensureOpenSpecDirs(cwd: string): void {
 }
 
 export default function (pi: ExtensionAPI) {
-	pi.registerCommand("sdd-init", {
+	pi.registerCommand("gentle-sdd-init", {
 		description:
 			"Auto-detect project stack and bootstrap openspec/config.yaml for SDD.",
 		handler: async (_args: unknown, ctx: any) => {
@@ -797,7 +797,7 @@ export default function (pi: ExtensionAPI) {
 			const configPath = join(ctx.cwd, CONFIG_REL_PATH);
 			if (existsSync(configPath)) {
 				ctx.ui.notify(
-					`${CONFIG_REL_PATH} already exists. Edit it manually or remove it before re-running /sdd-init.`,
+					`${CONFIG_REL_PATH} already exists. Edit it manually or remove it before re-running /gentle-sdd-init.`,
 					"warning",
 				);
 				return;

--- a/lib/sdd-preflight.ts
+++ b/lib/sdd-preflight.ts
@@ -586,7 +586,7 @@ export function installSddAssets(
 
 export function isSddPreflightTrigger(text: string): boolean {
 	const trimmed = text.trim();
-	if (/^\/sdd(?:[-:][^\s]*)?(?:\s|$)/i.test(trimmed)) return true;
+	if (/^\/(?:gentle-)?sdd(?:[-:][^\s]*)?(?:\s|$)/i.test(trimmed)) return true;
 	if (/[?？]\s*$/.test(trimmed)) return false;
 	if (
 		/\b(?:don't|do\s+not|not\s+use|never\s+use|without\s+using|sin\s+usar|no\s+(?:quiero|queremos|vamos\s+a)?\s*usar)\s+sdd\b/i.test(

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -31,18 +31,23 @@ const EXPECTED_BANNER_COMMANDS = [
 const EXPECTED_COMMANDS = [
 	"gentle:install-sdd",
 	"gentle:sdd-preflight",
-	"sdd-status",
-	"sdd-continue",
+	"gentle-sdd-status",
+	"gentle-sdd-continue",
 	"gentle:models",
 	"gentle:persona",
 	"gentle:status",
 	"gentle:doctor",
-	"sdd-init",
+	"gentle-sdd-init",
 	"skill-registry:refresh",
 	...EXPECTED_BANNER_COMMANDS,
 ];
 
 const FORBIDDEN_COMPAT_COMMANDS = [
+	// The SDD entry points carry the gentle- prefix so they read identically in
+	// Claude Code and Pi. The bare names are retired without an alias.
+	"sdd-init",
+	"sdd-continue",
+	"sdd-status",
 	"gentle-ai:install-sdd",
 	"gentle-ai:sdd-preflight",
 	"gentle-ai:sdd-status",
@@ -482,10 +487,10 @@ async function run() {
 		assert.match(applyPromptResult.systemPrompt, /"changeName": "status-demo"/);
 		assert.match(applyPromptResult.systemPrompt, /### apply instructions/);
 		const statusCtx = createCtx(promptCwd, true);
-		await commands.get("sdd-status").handler("status-demo --json", statusCtx);
+		await commands.get("gentle-sdd-status").handler("status-demo --json", statusCtx);
 		assert.match(statusCtx.ui.notifications.at(-1).message, /"schemaName": "gentle-pi\.sdd-status"/);
 		const continueCtx = createCtx(promptCwd, true);
-		await commands.get("sdd-continue").handler("status-demo", continueCtx);
+		await commands.get("gentle-sdd-continue").handler("status-demo", continueCtx);
 		assert.match(continueCtx.ui.notifications.at(-1).message, /Native SDD Dispatcher/);
 		assert.match(continueCtx.ui.notifications.at(-1).message, /nextPhase: sdd-apply/);
 		const { execFileSync } = await import("node:child_process");
@@ -497,7 +502,7 @@ async function run() {
 			'{"schema":"gentle-ai.recovery-required/v1","change_name":"status-demo"}',
 		);
 		const blockedContinueCtx = createCtx(promptCwd, true);
-		await commands.get("sdd-continue").handler("status-demo", blockedContinueCtx);
+		await commands.get("gentle-sdd-continue").handler("status-demo", blockedContinueCtx);
 		assert.doesNotMatch(blockedContinueCtx.ui.notifications.at(-1).message, /resolve-review:/);
 		assert.match(blockedContinueCtx.ui.notifications.at(-1).message, /nextPhase: sdd-apply/);
 	} finally {
@@ -1161,7 +1166,7 @@ async function run() {
 		await rm(globalModelsPath, { force: true });
 	}
 
-	for (const [index, text] of ["/sdd", "/sdd plan", "/sdd:plan", "/sdd-plan this change"].entries()) {
+	for (const [index, text] of ["/sdd", "/sdd plan", "/sdd:plan", "/sdd-plan this change", "/gentle-sdd-continue", "/gentle-sdd-status fix-rose --json", "/gentle-sdd-init"].entries()) {
 		const slashSddCwd = await tempWorkspace();
 		try {
 			const ctx = createCtx(slashSddCwd, true, `slash-sdd-session-${index}`);
@@ -1282,7 +1287,7 @@ async function run() {
 	}
 
 	// Issue #64: selecting engram as the artifact store must not cause
-	// /sdd-init to create openspec/ or openspec/config.yaml.
+	// /gentle-sdd-init to create openspec/ or openspec/config.yaml.
 	const engramSddInitCwd = await tempWorkspace();
 	try {
 		pi.setActiveTools(["read", "bash", "edit", "write", "mem_save"]);
@@ -1292,21 +1297,21 @@ async function run() {
 			return options[0];
 		};
 		await commands.get("gentle:sdd-preflight").handler("", ctx);
-		await commands.get("sdd-init").handler("", ctx);
+		await commands.get("gentle-sdd-init").handler("", ctx);
 		assert.equal(
 			existsSync(join(engramSddInitCwd, "openspec")),
 			false,
-			"/sdd-init must not create openspec/ when artifactStore is engram",
+			"/gentle-sdd-init must not create openspec/ when artifactStore is engram",
 		);
 		assert.equal(
 			existsSync(join(engramSddInitCwd, "openspec", "config.yaml")),
 			false,
-			"/sdd-init must not write openspec/config.yaml when artifactStore is engram",
+			"/gentle-sdd-init must not write openspec/config.yaml when artifactStore is engram",
 		);
 		assert.doesNotMatch(
 			ctx.ui.notifications.at(-1).message,
 			/Wrote openspec\/config\.yaml/,
-			"/sdd-init must not announce openspec/config.yaml when artifactStore is engram",
+			"/gentle-sdd-init must not announce openspec/config.yaml when artifactStore is engram",
 		);
 		assert.match(
 			ctx.ui.notifications.at(-1).message,
@@ -1330,26 +1335,26 @@ async function run() {
 			return options[0];
 		};
 		await commands.get("gentle:sdd-preflight").handler("", ctx);
-		await commands.get("sdd-init").handler("", ctx);
+		await commands.get("gentle-sdd-init").handler("", ctx);
 		assert.equal(
 			existsSync(join(bothSddInitCwd, "openspec", "specs")),
 			true,
-			"/sdd-init must create openspec/specs when artifactStore is both",
+			"/gentle-sdd-init must create openspec/specs when artifactStore is both",
 		);
 		assert.equal(
 			existsSync(join(bothSddInitCwd, "openspec", "changes", "archive")),
 			true,
-			"/sdd-init must create openspec/changes/archive when artifactStore is both",
+			"/gentle-sdd-init must create openspec/changes/archive when artifactStore is both",
 		);
 		assert.equal(
 			existsSync(join(bothSddInitCwd, "openspec", "config.yaml")),
 			true,
-			"/sdd-init must write openspec/config.yaml when artifactStore is both",
+			"/gentle-sdd-init must write openspec/config.yaml when artifactStore is both",
 		);
 		assert.match(
 			ctx.ui.notifications.at(-1).message,
 			/Wrote openspec\/config\.yaml/,
-			"/sdd-init must announce openspec/config.yaml when artifactStore is both",
+			"/gentle-sdd-init must announce openspec/config.yaml when artifactStore is both",
 		);
 		assert.equal(ctx.ui.notifications.at(-1).level, "info");
 	} finally {
@@ -1412,7 +1417,7 @@ async function run() {
 	const sddCwd = await tempWorkspace();
 	try {
 		const ctx = createCtx(sddCwd, true);
-		await commands.get("sdd-init").handler("", ctx);
+		await commands.get("gentle-sdd-init").handler("", ctx);
 		assert.equal(existsSync(join(sddCwd, ".pi", "agents", "sdd-apply.md")), false);
 		assert.equal(existsSync(join(sddCwd, ".pi", "chains", "sdd-full.chain.md")), false);
 		assert.equal(existsSync(join(globalAgentHome, "agents", "sdd-apply.md")), true);
@@ -1439,7 +1444,7 @@ async function run() {
 		);
 		await writeFile(globalModelsPath, "{ invalid json");
 		const ctx = createCtx(invalidSddInitCwd, true, "invalid-sdd-init-session");
-		await commands.get("sdd-init").handler("", ctx);
+		await commands.get("gentle-sdd-init").handler("", ctx);
 		assert.equal(ctx.ui.notifications[0].level, "warning");
 		assert.match(ctx.ui.notifications[0].message, /Model routing skipped:/);
 		assert.match(ctx.ui.notifications[0].message, /models\.json/);

--- a/tests/sdd-preflight.test.ts
+++ b/tests/sdd-preflight.test.ts
@@ -16,6 +16,7 @@ import {
 	collectSddPreflightPreferences,
 	DEFAULT_SDD_PREFLIGHT,
 	installSddAssets,
+	isSddPreflightTrigger,
 	readSddPreflightFromDisk,
 	sddPreflightDiskPath,
 	writeSddPreflightToDisk,
@@ -279,4 +280,13 @@ test("a persisted canonical 'hybrid' artifact store loads unchanged", async () =
 
 	const loaded = readSddPreflightFromDisk(cwd, true);
 	assert.equal(loaded?.artifactStore, "hybrid");
+});
+
+test("slash SDD preflight trigger accepts the gentle-sdd command prefix", () => {
+	for (const text of ["/gentle-sdd-init", "/gentle-sdd-continue", "/gentle-sdd-status fix-rose --json", "/sdd", "/sdd:plan", "/sdd-plan this change"]) {
+		assert.equal(isSddPreflightTrigger(text), true, text);
+	}
+	for (const text of ["/gentle-sddx", "/gentle:sdd-preflight", "/gentle-status", "gentle-sdd-init"]) {
+		assert.equal(isSddPreflightTrigger(text), false, text);
+	}
 });


### PR DESCRIPTION
## What changed

gentle-ai is renaming every Claude Code SDD command from `/sdd-<name>` to `/gentle-sdd-<name>` because Claude Code resolves a command and a skill with the same name in favour of the skill, and the delegate-only SDD skills are not user-invocable (gentle-ai #2644, #2322). This PR carries the same user-facing names in gentle-pi so the SDD entry points read identically in Claude Code and Pi.

- `extensions/gentle-ai.ts`, `extensions/sdd-init.ts`: `/sdd-init`, `/sdd-continue`, `/sdd-status` are registered as `/gentle-sdd-init`, `/gentle-sdd-continue`, `/gentle-sdd-status`. No alias for the old names; typing `/sdd-init` after the upgrade gets Pi's ordinary unknown-command answer.
- `assets/sdd-orchestrator-workflow.md`, `assets/orchestrator.md`, `assets/orchestrator-delegation.md`, `README.md`: every user-typed mention follows, including the `/gentle-sdd-new` and `/gentle-sdd-ff` mentions that name the Claude Code commands, so no sentence reads mixed.
- `tests/runtime-harness.mjs`: the registration check now requires the three new names and forbids the three old ones (red on the unmodified tree with `missing command gentle-sdd-status`).

## Hidden site: the lazy preflight trigger

`lib/sdd-preflight.ts` `isSddPreflightTrigger` matched `/sdd`, `/sdd-...`, and `/sdd:...` input to run the session SDD preflight from the input hook. `/gentle-sdd-continue` and `/gentle-sdd-status` do not call the preflight from their handlers, so after the rename they would have silently skipped it. The regex now accepts an optional `gentle-` prefix; the bare `/sdd` and `/sdd:plan` forms still trigger. `tests/sdd-preflight.test.ts` pins the new spellings as triggers and the near-misses as non-triggers.

## Left unchanged

- `extensions/quiet-tools.ts` `GentleAiRoutineCommand` and its token routing: those are gentle-ai CLI subcommand names (`gentle-ai sdd-status ...`), not slash commands.
- `SDD_AGENT_NAMES` and the agent asset files (`sdd-init.md`, `sdd-status.md`): agent names, not commands.
- Binary pin, `NATIVE_CLI_CONTRACTS`, asset digests, schema identities, `openspec/changes/**` history, and the frozen pre-diet fixture.
- `runtime/*.mjs`: generated from `lib/` modules that carry no command names; `check:runtime-modules` reports no drift.

## Verification

Run in the foreground with the `~/.pi/gentle-ai/dev-binary.json` override moved aside and restored afterwards:

- `pnpm test`: 1138 tests, 1137 pass, 0 fail, 1 pre-existing skip; `check:provider-contract` passed (contract 1.1.0); `test:harness` exit 0.
- `pnpm run check:runtime-modules`: runtime matches TypeScript sources (4 modules).
- `node scripts/verify-package-files.mjs`: passed (162 files; 68 byte-pinned contract artifacts for the v2.5.0-rc.3 runtime).

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `/gentle-sdd-init`, `/gentle-sdd-status`, and `/gentle-sdd-continue` command names.
  * SDD command variants using the new `gentle-` prefix now trigger preflight checks.
  * Added guidance for resolving readiness through Engram when native status is not authoritative.

* **Documentation**
  * Updated setup instructions, command listings, workflow guidance, and routing documentation to use the new command names.

* **Tests**
  * Expanded coverage for the renamed commands and preflight trigger recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->