### PR TITLE
fix(review): execute intended untracked selection handoff

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -128,6 +128,7 @@ import {
 	NATIVE_REVIEW_RECONCILE_ANOMALIES,
 	sanitizeForeignNativeReviewDiagnostics,
 	type NativeReviewCli,
+	type NativeIntendedUntrackedSelectionSubmission,
 	type NativeReviewAcknowledgeApprovedOutcome,
 	type NativeReviewAcknowledgeApprovedRequest,
 	type NativeTargetStatusRequest,
@@ -2576,6 +2577,7 @@ const REVIEW_CONTROLLER_OPERATION = {
 	ADVANCE: "advance",
 	ACKNOWLEDGE_APPROVED: "acknowledge-approved",
 	STATUS: "status",
+	SELECT_INTENDED_UNTRACKED: "select-intended-untracked",
 	EXPORT: "export",
 	IMPORT: "import",
 	INSPECT: "inspect",
@@ -2617,6 +2619,8 @@ const REVIEW_CONTROLLER_PARAMETERS = {
 			type: "string",
 			description: "Bounded review lineage identifier. A failed start creates no lineage; do not use it with status or advance.",
 		},
+		selectionBinding: { type: "string", description: "Opaque provider-issued pre-lineage intended-untracked selection binding." },
+		intendedUntracked: { type: "array", items: { type: "string" }, description: "Repository-relative paths selected from the provider binding." },
 		changeName: {
 			type: "string",
 			description: "Canonical OpenSpec change name required to resolve a recovered authority during lifecycle validate.",
@@ -2703,6 +2707,8 @@ interface ReviewScopeParameters {
 interface ReviewControllerParameters {
 	operation: ReviewControllerOperation;
 	lineageId?: string;
+	selectionBinding?: string;
+	intendedUntracked?: readonly string[];
 	changeName?: string;
 	idempotencyKey?: string;
 	transition?: string;
@@ -2736,6 +2742,11 @@ function parseReviewControllerParameters(value: unknown): ReviewControllerParame
 	if (!isRecord(value)) throw new Error("Review controller parameters must be an object");
 	if (typeof value.operation !== "string" || !isReviewControllerOperation(value.operation)) {
 		throw new Error("Review controller operation is unsupported");
+	}
+	if (value.operation === REVIEW_CONTROLLER_OPERATION.SELECT_INTENDED_UNTRACKED) {
+		const unexpected = Object.keys(value).find((key) => !["operation", "selectionBinding", "intendedUntracked"].includes(key));
+		if (unexpected !== undefined || typeof value.selectionBinding !== "string" || !Array.isArray(value.intendedUntracked)) throw new Error("Review intended-untracked selection accepts exactly selectionBinding and intendedUntracked");
+		return { operation: value.operation, selectionBinding: value.selectionBinding, intendedUntracked: value.intendedUntracked };
 	}
 	const needsLineage = ![REVIEW_CONTROLLER_OPERATION.START, REVIEW_CONTROLLER_OPERATION.ANSWER_CONSENT, REVIEW_CONTROLLER_OPERATION.STATUS, REVIEW_CONTROLLER_OPERATION.EXPORT, REVIEW_CONTROLLER_OPERATION.IMPORT, REVIEW_CONTROLLER_OPERATION.INSPECT, REVIEW_CONTROLLER_OPERATION.RESET, REVIEW_CONTROLLER_OPERATION.RECOVER, REVIEW_CONTROLLER_OPERATION.RECOVER_LOCK, REVIEW_CONTROLLER_OPERATION.ABANDON, REVIEW_CONTROLLER_OPERATION.QUARANTINE_LEGACY, REVIEW_CONTROLLER_OPERATION.RECONCILE_AUTHORITY, REVIEW_CONTROLLER_OPERATION.REPAIR_LEGACY_ALIAS, REVIEW_CONTROLLER_OPERATION.REPAIR].includes(value.operation as ReviewControllerOperation);
 	if (needsLineage && (typeof value.lineageId !== "string" || value.lineageId.trim().length === 0)) {
@@ -3318,11 +3329,12 @@ function mapNativeTargetStatus(operation: ReviewControllerOperation, status: Rev
 		status.nextTransition?.kind === "collect" &&
 		(operation === REVIEW_CONTROLLER_OPERATION.START || operation === REVIEW_CONTROLLER_OPERATION.INSPECT || operation === REVIEW_CONTROLLER_OPERATION.STATUS)
 	) {
+		const selection = reviewIntendedUntrackedInput(status);
 		return {
 			operation,
 			status: "blocked",
 			result: status.raw,
-			collectBindings: publicReviewCaptureBindings(status),
+			...(selection === undefined ? { collectBindings: publicReviewCaptureBindings(status) } : { selectionBinding: canonicalReviewCaptureBinding(selection) }),
 		};
 	}
 	if (status.action === "recover") {
@@ -4362,15 +4374,19 @@ function exactCollectArgument(input: ReviewCollectInputV3, name: string): string
 	return matches.length === 1 ? matches[0]!.value : undefined;
 }
 
-interface PublicReviewCaptureBinding {
-	collectBinding: string;
+function reviewIntendedUntrackedInput(status: ReviewStatusV3): ReviewCollectInputV3 | undefined {
+	if (status.raw.schema !== "gentle-ai.review-integration.status/v6" || status.nextTransition?.kind !== "collect") return undefined;
+	const matches = (status.nextTransition.collect?.inputs ?? []).filter((input) => {
+		const value = input.submission?.values[0];
+		return input.name === "intended_untracked_selection" && input.schema === "gentle-ai.review-intended-untracked-selection/v1" && input.captureOperation === "external.select_intended_untracked" && input.submission?.operationToken === "status" && input.submission.values.length === 1 && value?.slot === "intended_untracked_selection" && value.domain === "schema_bound_json";
+	});
+	return matches.length === 1 ? matches[0] : undefined;
 }
 
+interface PublicReviewCaptureBinding { collectBinding: string; }
 function publicReviewCaptureBindings(status: ReviewStatusV3): readonly PublicReviewCaptureBinding[] {
 	if (status.nextTransition?.kind !== "collect") return [];
-	return (status.nextTransition.collect?.inputs ?? []).map((input) => ({
-		collectBinding: canonicalReviewCaptureBinding(input),
-	}));
+	return (status.nextTransition.collect?.inputs ?? []).filter((input) => input.captureOperation !== "external.select_intended_untracked").map((input) => ({ collectBinding: canonicalReviewCaptureBinding(input) }));
 }
 
 function captureBindingRejected(reason: string): Record<string, unknown> {
@@ -4584,6 +4600,7 @@ async function executeReviewControllerOperation(
 	writeReviewConsentLatch: typeof recordReviewConsentLatch = recordReviewConsentLatch,
 	reviewConsentNow: () => number = Date.now,
 	reviewConsentScheduleTimer: (callback: () => void, delayMs: number) => { unref: () => void } = setTimeout,
+	intendedUntrackedSelection?: NativeIntendedUntrackedSelectionSubmission,
 ): Promise<Record<string, unknown>> {
 	const parameters = parseReviewControllerParameters(parametersValue);
 	const defaultCwd = resolveReviewControllerWorkspaceRoot(parameters.workspaceRoot, sessionCwd, candidateViews, parameters.lineageId);
@@ -4937,6 +4954,26 @@ async function executeReviewControllerOperation(
 		}
 		return completed;
 	}
+	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.SELECT_INTENDED_UNTRACKED) {
+		if (nativeReviewCli?.targetStatus === undefined || nativeReviewCli.start === undefined) return nativeStatusUnsupported(parameters.operation);
+		const canonicalBinding = parseCanonicalReviewCaptureBinding(parameters.selectionBinding!);
+		let status: ReviewStatusV3;
+		try {
+			const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, { cwd: defaultCwd, ...(signal === undefined ? {} : { signal }) }, retainedUntrackedSelections, defaultCwd);
+			if (negotiated.transport !== undefined) return hostTransportUnavailable(parameters.operation, negotiated.transport);
+			status = negotiated.status!;
+		} catch (error) { return nativeStatusFailed(parameters.operation, error); }
+		const input = reviewIntendedUntrackedInput(status), eligibleJson = input === undefined ? undefined : exactCollectArgument(input, "eligible_paths_json"), inventory = input === undefined ? undefined : exactCollectArgument(input, "expected_untracked_inventory");
+		let eligible: unknown;
+		try { eligible = JSON.parse(eligibleJson ?? ""); } catch { eligible = undefined; }
+		const scope = parameters.intendedUntracked!.length === 0 ? NATIVE_START_UNTRACKED_SCOPE.EXCLUDE : NATIVE_START_UNTRACKED_SCOPE.SELECT;
+		const selected = validateNativeStartUntrackedSelection({ untrackedScope: scope, expectedUntrackedInventory: inventory, intendedUntracked: parameters.intendedUntracked });
+		const rejected = input === undefined || canonicalReviewCaptureBinding(input) !== canonicalBinding || exactCollectArgument(input, "target_identity") !== status.targetIdentity || exactCollectArgument(input, "projection") !== status.projection.projection || exactCollectArgument(input, "base_tree") !== status.projection.baseTree || exactCollectArgument(input, "candidate_tree") !== status.projection.currentCandidateTree || !Array.isArray(eligible) || selected.reason !== undefined || selected.intendedUntracked!.some((path) => !eligible.includes(path));
+		if (rejected) return { operation: parameters.operation, status: "blocked", outcome: "intended-untracked-selection-binding-rejected", mutation_performed: false, mutation_outcome: "none" };
+		const submission = { argumentTokens: input.submission!.argumentTokens, value: JSON.stringify({ schema: "gentle-ai.review-intended-untracked-selection/v1", untracked_scope: scope, expected_untracked_inventory: inventory, intended_untracked: selected.intendedUntracked }) };
+		const result = await executeReviewControllerOperation({ operation: REVIEW_CONTROLLER_OPERATION.START, input: JSON.stringify({ mode: REVIEW_MODE.ORDINARY, untrackedScope: scope, expectedUntrackedInventory: inventory, intendedUntracked: selected.intendedUntracked }) }, sessionCwd, nativeReviewCli, signal, candidateViews, context, retainedUntrackedSelections, pendingReviewConsentRegistry, pendingReviewConsentFallbackKey, writeReviewConsentLatch, reviewConsentNow, reviewConsentScheduleTimer, submission);
+		return { ...result, operation: parameters.operation };
+	}
 	if (parameters.operation === REVIEW_CONTROLLER_OPERATION.START) {
 		const rawStart = parseControllerJson(
 			requiredControllerString(parameters, "input"),
@@ -4983,6 +5020,7 @@ async function executeReviewControllerOperation(
 					...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 					...(canonicalBaseRef === undefined ? {} : { baseRef: canonicalBaseRef, committedOnly: true }),
 					...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
+					...(intendedUntrackedSelection === undefined ? {} : { intendedUntrackedSelection }),
 					...(signal === undefined ? {} : { signal }),
 				}, retainedUntrackedSelections, defaultCwd);
 				if (negotiated.transport !== undefined) return hostTransportUnavailable(parameters.operation, negotiated.transport);
@@ -4998,10 +5036,16 @@ async function executeReviewControllerOperation(
 			// candidate-target-projection-drift. Timer order must not decide
 			// correctness: the queued cleanup macrotask may not have fired yet.
 			pruneExpiredReviewConsents(pendingReviewConsentRegistry, pendingReviewConsentSession, reviewConsentNow);
+			const candidateIntendedUntracked = target.projection.intendedUntracked;
 			let candidateView: ReturnType<CandidateViewRegistry["create"]> | undefined;
 			let nativeStartAttempted = false;
 			try {
-				candidateView = candidateViews?.createOrReuse({ contributorRoot: defaultCwd, replayKey, ...(canonicalBaseRef === undefined ? {} : { baseRef: canonicalBaseRef, committedOnly: true }), ...(untrackedSelection.untrackedScope === undefined ? {} : { intendedUntracked: untrackedSelection.intendedUntracked }) });
+				const candidateRequest = { contributorRoot: defaultCwd, replayKey, ...(canonicalBaseRef === undefined ? {} : { baseRef: canonicalBaseRef, committedOnly: true }) };
+				candidateView = candidateViews?.createOrReuse({ ...candidateRequest, ...(candidateIntendedUntracked.length === 0 ? {} : { intendedUntracked: candidateIntendedUntracked }) });
+				if (candidateView !== undefined && candidateIntendedUntracked.length === 0 && candidateView.candidateTree !== target.projection.currentCandidateTree) {
+					candidateView.cleanup();
+					candidateView = candidateViews?.createOrReuse({ ...candidateRequest, intendedUntracked: [] });
+				}
 				if (candidateView !== undefined) assertNativeStartCandidateBinding(candidateView, target);
 				let result: NativeStartResult;
 				try {
@@ -5014,6 +5058,7 @@ async function executeReviewControllerOperation(
 						targetIdentity: target.targetIdentity,
 						projection: target.projection.projection,
 						...(untrackedSelection.untrackedScope === undefined ? {} : untrackedSelection),
+						...(intendedUntrackedSelection === undefined ? {} : { intendedUntrackedSelection }),
 						...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
 						...(policy.policyPath === undefined ? {} : { policyPath: policy.policyPath }),
 						...(focus === undefined ? {} : { focus }),

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -423,10 +423,15 @@ export const NATIVE_UNTRACKED_SCOPE = {
 } as const;
 export type NativeUntrackedScope = (typeof NATIVE_UNTRACKED_SCOPE)[keyof typeof NATIVE_UNTRACKED_SCOPE];
 
+export interface NativeIntendedUntrackedSelectionSubmission {
+	readonly argumentTokens: readonly string[];
+	readonly value: string;
+}
 interface NativeUntrackedSelectionRequest {
 	untrackedScope?: NativeUntrackedScope;
 	expectedUntrackedInventory?: string;
 	intendedUntracked?: readonly string[];
+	intendedUntrackedSelection?: NativeIntendedUntrackedSelectionSubmission;
 }
 
 export interface NativeStartRequest extends NativeUntrackedSelectionRequest {
@@ -1852,6 +1857,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			...(request.baseRef === undefined ? {} : { baseRef: request.baseRef, committedOnly: true }),
 			...(request.lineageId === undefined ? {} : { lineageId: request.lineageId }),
 			...selection,
+			...(request.intendedUntrackedSelection === undefined ? {} : { intendedUntrackedSelection: request.intendedUntrackedSelection }),
 			agent: "pi",
 			...(request.signal === undefined ? {} : { signal: request.signal }),
 		});
@@ -1955,7 +1961,9 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		if (request.baseRef !== undefined && request.committedOnly !== true) throw new TypeError("Native STATUS baseRef requires explicit committedOnly acknowledgement");
 		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native STATUS committedOnly requires an explicit baseRef");
 		const selection = nativeUntrackedSelection(request);
-		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.STATUS, request.cwd, [
+		const submitted = request.intendedUntrackedSelection;
+		if (submitted !== undefined && submitted.argumentTokens.filter((token) => token.includes("{{value}}")).length !== 1) throw new TypeError("Native intended-untracked selection requires exactly one provider-issued {{value}} token");
+		const statusArguments = submitted === undefined ? [
 			"review", "status", "--contract", REVIEW_INTEGRATION_CONTRACT, "--cwd", request.cwd,
 			"--projection", request.projection ?? "workspace",
 			...nativeUntrackedSelectionArguments(selection),
@@ -1963,7 +1971,8 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 			...(request.lineageId === undefined ? [] : ["--lineage", request.lineageId]),
 			...(request.agent === undefined ? [] : ["--agent", request.agent]),
 			"--next-transition",
-		], false, request.signal);
+		] : ["review", "status", "--cwd", request.cwd, ...submitted.argumentTokens.map((token) => token.replaceAll("{{value}}", submitted.value))];
+		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.STATUS, request.cwd, statusArguments, false, request.signal);
 		assertSupportedNextTransitionOperation(execution.body);
 		return decode(NATIVE_REVIEW_OPERATION.STATUS, false, () => decodeReviewStatusV3(execution.body));
 	}

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -177,6 +177,12 @@ const CAPABILITIES_SCHEMA_IDENTITIES: Readonly<Record<string, { protocolMinor: n
 		requiredMandatoryFeatures: REQUIRED_MANDATORY_FEATURES_V23,
 		optionalFeatureFloor: 14,
 	}),
+	"gentle-ai.review-integration.capabilities/v2.4": Object.freeze({
+		protocolMinor: 4,
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON_V23, "gentle-ai.review-integration.capabilities/v2.4", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.start/v4", "gentle-ai.review-integration.status/v6", "gentle-ai.review-intended-untracked-selection/v1"]),
+		requiredMandatoryFeatures: REQUIRED_MANDATORY_FEATURES_V23,
+		optionalFeatureFloor: 14,
+	}),
 });
 const OPTIONAL_FEATURE_NAMES = Object.freeze([
 	"base_ref_workspace_overlay",
@@ -1340,7 +1346,29 @@ function decodeTransitionArguments(value: unknown, label: string): readonly Revi
 	});
 }
 
-function decodeCaptureSubmission(value: unknown, label: string, v5: boolean): ReviewCaptureSubmissionV1 {
+function decodeCaptureSubmission(value: unknown, label: string, v5: boolean, v6: boolean, captureOperation: string): ReviewCaptureSubmissionV1 {
+	// status/v6 adds the provider-owned intended-untracked selection form.
+	if (v6 && captureOperation === "external.select_intended_untracked" && typeof value === "object" && value !== null && (value as Record<string, unknown>).operation_token === "status") {
+		const submission = exactRecord(value, label, ["operation_token", "argument_tokens", "value"]);
+		const expectedTokens = [
+			"--contract=gentle-ai.review-integration/v2", "--next-transition=true", "--agent=pi",
+			"--projection=workspace", "--intended-untracked-selection={{value}}",
+		] as const;
+		const operationToken = enumeration(submission.operation_token, ["status"] as const, `${label}.operation_token`);
+		const argumentTokens = stringArray(submission.argument_tokens, `${label}.argument_tokens`, { minimum: expectedTokens.length, maximum: expectedTokens.length });
+		if (argumentTokens.some((token, index) => token !== expectedTokens[index])) throw new TypeError(`${label}.argument_tokens substitution binding is invalid`);
+		const row = exactRecord(submission.value, `${label}.value`, ["slot", "domain", "schema", "substitution_location"]);
+		return {
+			operationToken,
+			argumentTokens,
+			values: [{
+				slot: enumeration(row.slot, ["intended_untracked_selection"] as const, `${label}.value.slot`),
+				domain: enumeration(row.domain, ["schema_bound_json"] as const, `${label}.value.domain`),
+				schema: enumeration(row.schema, ["gentle-ai.review-intended-untracked-selection/v1"] as const, `${label}.value.schema`),
+				substitutionLocation: integer(row.substitution_location, `${label}.value.substitution_location`, 4, 4),
+			}],
+		};
+	}
 	// status/v5: the live 2.4.0-main binary emits the materialize
 	// capture-result submission as a SINGULAR `value` object carrying a
 	// `schema` key (captured 2026-08-16 from 2.4.0-main.b1afef46; the
@@ -1503,7 +1531,7 @@ const CORRECTION_REQUEST_REASON_CODES = Object.freeze(["correction_plan_required
 // v5 capture operations that must carry a submission descriptor.
 const V5_SUBMISSION_CAPTURE_OPERATIONS = Object.freeze(["review.capture-correction-plan"] as const);
 
-function decodeCollectInput(value: unknown, label: string, v5: boolean): ReviewCollectInputV3 {
+function decodeCollectInput(value: unknown, label: string, v5: boolean, v6: boolean): ReviewCollectInputV3 {
 	const input = exactRecord(value, label, ["name", "schema", "capture_operation", "arguments"], ["artifact_subject", "base_tree", "candidate_tree", "changed_path_manifest", "submission", ...(v5 ? ["provider_task", "validation_request"] : [])]);
 	const name = text(input.name, `${label}.name`, { minimum: 1, pattern: /^[a-z0-9_]+$/ });
 	const schema = nonempty(input.schema, `${label}.schema`);
@@ -1523,6 +1551,32 @@ function decodeCollectInput(value: unknown, label: string, v5: boolean): ReviewC
 			if (input.submission === undefined) throw new TypeError(`${label}.submission is required for ${captureOperation}`);
 			if (captureOperation === "review.capture-correction-plan" && schema !== "gentle-ai.review-correction-plan/v1") throw new TypeError(`${label}.schema must be gentle-ai.review-correction-plan/v1`);
 		}
+	}
+
+	const intendedUntracked = v6
+		&& name === "intended_untracked_selection"
+		&& schema === "gentle-ai.review-intended-untracked-selection/v1"
+		&& captureOperation === "external.select_intended_untracked";
+	if (intendedUntracked) {
+		const expectedNames = ["target_identity", "projection", "base_tree", "candidate_tree", "eligible_paths_json", "expected_untracked_inventory"] as const;
+		if (argumentsList.length !== expectedNames.length || argumentsList.some((argument, index) => argument.name !== expectedNames[index] || argument.token !== undefined)) {
+			throw new TypeError(`${label}.arguments must preserve the exact intended-untracked metadata binding`);
+		}
+		sha256(argumentsList[0]!.value, `${label}.arguments[0].value`);
+		enumeration(argumentsList[1]!.value, ["workspace"] as const, `${label}.arguments[1].value`);
+		gitTree(argumentsList[2]!.value, `${label}.arguments[2].value`);
+		gitTree(argumentsList[3]!.value, `${label}.arguments[3].value`);
+		const eligiblePathsJson = argumentsList[4]!.value;
+		let eligiblePaths: unknown;
+		try { eligiblePaths = JSON.parse(eligiblePathsJson); } catch { throw new TypeError(`${label}.arguments[4].value must be canonical JSON`); }
+		if (!Array.isArray(eligiblePaths) || eligiblePaths.length === 0 || eligiblePaths.some((path) => {
+			if (typeof path !== "string" || path.length === 0 || path.startsWith("/") || /^[A-Za-z]:\//.test(path) || path.includes("\\") || path.includes("\0")) return true;
+			const segments = path.split("/");
+			return segments.some((segment) => segment === "" || segment === "." || segment === "..");
+		}) || new Set(eligiblePaths).size !== eligiblePaths.length || JSON.stringify(eligiblePaths) !== eligiblePathsJson) {
+			throw new TypeError(`${label}.arguments[4].value must contain unique canonical repository-relative paths`);
+		}
+		sha256(argumentsList[5]!.value, `${label}.arguments[5].value`);
 	}
 
 	// gentle-pi#311 P4-roles: the two Go-owned non-lens provider role capture
@@ -1574,16 +1628,17 @@ function decodeCollectInput(value: unknown, label: string, v5: boolean): ReviewC
 	} else if (input.artifact_subject !== undefined || input.base_tree !== undefined || input.candidate_tree !== undefined || input.changed_path_manifest !== undefined) {
 		throw new TypeError(`${label} carries capture-result fields without review.capture-result`);
 	}
-	const submissionOperations: readonly string[] = v5 ? ["review.capture-result", "review.capture-correction-plan"] : ["review.capture-result"];
+	const submissionOperations: readonly string[] = v5
+		? ["review.capture-result", "review.capture-correction-plan", ...(v6 ? ["external.select_intended_untracked"] : [])]
+		: ["review.capture-result"];
 	if (input.submission !== undefined && !submissionOperations.includes(captureOperation)) {
 		throw new TypeError(v5 ? `${label}.submission is only valid for ${submissionOperations.join(", ")}` : `${label}.submission is only valid for review.capture-result`);
 	}
+	if (intendedUntracked && input.submission === undefined) throw new TypeError(`${label}.submission is required for external.select_intended_untracked`);
 
-	// The v5 descriptor forms are discriminated by their closed operation
-	// tokens; every other submission stays the host-relay completing form.
 	const submission = input.submission === undefined
 		? undefined
-		: decodeCaptureSubmission(input.submission, `${label}.submission`, v5);
+		: decodeCaptureSubmission(input.submission, `${label}.submission`, v5, v6, captureOperation);
 
 	return {
 		name,
@@ -1600,8 +1655,9 @@ function decodeCollectInput(value: unknown, label: string, v5: boolean): ReviewC
 	};
 }
 
-export function decodeReviewNextTransitionV3(value: unknown, options: { v5?: boolean } = {}): ReviewNextTransitionV3 {
-	const v5 = options.v5 === true;
+export function decodeReviewNextTransitionV3(value: unknown, options: { v5?: boolean; v6?: boolean } = {}): ReviewNextTransitionV3 {
+	const v6 = options.v6 === true;
+	const v5 = options.v5 === true || v6;
 	const transition = exactRecord(value, "next_transition", ["kind", "reason_code"], ["execute", "collect", ...(v5 ? ["correction_request"] : [])]);
 	const kind = enumeration(transition.kind, ["execute", "collect", "stop"] as const, "next_transition.kind");
 	const reasonCode = text(transition.reason_code, "next_transition.reason_code", { minimum: 1, pattern: /^[a-z0-9_]+$/ });
@@ -1649,7 +1705,7 @@ export function decodeReviewNextTransitionV3(value: unknown, options: { v5?: boo
 	}
 	if (kind === "collect") {
 		const collect = exactRecord(transition.collect, "next_transition.collect", ["inputs"]);
-		const inputs = array(collect.inputs, "next_transition.collect.inputs", (entry, label) => decodeCollectInput(entry, label, v5), { minimum: 1 });
+		const inputs = array(collect.inputs, "next_transition.collect.inputs", (entry, label) => decodeCollectInput(entry, label, v5, v6), { minimum: 1 });
 		if (transition.execute !== undefined) throw new TypeError("next_transition.execute is incompatible with collect");
 		return { kind, reasonCode, collect: { inputs }, ...(correctionRequest === undefined ? {} : { correctionRequest }) };
 	}
@@ -1702,12 +1758,15 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 	// Additive forward acceptance: status/v5 (gentle-ai main; ground-truthed
 	// against a live capture and the vendored status-v5.schema.json) is the v3
 	// key set plus the optional forecast and the v5-only next_transition
-	// surfaces. The v3 identity keeps rejecting every v5-only field.
-	const v5 = typeof value === "object" && value !== null && (value as Record<string, unknown>).schema === "gentle-ai.review-integration.status/v5";
+	// surfaces. status/v6 adds the intended-untracked selection; v3 keeps
+	// rejecting every v5/v6-only field.
+	const schema = typeof value === "object" && value !== null ? (value as Record<string, unknown>).schema : undefined;
+	const v6 = schema === "gentle-ai.review-integration.status/v6";
+	const v5 = v6 || schema === "gentle-ai.review-integration.status/v5";
 	const body = exactRecord(value, "status", [
 		"schema", "contract", "operation", "applicability", "action", "replayability", "target_identity", "projection", "repair", "candidates",
 	], ["authority", "frozen", "action_disposition", "eligibility", "next_transition", "authority_target_identity", ...(v5 ? ["receipt", "forecast", "repository_context", "validation_request"] : [])]);
-	requireIdentity(body, v5 ? "gentle-ai.review-integration.status/v5" : "gentle-ai.review-integration.status/v3", REVIEW_INTEGRATION_OPERATION.STATUS);
+	requireIdentity(body, v6 ? "gentle-ai.review-integration.status/v6" : v5 ? "gentle-ai.review-integration.status/v5" : "gentle-ai.review-integration.status/v3", REVIEW_INTEGRATION_OPERATION.STATUS);
 
 	const applicability = enumeration(body.applicability, ["current_target", "unrelated", "ambiguous", "corrupted"] as const, "status.applicability");
 	let receipt: ReviewStatusReceiptV1 | undefined;
@@ -1754,7 +1813,7 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 	if (action === "recover" && actionDisposition === undefined) throw new TypeError("recover status requires action_disposition");
 	if (action !== "recover" && actionDisposition !== undefined) throw new TypeError("status.action_disposition is only valid for the recover action");
 	if (body.eligibility !== undefined) decodeEligibility(body.eligibility, "status.eligibility");
-	const nextTransition = body.next_transition === undefined ? undefined : decodeReviewNextTransitionV3(body.next_transition, { v5 });
+	const nextTransition = body.next_transition === undefined ? undefined : decodeReviewNextTransitionV3(body.next_transition, { v5, v6 });
 	const validationRequest = v5 && body.validation_request !== undefined
 		? decodeReviewTargetedValidationRequestV1(body.validation_request, "status.validation_request")
 		: undefined;

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -441,6 +441,11 @@ export const NATIVE_UNTRACKED_SCOPE = {
 
 
 
+
+
+
+
+
 export const NATIVE_REVIEW_CONSENT_ANSWER = { GRANTED: "granted", DECLINED: "declined" }         ;
 
 
@@ -1853,6 +1858,7 @@ export class NativeReviewCliV216                            {
 			...(request.baseRef === undefined ? {} : { baseRef: request.baseRef, committedOnly: true }),
 			...(request.lineageId === undefined ? {} : { lineageId: request.lineageId }),
 			...selection,
+			...(request.intendedUntrackedSelection === undefined ? {} : { intendedUntrackedSelection: request.intendedUntrackedSelection }),
 			agent: "pi",
 			...(request.signal === undefined ? {} : { signal: request.signal }),
 		});
@@ -1956,7 +1962,9 @@ export class NativeReviewCliV216                            {
 		if (request.baseRef !== undefined && request.committedOnly !== true) throw new TypeError("Native STATUS baseRef requires explicit committedOnly acknowledgement");
 		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native STATUS committedOnly requires an explicit baseRef");
 		const selection = nativeUntrackedSelection(request);
-		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.STATUS, request.cwd, [
+		const submitted = request.intendedUntrackedSelection;
+		if (submitted !== undefined && submitted.argumentTokens.filter((token) => token.includes("{{value}}")).length !== 1) throw new TypeError("Native intended-untracked selection requires exactly one provider-issued {{value}} token");
+		const statusArguments = submitted === undefined ? [
 			"review", "status", "--contract", REVIEW_INTEGRATION_CONTRACT, "--cwd", request.cwd,
 			"--projection", request.projection ?? "workspace",
 			...nativeUntrackedSelectionArguments(selection),
@@ -1964,7 +1972,8 @@ export class NativeReviewCliV216                            {
 			...(request.lineageId === undefined ? [] : ["--lineage", request.lineageId]),
 			...(request.agent === undefined ? [] : ["--agent", request.agent]),
 			"--next-transition",
-		], false, request.signal);
+		] : ["review", "status", "--cwd", request.cwd, ...submitted.argumentTokens.map((token) => token.replaceAll("{{value}}", submitted.value))];
+		const execution = await this.negotiated(NATIVE_REVIEW_OPERATION.STATUS, request.cwd, statusArguments, false, request.signal);
 		assertSupportedNextTransitionOperation(execution.body);
 		return decode(NATIVE_REVIEW_OPERATION.STATUS, false, () => decodeReviewStatusV3(execution.body));
 	}

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -178,6 +178,12 @@ const CAPABILITIES_SCHEMA_IDENTITIES                                            
 		requiredMandatoryFeatures: REQUIRED_MANDATORY_FEATURES_V23,
 		optionalFeatureFloor: 14,
 	}),
+	"gentle-ai.review-integration.capabilities/v2.4": Object.freeze({
+		protocolMinor: 4,
+		requiredSchemas: Object.freeze([...REQUIRED_SCHEMAS_COMMON_V23, "gentle-ai.review-integration.capabilities/v2.4", "gentle-ai.review-integration.consent/v3", "gentle-ai.review-integration.start/v4", "gentle-ai.review-integration.status/v6", "gentle-ai.review-intended-untracked-selection/v1"]),
+		requiredMandatoryFeatures: REQUIRED_MANDATORY_FEATURES_V23,
+		optionalFeatureFloor: 14,
+	}),
 });
 const OPTIONAL_FEATURE_NAMES = Object.freeze([
 	"base_ref_workspace_overlay",
@@ -1341,7 +1347,29 @@ function decodeTransitionArguments(value         , label        )               
 	});
 }
 
-function decodeCaptureSubmission(value         , label        , v5         )                            {
+function decodeCaptureSubmission(value         , label        , v5         , v6         , captureOperation        )                            {
+	// status/v6 adds the provider-owned intended-untracked selection form.
+	if (v6 && captureOperation === "external.select_intended_untracked" && typeof value === "object" && value !== null && (value                           ).operation_token === "status") {
+		const submission = exactRecord(value, label, ["operation_token", "argument_tokens", "value"]);
+		const expectedTokens = [
+			"--contract=gentle-ai.review-integration/v2", "--next-transition=true", "--agent=pi",
+			"--projection=workspace", "--intended-untracked-selection={{value}}",
+		]         ;
+		const operationToken = enumeration(submission.operation_token, ["status"]         , `${label}.operation_token`);
+		const argumentTokens = stringArray(submission.argument_tokens, `${label}.argument_tokens`, { minimum: expectedTokens.length, maximum: expectedTokens.length });
+		if (argumentTokens.some((token, index) => token !== expectedTokens[index])) throw new TypeError(`${label}.argument_tokens substitution binding is invalid`);
+		const row = exactRecord(submission.value, `${label}.value`, ["slot", "domain", "schema", "substitution_location"]);
+		return {
+			operationToken,
+			argumentTokens,
+			values: [{
+				slot: enumeration(row.slot, ["intended_untracked_selection"]         , `${label}.value.slot`),
+				domain: enumeration(row.domain, ["schema_bound_json"]         , `${label}.value.domain`),
+				schema: enumeration(row.schema, ["gentle-ai.review-intended-untracked-selection/v1"]         , `${label}.value.schema`),
+				substitutionLocation: integer(row.substitution_location, `${label}.value.substitution_location`, 4, 4),
+			}],
+		};
+	}
 	// status/v5: the live 2.4.0-main binary emits the materialize
 	// capture-result submission as a SINGULAR `value` object carrying a
 	// `schema` key (captured 2026-08-16 from 2.4.0-main.b1afef46; the
@@ -1504,7 +1532,7 @@ const CORRECTION_REQUEST_REASON_CODES = Object.freeze(["correction_plan_required
 // v5 capture operations that must carry a submission descriptor.
 const V5_SUBMISSION_CAPTURE_OPERATIONS = Object.freeze(["review.capture-correction-plan"]         );
 
-function decodeCollectInput(value         , label        , v5         )                       {
+function decodeCollectInput(value         , label        , v5         , v6         )                       {
 	const input = exactRecord(value, label, ["name", "schema", "capture_operation", "arguments"], ["artifact_subject", "base_tree", "candidate_tree", "changed_path_manifest", "submission", ...(v5 ? ["provider_task", "validation_request"] : [])]);
 	const name = text(input.name, `${label}.name`, { minimum: 1, pattern: /^[a-z0-9_]+$/ });
 	const schema = nonempty(input.schema, `${label}.schema`);
@@ -1524,6 +1552,32 @@ function decodeCollectInput(value         , label        , v5         )         
 			if (input.submission === undefined) throw new TypeError(`${label}.submission is required for ${captureOperation}`);
 			if (captureOperation === "review.capture-correction-plan" && schema !== "gentle-ai.review-correction-plan/v1") throw new TypeError(`${label}.schema must be gentle-ai.review-correction-plan/v1`);
 		}
+	}
+
+	const intendedUntracked = v6
+		&& name === "intended_untracked_selection"
+		&& schema === "gentle-ai.review-intended-untracked-selection/v1"
+		&& captureOperation === "external.select_intended_untracked";
+	if (intendedUntracked) {
+		const expectedNames = ["target_identity", "projection", "base_tree", "candidate_tree", "eligible_paths_json", "expected_untracked_inventory"]         ;
+		if (argumentsList.length !== expectedNames.length || argumentsList.some((argument, index) => argument.name !== expectedNames[index] || argument.token !== undefined)) {
+			throw new TypeError(`${label}.arguments must preserve the exact intended-untracked metadata binding`);
+		}
+		sha256(argumentsList[0] .value, `${label}.arguments[0].value`);
+		enumeration(argumentsList[1] .value, ["workspace"]         , `${label}.arguments[1].value`);
+		gitTree(argumentsList[2] .value, `${label}.arguments[2].value`);
+		gitTree(argumentsList[3] .value, `${label}.arguments[3].value`);
+		const eligiblePathsJson = argumentsList[4] .value;
+		let eligiblePaths         ;
+		try { eligiblePaths = JSON.parse(eligiblePathsJson); } catch { throw new TypeError(`${label}.arguments[4].value must be canonical JSON`); }
+		if (!Array.isArray(eligiblePaths) || eligiblePaths.length === 0 || eligiblePaths.some((path) => {
+			if (typeof path !== "string" || path.length === 0 || path.startsWith("/") || /^[A-Za-z]:\//.test(path) || path.includes("\\") || path.includes("\0")) return true;
+			const segments = path.split("/");
+			return segments.some((segment) => segment === "" || segment === "." || segment === "..");
+		}) || new Set(eligiblePaths).size !== eligiblePaths.length || JSON.stringify(eligiblePaths) !== eligiblePathsJson) {
+			throw new TypeError(`${label}.arguments[4].value must contain unique canonical repository-relative paths`);
+		}
+		sha256(argumentsList[5] .value, `${label}.arguments[5].value`);
 	}
 
 	// gentle-pi#311 P4-roles: the two Go-owned non-lens provider role capture
@@ -1575,16 +1629,17 @@ function decodeCollectInput(value         , label        , v5         )         
 	} else if (input.artifact_subject !== undefined || input.base_tree !== undefined || input.candidate_tree !== undefined || input.changed_path_manifest !== undefined) {
 		throw new TypeError(`${label} carries capture-result fields without review.capture-result`);
 	}
-	const submissionOperations                    = v5 ? ["review.capture-result", "review.capture-correction-plan"] : ["review.capture-result"];
+	const submissionOperations                    = v5
+		? ["review.capture-result", "review.capture-correction-plan", ...(v6 ? ["external.select_intended_untracked"] : [])]
+		: ["review.capture-result"];
 	if (input.submission !== undefined && !submissionOperations.includes(captureOperation)) {
 		throw new TypeError(v5 ? `${label}.submission is only valid for ${submissionOperations.join(", ")}` : `${label}.submission is only valid for review.capture-result`);
 	}
+	if (intendedUntracked && input.submission === undefined) throw new TypeError(`${label}.submission is required for external.select_intended_untracked`);
 
-	// The v5 descriptor forms are discriminated by their closed operation
-	// tokens; every other submission stays the host-relay completing form.
 	const submission = input.submission === undefined
 		? undefined
-		: decodeCaptureSubmission(input.submission, `${label}.submission`, v5);
+		: decodeCaptureSubmission(input.submission, `${label}.submission`, v5, v6, captureOperation);
 
 	return {
 		name,
@@ -1601,8 +1656,9 @@ function decodeCollectInput(value         , label        , v5         )         
 	};
 }
 
-export function decodeReviewNextTransitionV3(value         , options                   = {})                         {
-	const v5 = options.v5 === true;
+export function decodeReviewNextTransitionV3(value         , options                                 = {})                         {
+	const v6 = options.v6 === true;
+	const v5 = options.v5 === true || v6;
 	const transition = exactRecord(value, "next_transition", ["kind", "reason_code"], ["execute", "collect", ...(v5 ? ["correction_request"] : [])]);
 	const kind = enumeration(transition.kind, ["execute", "collect", "stop"]         , "next_transition.kind");
 	const reasonCode = text(transition.reason_code, "next_transition.reason_code", { minimum: 1, pattern: /^[a-z0-9_]+$/ });
@@ -1650,7 +1706,7 @@ export function decodeReviewNextTransitionV3(value         , options            
 	}
 	if (kind === "collect") {
 		const collect = exactRecord(transition.collect, "next_transition.collect", ["inputs"]);
-		const inputs = array(collect.inputs, "next_transition.collect.inputs", (entry, label) => decodeCollectInput(entry, label, v5), { minimum: 1 });
+		const inputs = array(collect.inputs, "next_transition.collect.inputs", (entry, label) => decodeCollectInput(entry, label, v5, v6), { minimum: 1 });
 		if (transition.execute !== undefined) throw new TypeError("next_transition.execute is incompatible with collect");
 		return { kind, reasonCode, collect: { inputs }, ...(correctionRequest === undefined ? {} : { correctionRequest }) };
 	}
@@ -1703,12 +1759,15 @@ export function decodeReviewStatusV3(value         )                 {
 	// Additive forward acceptance: status/v5 (gentle-ai main; ground-truthed
 	// against a live capture and the vendored status-v5.schema.json) is the v3
 	// key set plus the optional forecast and the v5-only next_transition
-	// surfaces. The v3 identity keeps rejecting every v5-only field.
-	const v5 = typeof value === "object" && value !== null && (value                           ).schema === "gentle-ai.review-integration.status/v5";
+	// surfaces. status/v6 adds the intended-untracked selection; v3 keeps
+	// rejecting every v5/v6-only field.
+	const schema = typeof value === "object" && value !== null ? (value                           ).schema : undefined;
+	const v6 = schema === "gentle-ai.review-integration.status/v6";
+	const v5 = v6 || schema === "gentle-ai.review-integration.status/v5";
 	const body = exactRecord(value, "status", [
 		"schema", "contract", "operation", "applicability", "action", "replayability", "target_identity", "projection", "repair", "candidates",
 	], ["authority", "frozen", "action_disposition", "eligibility", "next_transition", "authority_target_identity", ...(v5 ? ["receipt", "forecast", "repository_context", "validation_request"] : [])]);
-	requireIdentity(body, v5 ? "gentle-ai.review-integration.status/v5" : "gentle-ai.review-integration.status/v3", REVIEW_INTEGRATION_OPERATION.STATUS);
+	requireIdentity(body, v6 ? "gentle-ai.review-integration.status/v6" : v5 ? "gentle-ai.review-integration.status/v5" : "gentle-ai.review-integration.status/v3", REVIEW_INTEGRATION_OPERATION.STATUS);
 
 	const applicability = enumeration(body.applicability, ["current_target", "unrelated", "ambiguous", "corrupted"]         , "status.applicability");
 	let receipt                                   ;
@@ -1755,7 +1814,7 @@ export function decodeReviewStatusV3(value         )                 {
 	if (action === "recover" && actionDisposition === undefined) throw new TypeError("recover status requires action_disposition");
 	if (action !== "recover" && actionDisposition !== undefined) throw new TypeError("status.action_disposition is only valid for the recover action");
 	if (body.eligibility !== undefined) decodeEligibility(body.eligibility, "status.eligibility");
-	const nextTransition = body.next_transition === undefined ? undefined : decodeReviewNextTransitionV3(body.next_transition, { v5 });
+	const nextTransition = body.next_transition === undefined ? undefined : decodeReviewNextTransitionV3(body.next_transition, { v5, v6 });
 	const validationRequest = v5 && body.validation_request !== undefined
 		? decodeReviewTargetedValidationRequestV1(body.validation_request, "status.validation_request")
 		: undefined;

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -294,6 +294,40 @@ test("native START queries STATUS then executes only the provider-rendered order
 	]);
 });
 
+test("native START relays provider-owned intended-untracked selection and transition argv verbatim", async () => {
+	const selectionValue = JSON.stringify(["new.ts", "nested/other.ts"]);
+	const selectionTokens = ["--selection-kind=untracked", "--selection-json={{value}}", "--selection-proof=provider-issued"];
+	const startTokens = [
+		"--contract=gentle-ai.review-integration/v2", "--cwd=/repo", `--target=${TARGET}`,
+		"--projection=workspace", "--agent=pi", "--consent=relay",
+	];
+	const queue = queuedAdapter([
+		{ stdout: JSON.stringify(negotiatedStartStatus(TARGET, startTokens)) },
+		{ stdout: JSON.stringify(fixture("start-v3-zero-lens-closed.captured.json")) },
+	]);
+	await client(queue.adapter).start({
+		cwd: "/repo",
+		targetIdentity: TARGET,
+		intendedUntrackedSelection: { argumentTokens: selectionTokens, value: selectionValue },
+	});
+	assert.deepEqual(queue.calls.map((call) => call.arguments), [
+		["review", "status", "--cwd", "/repo", "--selection-kind=untracked", `--selection-json=${selectionValue}`, "--selection-proof=provider-issued"],
+		["review", "start", ...startTokens],
+	]);
+	for (const flag of ["--untracked-scope", "--expected-untracked-inventory", "--intended-untracked", "--contract", "--agent", "--projection"]) {
+		assert.equal(queue.calls[0]?.arguments.includes(flag), false, flag);
+	}
+
+	for (const argumentTokens of [["--selection-json=value"], ["--selection-json={{value}}", "--duplicate={{value}}"]]) {
+		const rejected = queuedAdapter([]);
+		await assert.rejects(
+			() => client(rejected.adapter).start({ cwd: "/repo", targetIdentity: TARGET, intendedUntrackedSelection: { argumentTokens, value: selectionValue } }),
+			/exactly one provider-issued \{\{value\}\} token/,
+		);
+		assert.equal(rejected.calls.length, 0);
+	}
+});
+
 test("native START retains the provider-owned START/v4 status transition in exact argument order", async () => {
 	const tokens = [
 		"--contract=gentle-ai.review-integration/v2", "--cwd=/repo", `--target=${TARGET}`,

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -573,9 +573,9 @@ function reviewContext(cwd: string): ExtensionContext {
 	return { cwd, hasUI: false, ui: { confirm: async () => true } } as unknown as ExtensionContext;
 }
 
-function startStatus(cwd: string, baseRef?: string): ReviewStatusV3 {
+function startStatus(cwd: string, baseRef?: string, intendedUntracked: readonly string[] = []): ReviewStatusV3 {
 	const candidateViews = new CandidateViewRegistry();
-	const view = candidateViews.create({ contributorRoot: cwd, ...(baseRef === undefined ? {} : { baseRef, committedOnly: true }) });
+	const view = candidateViews.create({ contributorRoot: cwd, intendedUntracked, ...(baseRef === undefined ? {} : { baseRef, committedOnly: true }) });
 	try {
 		return {
 			contract: "gentle-ai.review-integration/v2",
@@ -592,7 +592,7 @@ function startStatus(cwd: string, baseRef?: string): ReviewStatusV3 {
 				currentCandidateTree: view.candidateTree,
 				pathsDigest: SHA,
 				paths: [...view.paths],
-				intendedUntracked: [],
+				intendedUntracked: [...intendedUntracked],
 				intendedUntrackedProof: SHA,
 				initialSnapshotIdentity: SHA,
 				currentSnapshotIdentity: SHA,
@@ -626,6 +626,41 @@ test("ordinary START binds the native workspace candidate and returns the native
 	assert.equal(result.operation, "start");
 	assert.equal(targetCalls, 1);
 	assert.equal(startCalls, 1);
+});
+
+test("pre-lineage intended-untracked selection uses one opaque STATUS binding before START", async (t) => {
+	const cwd = realpathSync(repository(t)), eligible = "selected.md";
+	writeFileSync(join(cwd, eligible), "selected\n");
+	const initialTarget = startStatus(cwd), target = startStatus(cwd, undefined, [eligible]);
+	const selection: ReviewCollectInputV3 = {
+		name: "intended_untracked_selection", schema: "gentle-ai.review-intended-untracked-selection/v1", captureOperation: "external.select_intended_untracked",
+		arguments: [
+			{ name: "target_identity", value: SHA }, { name: "projection", value: "workspace" },
+			{ name: "base_tree", value: initialTarget.projection.baseTree }, { name: "candidate_tree", value: initialTarget.projection.currentCandidateTree },
+			{ name: "eligible_paths_json", value: JSON.stringify([eligible]) }, { name: "expected_untracked_inventory", value: SHA },
+		],
+		submission: { operationToken: "status", argumentTokens: ["--contract=gentle-ai.review-integration/v2", "--next-transition=true", "--agent=pi", "--projection=workspace", "--intended-untracked-selection={{value}}"], values: [{ slot: "intended_untracked_selection", domain: "schema_bound_json", schema: "gentle-ai.review-intended-untracked-selection/v1", substitutionLocation: 4 }] },
+	};
+	const initial = { ...initialTarget, nextTransition: { kind: "collect", reasonCode: "intended_untracked_selection_required", collect: { inputs: [selection] } }, raw: { schema: "gentle-ai.review-integration.status/v6" } } as ReviewStatusV3;
+	const requests: Array<Record<string, unknown>> = [], starts: Array<Record<string, unknown>> = [], retained = new Map();
+	const native = {
+		reviewMode: async () => ({ operation: "status", scope: "clone", status: { global: "on", cloneLocal: "on", effective: "on", source: "clone_local" } }),
+		targetStatus: async (request: Record<string, unknown>) => { requests.push(request); return "intendedUntrackedSelection" in request ? target : initial; },
+		start: async (request: Record<string, unknown>) => { assert.equal(retained.size, 0); starts.push(request); return { lineageId: "selected", state: "reviewing", riskLevel: "low", selectedLenses: [], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: false, riskReasons: [], raw: {} }; },
+	} as unknown as NativeReviewCli;
+	const listed = await __testing.executeReviewControllerOperation({ operation: "status" }, cwd, native, undefined, undefined, undefined, retained);
+	const selectionBinding = listed.selectionBinding as string;
+	assert.equal(typeof selectionBinding, "string");
+	const selectedResult = await __testing.executeReviewControllerOperation({ operation: "select-intended-untracked", selectionBinding, intendedUntracked: [eligible] } as never, cwd, native, undefined, undefined, undefined, retained);
+	assert.equal(starts.length, 1, JSON.stringify(selectedResult));
+	assert.deepEqual(starts[0]!.intendedUntrackedSelection, { argumentTokens: selection.submission!.argumentTokens, value: JSON.stringify({ schema: "gentle-ai.review-intended-untracked-selection/v1", untracked_scope: "select", expected_untracked_inventory: SHA, intended_untracked: [eligible] }) });
+	for (const invalid of [
+		{ selectionBinding: selectionBinding.replace(eligible, "docs/stale.md"), intendedUntracked: [eligible] },
+		{ selectionBinding, intendedUntracked: [eligible, eligible] }, { selectionBinding, intendedUntracked: ["docs/unknown.md"] },
+	]) await __testing.executeReviewControllerOperation({ operation: "select-intended-untracked", ...invalid } as never, cwd, native, undefined, undefined, undefined, retained);
+	await assert.rejects(() => __testing.executeReviewControllerOperation({ operation: "select-intended-untracked", selectionBinding, intendedUntracked: [eligible], input: "{}" } as never, cwd, native, undefined, undefined, undefined, retained), /exactly selectionBinding/);
+	assert.equal(starts.length, 1);
+	assert.equal(requests.every((request) => !("lineageId" in request)), true);
 });
 
 test("ordinary START relays native consent without authoring or advancing it", async (t) => {

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -43,6 +43,33 @@ function currentStatusFixture(name: string): Record<string, unknown> {
 	return body;
 }
 
+function initialIntendedUntrackedStatusV6(): JsonObject {
+	const body = currentStatusFixture("status-v5.captured.json");
+	const projection = body.projection as JsonObject;
+	const schema = "gentle-ai.review-intended-untracked-selection/v1";
+	body.schema = "gentle-ai.review-integration.status/v6";
+	body.forecast = {
+		horizon: "partial", steps: [{ step: 1, kind: "collect", reason_code: "intended_untracked_selection_required", description: "initial intended-untracked selection required" }],
+	};
+	body.next_transition = {
+		kind: "collect",
+		reason_code: "intended_untracked_selection_required",
+		collect: { inputs: [{
+			name: "intended_untracked_selection", schema, capture_operation: "external.select_intended_untracked",
+			arguments: [
+				["target_identity", body.target_identity], ["projection", "workspace"], ["base_tree", projection.base_tree],
+				["candidate_tree", projection.current_candidate_tree], ["eligible_paths_json", '["docs/selected.md"]'], ["expected_untracked_inventory", sha("e")],
+			].map(([name, value]) => ({ name, value })),
+			submission: {
+				operation_token: "status",
+				argument_tokens: ["--contract=gentle-ai.review-integration/v2", "--next-transition=true", "--agent=pi", "--projection=workspace", "--intended-untracked-selection={{value}}"],
+				value: { slot: "intended_untracked_selection", domain: "schema_bound_json", schema, substitution_location: 4 },
+			},
+		}] },
+	};
+	return body;
+}
+
 test("captured capabilities retain their exact schema identity", () => {
 	const capabilities = decodeReviewCapabilitiesV2(
 		fixture(DEV_FIXTURES, "capabilities-v2.2.captured.json"),
@@ -57,15 +84,6 @@ test("historical v3 FINALIZE status remains rejected without rewriting fixture b
 		() => decodeReviewStatusV3(fixture(V2_FIXTURES, "status.fixture.json")),
 		/receipt|finalize|status/i,
 	);
-});
-
-test("captured v5 STATUS preserves its strict receipt while routing intended-untracked selection", () => {
-	const body = currentStatusFixture("status-v5.captured.json");
-	(body.next_transition as JsonObject).reason_code = "intended_untracked_selection_required";
-	const decoded = decodeReviewStatusV3(body);
-	assert.deepEqual(decoded.receipt, { status: "not_applicable" });
-	assert.equal(decoded.nextTransition?.kind, "collect");
-	assert.equal(decoded.nextTransition?.reasonCode, "intended_untracked_selection_required");
 });
 
 test("v5 STATUS rejects malformed receipt status, identity, and extra fields", () => {
@@ -323,7 +341,7 @@ function reviewingStartV4(action: "created" | "replayed" = "created"): JsonObjec
 	return body;
 }
 
-test("capabilities/v2.3 requires START/v4 and rejects future identities", () => {
+test("capabilities/v2.3 retains status/v5 while v2.4 requires status/v6", () => {
 	const v23 = clone(fixture(DEV_FIXTURES, "capabilities-v2.2.captured.json") as JsonObject);
 	v23.schema = "gentle-ai.review-integration.capabilities/v2.3";
 	(v23.protocol as JsonObject).minor = 3;
@@ -338,12 +356,24 @@ test("capabilities/v2.3 requires START/v4 and rejects future identities", () => 
 	const decoded = decodeReviewCapabilitiesV2(v23, CAPTURED_DIGEST);
 	assert.equal(decoded.schemas.has("gentle-ai.review-integration.start/v4"), true);
 	assert.equal(decoded.schemas.has("gentle-ai.review-integration.start/v3"), false);
+	assert.equal(decoded.schemas.has("gentle-ai.review-integration.status/v5"), true);
 
-	const future = clone(v23);
-	future.schema = "gentle-ai.review-integration.capabilities/v2.4";
-	(future.protocol as JsonObject).minor = 4;
-	future.schemas = (future.schemas as string[]).map((schema) => schema.replace("capabilities/v2.3", "capabilities/v2.4"));
-	assert.throws(() => decodeReviewCapabilitiesV2(future, CAPTURED_DIGEST), /schema must be one of/);
+	const v24 = clone(v23);
+	v24.schema = "gentle-ai.review-integration.capabilities/v2.4";
+	(v24.protocol as JsonObject).minor = 4;
+	v24.schemas = [
+		...(v24.schemas as string[]).map((schema) => schema
+			.replace("capabilities/v2.3", "capabilities/v2.4")
+			.replace("status/v5", "status/v6")),
+		"gentle-ai.review-intended-untracked-selection/v1",
+	];
+	const v24Decoded = decodeReviewCapabilitiesV2(v24, CAPTURED_DIGEST);
+	assert.equal(v24Decoded.schemas.has("gentle-ai.review-integration.status/v6"), true);
+	assert.equal(v24Decoded.schemas.has("gentle-ai.review-integration.status/v5"), false);
+
+	const missingStatusV6 = clone(v24);
+	missingStatusV6.schemas = (missingStatusV6.schemas as string[]).map((schema) => schema.replace("status/v6", "status/v5"));
+	assert.throws(() => decodeReviewCapabilitiesV2(missingStatusV6, CAPTURED_DIGEST), /status\/v6/);
 
 	// Distinguishing case for the v2.3 retired-schema filter: the real rc.3
 	// provider no longer advertises these three identities, so a v2.3
@@ -361,6 +391,51 @@ test("capabilities/v2.3 requires START/v4 and rejects future identities", () => 
 	const v22Retired = clone(fixture(DEV_FIXTURES, "capabilities-v2.2.captured.json") as JsonObject);
 	v22Retired.schemas = (v22Retired.schemas as string[]).filter((schema) => !retiredSchemas.includes(schema));
 	assert.throws(() => decodeReviewCapabilitiesV2(v22Retired, CAPTURED_DIGEST), /schema/);
+});
+
+test("status/v6 decodes and enforces the intended-untracked selection submission", () => {
+	const decoded = decodeReviewStatusV3(initialIntendedUntrackedStatusV6());
+	const input = decoded.nextTransition?.collect?.inputs[0];
+	assert.deepEqual([input?.schema, input?.captureOperation, input?.arguments, input?.submission], [
+		"gentle-ai.review-intended-untracked-selection/v1", "external.select_intended_untracked", [
+			{ name: "target_identity", value: decoded.targetIdentity }, { name: "projection", value: "workspace" },
+			{ name: "base_tree", value: decoded.projection.baseTree }, { name: "candidate_tree", value: decoded.projection.currentCandidateTree },
+			{ name: "eligible_paths_json", value: '["docs/selected.md"]' }, { name: "expected_untracked_inventory", value: sha("e") },
+		], {
+			operationToken: "status",
+			argumentTokens: ["--contract=gentle-ai.review-integration/v2", "--next-transition=true", "--agent=pi", "--projection=workspace", "--intended-untracked-selection={{value}}"],
+			values: [{ slot: "intended_untracked_selection", domain: "schema_bound_json", schema: "gentle-ai.review-intended-untracked-selection/v1", substitutionLocation: 4 }],
+		},
+	]);
+	const submission = (body: JsonObject) => (((body.next_transition as JsonObject).collect as JsonObject).inputs as JsonObject[])[0]!.submission as JsonObject;
+	const cases: Array<[string, (value: JsonObject) => void, RegExp]> = [
+		["operation", (value) => { value.operation_token = "start"; }, /operation/],
+		["competing values", (value) => { value.values = [clone(value.value)]; }, /value/],
+		["slot", (value) => { delete (value.value as JsonObject).slot; }, /slot/],
+		["schema", (value) => { (value.value as JsonObject).schema = "gentle-ai.review-intended-untracked-selection/v2"; }, /schema/],
+		["placeholder", (value) => { (value.argument_tokens as string[])[4] = "--intended-untracked-selection={{selection}}"; }, /value|substitution/],
+		["location", (value) => { (value.value as JsonObject).substitution_location = 3; }, /substitution/],
+	];
+	for (const [name, mutate, pattern] of cases) {
+		const body = initialIntendedUntrackedStatusV6();
+		mutate(submission(body));
+		assert.throws(() => decodeReviewStatusV3(body), pattern, name);
+	}
+	const v5 = initialIntendedUntrackedStatusV6();
+	v5.schema = "gentle-ai.review-integration.status/v5";
+	assert.throws(() => decodeReviewStatusV3(v5), /submission/);
+
+	const collectInput = (body: JsonObject) => (((body.next_transition as JsonObject).collect as JsonObject).inputs as JsonObject[])[0]!;
+	const artifactSubject = { schema: "gentle-ai.review-artifact-subject/v2", subject_hash: sha("a"), lineage_id: "review-test", authority_revision: sha("b"), target_identity: sha("c"), base_tree: "a".repeat(40), candidate_tree: "b".repeat(40), changed_path_manifest_sha256: sha("d"), lens: "review-risk", selected_order: 0 };
+	const incompatibleCaptures: ReadonlyArray<readonly [string, JsonObject]> = [
+		["review.capture-result", { schema: "https://gentle-ai.dev/schema/review/reviewer/v1", artifact_subject: artifactSubject, base_tree: "a".repeat(40), candidate_tree: "b".repeat(40), changed_path_manifest: [{ path: "x.ts", status: "M", old_mode: "100644", new_mode: "100644", deleted: false, type_changed: false, mode_only: false, intended_untracked: false }] }],
+		["review.capture-correction-plan", { schema: "gentle-ai.review-correction-plan/v1" }],
+	];
+	for (const [captureOperation, fields] of incompatibleCaptures) {
+		const body = initialIntendedUntrackedStatusV6();
+		Object.assign(collectInput(body), { capture_operation: captureOperation, ...fields });
+		assert.throws(() => decodeReviewStatusV3(body), /operation_token/, captureOperation);
+	}
 });
 
 test("START/v4 accepts only its reviewing status continuation and preserves v3 strictness", () => {


### PR DESCRIPTION
## Summary

- add public `select-intended-untracked` controller support for the provider-issued status/v6 selection descriptor
- validate the opaque binding, current inventory, eligible canonical paths, and exact provider-owned argument substitution before executing selected STATUS
- execute the returned START transition verbatim without routing through lineage-bound capture
- preserve capabilities v2.3, status/v5, manual compatibility, and generated runtime parity

## Safety properties

- selection remains pre-lineage and creates no authority by itself
- stale bindings, changed inventories, malformed paths, duplicate paths, unsupported operations, and operation-confused submissions fail closed
- selected STATUS tokens remain provider-owned; Pi substitutes exactly one schema-bound JSON value
- ordinary START retains focus/policy forwarding and candidate binding behavior

## Validation

- focused explicit-workspace correction: 1/1 passed
- decoder forward suite: 37/37 passed
- native consent parity: 20/20 passed
- post-rebase full direct suite: 1140 passed, 10 skipped, 1 accepted macOS `/tmp` vs `/private/tmp` baseline failure
- provider contract mirror: passed
- runtime harness: passed
- generated runtime module check: passed
- `git diff --check`: passed

## RDD

- post-rebase high-risk four-lens review completed against the final candidate tree
- one deterministic explicit-workspace finding was corrected in 18 lines within the exact 32-line plan
- targeted native validation approved the corrected tree and the acknowledgement was consumed
- remaining advisory findings are non-blocking follow-ups

## Size exception

The final diff is 441 changed lines. The exception is intentional: generated runtime mirrors and compatibility/negative contract coverage account for the excess. Guards and tests were not compressed or removed merely to cross the 400-line threshold.

Closes #502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting intended untracked repository paths before starting a review.
  * Added protocol support for provider-issued selection requests and status/v6 responses.
  * Provider-supplied selection arguments are validated and forwarded during review startup.

* **Bug Fixes**
  * Prevented invalid selection bindings from launching review processes.
  * Ensured selected paths are reflected in the review’s candidate view and status information.

* **Tests**
  * Added coverage for valid, invalid, and pre-lineage intended-untracked selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
