### PR TITLE
fix(review): harden intended-untracked selection guards

### DIFF
--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -1962,7 +1962,7 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native STATUS committedOnly requires an explicit baseRef");
 		const selection = nativeUntrackedSelection(request);
 		const submitted = request.intendedUntrackedSelection;
-		if (submitted !== undefined && submitted.argumentTokens.filter((token) => token.includes("{{value}}")).length !== 1) throw new TypeError("Native intended-untracked selection requires exactly one provider-issued {{value}} token");
+		if (submitted !== undefined && submitted.argumentTokens.reduce((count, token) => count + token.split("{{value}}").length - 1, 0) !== 1) throw new TypeError("Native intended-untracked selection requires exactly one provider-issued {{value}} token");
 		const statusArguments = submitted === undefined ? [
 			"review", "status", "--contract", REVIEW_INTEGRATION_CONTRACT, "--cwd", request.cwd,
 			"--projection", request.projection ?? "workspace",

--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1557,6 +1557,9 @@ function decodeCollectInput(value: unknown, label: string, v5: boolean, v6: bool
 		&& name === "intended_untracked_selection"
 		&& schema === "gentle-ai.review-intended-untracked-selection/v1"
 		&& captureOperation === "external.select_intended_untracked";
+	if (captureOperation === "external.select_intended_untracked" && (name !== "intended_untracked_selection" || schema !== "gentle-ai.review-intended-untracked-selection/v1")) {
+		throw new TypeError(`${label} external.select_intended_untracked requires the intended_untracked_selection binding`);
+	}
 	if (intendedUntracked) {
 		const expectedNames = ["target_identity", "projection", "base_tree", "candidate_tree", "eligible_paths_json", "expected_untracked_inventory"] as const;
 		if (argumentsList.length !== expectedNames.length || argumentsList.some((argument, index) => argument.name !== expectedNames[index] || argument.token !== undefined)) {

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -1963,7 +1963,7 @@ export class NativeReviewCliV216                            {
 		if (request.baseRef === undefined && request.committedOnly !== undefined) throw new TypeError("Native STATUS committedOnly requires an explicit baseRef");
 		const selection = nativeUntrackedSelection(request);
 		const submitted = request.intendedUntrackedSelection;
-		if (submitted !== undefined && submitted.argumentTokens.filter((token) => token.includes("{{value}}")).length !== 1) throw new TypeError("Native intended-untracked selection requires exactly one provider-issued {{value}} token");
+		if (submitted !== undefined && submitted.argumentTokens.reduce((count, token) => count + token.split("{{value}}").length - 1, 0) !== 1) throw new TypeError("Native intended-untracked selection requires exactly one provider-issued {{value}} token");
 		const statusArguments = submitted === undefined ? [
 			"review", "status", "--contract", REVIEW_INTEGRATION_CONTRACT, "--cwd", request.cwd,
 			"--projection", request.projection ?? "workspace",

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1558,6 +1558,9 @@ function decodeCollectInput(value         , label        , v5         , v6      
 		&& name === "intended_untracked_selection"
 		&& schema === "gentle-ai.review-intended-untracked-selection/v1"
 		&& captureOperation === "external.select_intended_untracked";
+	if (captureOperation === "external.select_intended_untracked" && (name !== "intended_untracked_selection" || schema !== "gentle-ai.review-intended-untracked-selection/v1")) {
+		throw new TypeError(`${label} external.select_intended_untracked requires the intended_untracked_selection binding`);
+	}
 	if (intendedUntracked) {
 		const expectedNames = ["target_identity", "projection", "base_tree", "candidate_tree", "eligible_paths_json", "expected_untracked_inventory"]         ;
 		if (argumentsList.length !== expectedNames.length || argumentsList.some((argument, index) => argument.name !== expectedNames[index] || argument.token !== undefined)) {

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -318,7 +318,7 @@ test("native START relays provider-owned intended-untracked selection and transi
 		assert.equal(queue.calls[0]?.arguments.includes(flag), false, flag);
 	}
 
-	for (const argumentTokens of [["--selection-json=value"], ["--selection-json={{value}}", "--duplicate={{value}}"]]) {
+	for (const argumentTokens of [["--selection-json=value"], ["--selection-json={{value}}", "--duplicate={{value}}"], ["--selection-json={{value}}{{value}}"]]) {
 		const rejected = queuedAdapter([]);
 		await assert.rejects(
 			() => client(rejected.adapter).start({ cwd: "/repo", targetIdentity: TARGET, intendedUntrackedSelection: { argumentTokens, value: selectionValue } }),

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -714,7 +714,13 @@ test("pre-lineage intended-untracked selection revalidates and starts at an expl
 	for (const invalid of [
 		{ selectionBinding: selectionBinding.replace(eligible, "docs/stale.md"), intendedUntracked: [eligible] },
 		{ selectionBinding, intendedUntracked: [eligible, eligible] }, { selectionBinding, intendedUntracked: ["docs/unknown.md"] },
-	]) await __testing.executeReviewControllerOperation({ operation: "select-intended-untracked", ...invalid } as never, cwd, native, undefined, undefined, undefined, retained);
+	]) {
+		const rejection = await __testing.executeReviewControllerOperation({ operation: "select-intended-untracked", ...invalid } as never, cwd, native, undefined, undefined, undefined, retained);
+		assert.equal(rejection.status, "blocked", JSON.stringify(invalid));
+		assert.equal(rejection.outcome, "intended-untracked-selection-binding-rejected", JSON.stringify(invalid));
+		assert.equal(rejection.mutation_performed, false, JSON.stringify(invalid));
+		assert.equal(rejection.mutation_outcome, "none", JSON.stringify(invalid));
+	}
 	await assert.rejects(() => __testing.executeReviewControllerOperation({ operation: "select-intended-untracked", selectionBinding, intendedUntracked: [eligible], input: "{}" } as never, cwd, native, undefined, undefined, undefined, retained), /exactly selectionBinding/);
 	assert.equal(starts.length, 1);
 	assert.equal(requests.every((request) => !("lineageId" in request)), true);

--- a/tests/review-integration-v2-forward.test.ts
+++ b/tests/review-integration-v2-forward.test.ts
@@ -436,6 +436,16 @@ test("status/v6 decodes and enforces the intended-untracked selection submission
 		Object.assign(collectInput(body), { capture_operation: captureOperation, ...fields });
 		assert.throws(() => decodeReviewStatusV3(body), /operation_token/, captureOperation);
 	}
+
+	const mismatchedBindings: ReadonlyArray<readonly [string, string]> = [
+		["name", "renamed_selection"],
+		["schema", "gentle-ai.review-intended-untracked-selection/v0"],
+	];
+	for (const [field, value] of mismatchedBindings) {
+		const body = initialIntendedUntrackedStatusV6();
+		collectInput(body)[field] = value;
+		assert.throws(() => decodeReviewStatusV3(body), /intended_untracked_selection binding/, field);
+	}
 });
 
 test("START/v4 accepts only its reviewing status continuation and preserves v3 strictness", () => {


### PR DESCRIPTION
## Summary

- reject `external.select_intended_untracked` collect inputs whose `name`/`schema` do not match the selection contract, so a mismatched binding fails the decode instead of being silently dropped downstream
- count `{{value}}` placeholder occurrences across all provider-issued tokens (instead of counting tokens that contain it), so a single token carrying the placeholder twice is rejected
- assert the exact blocked shape (`status`, `outcome`, `mutation_performed`, `mutation_outcome`) for every rejected pre-lineage intended-untracked selection

## Type

- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `lib/review-integration-v2.ts` | `decodeCollectInput` throws when the selection capture operation carries a mismatched `name`/`schema` |
| `lib/native-review-cli.ts` | `targetStatus` guard requires exactly one `{{value}}` occurrence, not one carrying token |
| `runtime/*.mjs` | regenerated via `build:runtime-modules`; parity verified |
| `tests/review-integration-v2-forward.test.ts` | negative coverage for mutated selection `name`/`schema` |
| `tests/native-review-cli.test.ts` | negative coverage for a doubled `{{value}}` placeholder in one token |
| `tests/review-controller-native-routing.test.ts` | rejected selections now assert the exact blocked outcome shape |

## Validation

- strict TDD: both behavior fixes had their failing test captured before implementation
- targeted suites (`review-integration-v2-forward`, `native-review-cli`, `review-controller-native-routing`): 109/109 passed
- `pnpm run build:runtime-modules` + `pnpm run check:runtime-modules`: runtime matches TypeScript sources (4 modules)
- full `pnpm test`: 1150 passed, 0 failed, 1 skipped (pre-existing); provider contract mirror and runtime harness passed

## RDD

- high-risk four-lens review completed against the frozen candidate tree (lineage `review-104e06d0aced6f02`)
- approved with zero blocking findings and no correction consumed; 11 advisory informational findings remain documented as non-blocking
- the approved acknowledgement was consumed (`authority: burned`)

Closes #536

https://claude.ai/code/session_019Fnv65tLLmD1b6H83YZrjq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of intended-untracked selections to reject submissions containing multiple value placeholders.
  * Added stricter checks for required selection names and schemas.
  * Invalid selection payloads are now blocked without performing mutations.

* **Tests**
  * Expanded coverage for malformed placeholders, mismatched metadata, blocked operations, and mutation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->