### PR TITLE
fix(review): serialize collect inputs once, bound go install separately, and launch pi through the host entry on Windows

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3313,6 +3313,18 @@ function requiredStatusActionText(lineageId?: string): string {
 	return `Run target-scoped review.status${lineageId === undefined ? "" : ` for lineage ${lineageId}`} and follow only its declared action.`;
 }
 
+// The public collect projection is collectBindings: each provider collect
+// input serialized once as the opaque binding gentle_review_capture consumes.
+// The raw next_transition.collect.inputs carry the same bytes, so a four-lens
+// collect state used to cost about 28k characters per STATUS, INSPECT, or
+// START answer and again on every blocked retry (#465). The raw transition
+// keeps its kind and reason so the orchestrator still sees the collect state.
+function withoutRawCollectInputs(raw: Record<string, unknown>): Record<string, unknown> {
+	if (!isRecord(raw.next_transition)) return raw;
+	const { collect: _collect, ...transition } = raw.next_transition;
+	return { ...raw, next_transition: transition };
+}
+
 function mapNativeTargetStatus(operation: ReviewControllerOperation, status: ReviewStatusV3, requestedLineageId?: string): Record<string, unknown> {
 	if (
 		status.nextTransition?.kind === "collect" &&
@@ -3321,7 +3333,7 @@ function mapNativeTargetStatus(operation: ReviewControllerOperation, status: Rev
 		return {
 			operation,
 			status: "blocked",
-			result: status.raw,
+			result: withoutRawCollectInputs(status.raw),
 			collectBindings: publicReviewCaptureBindings(status),
 		};
 	}

--- a/lib/opaque-pi-reviewer-adapter.ts
+++ b/lib/opaque-pi-reviewer-adapter.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { chmod, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix, win32 } from "node:path";
 
 export const OPAQUE_PI_REVIEWER_ARGV = Object.freeze([
 	"--print",
@@ -85,6 +85,37 @@ interface OpaquePiProcessResult {
 
 const DEFAULT_OPAQUE_PI_TIMEOUT_MS = 600_000;
 
+export interface PiLaunch {
+	readonly file: string;
+	readonly arguments: readonly string[];
+}
+
+interface PiHostProcess {
+	readonly execPath: string;
+	readonly entry: string | undefined;
+}
+
+/**
+ * The exact spawn shape for the fresh Pi process. A bare `pi` on Windows
+ * resolves to pi.cmd, pi.ps1, or a POSIX shim, none of which Node can spawn
+ * with shell:false (EINVAL or ENOENT). This adapter already runs inside Pi, so
+ * on win32 the host's own JavaScript entry is spawned through the host's
+ * process.execPath instead; a shell is never enabled. Every other platform,
+ * and every explicit launcher, keeps the exact shape it always had.
+ */
+export function resolvePiLaunch(
+	piExecutable: string | undefined,
+	platform: NodeJS.Platform = process.platform,
+	host: PiHostProcess = { execPath: process.execPath, entry: process.argv[1] },
+): PiLaunch {
+	if (piExecutable !== undefined) return { file: piExecutable, arguments: [...OPAQUE_PI_REVIEWER_ARGV] };
+	if (platform !== "win32") return { file: "pi", arguments: [...OPAQUE_PI_REVIEWER_ARGV] };
+	if (typeof host.entry !== "string" || host.entry.length === 0 || !(platform === "win32" ? win32 : posix).isAbsolute(host.entry)) {
+		throw new Error(`Pi host entry could not be resolved from the running process (received ${JSON.stringify(host.entry ?? null)}); a bare pi launcher cannot be spawned on Windows without a shell`);
+	}
+	return { file: host.execPath, arguments: [host.entry, ...OPAQUE_PI_REVIEWER_ARGV] };
+}
+
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
@@ -92,7 +123,14 @@ function errorMessage(error: unknown): string {
 function runPiProcess(prompt: Buffer, scratchDirectory: string, options: OpaquePiReviewerOptions): Promise<OpaquePiProcessResult> {
 	return new Promise((resolve, reject) => {
 		const startedAt = Date.now();
-		const child = spawn(options.piExecutable ?? "pi", [...OPAQUE_PI_REVIEWER_ARGV], {
+		let launch: PiLaunch;
+		try {
+			launch = resolvePiLaunch(options.piExecutable);
+		} catch (error) {
+			reject(error);
+			return;
+		}
+		const child = spawn(launch.file, [...launch.arguments], {
 			cwd: scratchDirectory,
 			env: options.environment ?? process.env,
 			stdio: ["pipe", "pipe", "pipe"],

--- a/scripts/gentle-ai-installer.mjs
+++ b/scripts/gentle-ai-installer.mjs
@@ -23,6 +23,12 @@ const MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024;
 const MAX_REDIRECTS = 3;
 const DOWNLOAD_TIMEOUTS = { headers: 10_000, body: 30_000, attempts: 2, retryDelay: 100 };
 const GO_COMMAND_TIMEOUT_MS = 120_000;
+// `go install` compiles the pinned module from source on Windows. A clean
+// build on a cold module cache measured about 232 s (#400), so the 120 s
+// probe bound killed a healthy build; fifteen minutes leaves close to a 4x
+// margin for slower disks and real-time scanners while still bounding a hung
+// toolchain. The `go version` and `where.exe` probes keep the 120 s bound.
+const GO_INSTALL_TIMEOUT_MS = 15 * 60_000;
 const GO_COMMAND_MAX_BUFFER = 1024 * 1024;
 const WINDOWS_SYSTEM_ROOT = "C:\\Windows";
 // The one authoritative pinned Gentle AI version. Every other location in this
@@ -295,8 +301,8 @@ function isCanonicalManifest(contents, parsed, expected) {
 
 function commandOutput(result) { return typeof result?.stdout === "string" ? result.stdout : ""; }
 
-function commandOptions(env, cwd) {
-	return { cwd, env, shell: false, windowsHide: true, timeout: GO_COMMAND_TIMEOUT_MS, maxBuffer: GO_COMMAND_MAX_BUFFER };
+function commandOptions(env, cwd, timeout = GO_COMMAND_TIMEOUT_MS) {
+	return { cwd, env, shell: false, windowsHide: true, timeout, maxBuffer: GO_COMMAND_MAX_BUFFER };
 }
 
 function outputVersion(output) {
@@ -630,7 +636,7 @@ async function installWindowsGentleAiFromGoSumdb(options, packageRoot, architect
 			const existing = versionBundlePath(runtimeRoot);
 			if (await existingWindowsSourceBundleMatches(existing, execute, goPath, environment, architecture)) return { installed: false, binaryPath: join(existing, "gentle-ai.exe"), method: GENTLE_AI_INSTALL_METHOD.GO_SUMDB_SOURCE_BUILD };
 			await assertGoToolchain(execute, goPath, environment, stagingDirectory);
-			try { await runCommand(execute, goPath, ["install", GENTLE_AI_WINDOWS_SOURCE_PACKAGE], commandOptions(environment, stagingDirectory)); }
+			try { await runCommand(execute, goPath, ["install", GENTLE_AI_WINDOWS_SOURCE_PACKAGE], commandOptions(environment, stagingDirectory, GO_INSTALL_TIMEOUT_MS)); }
 			catch (error) { throw new GentleAiInstallerError(GENTLE_AI_GO_INSTALL_FAILED_CODE, `Gentle AI Go SumDB source installation failed for ${GENTLE_AI_WINDOWS_SOURCE_PACKAGE}.`, error); }
 			const builtBinary = join(environment.GOBIN, "gentle-ai.exe"), binaryPath = join(stagingDirectory, "gentle-ai.exe");
 			const details = await lstat(builtBinary);

--- a/tests/gentle-ai-installer.test.ts
+++ b/tests/gentle-ai-installer.test.ts
@@ -873,3 +873,22 @@ test("installer rejects an archive without the expected regular executable", asy
 	);
 	assert.equal(existsSync(join(packageRoot, ".gentle-ai", "v2.5.0-rc.3", "gentle-ai")), false);
 });
+
+// #400: a clean Windows source build measured 232 s on a cold module cache,
+// so `go install` cannot share the 120 s bound that fits the `go version`
+// probes. The probes keep their bound; the build gets its own.
+test("Windows source build bounds go install separately from the Go toolchain probes", async () => {
+	const packageRoot = await mkdtemp(join(tmpdir(), "gentle-pi-installer-windows-timeout-"));
+	const fixture = windowsGoFixture();
+	const goPath = join(packageRoot, "go.exe");
+	await writeFile(goPath, "trusted local Go executable");
+	fixture.setGoExecutable(goPath);
+	await installGentleAi({ packageRoot, platform: "win32", arch: "x64", execFile: fixture.run, resolveGoExecutable: async () => goPath });
+	const goCalls = fixture.calls.filter((call) => call.file === goPath);
+	const install = goCalls.find((call) => call.arguments_[0] === "install");
+	assert.ok(install, "go install must run");
+	assert.ok(typeof install.options.timeout === "number" && install.options.timeout >= 600_000, `go install must get at least a ten-minute bound, received ${install.options.timeout}`);
+	const probes = goCalls.filter((call) => call.arguments_[0] === "version");
+	assert.ok(probes.length >= 2, "go version probes must run");
+	for (const probe of probes) assert.equal(probe.options.timeout, 120_000, `go ${probe.arguments_.join(" ")} keeps the probe bound`);
+});

--- a/tests/opaque-pi-reviewer-adapter.test.ts
+++ b/tests/opaque-pi-reviewer-adapter.test.ts
@@ -8,6 +8,7 @@ import {
 	OPAQUE_PI_REVIEWER_ARGV,
 	OPAQUE_PI_REVIEWER_TRANSPORT_FAILURE,
 	OpaquePiReviewerTransportError,
+	resolvePiLaunch,
 	runOpaquePiReviewer,
 } from "../lib/opaque-pi-reviewer-adapter.ts";
 
@@ -229,5 +230,37 @@ test("the opaque adapter has no review lifecycle imports or identifiers", () => 
 	assert.doesNotMatch(source, /review-integration|gentle-ai|materialize|submit/i);
 	for (const identifier of ["lineage", "target", "revision", "receipt", "lens", "order", "subject", "schema", "capture", "submission", "status", "model", "provider", "profile"]) {
 		assert.doesNotMatch(source, new RegExp(`\\b${identifier}\\b`, "i"), `adapter must not contain lifecycle identifier ${identifier}`);
+	}
+});
+
+// #468 / #519: on Windows a bare `pi` resolves to pi.cmd, pi.ps1, or a POSIX
+// shim, none of which Node can spawn with shell:false (EINVAL or ENOENT). The
+// relay already runs inside Pi, so the host's own JavaScript entry is spawned
+// through process.execPath instead. Other platforms keep today's exact shape.
+test("the Pi launch shape spawns the host entry through process.execPath on win32 and stays byte-identical elsewhere", () => {
+	const host = {
+		execPath: "C:\\Program Files\\nodejs\\node.exe",
+		entry: "C:\\Users\\dev\\AppData\\Local\\pnpm\\global\\5\\node_modules\\@earendil-works\\pi-coding-agent\\dist\\bundle\\cli.js",
+	};
+	const windows = resolvePiLaunch(undefined, "win32", host);
+	assert.deepEqual(windows, { file: host.execPath, arguments: [host.entry, ...OPAQUE_PI_REVIEWER_ARGV] });
+	assert.notEqual(windows.file, "pi");
+	assert.equal(windows.arguments.includes("pi"), false);
+	for (const platform of ["linux", "darwin", "freebsd"] as const) {
+		assert.deepEqual(resolvePiLaunch(undefined, platform, host), { file: "pi", arguments: [...OPAQUE_PI_REVIEWER_ARGV] }, platform);
+		assert.deepEqual(resolvePiLaunch("/opt/pi/bin/pi", platform, host), { file: "/opt/pi/bin/pi", arguments: [...OPAQUE_PI_REVIEWER_ARGV] }, platform);
+	}
+	assert.deepEqual(resolvePiLaunch("C:\\tools\\pi.exe", "win32", host), { file: "C:\\tools\\pi.exe", arguments: [...OPAQUE_PI_REVIEWER_ARGV] });
+	for (const entry of [undefined, "", "cli.js", "dist/bundle/cli.js"]) {
+		assert.throws(() => resolvePiLaunch(undefined, "win32", { execPath: host.execPath, entry }), /host entry/, `entry ${JSON.stringify(entry)} must fail closed instead of spawning a bare pi`);
+	}
+});
+
+test("the default Pi launch resolves from the running host process", () => {
+	const launch = resolvePiLaunch(undefined);
+	if (process.platform === "win32") {
+		assert.deepEqual(launch, { file: process.execPath, arguments: [process.argv[1]!, ...OPAQUE_PI_REVIEWER_ARGV] });
+	} else {
+		assert.deepEqual(launch, { file: "pi", arguments: [...OPAQUE_PI_REVIEWER_ARGV] });
 	}
 });

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -8,7 +8,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { __testing, createGentleAiExtension, PendingReviewConsentRegistry } from "../extensions/gentle-ai.ts";
 import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
 import { NATIVE_REVIEW_ERROR_CODE, NativeReviewCliError, NativeReviewConsentRequiredError, type NativeReviewCli } from "../lib/native-review-cli.ts";
-import { decodeReviewConsentV3, type ReviewCollectInputV3, type ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+import { decodeReviewConsentV3, decodeReviewStatusV3, type ReviewCollectInputV3, type ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 
 const SHA = `sha256:${"a".repeat(64)}`;
 const TREE = "b".repeat(40);
@@ -1088,5 +1088,55 @@ test("controller forwards AbortSignal and retains typed native diagnostics witho
 		assert.equal(failed.outcome, "native-status-package-binary-missing");
 		assert.equal(failed.mutation_outcome, "none");
 		assert.equal((failed.diagnostics as { error_code?: string }).error_code, NATIVE_REVIEW_ERROR_CODE.PACKAGE_BINARY_MISSING);
+	}
+});
+
+// #465: a collect-state STATUS/INSPECT/START answer used to carry every
+// provider collect input twice, once inside result.next_transition.collect
+// and once as the canonical collectBinding string, so a four-lens review paid
+// roughly 28k characters per call and again on every blocked retry. The
+// consumed projection is collectBindings; the raw inputs are the duplicate.
+function fourLensCollectStatus(): { raw: Record<string, unknown>; lenses: readonly string[] } {
+	const captured = JSON.parse(readFileSync(new URL("./fixtures/devbinary/status-v5-capture-result-submission.captured.json", import.meta.url), "utf8")) as Record<string, unknown>;
+	const nextTransition = captured.next_transition as { collect: { inputs: Array<Record<string, unknown>> } };
+	const template = nextTransition.collect.inputs[0]!;
+	const lenses = ["review-risk", "review-readability", "review-reliability", "review-resilience"] as const;
+	// The captured input names its lens in the capture arguments and again in
+	// the provider-owned submission tokens; rewrite every occurrence so each of
+	// the four inputs is one distinct provider slot.
+	const inputs = lenses.map((lens, order) => JSON.parse(JSON.stringify(template).replaceAll("review-reliability", lens).replaceAll("--order=0", `--order=${order}`)) as Record<string, unknown>);
+	// The captured envelope predates the current action enumeration; the collect transition is what this test exercises.
+	return { raw: { ...captured, action: "stop", next_transition: { ...nextTransition, collect: { inputs } } }, lenses };
+}
+
+function occurrences(haystack: string, needle: string): number {
+	return haystack.split(needle).length - 1;
+}
+
+test("collect-state public STATUS, INSPECT, and START serialize each provider collect input exactly once", async () => {
+	const { raw, lenses } = fourLensCollectStatus();
+	const status = decodeReviewStatusV3(raw);
+	const lineageId = status.authority!.lineageId!;
+	const native = { targetStatus: async () => status } as unknown as NativeReviewCli;
+	for (const parameters of [
+		{ operation: "status", lineageId },
+		{ operation: "inspect" },
+		{ operation: "start", input: JSON.stringify({ mode: "ordinary" }) },
+	] as const) {
+		const result = await __testing.executeReviewControllerOperation(parameters, process.cwd(), native);
+		assert.equal(result.status, "blocked", parameters.operation);
+		const bindings = result.collectBindings as readonly { collectBinding: string }[];
+		assert.equal(bindings.length, lenses.length, parameters.operation);
+		const serialized = JSON.stringify(result);
+		const projected = JSON.stringify(bindings);
+		for (const lens of lenses) {
+			const needle = `--lens=${lens}`;
+			assert.ok(occurrences(projected, needle) > 0, `${lens} must be published through collectBindings`);
+			assert.equal(occurrences(JSON.stringify(result.result), needle), 0, `${parameters.operation} must not repeat the ${lens} collect input inside result (${serialized.length} characters)`);
+			assert.equal(occurrences(serialized, needle), occurrences(projected, needle), `${parameters.operation} must serialize the ${lens} collect input exactly once (${serialized.length} characters)`);
+		}
+		const transition = (result.result as { next_transition: { kind: string } }).next_transition;
+		assert.equal(transition.kind, "collect", `${parameters.operation} keeps the transition kind so the orchestrator still sees the collect state`);
+		assert.ok(serialized.length < 2 * JSON.stringify(bindings).length, `${parameters.operation} answer (${serialized.length} characters) must not double the ${JSON.stringify(bindings).length}-character binding projection`);
 	}
 });


### PR DESCRIPTION
Three Windows and payload defects from today's triage, fixed as one batch with a red test first for each root.

## #465: collect-state answers serialized every provider collect input twice

**What**: `mapNativeTargetStatus` returned `result: status.raw` (carrying `next_transition.collect.inputs`) and `collectBindings` (the same inputs canonicalized as opaque binding strings). The consumed projection is `collectBindings` (`gentle_review_capture`, the harness, the restart-parity and dev-binary tests all read it; nothing reads the raw inputs from the public answer), so the raw `next_transition.collect` member is now dropped from `result` in the collect branch. `kind` and `reason_code` stay so the orchestrator still sees the collect state.

**Measured** on a four-lens collect STATUS built from the captured v5 fixture: 26,926 -> 15,183 characters per STATUS/INSPECT/START answer (`result` 14,191 -> 2,448; `collectBindings` 12,665 both ways). Every blocked retry pays the smaller answer.

**Red test**: `collect-state public STATUS, INSPECT, and START serialize each provider collect input exactly once` (`tests/review-controller-native-routing.test.ts`), failing on main with `status must not repeat the review-risk collect input inside result (26926 characters)`.

## #400: Windows source build shared the 120 s probe timeout

**What**: `scripts/gentle-ai-installer.mjs` applied `GO_COMMAND_TIMEOUT_MS = 120_000` to every Go command, including `go install`, while a clean cold-cache build measured about 232 s. `commandOptions` now takes a timeout parameter; `go install` gets `GO_INSTALL_TIMEOUT_MS = 15 * 60_000` (justified in a comment, close to a 4x margin), and the `go version`, `go version -m`, binary `version`, and `where.exe` probes keep 120 s.

**Red test**: `Windows source build bounds go install separately from the Go toolchain probes` (`tests/gentle-ai-installer.test.ts`), failing on main with `go install must get at least a ten-minute bound, received 120000`.

## #468 (tracks #519): the Pi host relay spawned a bare `pi` on Windows

**What**: `lib/opaque-pi-reviewer-adapter.ts` spawned `piExecutable ?? "pi"` with `shell: false`; on Windows `pi` resolves to `pi.cmd`, `pi.ps1`, or a POSIX shim, so Node fails with `spawn EINVAL` (#468) or `spawn pi ENOENT` (#519). The adapter already runs inside Pi, so a new pure builder `resolvePiLaunch(piExecutable, platform, host)` spawns `process.execPath` with the running host's JavaScript entry (`process.argv[1]`) on win32 and fails closed (`launch-failed`) when that entry is missing or not a win32-absolute path. Explicit launchers and every other platform keep the exact previous shape; a shell is never enabled. The gentle-ai binary spawn in `lib/review-host-relay.ts` is unchanged (a real executable).

**Red test**: `the Pi launch shape spawns the host entry through process.execPath on win32 and stays byte-identical elsewhere` plus `the default Pi launch resolves from the running host process` (`tests/opaque-pi-reviewer-adapter.test.ts`), failing on main with `does not provide an export named 'resolvePiLaunch'`.

## Verification (foreground, after merging origin/main)

- `pnpm test`: 1142 tests, 1141 pass, 1 skipped (pre-existing), 0 fail; provider contract mirror check passed; runtime harness exit 0.
- `pnpm run check:runtime-modules`: runtime matches TypeScript sources (4 modules). The adapter is not one of the generated runtime modules, so no `runtime/*.mjs` changed.
- `node scripts/verify-package-files.mjs`: passed (162 files, 68 byte-pinned artifacts).
- Dev-binary journeys `tests/devbinary/*.devtest.ts` against a gentle-ai main build (`2.5.0-rc.3.0.20260831105332-9e1ec40a92d7`): 7/7 pass, including the POSIX Pi host relay slot capture and the Go-owned validation approval journey.

## Left out on purpose

- No new verb, flag, schema identity, contract row, alias, pin, `NATIVE_CLI_CONTRACTS`, or asset digest change.
- #465 keeps `collectBindings` as the only carrier of collect inputs; the "abandon binding schema in stderr" part of the report is not what main emits (per triage) and was not touched.
- #468 does not forward `process.execArgv`, does not add Windows handling for an explicit `piExecutable` (only tests pass one), and does not touch the gentle-ai binary spawn. The dev-binary relay journey still skips on Windows as before.

Closes #465
Closes #400
Closes #468

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Pi launch reliability on Windows by using the correct host runtime when needed.
  - Increased the Windows source-install timeout to accommodate longer builds.
  - Reduced duplicated data in collect-status responses while preserving status details and provider inputs.

- **Tests**
  - Added coverage for Windows process launching, installation timeouts, and collect-status response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->