### PR TITLE
fix(skills): stop subagents from minifying code to chase the review budget

### DIFF
--- a/assets/agents/sdd-apply.md
+++ b/assets/agents/sdd-apply.md
@@ -87,6 +87,8 @@ then continue only when the parent prompt gives a resolved delivery path:
 
 If no delivery decision is provided, STOP before writing code and return `blocked` with the exact decision needed.
 
+The budget constrains how work is sliced, never the code itself. Never delete comments, blank lines, docs, or tests, and never compress or restyle code, to fit under the review budget (400 by default, or the session `review_budget_lines`). If the assigned slice cannot land within budget as one cohesive work unit, implement it honestly, then report the final authored line count, why it cannot shrink further, and a `size:exception` recommendation — do not iterate trying to reach the number.
+
 ## Strict TDD Gate
 
 If `openspec/config.yaml` declares strict TDD and a test runner, or the parent prompt says strict TDD is active:

--- a/skills/chained-pr/SKILL.md
+++ b/skills/chained-pr/SKILL.md
@@ -14,6 +14,8 @@ Load this skill when a planned PR may exceed **400 changed lines**, SDD forecast
 ## Hard Rules
 
 - Split PRs over **400 changed lines** unless a maintainer explicitly accepts `size:exception`.
+- The budget constrains how work is **sliced**, never the code itself. Never delete comments, blank lines, docs, or tests, and never compress or restyle code, to fit under the budget.
+- Slicing is bounded: make **one** honest slicing pass. If no cohesive split brings every slice within budget, stop iterating, keep the best cohesive split, and report the final line count with a `size:exception` recommendation.
 - Keep each PR reviewable in about **≤60 minutes**.
 - Use one deliverable work unit per PR; keep tests/docs with the unit they verify.
 - State start, end, prior dependencies, follow-up work, and out-of-scope items in every chained PR.
@@ -30,6 +32,7 @@ Load this skill when a planned PR may exceed **400 changed lines**, SDD forecast
 | PR >400, each slice can land independently | Use Stacked PRs to main. |
 | PR >400, feature must integrate before main | Use Feature Branch Chain with tracker. |
 | Generated/vendor/migration diff cannot split cleanly | Ask maintainer for `size:exception`. |
+| No cohesive split fits the budget after one slicing pass | Stop; deliver the best split, report the overage and why it cannot shrink further, and recommend `size:exception`. |
 | SDD provides `delivery_strategy` | Follow it before apply/PR creation. |
 
 ## Execution Steps

--- a/skills/work-unit-commits/SKILL.md
+++ b/skills/work-unit-commits/SKILL.md
@@ -30,6 +30,7 @@ Use it for:
 | Tell a story | A reviewer should understand why each commit exists from its diff and message. |
 | Future PR-ready | Each commit should be a candidate chained PR when the change grows. |
 | SDD workload guard | If SDD tasks forecast a >400-line change, group commits into chained PR slices before implementation. |
+| Budget is not code-golf | Never shrink a diff by deleting comments, blank lines, docs, or tests, or by compressing code, to fit the review budget (400 by default, or the session `review_budget_lines`). Slice by work unit or report the overage. |
 
 ## Work Unit Checklist
 
@@ -66,6 +67,7 @@ When `sdd-tasks` produces a Review Workload Forecast:
 - Low risk: keep work-unit commits inside one PR.
 - Medium risk: commit by work unit and monitor changed lines before PR creation.
 - High risk: follow SDD `delivery_strategy` — ask on `ask-on-risk`, auto-slice on `auto-chain`, require `size:exception` on over-budget `single-pr`, or record accepted `size:exception` on `exception-ok`.
+- Splitting is bounded: after one honest slicing pass, if no cohesive work-unit split fits the budget, stop and report the smallest honest count with a `size:exception` recommendation. Do not iterate shrinking the code to reach the number.
 
 Each SDD work unit should map cleanly to a commit or PR with:
 


### PR DESCRIPTION
## Summary

Port of Gentleman-Programming/gentle-ai#3981 (fixed there by Gentleman-Programming/gentle-ai#3982) into gentle-pi's own copies of the skill assets.

The 400-line review budget in `skills/chained-pr`, `skills/work-unit-commits`, and `assets/agents/sdd-apply.md` reads as a hard rule whose only exit (`size:exception`) needs a maintainer, so a mid-run subagent that cannot split a cohesive work unit below the budget minifies the code instead — stripping comments, blank lines, and compressing code to force the diff under the number.

- Adds the anti-code-golf rule: the budget constrains how work is sliced, never the code itself; never delete comments, blank lines, docs, or tests to fit it.
- Adds the bounded exit: one honest slicing pass, then stop, deliver the best cohesive split, and report the overage with a `size:exception` recommendation.
- Honors the session `review_budget_lines` (400 by default) instead of hardcoding the number in the new rules.

## Changes

| File | Change |
|------|--------|
| `skills/chained-pr/SKILL.md` | Anti-gaming + bounded-slicing hard rules; new decision gate. |
| `skills/work-unit-commits/SKILL.md` | "Budget is not code-golf" rule; bounded-splitting rule in the SDD section. |
| `assets/agents/sdd-apply.md` | Implementer-facing anti-minification rule in the Review Workload Gate. |

## Test Plan

- [x] `pnpm test` — 1147 pass, 0 fail
- [x] `check:provider-contract` — passed (contract 1.1.0)

https://claude.ai/code/session_01YGgZFbfavEvP84zm1vtFQv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that review budgets limit work slicing, not code content.
  - Prohibited deleting or compressing comments, documentation, tests, blank lines, or code to meet size limits.
  - Added guidance to make one honest slicing pass and report an exception when cohesive work cannot fit the budget.
  - Added consistent `size:exception` recommendations and overage reporting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->