### PR TITLE
fix(review): support pre-start untracked selection

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -2647,12 +2647,12 @@ const REVIEW_CONTROLLER_PARAMETERS = {
 const REVIEW_CAPTURE_PARAMETERS = {
 	type: "object",
 	additionalProperties: false,
-	required: ["lineageId", "collectBinding"],
+	required: ["collectBinding"],
 	properties: {
 		lineageId: {
 			type: "string",
 			minLength: 1,
-			description: "Exact lineage from the current provider-issued collect transition.",
+			description: "Exact lineage from the current provider-issued collect transition. Required for every lineage-bound capture; omit it only when answering the pre-START intended_untracked_selection input, which has no lineage yet.",
 		},
 		collectBinding: {
 			type: "string",
@@ -2672,16 +2672,35 @@ const REVIEW_CAPTURE_PARAMETERS = {
 			type: "string",
 			description: "Optional explicit existing Git worktree root, resolved with the controller's worktree confinement semantics.",
 		},
+		untrackedScope: {
+			type: "string",
+			enum: ["exclude", "select"],
+			description: "Pre-START route only: answers the provider intended_untracked_selection input without lineageId. \"exclude\" declares no intended untracked paths; \"select\" requires a non-empty intendedUntracked subset of the provider eligible inventory.",
+		},
+		intendedUntracked: {
+			type: "array",
+			items: { type: "string", minLength: 1 },
+			description: "Pre-START route only: unique repository-relative untracked paths from the provider's eligible_paths_json inventory; valid solely with untrackedScope \"select\".",
+		},
 	},
 } as const;
 
-interface ReviewCaptureParameters {
+interface ReviewLineageCaptureParameters {
 	lineageId: string;
 	collectBinding: string;
 	reviewerRunAcknowledged?: boolean;
 	correctionLines?: number;
 	workspaceRoot?: string;
 }
+
+interface ReviewPreStartSelectionCaptureParameters {
+	untrackedScope: NativeStartUntrackedScope;
+	intendedUntracked: readonly string[];
+	collectBinding: string;
+	workspaceRoot?: string;
+}
+
+type ReviewCaptureParameters = ReviewLineageCaptureParameters | ReviewPreStartSelectionCaptureParameters;
 
 const REVIEW_SCOPE_PARAMETERS = {
 	type: "object",
@@ -2760,9 +2779,30 @@ function parseReviewControllerParameters(value: unknown): ReviewControllerParame
 
 function parseReviewCaptureParameters(value: unknown): ReviewCaptureParameters {
 	if (!isRecord(value)) throw new Error("Review capture parameters must be an object");
-	const allowed = new Set(["lineageId", "collectBinding", "reviewerRunAcknowledged", "correctionLines", "workspaceRoot"]);
+	const allowed = new Set(["lineageId", "collectBinding", "reviewerRunAcknowledged", "correctionLines", "workspaceRoot", "untrackedScope", "intendedUntracked"]);
 	const unexpected = Object.keys(value).find((key) => !allowed.has(key));
 	if (unexpected !== undefined) throw new Error(`Review capture does not accept ${unexpected}`);
+	if (value.untrackedScope !== undefined || value.intendedUntracked !== undefined) {
+		const scope = value.untrackedScope;
+		if (scope !== NATIVE_START_UNTRACKED_SCOPE.EXCLUDE && scope !== NATIVE_START_UNTRACKED_SCOPE.SELECT) throw new Error('Review capture untrackedScope must be "exclude" or "select"');
+		for (const key of ["lineageId", "reviewerRunAcknowledged", "correctionLines"] as const) {
+			if (value[key] !== undefined) throw new Error(`Review capture pre-START selection does not accept ${key}`);
+		}
+		if (typeof value.collectBinding !== "string" || value.collectBinding.length === 0) throw new Error("Review capture requires a JSON-serialized collectBinding");
+		if (value.workspaceRoot !== undefined && typeof value.workspaceRoot !== "string") throw new Error("Review capture workspaceRoot must be a string");
+		const intendedUntracked = value.intendedUntracked;
+		if (intendedUntracked !== undefined && (!Array.isArray(intendedUntracked) || intendedUntracked.some((path) => !isNativeStartUntrackedPath(path) || intendedUntracked.indexOf(path) !== intendedUntracked.lastIndexOf(path)))) {
+			throw new Error("Review capture intendedUntracked must be unique repository-relative untracked paths");
+		}
+		if (scope === NATIVE_START_UNTRACKED_SCOPE.EXCLUDE && (intendedUntracked?.length ?? 0) > 0) throw new Error('Review capture untrackedScope "exclude" forbids intendedUntracked paths');
+		if (scope === NATIVE_START_UNTRACKED_SCOPE.SELECT && (intendedUntracked?.length ?? 0) === 0) throw new Error('Review capture untrackedScope "select" requires a non-empty intendedUntracked subset');
+		return {
+			untrackedScope: scope,
+			intendedUntracked: intendedUntracked === undefined ? [] : [...intendedUntracked],
+			collectBinding: value.collectBinding,
+			...(value.workspaceRoot === undefined ? {} : { workspaceRoot: value.workspaceRoot }),
+		};
+	}
 	if (!isCanonicalProcessString(value.lineageId)) throw new Error("Review capture requires an exact non-empty lineageId");
 	if (typeof value.collectBinding !== "string" || value.collectBinding.length === 0) throw new Error("Review capture requires a JSON-serialized collectBinding");
 	if (value.reviewerRunAcknowledged !== undefined && typeof value.reviewerRunAcknowledged !== "boolean") throw new Error("Review capture reviewerRunAcknowledged must be boolean");
@@ -3938,6 +3978,22 @@ function isRetainedNativeCaptureRoute(selection: RetainedNativeStatusSelection |
 	return selection !== undefined && "workspaceRoot" in selection;
 }
 
+function reviewPreStartSelectionStorageKey(workspaceRoot: string): string {
+	return `pre-start\u0000${workspaceRoot}`;
+}
+
+function consumeRetainedPreStartUntrackedSelection(selections: Map<string, RetainedNativeStatusSelection>, workspaceRoot: string): NativeStartUntrackedSelection {
+	const key = reviewPreStartSelectionStorageKey(workspaceRoot);
+	const selection = selections.get(key);
+	if (selection === undefined || isRetainedNativeCaptureRoute(selection)) return {};
+	selections.delete(key);
+	return {
+		untrackedScope: selection.untrackedScope,
+		expectedUntrackedInventory: selection.expectedUntrackedInventory,
+		intendedUntracked: [...selection.intendedUntracked],
+	};
+}
+
 function retainNativeCaptureRoutes(selections: Map<string, RetainedNativeStatusSelection>, workspaceRoot: string, status: ReviewStatusV3, baseRef: string | undefined): void {
 	const lineageId = status.authority?.lineageId;
 	if (status.applicability !== "current_target" || !isCanonicalProcessString(lineageId) || isTerminalReviewAuthorityState(status.authority?.state)) return;
@@ -4396,6 +4452,82 @@ function captureBindingRejected(reason: string): Record<string, unknown> {
 	};
 }
 
+const REVIEW_PRE_START_SELECTION_INPUT_NAME = "intended_untracked_selection";
+const REVIEW_PRE_START_SELECTION_CAPTURE_OPERATION = "external.select_intended_untracked";
+const REVIEW_PRE_START_SELECTION_REASON_CODE = "intended_untracked_selection_required";
+const REVIEW_PRE_START_SELECTION_NEXT_ACTION =
+	"Answer the pre-START intended_untracked_selection collect input through gentle_review_capture without lineageId: pass its exact collectBinding plus untrackedScope \"exclude\", or \"select\" with a non-empty intendedUntracked subset of the provider eligible inventory. Then call ordinary START again; it consumes the retained exact selection once. Never bypass through the native CLI or by moving untracked files.";
+
+async function executePreStartUntrackedSelectionCapture(
+	parameters: ReviewPreStartSelectionCaptureParameters,
+	sessionCwd: string,
+	nativeReviewCli: NativeReviewCli,
+	candidateViews: CandidateViewRegistry | null,
+	retainedUntrackedSelections: Map<string, RetainedNativeStatusSelection>,
+	signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+	const canonicalBinding = parseCanonicalReviewCaptureBinding(parameters.collectBinding);
+	const cwd = resolveReviewControllerWorkspaceRoot(parameters.workspaceRoot, sessionCwd, candidateViews, undefined);
+	let status: ReviewStatusV3;
+	try {
+		const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, { cwd, ...(signal === undefined ? {} : { signal }) }, retainedUntrackedSelections, cwd);
+		if (negotiated.transport !== undefined) return hostTransportUnavailable("gentle_review_capture", negotiated.transport);
+		status = negotiated.status!;
+	} catch (error) {
+		return nativeOperationFailure("gentle_review_capture", error);
+	}
+	if (status.applicability !== "unrelated" || status.authority !== undefined) {
+		return captureBindingRejected(status.applicability === "current_target"
+			? "a review lineage already exists for this target; answer its lineage-bound collect transition instead of a pre-START selection"
+			: "current STATUS is ambiguous and cannot authorize a pre-START intended-untracked selection");
+	}
+	if (status.nextTransition?.kind !== "collect") return captureBindingRejected("current STATUS does not offer a collect transition");
+	const matches = (status.nextTransition.collect?.inputs ?? []).filter((input) => canonicalReviewCaptureBinding(input) === canonicalBinding);
+	if (matches.length !== 1) {
+		return captureBindingRejected(matches.length === 0
+			? "collectBinding is missing or stale for current STATUS"
+			: "collectBinding matches more than one current STATUS input");
+	}
+	const input = matches[0]!;
+	if (input.captureOperation !== REVIEW_PRE_START_SELECTION_CAPTURE_OPERATION || input.name !== REVIEW_PRE_START_SELECTION_INPUT_NAME) {
+		return captureBindingRejected("collectBinding is not the provider pre-START intended-untracked selection input");
+	}
+	if (!isCanonicalProcessString(status.targetIdentity)) return captureBindingRejected("current STATUS does not name an exact pre-START target identity");
+	const expectedUntrackedInventory = exactCollectArgument(input, "expected_untracked_inventory");
+	const eligiblePathsJson = exactCollectArgument(input, "eligible_paths_json");
+	if (!isCanonicalProcessString(expectedUntrackedInventory) || eligiblePathsJson === undefined) {
+		return captureBindingRejected("provider selection input omitted its exact expected-inventory or eligible-path binding");
+	}
+	let eligible: unknown;
+	try { eligible = JSON.parse(eligiblePathsJson); } catch { eligible = undefined; }
+	if (!Array.isArray(eligible) || eligible.some((path) => !isNativeStartUntrackedPath(path)) || new Set(eligible).size !== eligible.length) {
+		return captureBindingRejected("provider selection input published a malformed eligible-path inventory");
+	}
+	const outside = parameters.intendedUntracked.filter((path) => !eligible.includes(path));
+	if (outside.length > 0) return captureBindingRejected(`intendedUntracked names paths outside the provider eligible inventory: ${outside.join(", ")}`);
+	retainNativeStatusSelection(retainedUntrackedSelections, reviewPreStartSelectionStorageKey(cwd), Object.freeze({
+		untrackedScope: parameters.untrackedScope,
+		expectedUntrackedInventory,
+		intendedUntracked: Object.freeze([...parameters.intendedUntracked]),
+	}));
+	return {
+		tool: "gentle_review_capture",
+		status: "completed",
+		outcome: "pre-start-untracked-selection-retained",
+		workspace_root: cwd,
+		target_identity: status.targetIdentity,
+		projection: status.projection.projection,
+		base_tree: status.projection.baseTree,
+		current_candidate_tree: status.projection.currentCandidateTree,
+		untracked_scope: parameters.untrackedScope,
+		expected_untracked_inventory: expectedUntrackedInventory,
+		intended_untracked: [...parameters.intendedUntracked],
+		mutation_performed: false,
+		mutation_outcome: "none",
+		next_action: 'Call ordinary START (gentle_review {"operation":"start"}) for this workspace root without untracked fields; it consumes this exact retained selection once. A changed untracked inventory fails closed and reissues the provider selection input.',
+	};
+}
+
 interface SelectedReviewCapture {
 	input: ReviewCollectInputV3;
 	binding: ReviewLastEventClosureBinding;
@@ -4469,6 +4601,9 @@ async function executeReviewCaptureOperation(
 			mutation_performed: false,
 			mutation_outcome: "none",
 		};
+	}
+	if ("untrackedScope" in parameters) {
+		return await executePreStartUntrackedSelectionCapture(parameters, sessionCwd, nativeReviewCli, candidateViews, retainedUntrackedSelections, signal);
 	}
 	const canonicalBinding = parseCanonicalReviewCaptureBinding(parameters.collectBinding);
 	const cwd = resolveReviewControllerWorkspaceRoot(parameters.workspaceRoot, sessionCwd, candidateViews, parameters.lineageId);
@@ -4968,8 +5103,11 @@ async function executeReviewControllerOperation(
 			if (baseRef !== undefined && !isCanonicalProcessString(baseRef)) return nativeStartRejection("base-ref-invalid");
 			if (baseRef !== undefined && rawStart.committedOnly !== true) return nativeStartRejection("committed-only-required");
 			if (baseRef === undefined && "committedOnly" in rawStart) return nativeStartRejection("committed-only-invalid");
-			const untrackedSelection = validateNativeStartUntrackedSelection(rawStart);
-			if (untrackedSelection.reason !== undefined) return nativeStartRejection(untrackedSelection.reason);
+			const declaredUntrackedSelection = validateNativeStartUntrackedSelection(rawStart);
+			if (declaredUntrackedSelection.reason !== undefined) return nativeStartRejection(declaredUntrackedSelection.reason);
+			const untrackedSelection = declaredUntrackedSelection.untrackedScope === undefined
+				? consumeRetainedPreStartUntrackedSelection(retainedUntrackedSelections, defaultCwd)
+				: declaredUntrackedSelection;
 			const retainedUntrackedSelection = cloneRetainedNativeUntrackedSelection(untrackedSelection);
 			let canonicalBaseRef: string | undefined;
 			if (baseRef !== undefined) {
@@ -4999,7 +5137,12 @@ async function executeReviewControllerOperation(
 				}, retainedUntrackedSelections, defaultCwd);
 				if (negotiated.transport !== undefined) return hostTransportUnavailable(parameters.operation, negotiated.transport);
 				target = negotiated.status!;
-				if (target.nextTransition?.kind === "collect" || target.applicability !== "unrelated" || target.action !== "start") return mapNativeTargetStatus(parameters.operation, target, parameters.lineageId);
+				if (target.nextTransition?.kind === "collect" || target.applicability !== "unrelated" || target.action !== "start") {
+					const mapped = mapNativeTargetStatus(parameters.operation, target, parameters.lineageId);
+					return target.applicability === "unrelated" && target.nextTransition?.kind === "collect" && target.nextTransition.reasonCode === REVIEW_PRE_START_SELECTION_REASON_CODE
+						? { ...mapped, next_action: REVIEW_PRE_START_SELECTION_NEXT_ACTION }
+						: mapped;
+				}
 			} catch (error) {
 				return nativeOperationFailure(parameters.operation, error);
 			}
@@ -5356,7 +5499,8 @@ function createGentleAiExtensionForTesting(
 		description: "Capture exactly one provider-issued ordinary native review collect slot. This is not a controller operation: it validates one opaque collect binding against current target-scoped STATUS, executes at most one capture, and never follows a transition.",
 		promptSnippet: "Use one exact current STATUS collectBinding for one ordinary native capture; call fresh STATUS before every additional capture.",
 		promptGuidelines: [
-			"Pass only lineageId, the JSON-serialized exact collectBinding from current STATUS, and the route-specific optional acknowledgement or correctionLines value. Never compose provider argument tokens, prompts, results, verdicts, or lens arrays.",
+			"For lineage-bound captures pass only lineageId, the JSON-serialized exact collectBinding from current STATUS, and the route-specific optional acknowledgement or correctionLines value. Never compose provider argument tokens, prompts, results, verdicts, or lens arrays.",
+			"A pre-START intended_untracked_selection input is the one lineage-less route: omit lineageId and pass its exact collectBinding plus untrackedScope \"exclude\", or \"select\" with a non-empty intendedUntracked subset of the provider eligible inventory. The accepted exact selection is retained for this workspace root and the next ordinary START consumes it once.",
 			"A materialize reviewer slot first forecasts one model run; re-submit that same exact binding with reviewerRunAcknowledged: true to authorize one host relay. Correction-plan slots require correctionLines inside the provider-issued bounds. Refuter and validation vectors execute exactly once as provider-rendered.",
 			"A native terminal closure or nonterminal capture returns directly. Do not expect automatic STATUS, FINALIZE, receipt, delivery, or another capture; call fresh STATUS before any next capture.",
 		],

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -308,7 +308,7 @@ test("ordinary native capture exposes a registered schema and STATUS binding cop
 	createGentleAiExtension({ nativeReviewCli: null })(pi);
 
 	assert.ok(tools.has("gentle_review_capture"));
-	assert.deepEqual(tools.get("gentle_review_capture")?.parameters.required, ["lineageId", "collectBinding"]);
+	assert.deepEqual(tools.get("gentle_review_capture")?.parameters.required, ["collectBinding"]);
 
 	const sha = `sha256:${"a".repeat(64)}`;
 	const lineageId = "ordinary-capture";

--- a/tests/review-pre-start-untracked-selection.test.ts
+++ b/tests/review-pre-start-untracked-selection.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { __testing } from "../extensions/gentle-ai.ts";
+import type { NativeReviewCli } from "../lib/native-review-cli.ts";
+import type { ReviewCollectInputV3, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+
+const SHA = `sha256:${"a".repeat(64)}`;
+const TREE = "b".repeat(40);
+const INVENTORY = `sha256:${"d".repeat(64)}`;
+
+function preStartSelectionInput(inventory = INVENTORY, eligible: readonly string[] = ["selected.txt", "excluded.txt"]): ReviewCollectInputV3 {
+	return {
+		name: "intended_untracked_selection",
+		schema: "https://gentle-ai.dev/schema/review/intended-untracked-selection/v1",
+		captureOperation: "external.select_intended_untracked",
+		arguments: [
+			{ name: "expected_untracked_inventory", value: inventory },
+			{ name: "eligible_paths_json", value: JSON.stringify(eligible) },
+		],
+	};
+}
+
+function preStartStatus(inputs: readonly ReviewCollectInputV3[], applicability = "unrelated"): ReviewStatusV3 {
+	return {
+		contract: "gentle-ai.review-integration/v2",
+		applicability,
+		action: "start",
+		replayability: "not_replayable",
+		targetIdentity: SHA,
+		projection: {
+			schema: "gentle-ai.review-candidate-projection/v1",
+			kind: "current-changes",
+			projection: "workspace",
+			baseTree: TREE,
+			initialReviewTree: TREE,
+			currentCandidateTree: TREE,
+			pathsDigest: SHA,
+			paths: ["app.ts"],
+			intendedUntracked: [],
+			intendedUntrackedProof: SHA,
+			initialSnapshotIdentity: SHA,
+			currentSnapshotIdentity: SHA,
+		},
+		candidates: [],
+		nextTransition: { kind: "collect", reasonCode: "intended_untracked_selection_required", collect: { inputs } },
+		raw: { schema: "gentle-ai.review-integration.status/v5" },
+	} as unknown as ReviewStatusV3;
+}
+
+function lineageBoundStatus(lineageId: string): ReviewStatusV3 {
+	const bound = preStartStatus([]) as unknown as Record<string, unknown>;
+	return {
+		...bound,
+		applicability: "current_target",
+		action: "stop",
+		authority: { version: "compact-v2", lineageId, state: "reviewing", generation: 1, revision: SHA },
+		nextTransition: { kind: "stop", reasonCode: "capture_required" },
+	} as unknown as ReviewStatusV3;
+}
+
+function startableStatus(): ReviewStatusV3 {
+	const startable = preStartStatus([]) as unknown as Record<string, unknown>;
+	delete startable.nextTransition;
+	return startable as unknown as ReviewStatusV3;
+}
+
+function bindingOf(result: Record<string, unknown>): string {
+	return (result.collectBindings as readonly { collectBinding: string }[])[0]!.collectBinding;
+}
+
+test("pre-START selection capture retains one exact wrapper answer that ordinary START consumes once", async () => {
+	const cwd = process.cwd();
+	const selections = new Map();
+	const requests: Array<Record<string, unknown>> = [];
+	const startRequests: Array<Record<string, unknown>> = [];
+	const native = {
+		targetStatus: async (request: Record<string, unknown>) => {
+			requests.push(request);
+			return request.untrackedScope === undefined
+				? preStartStatus([preStartSelectionInput()])
+				: startableStatus();
+		},
+		start: async (request: Record<string, unknown>) => {
+			startRequests.push(request);
+			return { lineageId: "selected-lineage", state: "reviewing", riskLevel: "low", selectedLenses: [], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: false, riskReasons: [], raw: {} };
+		},
+	} as unknown as NativeReviewCli;
+
+	const published = await __testing.executeReviewControllerOperation({ operation: "status" }, cwd, native, undefined, null, undefined, selections);
+	assert.equal(published.status, "blocked");
+	const binding = bindingOf(published);
+	assert.equal(JSON.parse(binding).name, "intended_untracked_selection");
+
+	const captured = await __testing.executeReviewCaptureOperation(
+		{ collectBinding: binding, untrackedScope: "select", intendedUntracked: ["selected.txt"] },
+		cwd,
+		native,
+		undefined,
+		null,
+		selections,
+		true,
+	);
+	const { next_action: capturedNextAction, ...capturedRest } = captured;
+	assert.deepEqual(capturedRest, {
+		tool: "gentle_review_capture",
+		status: "completed",
+		outcome: "pre-start-untracked-selection-retained",
+		workspace_root: cwd,
+		target_identity: SHA,
+		projection: "workspace",
+		base_tree: TREE,
+		current_candidate_tree: TREE,
+		untracked_scope: "select",
+		expected_untracked_inventory: INVENTORY,
+		intended_untracked: ["selected.txt"],
+		mutation_performed: false,
+		mutation_outcome: "none",
+	});
+	assert.match(String(capturedNextAction), /START/);
+
+	const started = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native, undefined, null, undefined, selections);
+	assert.equal(started.operation, "start");
+	assert.equal((started.result as { lineage_id?: string }).lineage_id, "selected-lineage");
+	assert.deepEqual(requests[2], { cwd, agent: "pi", untrackedScope: "select", expectedUntrackedInventory: INVENTORY, intendedUntracked: ["selected.txt"] });
+	assert.equal(startRequests.length, 1);
+	assert.deepEqual(
+		{ untrackedScope: startRequests[0]!.untrackedScope, expectedUntrackedInventory: startRequests[0]!.expectedUntrackedInventory, intendedUntracked: startRequests[0]!.intendedUntracked },
+		{ untrackedScope: "select", expectedUntrackedInventory: INVENTORY, intendedUntracked: ["selected.txt"] },
+	);
+
+	// The retained pre-START selection is one-shot: a second selectorless START
+	// finds nothing retained and surfaces the provider collect state again.
+	const replayed = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native, undefined, null, undefined, selections);
+	assert.equal(replayed.status, "blocked");
+	assert.deepEqual(requests[3], { cwd, agent: "pi" });
+	assert.equal(startRequests.length, 1);
+
+	// The accepted START retained the consumed selection under its real lineage.
+	await __testing.executeReviewControllerOperation({ operation: "status", lineageId: "selected-lineage" }, cwd, native, undefined, null, undefined, selections);
+	assert.deepEqual(requests[4], { cwd, lineageId: "selected-lineage", agent: "pi", untrackedScope: "select", expectedUntrackedInventory: INVENTORY, intendedUntracked: ["selected.txt"] });
+});
+
+test("pre-START exclude answer retains an exact empty selection for START", async () => {
+	const cwd = process.cwd();
+	const selections = new Map();
+	const startRequests: Array<Record<string, unknown>> = [];
+	const native = {
+		targetStatus: async (request: Record<string, unknown>) =>
+			request.untrackedScope === undefined ? preStartStatus([preStartSelectionInput()]) : startableStatus(),
+		start: async (request: Record<string, unknown>) => {
+			startRequests.push(request);
+			return { lineageId: "excluded-lineage", state: "reviewing", riskLevel: "low", selectedLenses: [], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: false, riskReasons: [], raw: {} };
+		},
+	} as unknown as NativeReviewCli;
+
+	const captured = await __testing.executeReviewCaptureOperation(
+		{ collectBinding: JSON.stringify(preStartSelectionInput()), untrackedScope: "exclude" },
+		cwd,
+		native,
+		undefined,
+		null,
+		selections,
+		true,
+	);
+	assert.equal(captured.outcome, "pre-start-untracked-selection-retained");
+	assert.deepEqual({ scope: captured.untracked_scope, intended: captured.intended_untracked }, { scope: "exclude", intended: [] });
+
+	await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native, undefined, null, undefined, selections);
+	assert.deepEqual(
+		{ untrackedScope: startRequests[0]!.untrackedScope, expectedUntrackedInventory: startRequests[0]!.expectedUntrackedInventory, intendedUntracked: startRequests[0]!.intendedUntracked },
+		{ untrackedScope: "exclude", expectedUntrackedInventory: INVENTORY, intendedUntracked: [] },
+	);
+});
+
+test("pre-START selection capture rejects stale, foreign, malformed, and out-of-inventory answers fail-closed", async () => {
+	const cwd = process.cwd();
+	const wrongSlot: ReviewCollectInputV3 = { ...preStartSelectionInput(), name: "reviewer_result", captureOperation: "review.capture-result" };
+	const missingInventory: ReviewCollectInputV3 = { ...preStartSelectionInput(), arguments: [{ name: "eligible_paths_json", value: JSON.stringify(["selected.txt"]) }] };
+	const malformedEligible: ReviewCollectInputV3 = { ...preStartSelectionInput(), arguments: [{ name: "expected_untracked_inventory", value: INVENTORY }, { name: "eligible_paths_json", value: "not json" }] };
+	const cases: ReadonlyArray<[string, ReviewStatusV3, Record<string, unknown>, RegExp]> = [
+		["out-of-inventory", preStartStatus([preStartSelectionInput()]), { collectBinding: JSON.stringify(preStartSelectionInput()), untrackedScope: "select", intendedUntracked: ["outside.txt"] }, /eligible inventory/],
+		["stale", preStartStatus([preStartSelectionInput(`sha256:${"e".repeat(64)}`)]), { collectBinding: JSON.stringify(preStartSelectionInput()), untrackedScope: "exclude" }, /missing or stale/],
+		["existing lineage", lineageBoundStatus("already-started"), { collectBinding: JSON.stringify(preStartSelectionInput()), untrackedScope: "exclude" }, /lineage already exists/],
+		["ambiguous", preStartStatus([preStartSelectionInput()], "ambiguous"), { collectBinding: JSON.stringify(preStartSelectionInput()), untrackedScope: "exclude" }, /ambiguous/],
+		["wrong slot", preStartStatus([wrongSlot]), { collectBinding: JSON.stringify(wrongSlot), untrackedScope: "exclude" }, /not the provider pre-START/],
+		["missing inventory", preStartStatus([missingInventory]), { collectBinding: JSON.stringify(missingInventory), untrackedScope: "exclude" }, /omitted its exact/],
+		["malformed eligible", preStartStatus([malformedEligible]), { collectBinding: JSON.stringify(malformedEligible), untrackedScope: "exclude" }, /malformed eligible-path inventory/],
+	];
+	for (const [label, status, parameters, reason] of cases) {
+		const selections = new Map();
+		let startCalls = 0;
+		const native = {
+			targetStatus: async () => status,
+			start: async () => { startCalls += 1; throw new Error("unreachable"); },
+		} as unknown as NativeReviewCli;
+		const rejected = await __testing.executeReviewCaptureOperation(parameters, cwd, native, undefined, null, selections, true);
+		assert.deepEqual(
+			{ label, outcome: rejected.outcome, mutation: rejected.mutation_outcome, retained: selections.size, startCalls },
+			{ label, outcome: "capture-binding-rejected", mutation: "none", retained: 0, startCalls: 0 },
+		);
+		assert.match(String(rejected.reason), reason, label);
+	}
+});
+
+test("pre-START selection capture parameters are validated fail-closed before any native call", async () => {
+	const binding = JSON.stringify(preStartSelectionInput());
+	const cases: ReadonlyArray<[Record<string, unknown>, RegExp]> = [
+		[{ collectBinding: binding, untrackedScope: "select", intendedUntracked: ["a.txt"], lineageId: "x" }, /does not accept lineageId/],
+		[{ collectBinding: binding, untrackedScope: "select", intendedUntracked: ["a.txt"], reviewerRunAcknowledged: true }, /does not accept reviewerRunAcknowledged/],
+		[{ collectBinding: binding, untrackedScope: "select", intendedUntracked: ["a.txt"], correctionLines: 1 }, /does not accept correctionLines/],
+		[{ collectBinding: binding, untrackedScope: "select" }, /requires a non-empty intendedUntracked/],
+		[{ collectBinding: binding, untrackedScope: "select", intendedUntracked: [] }, /requires a non-empty intendedUntracked/],
+		[{ collectBinding: binding, untrackedScope: "exclude", intendedUntracked: ["a.txt"] }, /forbids intendedUntracked/],
+		[{ collectBinding: binding, untrackedScope: "select", intendedUntracked: ["a.txt", "a.txt"] }, /unique repository-relative untracked paths/],
+		[{ collectBinding: binding, untrackedScope: "select", intendedUntracked: ["../escape"] }, /unique repository-relative untracked paths/],
+		[{ collectBinding: binding, untrackedScope: "select", intendedUntracked: ["/absolute.txt"] }, /unique repository-relative untracked paths/],
+		[{ collectBinding: binding, untrackedScope: "all", intendedUntracked: ["a.txt"] }, /untrackedScope must be/],
+		[{ collectBinding: binding, intendedUntracked: ["a.txt"] }, /untrackedScope must be/],
+		[{ collectBinding: binding }, /requires an exact non-empty lineageId/],
+	];
+	for (const [parameters, expected] of cases) {
+		await assert.rejects(() => __testing.executeReviewCaptureOperation(parameters, process.cwd(), null), expected);
+	}
+});
+
+test("selectorless ordinary START names the wrapper route for the pre-START selection collect", async () => {
+	const native = {
+		targetStatus: async () => preStartStatus([preStartSelectionInput()]),
+		start: async () => { throw new Error("unreachable"); },
+	} as unknown as NativeReviewCli;
+	const blocked = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, process.cwd(), native, undefined, null);
+	assert.equal(blocked.status, "blocked");
+	assert.equal((blocked.collectBindings as readonly unknown[]).length, 1);
+	assert.match(String(blocked.next_action), /gentle_review_capture/);
+	assert.match(String(blocked.next_action), /untrackedScope/);
+});


### PR DESCRIPTION
## Summary

- add a lineage-less `gentle_review_capture` route for the provider-issued pre-START `intended_untracked_selection` collect
- validate the exact collect binding, expected inventory, and selected repository-relative paths before retaining anything
- consume the retained selection exactly once during the next ordinary START and keep lineage-bound captures unchanged
- document the new route in the tool schema and guidance

## Safety properties

- no native mutation occurs during selection capture
- stale, foreign, malformed, duplicate, absolute, escaping, or out-of-inventory paths fail closed
- `exclude` requires an empty selection; `select` requires a non-empty subset
- an existing lineage cannot use the pre-START route
- a changed inventory is revalidated by native STATUS/START

## Validation

- `tests/review-pre-start-untracked-selection.test.ts`: 5/5 passed
- `tests/review-candidate-view.test.ts`: 77/77 passed with hermetic HOME/XDG state
- `tests/review-transaction.test.ts`: 11/11 passed with hermetic HOME/XDG state
- `pnpm run check:provider-contract`: passed
- `pnpm run test:harness`: passed
- `pnpm run check:runtime-modules`: passed
- `pnpm run test:packed-package`: passed
- `git diff --check`: passed

Five guarded-command/Herdr tests that fail in the ambient workstation environment reproduce identically on archived `upstream/main`; this change does not introduce them.

Fixes #502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-review selection step for handling untracked files.
  * Supports selecting specific files or excluding untracked files before starting a review.
  * Preserves the chosen selection for the next review start.

* **Bug Fixes**
  * Added validation to reject stale, invalid, duplicate, or out-of-scope file selections.
  * Prevents reviews from starting when selection details are malformed or no longer valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
