### PR TITLE
fix(review): name stale consent bindings, project renames like Go, and surface admission refusals

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3605,6 +3605,34 @@ function reviewConsentDigest(consent: ReviewConsentEnvelope): string {
 	return createHash("sha256").update(JSON.stringify(consent)).digest("hex");
 }
 
+// gentle-pi#516: a binding this session does not hold (already answered,
+// expired, or issued by another Pi session or process) used to fall through
+// to the plain negotiated STATUS, which reads exactly like a healthy pre-start
+// "ready" and sent the model back into START for a second consent prompt. The
+// fact is local and proven before any provider call, so the outcome names the
+// binding and the exit; the current STATUS rides along as context only.
+function staleConsentBindingDiagnostics(binding: string, expired: boolean): { code: "consent-binding-expired" | "consent-binding-unknown"; message: string } {
+	const exit = "Run START again for this candidate to obtain a fresh consent envelope and answer that envelope's binding once; do not resend this binding.";
+	return expired
+		? { code: "consent-binding-expired", message: `consent binding ${binding} expired after ${PENDING_REVIEW_CONSENT_TTL_MS / 60_000} minutes without an answer. ${exit}` }
+		: { code: "consent-binding-unknown", message: `consent binding ${binding} is not held by this Pi session: it was already answered, expired, or was issued by another Pi session or process. ${exit}` };
+}
+
+function staleConsentBindingOutcome(operation: ReviewControllerOperation, binding: string, diagnostics: ReturnType<typeof staleConsentBindingDiagnostics>, status: ReviewStatusV3): Record<string, unknown> {
+	const mapped = mapNativeTargetStatus(operation, status);
+	return {
+		...mapped,
+		status: "blocked",
+		outcome: "consent-binding-stale",
+		consent_binding: binding,
+		diagnostics,
+		native_invocation_attempted: false,
+		...nativeStartPreAuthorityRejection(),
+		provider_action: status.action,
+		...(status.action === "start" ? { next_action: "restart-for-fresh-consent" } : mapped.next_action === undefined ? { next_action: status.action } : {}),
+	};
+}
+
 function assertNativeStartCandidateBinding(candidateView: CandidateView, target: ReviewStatusV3): void {
 	candidateView.verify();
 	if (
@@ -3946,6 +3974,14 @@ function setReviewHostRelayRunnerForTesting(runner?: ReviewHostRelayRunner): voi
 const REVIEW_HOST_RELAY_RETRY_ACTION =
 	"Call fresh STATUS and submit only an exact reoffered one-slot binding; never replay this capture from transcript inference.";
 
+// gentle-pi#522 / #524: gentle-ai refused the submission at admission and
+// stated that the lens slot was not consumed. The refused bytes are the
+// problem, so the continuation is a fresh reviewer run on the reoffered slot,
+// not a replay and not an unknown-outcome reconciliation.
+const REVIEW_HOST_RELAY_REFUSED_ACTION =
+	"gentle-ai refused this submission at admission and did not consume the lens slot; the reason is in failure.stderr. "
+	+ "Call fresh STATUS and run only the exact slot it reoffers so the reviewer produces a new result that satisfies that refusal; never resubmit the refused bytes.";
+
 function reviewHostRelayTimeoutNextAction(error: ReviewHostRelayError): string {
 	const measured = error.elapsedMs === null || error.timeoutMs === null
 		? ""
@@ -3963,6 +3999,10 @@ function reviewHostRelayFailureReport(error: ReviewHostRelayError): Record<strin
 		timed_out: error.timedOut,
 		...(error.elapsedMs === null ? {} : { elapsed_ms: error.elapsedMs }),
 		...(error.timeoutMs === null ? {} : { timeout_ms: error.timeoutMs }),
+		// The captured native stderr is the only place the provider's exact
+		// refusal reason lives (gentle-pi#524); dropping it hid every admission
+		// refusal behind "submission-refused".
+		...(error.stderr.length === 0 ? {} : { stderr: error.stderr }),
 	};
 }
 
@@ -4098,7 +4138,13 @@ async function executeReviewHostRelayCapture(
 		};
 	} catch (error) {
 		if (!(error instanceof ReviewHostRelayError)) return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding, selections, route);
-		if (error.mutationOutcome === "unknown") return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding, selections, route);
+		if (error.mutationOutcome === "unknown") {
+			return {
+				...(await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, binding, selections, route)),
+				failure: reviewHostRelayFailureReport(error),
+				reason: error.message,
+			};
+		}
 		if (error.kind === REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE) {
 			return {
 				tool: "gentle_review_capture",
@@ -4130,7 +4176,9 @@ async function executeReviewHostRelayCapture(
 			mutation_outcome: "none",
 			next_action: error.kind === REVIEW_HOST_RELAY_FAILURE.PI_TIMED_OUT
 				? reviewHostRelayTimeoutNextAction(error)
-				: REVIEW_HOST_RELAY_RETRY_ACTION,
+				: error.kind === REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED
+					? REVIEW_HOST_RELAY_REFUSED_ACTION
+					: REVIEW_HOST_RELAY_RETRY_ACTION,
 		};
 	}
 }
@@ -4819,6 +4867,7 @@ async function executeReviewControllerOperation(
 		if (input.answer !== "granted" && input.answer !== "declined") throw new Error("Review controller answer-consent answer must be granted or declined");
 		const pending = pendingReviewConsentRegistry.get(pendingReviewConsentSession)?.get(input.consentBinding);
 		if (pending === undefined || pending.expiresAt <= reviewConsentNow()) {
+			const stale = staleConsentBindingDiagnostics(input.consentBinding, pending !== undefined);
 			if (pending !== undefined) cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession);
 			if (nativeReviewCli?.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
 			try {
@@ -4827,7 +4876,7 @@ async function executeReviewControllerOperation(
 					...(signal === undefined ? {} : { signal }),
 				}, retainedUntrackedSelections, defaultCwd);
 				if (negotiated.transport !== undefined) return hostTransportUnavailable(parameters.operation, negotiated.transport);
-				return mapNativeTargetStatus(parameters.operation, negotiated.status!);
+				return staleConsentBindingOutcome(parameters.operation, input.consentBinding, stale, negotiated.status!);
 			} catch (error) {
 				return nativeStatusFailed(parameters.operation, error);
 			}

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -423,23 +423,30 @@ export interface ChangedPathEntry {
 	readonly modeOnly: boolean;
 }
 
+//
+// gentle-pi#518: both derivations diff with `--no-renames`, exactly as the
+// native provider does. A rename is then its source deletion plus its
+// destination addition, one path each, so the projection identity Pi freezes
+// is the identity native STATUS projects. Rename detection here previously
+// kept only the destination, and an exact staged rename was rejected before
+// native admission with candidate-target-projection-drift.
 export function deriveChangedPathManifest(cwd: string, baseTree: string, candidateTree: string, executor: CandidateGitExecutor = defaultCandidateGitExecutor): readonly ChangedPathEntry[] {
-	const tokens = gitPathTokens(cwd, ["diff", "--raw", "-z", "--abbrev=40", "--no-ext-diff", "--find-renames=100%", baseTree, candidateTree], executor);
+	const tokens = gitPathTokens(cwd, ["diff", "--raw", "-z", "--abbrev=40", "--no-ext-diff", "--no-renames", baseTree, candidateTree], executor);
 	const entries: ChangedPathEntry[] = [];
 	for (let index = 0; index < tokens.length;) {
 		const header = tokens[index++]?.toString("ascii");
 		if (header === undefined) break;
-		// `:<old_mode> <new_mode> <old_sha> <new_sha> <status>`
-		const match = /^:([0-7]{6}) ([0-7]{6}) ([0-9a-f]{7,64}) ([0-9a-f]{7,64}) ([AMDT]|R[0-9]{3})$/.exec(header);
+		// `:<old_mode> <new_mode> <old_sha> <new_sha> <status>`; with rename
+		// detection off, Git never emits a two-path R or C record here.
+		const match = /^:([0-7]{6}) ([0-7]{6}) ([0-9a-f]{7,64}) ([0-9a-f]{7,64}) ([AMDT])$/.exec(header);
 		if (match === null) throw new CandidateViewError("candidate manifest Git output contains an unsafe raw header", "manifest-derivation-invalid");
 		const [, oldMode, newMode, oldSha, newSha, status] = match;
-		const firstPath = tokens[index++];
-		if (firstPath === undefined) throw new CandidateViewError("candidate manifest Git output is incomplete", "manifest-derivation-invalid");
-		// A rename emits both the old and the new path; the new one is the scope.
-		const path = status.startsWith("R") ? decodeCanonicalPath(tokens[index++] ?? firstPath) : decodeCanonicalPath(firstPath);
+		const rawPath = tokens[index++];
+		if (rawPath === undefined) throw new CandidateViewError("candidate manifest Git output is incomplete", "manifest-derivation-invalid");
+		const path = decodeCanonicalPath(rawPath);
 		entries.push(Object.freeze({
 			path,
-			status: status.startsWith("R") ? "A" : status,
+			status,
 			oldMode,
 			newMode,
 			deleted: status === "D",
@@ -515,20 +522,16 @@ function deriveChangedScope(cwd: string, baseTree: string, candidateTree: string
 	const present = new Map(entries.map((entry) => [entry.path, entry]));
 	const paths = new Set<string>();
 	const deleted = new Set<string>();
-	const tokens = gitPathTokens(cwd, ["diff", "--name-status", "-z", "--no-ext-diff", "--find-renames=100%", baseTree, candidateTree], executor);
+	// `--no-renames` mirrors the native projection: a rename is one deleted
+	// path plus one added path (gentle-pi#518), and every record carries
+	// exactly one path.
+	const tokens = gitPathTokens(cwd, ["diff", "--name-status", "-z", "--no-ext-diff", "--no-renames", baseTree, candidateTree], executor);
 	for (let index = 0; index < tokens.length;) {
 		const status = tokens[index++]?.toString("ascii");
-		if (status === undefined || !/^(?:[AMDT]|R[0-9]{3})$/.test(status)) throw new CandidateViewError("candidate scope Git output contains an unsafe status");
-		const oldPath = tokens[index++];
-		if (oldPath === undefined) throw new CandidateViewError("candidate scope Git output is incomplete");
-		const firstPath = decodeCanonicalPath(oldPath);
-		const path = status.startsWith("R")
-			? (() => {
-				const newPath = tokens[index++];
-				if (newPath === undefined) throw new CandidateViewError("candidate scope rename output is incomplete");
-				return decodeCanonicalPath(newPath);
-			})()
-			: firstPath;
+		if (status === undefined || !/^[AMDT]$/.test(status)) throw new CandidateViewError("candidate scope Git output contains an unsafe status");
+		const rawPath = tokens[index++];
+		if (rawPath === undefined) throw new CandidateViewError("candidate scope Git output is incomplete");
+		const path = decodeCanonicalPath(rawPath);
 		if (paths.has(path) || deleted.has(path)) throw new CandidateViewError("candidate scope Git output contains duplicate paths");
 		if (status === "D") {
 			if (present.has(path)) throw new CandidateViewError("candidate scope deletion is present in the candidate tree");

--- a/lib/review-host-relay.ts
+++ b/lib/review-host-relay.ts
@@ -85,9 +85,12 @@ export class ReviewHostRelayError extends Error {
 	readonly timeoutMs: number | null;
 	// "none" until the submission invocation launches; a launched submission
 	// whose outcome could not be read is "unknown" and the caller reconciles
-	// through negotiated STATUS, never through a blind retry.
+	// through negotiated STATUS, never through a blind retry. A launched
+	// submission that gentle-ai refused with its typed admission refusal is
+	// "none" again: the provider states that the lens slot was not consumed
+	// (gentle-pi#522 / #524).
 	readonly mutationOutcome: "none" | "unknown";
-	constructor(kind: ReviewHostRelayFailureKind, stage: ReviewHostRelayStage, message: string, details?: { exitCode?: number | null; stderr?: string; timedOut?: boolean; elapsedMs?: number; timeoutMs?: number }) {
+	constructor(kind: ReviewHostRelayFailureKind, stage: ReviewHostRelayStage, message: string, details?: { exitCode?: number | null; stderr?: string; timedOut?: boolean; elapsedMs?: number; timeoutMs?: number; mutationOutcome?: "none" | "unknown" }) {
 		super(message);
 		this.name = "ReviewHostRelayError";
 		this.kind = kind;
@@ -97,8 +100,19 @@ export class ReviewHostRelayError extends Error {
 		this.timedOut = details?.timedOut ?? false;
 		this.elapsedMs = details?.elapsedMs ?? null;
 		this.timeoutMs = details?.timeoutMs ?? null;
-		this.mutationOutcome = stage === "submit" ? "unknown" : "none";
+		this.mutationOutcome = details?.mutationOutcome ?? (stage === "submit" ? "unknown" : "none");
 	}
+}
+
+// gentle-pi#522 / #524: gentle-ai refuses a reviewer submission before any
+// admission with exit 1 and its typed operator line, `<reason> [invalid_request]`.
+// That code is the provider's preflight class: the request was refused as
+// sent and the lens slot was not consumed. The relay recognises only that
+// typed shape; it never parses the reason, and it never retries.
+const ADMISSION_REFUSAL = /\[invalid_request\]/;
+
+export function isReviewHostRelayAdmissionRefusal(capture: { exitCode: number | null; timedOut: boolean }, stderr: string): boolean {
+	return capture.exitCode === 1 && !capture.timedOut && ADMISSION_REFUSAL.test(stderr);
 }
 
 // Refusal classification for the materialize invocation. The installed
@@ -528,7 +542,17 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", `gentle-ai capture submission could not start: ${error instanceof Error ? error.message : String(error)}`);
 		}
 		if (submission.exitCode !== 0 || submission.timedOut || submission.stdout.length === 0) {
-			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", "gentle-ai refused the relayed capture submission", { exitCode: submission.exitCode, stderr: submission.stderr.toString("utf8"), timedOut: submission.timedOut, elapsedMs: submission.elapsedMs, timeoutMs: gentleAiTimeoutMs });
+			const stderr = submission.stderr.toString("utf8");
+			const details = { exitCode: submission.exitCode, stderr, timedOut: submission.timedOut, elapsedMs: submission.elapsedMs, timeoutMs: gentleAiTimeoutMs };
+			// A typed admission refusal is a proven non-mutation whose reason is
+			// the refusal text itself; everything else that launched (timeout,
+			// signal, untyped exit) stays unknown pending STATUS.
+			if (isReviewHostRelayAdmissionRefusal(submission, stderr)) {
+				throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", stderr.trim(), { ...details, mutationOutcome: "none" });
+			}
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", submission.timedOut
+				? `gentle-ai capture submission exceeded its ${gentleAiTimeoutMs}ms bound after ${submission.elapsedMs}ms`
+				: "gentle-ai refused the relayed capture submission", details);
 		}
 		return {
 			promptByteLength: promptBytes.length,

--- a/tests/devbinary/native-review-parity.devtest.ts
+++ b/tests/devbinary/native-review-parity.devtest.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { __testing } from "../../extensions/gentle-ai.ts";
 import {
 	NATIVE_REVIEW_ERROR_CODE,
 	NativeReviewCliError,
@@ -216,6 +217,39 @@ test("dev-binary: a low-risk START closes the review with no receipt or follow-u
 	assert.equal(started.state, "approved");
 	assert.deepEqual(started.selectedLenses, []);
 	assert.equal(started.lensesRequired, false);
+});
+
+// gentle-pi#518: native STATUS projects a staged exact rename as its source
+// and its destination. The Pi controller freezes the same identity, so
+// ordinary START reaches native admission instead of being rejected locally
+// with candidate-target-projection-drift.
+test("dev-binary: ordinary START through the Pi controller admits a staged exact rename plus an addition", { skip: !RUNNABLE }, async (t) => {
+	const cwd = repository(t);
+	mkdirSync(join(cwd, "active"));
+	writeFileSync(join(cwd, "active", "document.md"), "# Document\n\nline one\nline two\n");
+	git(cwd, "add", "active/document.md");
+	git(cwd, "commit", "-qm", "docs: base document");
+	mkdirSync(join(cwd, "archive"));
+	git(cwd, "mv", "active/document.md", "archive/document.md");
+	writeFileSync(join(cwd, "report.md"), "# Report\n\nPassive report\n");
+	git(cwd, "add", "-A");
+	assert.match(git(cwd, "diff", "--cached", "--name-status", "--find-renames=100%"), /^R100\tactive\/document\.md\tarchive\/document\.md$/m, "the candidate must stage an exact rename");
+
+	const { native, calls } = journeyNative(DEV_BINARY!);
+	await enableReview(native, cwd);
+	const status = await native.targetStatus({ cwd, agent: "pi" });
+	assert.deepEqual([...status.projection.paths].sort(), ["active/document.md", "archive/document.md", "report.md"], "native STATUS projects the rename as both of its paths");
+
+	const started = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native);
+	assert.notEqual(started.outcome, "native-operation-failed", `START must reach native admission: ${JSON.stringify(started)}`);
+	assert.equal(started.operation, "start");
+	const result = started.result as Record<string, unknown>;
+	assert.equal(typeof result.lineage_id, "string", "native START must create a lineage");
+	// Documentation-only candidate: native admission closes it approved with
+	// no lenses, exactly as the low-risk journey above.
+	assert.equal(result.action, "closed");
+	assert.equal(result.state, "approved");
+	assert.equal(calls.filter((arguments_) => arguments_.at(0) === "review" && arguments_.at(1) === "start").length, 1, "exactly one native START runs");
 });
 
 test.before(() => {

--- a/tests/devbinary/pi-host-relay.devtest.ts
+++ b/tests/devbinary/pi-host-relay.devtest.ts
@@ -9,7 +9,7 @@ import { __testing, createGentleAiExtension } from "../../extensions/gentle-ai.t
 import { resolveGentleAiBinary } from "../../lib/gentle-ai-binary.ts";
 import { OPAQUE_PI_REVIEWER_ARGV } from "../../lib/opaque-pi-reviewer-adapter.ts";
 import { NativeReviewCliV216, type ExecFileAdapter, type NativeReviewCli } from "../../lib/native-review-cli.ts";
-import { reviewHostRelaySlots, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
+import { REVIEW_HOST_RELAY_FAILURE, ReviewHostRelayError, reviewHostRelaySlots, runReviewHostRelaySlot } from "../../lib/review-host-relay.ts";
 import { GENTLE_PI_REVIEW_RELAY_CONTRACT, GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV } from "../../lib/review-relay-contract.ts";
 import { decodeReviewStatusV3 } from "../../lib/review-integration-v2.ts";
 import { requireDevBinary } from "../support/native-binary-gate.ts";
@@ -430,6 +430,87 @@ test("dev-binary: POSIX Pi host relay captures one real B-target slot from an A-
 	const sessionStatus = candidateStatus(RELAY_DEV_BINARY!, sessionA, sessionA, environment);
 	assert.equal(sessionStatus.authority, undefined, "A must remain without B's review authority");
 	assert.notEqual(sessionStatus.targetIdentity, advanced.targetIdentity, "A must remain unrelated to B's candidate binding");
+});
+
+// gentle-pi#522 / #524: a reviewer whose bytes gentle-ai refuses at admission
+// is a proven non-mutation. The real binary states that the lens slot was not
+// consumed; the host must relay that refusal and its continuation instead of
+// an unknown outcome the contract forbids replaying.
+test("dev-binary: a garbage reviewer result is refused at admission as a proven non-mutation and the same slot is reoffered", { skip: !RUNNABLE }, async (t) => {
+	const cwd = repository(t, "gentle-pi-relay-refused-");
+	const workflowDirectory = join(cwd, ".github", "workflows");
+	mkdirSync(workflowDirectory, { recursive: true });
+	const workflow = join(workflowDirectory, "relay.yml");
+	writeFileSync(workflow, "name: relay\non: push\n");
+	git(cwd, "add", ".github/workflows/relay.yml");
+	git(cwd, "commit", "-qm", "workflow baseline");
+	writeFileSync(workflow, "name: relay\non: push\njobs:\n  relay:\n    runs-on: ubuntu-latest\n");
+	const canonical = realpathSync(cwd);
+	// The isolated home and the fake reviewer live outside the candidate so
+	// the repository stays free of untracked paths and START needs no
+	// intended-untracked selection.
+	const scratch = mkdtempSync(join(tmpdir(), "gentle-pi-relay-refused-scratch-"));
+	t.after(() => rmSync(scratch, { recursive: true, force: true }));
+	const isolatedHome = join(scratch, "home");
+	mkdirSync(isolatedHome);
+	const environment = reviewEnvironment(isolatedHome);
+	assert.ok(RELAY_DEV_BINARY, "GENTLE_PI_GENTLE_AI_DEV_BINARY is required for this devtest");
+	enableGlobalReview(RELAY_DEV_BINARY!, cwd, canonical, environment);
+
+	const nativeCalls: NativeProcessCall[] = [];
+	const native = devNativeCli(RELAY_DEV_BINARY!, environment, nativeCalls);
+	const { controller, capture } = reviewToolsForNative(native);
+	const prompted = record((await controller.execute("refused-start", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, sessionContext(cwd))).details, "refused start consent");
+	assert.equal(prompted.outcome, "native-review-consent-required");
+	const consentBinding = stringValue(prompted.consent_binding, "refused consent binding");
+	const started = record((await controller.execute("refused-answer-consent", { operation: "answer-consent", input: JSON.stringify({ consentBinding, answer: "granted" }) }, undefined, undefined, sessionContext(cwd))).details, "refused granted start");
+	const lineage = stringValue(record(started.result, "refused start result").lineage_id, "refused lineage");
+
+	const status = record((await controller.execute("refused-status", { operation: "status", lineageId: lineage }, undefined, undefined, sessionContext(cwd))).details, "refused STATUS");
+	const reviewerBinding = collectBindingsFor(status, "review.capture-result")[0];
+	assert.ok(reviewerBinding, "current STATUS must publish a reviewer capture binding");
+	const subjectHash = collectBindingArgument(reviewerBinding!, "subject-hash");
+	const fakePi = join(scratch, "fake-pi");
+	writeFileSync(fakePi, "#!/usr/bin/env node\nprocess.stdin.resume();\nprocess.stdin.on('end', () => { process.stdout.write('not json at all'); });\n");
+	chmodSync(fakePi, 0o755);
+	let relayError: unknown;
+	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
+	__testing.setReviewHostRelayRunnerForTesting(async (request) => {
+		try {
+			return await runReviewHostRelaySlot({ ...request, gentleAiExecutable: RELAY_DEV_BINARY!, piExecutable: fakePi, environment, gentleAiTimeoutMs: 30_000, piTimeoutMs: 30_000 });
+		} catch (error) {
+			relayError = error;
+			throw error;
+		}
+	});
+	const forecast = record((await capture.execute("refused-forecast", { lineageId: lineage, collectBinding: reviewerBinding }, undefined, undefined, sessionContext(cwd))).details, "refused forecast");
+	const captured = forecast.outcome === "reviewer-model-run-forecast"
+		? record((await capture.execute("refused-capture", { lineageId: lineage, collectBinding: reviewerBinding, reviewerRunAcknowledged: true }, undefined, undefined, sessionContext(cwd))).details, "refused capture")
+		: forecast;
+
+	assert.ok(relayError instanceof ReviewHostRelayError, `the relay must fail with a typed error: ${String(relayError)}`);
+	assert.equal(relayError.kind, REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED);
+	assert.equal(relayError.stage, "submit");
+	assert.equal(relayError.exitCode, 1);
+	assert.equal(relayError.mutationOutcome, "none", "gentle-ai's typed admission refusal proves the slot was not consumed");
+	assert.match(relayError.stderr, /reviewer payload contains no complete JSON object/);
+	assert.match(relayError.stderr, /\[invalid_request\]/);
+
+	assert.equal(captured.status, "blocked", JSON.stringify(captured));
+	assert.equal(captured.outcome, "pi-host-relay-transport-failure");
+	const failure = record(captured.failure, "refused capture failure");
+	assert.equal(failure.kind, "submission-refused");
+	assert.equal(failure.exit_code, 1);
+	assert.match(stringValue(failure.stderr, "refused capture stderr"), /\[invalid_request\]/);
+	assert.match(stringValue(captured.reason, "refused capture reason"), /no complete JSON object/);
+	assert.equal(captured.mutation_performed, false);
+	assert.equal(captured.mutation_outcome, "none");
+	assert.match(stringValue(captured.next_action, "refused capture next action"), /did not consume the lens slot/);
+
+	const after = await native.targetStatus({ cwd: canonical, agent: "pi", lineageId: lineage });
+	assert.equal(after.authority?.state, "reviewing", "the refused submission must leave the lineage reviewing");
+	const reoffered = reviewHostRelaySlots(after.nextTransition?.collect?.inputs ?? []).some((slot) => slot.subjectHash === subjectHash);
+	assert.equal(reoffered, true, "the unconsumed slot must be reoffered by fresh STATUS");
 });
 
 // This completes the same organic A -> B path through correction evidence,

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -327,6 +327,24 @@ async function answerConsent(runtime: ParityRuntime, cwd: string, binding: unkno
 	return await executeController(runtime, { operation: "answer-consent", input: JSON.stringify({ consentBinding: binding, answer }) }, cwd, sessionId);
 }
 
+// gentle-pi#516: an unknown or expired binding is a typed, blocked outcome
+// that names itself and its exit. It still carries the current negotiated
+// STATUS as reconciliation context, but it never reads as a healthy
+// pre-start "ready".
+function assertStaleConsentBinding(outcome: Record<string, unknown>, binding: unknown, code: "consent-binding-unknown" | "consent-binding-expired"): void {
+	assert.equal(outcome.status, "blocked");
+	assert.equal(outcome.outcome, "consent-binding-stale");
+	assert.equal(outcome.consent_binding, binding);
+	assert.equal((outcome.diagnostics as { code?: unknown } | undefined)?.code, code);
+	assert.match(String((outcome.diagnostics as { message?: unknown } | undefined)?.message), /START again/);
+	assert.equal(outcome.native_invocation_attempted, false);
+	assert.equal(outcome.lineage_created, false);
+	assert.equal(outcome.mutation_performed, false);
+	assert.equal(outcome.mutation_outcome, "none");
+	assert.equal(outcome.provider_action, "start");
+	assert.equal(outcome.next_action, "restart-for-fresh-consent");
+}
+
 test("review-mode gate retains every off-source continuation and fails closed on native errors", async () => {
 	for (const [source, expected] of [
 		["clone_local", /clear this clone-local override/],
@@ -397,7 +415,9 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	assert.deepEqual(blockedA.consent, decodeReviewConsentV3(captured("consent-v3.captured.json")).raw);
 	const staleOtherSession = await answerConsent(second, cwd, blockedA.consent_binding, "declined", "session-b");
 	assert.equal(staleOtherSession.operation, "answer-consent");
-	assert.equal(staleOtherSession.status, "ready");
+	// gentle-pi#516: a binding this session does not hold must never read as
+	// a healthy pre-start STATUS; it names itself and the exit.
+	assertStaleConsentBinding(staleOtherSession, blockedA.consent_binding, "consent-binding-unknown");
 	assert.deepEqual(fixture.answers, ["declined"]);
 	const blockedB = await beginConsent(second, cwd, "session-b");
 	const declined = await answerConsent(second, cwd, blockedB.consent_binding, "declined", "session-b");
@@ -405,7 +425,7 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	assert.equal(declined.lineage_created, false);
 	const staleConsumed = await answerConsent(second, cwd, blockedB.consent_binding, "declined", "session-b");
 	assert.equal(staleConsumed.operation, "answer-consent");
-	assert.equal(staleConsumed.status, "ready");
+	assertStaleConsentBinding(staleConsumed, blockedB.consent_binding, "consent-binding-unknown");
 	assert.deepEqual(fixture.answers, ["declined", "declined"]);
 
 	const shutdown = first.events.get("session_shutdown");
@@ -414,7 +434,7 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	await shutdown!({}, context(cwd, "session-a"));
 	const staleShutdown = await answerConsent(first, cwd, blockedA.consent_binding, "declined", "session-a");
 	assert.equal(staleShutdown.operation, "answer-consent");
-	assert.equal(staleShutdown.status, "ready");
+	assertStaleConsentBinding(staleShutdown, blockedA.consent_binding, "consent-binding-unknown");
 
 	writeFileSync(join(cwd, "app.ts"), "export const value = 3;\n");
 	const nextCandidate = await beginConsent(second, cwd, "session-b");
@@ -429,7 +449,7 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	await disable!.handler("disable", context(cwd, "session-b"));
 	const staleModeCleared = await answerConsent(second, cwd, nextCandidate.consent_binding, "declined", "session-b");
 	assert.equal(staleModeCleared.operation, "answer-consent");
-	assert.equal(staleModeCleared.status, "ready");
+	assertStaleConsentBinding(staleModeCleared, nextCandidate.consent_binding, "consent-binding-unknown");
 	assert.equal(fixture.starts.count, 4);
 });
 
@@ -456,7 +476,7 @@ test("stale local consent bindings reconcile exactly once with the native status
 
 	const reconciled = await answerConsent(runtime, cwd, blocked.consent_binding, "declined");
 	assert.equal(reconciled.operation, "answer-consent");
-	assert.equal(reconciled.status, "ready");
+	assertStaleConsentBinding(reconciled, blocked.consent_binding, "consent-binding-unknown");
 	assert.deepEqual(reconciled.result, reconciledStatus.raw);
 	assert.deepEqual((reconciled.result as { next_transition?: unknown }).next_transition, nextTransition);
 	assert.equal(statusRequests.length, 2, "the stale binding performs one reconciliation after the initial START status");
@@ -506,7 +526,7 @@ test("launched answer-consent failures remain blocked after fresh-target STATUS 
 	assert.equal(answerCalls, 1, "reconciliation must not replay answer-consent");
 
 	const stale = await answerConsent(runtime, cwd, blocked.consent_binding, "granted");
-	assert.equal(stale.status, "ready");
+	assertStaleConsentBinding(stale, blocked.consent_binding, "consent-binding-unknown");
 	assert.equal(statusRequests.length, 3, "a later stale binding performs one current STATUS read");
 	assert.equal(answerCalls, 1, "the stale binding must not replay answer-consent");
 });
@@ -616,7 +636,7 @@ test("unavailable and ambiguous consent follow-ups never replay a consumed bindi
 	const callsBeforeStaleReconciliation = statusCalls;
 	const stale = await answerConsent(ambiguousRuntime, cwd, ambiguous.consent_binding, "granted");
 	assert.equal(stale.operation, "answer-consent");
-	assert.equal(stale.status, "ready");
+	assertStaleConsentBinding(stale, ambiguous.consent_binding, "consent-binding-unknown");
 	assert.equal(statusCalls, callsBeforeStaleReconciliation + 1, "stale binding reconciliation performs exactly one additional STATUS call");
 });
 
@@ -637,12 +657,17 @@ test("pending public consent expiry is synchronous and a fresh registry never re
 	assert.equal(reused.consent_binding, first.consent_binding);
 	assert.equal(scheduled.length, 1);
 	now += 10 * 60 * 1000;
+	// gentle-pi#516: a slow human answer must learn that its binding expired
+	// and that START issues a fresh envelope, not a healthy "ready".
+	const expired = await answerConsent(runtime, cwd, first.consent_binding, "declined");
+	assert.equal(expired.operation, "answer-consent");
+	assertStaleConsentBinding(expired, first.consent_binding, "consent-binding-expired");
+	assert.match(String((expired.diagnostics as { message?: unknown }).message), /expired after 10 minutes/);
 	const second = await beginConsent(runtime, cwd);
 	assert.notEqual(second.consent_binding, first.consent_binding);
 	assert.equal(scheduled.length, 2);
-	const expired = await answerConsent(runtime, cwd, first.consent_binding, "declined");
-	assert.equal(expired.operation, "answer-consent");
-	assert.equal(expired.status, "ready");
+	// Once START has pruned it, the same binding is simply unknown here.
+	assertStaleConsentBinding(await answerConsent(runtime, cwd, first.consent_binding, "declined"), first.consent_binding, "consent-binding-unknown");
 
 	const reloaded = parityRuntime(fixture.native, { pendingReviewConsentRegistry: new PendingReviewConsentRegistry() });
 	const afterReload = await beginConsent(reloaded, cwd);

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -640,17 +640,54 @@ test("candidate view derives deletion, rename, executable, and symlink scope fro
 	const registry = new CandidateViewRegistry();
 	const view = registry.create({ contributorRoot });
 	try {
-		assert.deepEqual(view.paths, ["deleted.txt", "linked.sh", "renamed.txt", "script.sh"]);
-		assert.deepEqual(view.deletedPaths, ["deleted.txt"]);
+		// The rename source (tracked.txt) is frozen as a deletion next to its
+		// destination: native STATUS projects the rename as both paths
+		// (gentle-pi#518), and the reviewer scope carries the same identity.
+		assert.deepEqual(view.paths, ["deleted.txt", "linked.sh", "renamed.txt", "script.sh", "tracked.txt"]);
+		assert.deepEqual(view.deletedPaths, ["deleted.txt", "tracked.txt"]);
 		assert.deepEqual(view.modes, { "linked.sh": "120000", "renamed.txt": "100644", "script.sh": "100755" });
 		registry.bind({ token: view.token, lineageId: "scope-kinds", selectedLenses: ["review-risk"] });
 		const dispatch = { agent: "review-risk", task: "review", mode: "task" };
 		injectReviewCandidateView(dispatch, registry);
-		assert.match(dispatch.task, /Frozen changed scope by mode: .*"deleted":\["deleted\.txt"\]/);
+		assert.match(dispatch.task, /Frozen changed scope by mode: .*"deleted":\["deleted\.txt","tracked\.txt"\]/);
 		assert.doesNotMatch(dispatch.task, /Frozen paths:|Frozen modes:/);
 		view.verify();
 	} finally {
 		registry.cleanup(view.token);
+	}
+});
+
+// gentle-pi#518: native STATUS projects every path whose state changed between
+// the frozen trees (Go diffs with --no-renames), so a staged exact rename is
+// its source deletion plus its destination addition. The candidate view must
+// project the same identity or ordinary START is rejected before native
+// admission with candidate-target-projection-drift.
+test("candidate view projects a staged exact rename as its source and destination, matching the native no-renames projection", (t) => {
+	const contributorRoot = repository(t);
+	mkdirSync(join(contributorRoot, "active"));
+	writeFileSync(join(contributorRoot, "active", "document.md"), "line one\nline two\n");
+	git(contributorRoot, "add", "active/document.md");
+	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "rename base");
+	mkdirSync(join(contributorRoot, "archive"));
+	git(contributorRoot, "mv", "active/document.md", "archive/document.md");
+	writeFileSync(join(contributorRoot, "report.md"), "report\n");
+	git(contributorRoot, "add", "-A");
+	const view = createCandidateView({ contributorRoot });
+	try {
+		const nativeProjection = git(contributorRoot, "diff-tree", "--no-commit-id", "--name-only", "-r", "-z", "--no-renames", view.baseTree, view.candidateTree)
+			.split("\0").filter((path) => path.length > 0).sort();
+		assert.deepEqual(nativeProjection, ["active/document.md", "archive/document.md", "report.md"]);
+		assert.deepEqual(view.paths, nativeProjection);
+		assert.deepEqual(view.deletedPaths, ["active/document.md"]);
+		assert.deepEqual(view.modes, { "archive/document.md": "100644", "report.md": "100644" });
+		const manifest = deriveChangedPathManifest(contributorRoot, view.baseTree, view.candidateTree);
+		assert.deepEqual(manifest.map((entry) => [entry.path, entry.status, entry.deleted]), [
+			["active/document.md", "D", true],
+			["archive/document.md", "A", false],
+			["report.md", "A", false],
+		]);
+	} finally {
+		view.cleanup();
 	}
 });
 

--- a/tests/review-host-relay-routing.test.ts
+++ b/tests/review-host-relay-routing.test.ts
@@ -219,6 +219,52 @@ test("a transport failure stops the selected capture without auto-follow", async
 	assert.equal(harness.statusCalls.length, 1, "no automatic relaunch after transport failure");
 });
 
+// gentle-pi#522 / #524: a submission Go refused at admission is a proven
+// non-mutation. The model must see the refusal text, mutation_outcome none,
+// and a continuation for the reoffered slot, never an unknown outcome that the
+// contract forbids replaying.
+test("an admission refusal reaches the model as a proven non-mutation carrying the refusal and a continuation", async (t) => {
+	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
+	const cwd = repository(t);
+	const lineageId = "relay-lineage";
+	const harness = nativeHarness([finalizeStatus(lineageId, [relayCollectInput(lineageId, "review-risk", 0)])]);
+	const refusal = "Error: reviewer artifact admission binding_mismatch: reviewer result echoed a different artifact subject: the rejected admission did not consume the lens slot, so re-run the lens and invoke gentle-ai review capture-result again on the same lineage with a result that echoes the binding's top-level subject_hash [invalid_request]\n";
+	__testing.setReviewHostRelayRunnerForTesting(async () => {
+		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", refusal.trim(), { exitCode: 1, stderr: refusal, elapsedMs: 40, timeoutMs: 120_000, mutationOutcome: "none" });
+	});
+
+	const result = await runCapture(cwd, harness, lineageId);
+
+	assert.equal(result.status, "blocked");
+	assert.equal(result.outcome, "pi-host-relay-transport-failure");
+	assert.deepEqual(result.failure, { kind: "submission-refused", stage: "submit", exit_code: 1, timed_out: false, elapsed_ms: 40, timeout_ms: 120_000, stderr: refusal });
+	assert.equal(result.reason, refusal.trim());
+	assert.equal(result.mutation_performed, false);
+	assert.equal(result.mutation_outcome, "none");
+	assert.match(String(result.next_action), /did not consume the lens slot/);
+	assert.match(String(result.next_action), /fresh STATUS/);
+	assert.equal(harness.statusCalls.length, 1, "a proven non-mutation needs no STATUS reconciliation and no relaunch");
+});
+
+test("a submission whose outcome is genuinely indeterminate still reconciles through STATUS and carries its evidence", async (t) => {
+	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
+	const cwd = repository(t);
+	const lineageId = "relay-lineage";
+	const pending = finalizeStatus(lineageId, [relayCollectInput(lineageId, "review-risk", 0)]);
+	const harness = nativeHarness([pending, pending]);
+	__testing.setReviewHostRelayRunnerForTesting(async () => {
+		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", "gentle-ai capture submission exceeded its 120000ms bound after 120004ms", { exitCode: null, stderr: "", timedOut: true, elapsedMs: 120_004, timeoutMs: 120_000 });
+	});
+
+	const result = await runCapture(cwd, harness, lineageId);
+
+	assert.equal(result.status, "reconciled");
+	assert.equal(result.outcome, "native-capture-outcome-unknown");
+	assert.deepEqual(result.failure, { kind: "submission-refused", stage: "submit", exit_code: null, timed_out: true, elapsed_ms: 120_004, timeout_ms: 120_000 });
+	assert.match(String(result.reason), /exceeded its 120000ms bound/);
+	assert.equal(harness.statusCalls.length, 2, "an indeterminate submission reconciles exactly once through STATUS");
+});
+
 test("a relay timeout reports its one-slot measurements and no auto-follow", async (t) => {
 	t.after(() => __testing.setReviewHostRelayRunnerForTesting());
 	const cwd = repository(t);

--- a/tests/review-host-relay.test.ts
+++ b/tests/review-host-relay.test.ts
@@ -62,6 +62,22 @@ if (inputToken !== undefined) {
 		process.exit(0);
 	}
 	if (mode === "refuse-cleanup-fail") fs.chmodSync(path.dirname(path.dirname(inputPath)), 0o500);
+	if (mode === "admit") {
+		// Go's admission refusal shape: a schema-bounded failure/v2 envelope on
+		// stdout, the operator line with the typed code suffix on stderr, exit 1.
+		const bytes = fs.readFileSync(inputPath);
+		let parsed;
+		try { parsed = JSON.parse(bytes.toString("utf8")); } catch { parsed = undefined; }
+		const refuse = (cause) => {
+			process.stdout.write(JSON.stringify({ schema: "gentle-ai.review-integration.failure/v2", contract: "gentle-ai.review-integration/v2", operation: "review.capture-result", phase: "preflight", code: "invalid_request", message: "The negotiated review request is invalid.", mutation_outcome: "not_started", authority_applicability: "not_evaluated", retry_safe: true, replayability: "not_replayable", required_inputs: [], next_action: "correct_request", cause }));
+			process.stderr.write("Error: " + cause + " [invalid_request]\\n");
+			process.exit(1);
+		};
+		if (parsed === undefined || typeof parsed !== "object") refuse("lens provider result admission incomplete: reviewer payload contains no complete JSON object: no object start was found in " + bytes.length + " bytes; the rejected reviewer payload was preserved at " + inputPath + ".rejected");
+		if (parsed.subject_hash !== process.env.RELAY_FAKE_EXPECTED_SUBJECT) refuse("reviewer artifact admission binding_mismatch: reviewer result echoed a different artifact subject: the rejected admission did not consume the lens slot, so re-run the lens and invoke gentle-ai review capture-result again on the same lineage with a result that echoes the binding's top-level subject_hash, which is " + process.env.RELAY_FAKE_EXPECTED_SUBJECT);
+		process.stdout.write(JSON.stringify({ schema: "gentle-ai.review-result-artifact/v2", admission_decision: "completed" }));
+		process.exit(0);
+	}
 	process.stderr.write("capture binding does not match the current reviewing authority\\n");
 	process.exit(1);
 }
@@ -436,6 +452,59 @@ test("submission refusal is a typed error whose outcome is unknown pending STATU
 	assert.equal(error.mutationOutcome, "unknown");
 	assert.match(error.stderr, /capture binding does not match/);
 	assert.equal(readLog(fixture.logPath).length, 2);
+});
+
+// gentle-pi#522 / #524: Go refuses a reviewer submission at admission with a
+// typed [invalid_request] refusal and states that the lens slot was not
+// consumed. That is a proven non-mutation, not an unknown outcome, and the
+// refusal text is the only thing that tells the host what to change.
+function admittingRequest(fixture: RelayHarness, reviewerOutput: Buffer) {
+	return relayRequest(fixture, {
+		environment: {
+			...fixture.environment,
+			RELAY_FAKE_PROMPT_B64: PROMPT_BYTES.toString("base64"),
+			RELAY_FAKE_PI_OUTPUT_B64: reviewerOutput.toString("base64"),
+		},
+	});
+}
+
+test("a reviewer printing garbage is refused at admission as a proven non-mutation carrying Go's refusal", async (t) => {
+	const fixture = harness(t, { RELAY_FAKE_SUBMIT_MODE: "admit", RELAY_FAKE_EXPECTED_SUBJECT: `sha256:${"a".repeat(64)}` });
+	const error = await rejectsWithRelayError(
+		runReviewHostRelaySlot(admittingRequest(fixture, Buffer.from("not json at all", "utf8"))),
+		REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED,
+		"submit",
+	);
+	assert.equal(error.mutationOutcome, "none");
+	assert.equal(error.exitCode, 1);
+	assert.equal(error.timedOut, false);
+	assert.match(error.stderr, /reviewer payload contains no complete JSON object/);
+	assert.match(error.stderr, /\[invalid_request\]/);
+	assert.match(error.message, /reviewer payload contains no complete JSON object/);
+	assert.equal(readLog(fixture.logPath).length, 2, "the refusal must not be retried by the relay");
+});
+
+test("a reviewer echoing a different subject is refused at admission as a proven non-mutation carrying Go's continuation", async (t) => {
+	const fixture = harness(t, { RELAY_FAKE_SUBMIT_MODE: "admit", RELAY_FAKE_EXPECTED_SUBJECT: `sha256:${"a".repeat(64)}` });
+	const wrongSubject = Buffer.from(JSON.stringify({ subject_hash: `sha256:${"0".repeat(64)}`, inspection: { status: "completed", paths: [] }, findings: [], evidence: ["x"] }), "utf8");
+	const error = await rejectsWithRelayError(
+		runReviewHostRelaySlot(admittingRequest(fixture, wrongSubject)),
+		REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED,
+		"submit",
+	);
+	assert.equal(error.mutationOutcome, "none");
+	assert.equal(error.exitCode, 1);
+	assert.match(error.stderr, /binding_mismatch/);
+	assert.match(error.stderr, /did not consume the lens slot/);
+	assert.match(error.stderr, /\[invalid_request\]/);
+	assert.match(error.message, /did not consume the lens slot/);
+	assert.equal(readLog(fixture.logPath).length, 2, "the refusal must not be retried by the relay");
+});
+
+test("a submission the fake admits with the expected subject still completes", async (t) => {
+	const fixture = harness(t, { RELAY_FAKE_SUBMIT_MODE: "admit", RELAY_FAKE_EXPECTED_SUBJECT: `sha256:${"a".repeat(64)}` });
+	const result = await runReviewHostRelaySlot(admittingRequest(fixture, Buffer.from(JSON.stringify({ subject_hash: `sha256:${"a".repeat(64)}`, inspection: { status: "completed", paths: [] }, findings: [], evidence: ["x"] }), "utf8")));
+	assert.equal(JSON.parse(result.submission).admission_decision, "completed");
 });
 
 test("submission refusal preserves its primary evidence when result staging cleanup also fails", async (t) => {


### PR DESCRIPTION
Three narrow controller and relay fixes for the review dead-ends triaged today on gentle-pi main (`584c495c`). Bugs only: no new verb, flag, TTL, persistence, or schema identity.

## #518: staged renames rejected before native START

**What changed**: `lib/review-candidate-view.ts` derives the changed scope and the changed-path manifest with `--no-renames`, exactly as the native provider does (`internal/reviewtransaction/snapshot.go`). A rename is now its source deletion plus its destination addition, so the identity Pi freezes equals native `projection.paths`. The rename-only parsing branches were removed and the status regex fails closed on anything but `A`, `M`, `D`, `T`.

**Why**: the candidate view ran `--find-renames=100%` and kept only the destination. For a staged exact rename plus one addition it froze `[new, added]` while native STATUS projected `[old, new, added]`, and `assertNativeStartCandidateBinding` rejected the candidate with `candidate-target-projection-drift` before native admission. Reviewer scope and projection identity turned out to be one list (`scope.paths` already unions present and deleted paths), so carrying both is the honest fix.

**Pin updated**: the existing "derives deletion, rename, executable, and symlink scope" test now expects the rename source (`tracked.txt`) in `paths` and `deletedPaths`; that is what the native projection carries.

## #516: an unknown or expired consent binding read as a healthy STATUS

**What changed**: `ANSWER_CONSENT` in `extensions/gentle-ai.ts` returns a typed blocked outcome when the binding is not held by this session or has expired: `outcome: consent-binding-stale`, `consent_binding`, `diagnostics.code` of `consent-binding-unknown` or `consent-binding-expired` with a message naming the exit, `native_invocation_attempted: false`, `lineage_created: false`, `mutation_outcome: none`, `provider_action`, and `next_action: restart-for-fresh-consent` when the provider is at `start`. The one negotiated STATUS read is kept as reconciliation context (`result`), so the transport-refusal and STATUS-failure pins stay untouched.

**Why**: `pending === undefined || pending.expiresAt <= now` fell through to `mapNativeTargetStatus`, which is indistinguishable from a healthy pre-start STATUS (`ready`, `action: start`, no diagnostic). A slow human answer, or an answer from another Pi session or process, therefore saw "ready, then consent again" (#514, #515 closed as duplicates). No TTL change and no cross-process persistence (#455 / #457 own that).

## #522 / #524: admission refusals classified as unknown and reconciled without their reason

**What changed**: `lib/review-host-relay.ts` recognises gentle-ai's typed admission refusal at the submit stage (exit code 1, not timed out, `[invalid_request]` on stderr) and throws `submission-refused` with `mutationOutcome: "none"` and the refusal text as the message. Timeouts, signals, and untyped exits stay `unknown` pending STATUS (timeouts now say they timed out instead of "refused"). In `extensions/gentle-ai.ts`, `reviewHostRelayFailureReport` carries the captured `stderr` when non-empty, a refused submission gets a `next_action` naming the unconsumed slot and fresh STATUS, and the unknown branch now carries `failure` and `reason` into the reconciled envelope.

**Why**: since `727c82ca` every submit-stage failure was `mutationOutcome: unknown`, so a submission Go refused at admission (garbage reviewer output, or a result echoing a different subject) was routed to `reconcileUnknownReviewCaptureFailure` without its message. The model saw `native-capture-outcome-unknown`, the same slot reoffered, and no `next_action`, while Go had already said the slot was not consumed and what to do. The relay only recognises the typed shape; it never parses the reason and never retries.

## Real-binary devtest proofs (gentle-ai main, `tests/devbinary/*.devtest.ts`)

- `dev-binary: ordinary START through the Pi controller admits a staged exact rename plus an addition`: native STATUS projects `active/document.md`, `archive/document.md`, `report.md`; the controller START creates a lineage and closes it approved (documentation-only candidate), exactly one native START runs.
- `dev-binary: a garbage reviewer result is refused at admission as a proven non-mutation and the same slot is reoffered`: the real binary refuses with exit 1 and `Error: lens provider result admission incomplete: reviewer payload contains no complete JSON object ... [invalid_request]`; the relay reports `mutationOutcome: none`; the capture envelope is `pi-host-relay-transport-failure` with `failure.stderr`, `mutation_outcome: none`, and the reoffered-slot `next_action`; the lineage stays `reviewing` and fresh STATUS reoffers the same subject hash.

## Red first

- `tests/review-candidate-view.test.ts`: new rename test failed on main with `actual: ['archive/document.md', 'report.md']`, `expected: ['active/document.md', 'archive/document.md', 'report.md']`.
- `tests/native-review-parity.test.ts`: every stale-binding pin (other session, consumed, shutdown, mode cleared, reconcile-once, post-launch failure, ambiguous, expired) failed on main with `actual: 'ready', expected: 'blocked'`. The expiry test now answers the expired binding before the next START, because START prunes expired bindings synchronously by design; both codes are asserted.
- `tests/review-host-relay.test.ts`: fake gentle-ai "admit" mode reproduces Go's refusal shape (failure/v2 envelope on stdout, `Error: <reason> [invalid_request]` on stderr, exit 1); a fake pi printing garbage and one echoing a wrong subject failed on main with `actual: 'unknown', expected: 'none'`.
- `tests/review-host-relay-routing.test.ts`: the typed refusal reached the model as `native-capture-status-reconciliation-failed` on main; the indeterminate (timeout) case carried no `failure`.

## Verification (foreground)

- `pnpm test`: 1144 tests, 1143 pass, 0 fail, 1 skipped (pre-existing); provider contract mirror check and runtime harness pass.
- `pnpm run check:provider-contract`: pass.
- `pnpm run build:runtime-modules` then `pnpm run check:runtime-modules`: runtime matches TypeScript sources (4 modules). No runtime file changed: the runtime modules are `gentle-ai-binary`, `native-review-cli`, `review-integration-v2`, `review-relay-contract`; neither touched lib file is one of them.
- `node scripts/verify-package-files.mjs`: pass (162 files).
- `pnpm run test:dev-binary` against the gentle-ai main binary: 9/9 pass (7 existing plus the 2 new journeys). The `~/.pi/gentle-ai/dev-binary.json` registration was moved aside for the run and restored byte-identical.

## Deliberately left out

- The stale-binding paths where STATUS is unsupported or fails still return the existing typed `native-status-unsupported` / `native-status-unavailable` envelopes; only the misleading `ready` fall-through changed.
- Go also emits a failure/v2 envelope (`mutation_outcome: not_started`) on stdout for refused submissions; the relay recognises only the stderr `[invalid_request]` code and does not decode that envelope.
- The committed-range occurrence mentioned in the #518 thread was not reproduced (no renames involved) and stays separate if it recurs.
- Cross-identity rejection tests are untouched; no new verb, flag, TTL, persistence, or schema identity.

Closes #516
Closes #518
Closes #522
Closes #524

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stale or expired review consent is now blocked with clear guidance to obtain fresh consent.
  * File renames are consistently shown as a deleted source path and a newly added destination path.
  * Host relay failures now include provider error details and timeout information.
  * Invalid review submissions are identified as non-mutating and blocked without unnecessary retries.

* **Workflow Improvements**
  * Submission refusals now direct reviewers to run a fresh review on the reoffered item.
  * Uncertain submission outcomes are reconciled before further action is taken.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->