### PR TITLE
fix(review): make the Pi SDD-to-RDD path continuous — gentle-pi slice of #535

### DIFF
--- a/assets/agents/sdd-verify.md
+++ b/assets/agents/sdd-verify.md
@@ -102,7 +102,27 @@ If a partial slice is approved, report unchecked lines as remaining scope and st
 
 ## Report
 
-Write `openspec/changes/{change}/verify-report.md` with:
+The report's first non-empty content MUST be this exact fenced YAML envelope, with every field exactly once and counts taken from the actual retrieved specs (no front matter, `~~~` fences, untagged fences, or any content before the fence):
+
+```yaml
+schema: gentle-ai.verify-result/v1
+evidence_revision: sha256:{current-evidence-digest}
+verdict: pass
+blockers: 0
+critical_findings: 0
+requirements: {complete}/{actual-total}
+scenarios: {complete}/{actual-total}
+test_command: {exact command}
+test_exit_code: 0
+test_output_hash: sha256:{exact-output-digest}
+build_command: {exact command}
+build_exit_code: 0
+build_output_hash: sha256:{exact-output-digest}
+```
+
+Before the first persistence attempt, hold the complete report as exact candidate bytes and run `gentle-ai sdd-verify-validate --input <path|-> --requirements <n> --scenarios <n>` before any OpenSpec or Engram write. If the validator is unavailable or denies admission, make zero writes and preserve the prior report; otherwise persist the same bytes, including a valid `fail`.
+
+The report is `openspec/changes/{change}/verify-report.md`. After the envelope, it continues with:
 
 - pass/fail status;
 - spec coverage;

--- a/assets/chains/sdd-verify.chain.md
+++ b/assets/chains/sdd-verify.chain.md
@@ -27,7 +27,7 @@ output: verify-report.md
 outputMode: file-only
 progress: true
 
-Run focused and full verification for {task} using the apply-progress and project artifacts. Include review/judgment blockers.
+Run focused and full verification for {task} using the apply-progress and project artifacts. Include review/judgment blockers. Start `verify-report.md` with the mandatory fenced `gentle-ai.verify-result/v1` YAML envelope as the first non-empty content, and run `gentle-ai sdd-verify-validate` on the exact report bytes before persisting; on denial or unavailable validator, persist nothing.
 
 ## sdd-sync
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4328,15 +4328,27 @@ function hostTransportUnavailable(
 	operation: ReviewControllerOperation | "gentle_review_capture",
 	transport: ReviewTransportRefusal,
 ): Record<string, unknown> {
+	// #535: a provider-printed raw `gentle-ai review ...` continuation is a dead
+	// end in this runtime — Pi is not in the provider's immutable review runtime
+	// list, so every CLI-only exit refuses with this same transport code. The
+	// refusal therefore names the continuation that runs in this surface (the
+	// gentle_review / gentle_review_capture wrapper tools) while the provider's
+	// own diagnostic stays intact in relay_transport as evidence.
+	const isCapture = operation === "gentle_review_capture";
 	return {
-		...(operation === "gentle_review_capture" ? { tool: operation } : { operation }),
+		...(isCapture ? { tool: operation } : { operation }),
 		status: "blocked",
 		outcome: "pi-host-relay-transport-unavailable",
 		reason: `The native provider refused the required pi reviewer transport (${transport.code}): ${transport.message}`,
 		relay_transport: transport,
 		mutation_performed: false,
 		mutation_outcome: "none",
-		next_action: "Install a native gentle-ai provider that supports `review status --agent pi`, then call fresh STATUS and submit its exact one-slot capture binding. Pi never falls back to an agent-less lifecycle route.",
+		wrapper_continuation: {
+			tool: "gentle_review",
+			operation: REVIEW_CONTROLLER_OPERATION.INSPECT,
+			...(isCapture ? { then: "gentle_review_capture" } : {}),
+		},
+		next_action: `Install a native gentle-ai provider that supports \`review status --agent pi\`, then re-enter negotiated STATUS with gentle_review {"operation":"inspect"}${isCapture ? " and resubmit gentle_review_capture with the exact one-slot collectBinding that fresh STATUS returns" : " and follow the transition it returns"}. A provider-printed raw CLI continuation does not run in this runtime, and Pi never falls back to an agent-less lifecycle route.`,
 	};
 }
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -2670,7 +2670,7 @@ const REVIEW_CAPTURE_PARAMETERS = {
 		correctionLines: {
 			type: "integer",
 			minimum: 1,
-			description: "Positive correction-line plan, accepted only for the selected provider correction-plan slot and within its exact bounds.",
+			description: "Positive correction-line plan in diff lines: one replaced source line counts as two (one deletion plus one addition). A different unit from the provider's frozen logical correction budget. Accepted only for the selected provider correction-plan slot and within its exact bounds.",
 		},
 		workspaceRoot: {
 			type: "string",
@@ -4515,6 +4515,14 @@ async function executeReviewCaptureOperation(
 	const selected = selectExactReviewCapture(status, parameters.lineageId, canonicalBinding);
 	if (!isSelectedReviewCapture(selected)) return selected;
 
+	// During correction the flow carries both the original authority target
+	// identity and a distinct provider-issued correction target identity
+	// (gentle-pi#535 row 15). Echo the correction one on the capture result so
+	// the caller never reconstructs which is which from the opaque binding.
+	const correctionTargetIdentity = selected.input.validationRequest?.correctionTargetIdentity ?? selected.input.artifactSubject?.correctionTargetIdentity;
+	const withCorrectionTarget = (result: Record<string, unknown>): Record<string, unknown> =>
+		correctionTargetIdentity === undefined ? result : { ...result, correction_target_identity: correctionTargetIdentity };
+
 	const hostRelaySlots = reviewHostRelaySlots([selected.input]);
 	if (hostRelaySlots.length === 1) {
 		if (parameters.correctionLines !== undefined) return captureBindingRejected("correctionLines is valid only for a correction-plan capture");
@@ -4532,7 +4540,7 @@ async function executeReviewCaptureOperation(
 				mutation_outcome: "none",
 			};
 		}
-		return await executeReviewHostRelayCapture(hostRelaySlots[0]!, nativeReviewCli, cwd, selected.binding, retainedUntrackedSelections, route, signal);
+		return withCorrectionTarget(await executeReviewHostRelayCapture(hostRelaySlots[0]!, nativeReviewCli, cwd, selected.binding, retainedUntrackedSelections, route, signal));
 	}
 
 	if (selected.input.captureOperation === "review.capture-correction-plan") {
@@ -4562,7 +4570,7 @@ async function executeReviewCaptureOperation(
 				cwd,
 				...(signal === undefined ? {} : { signal }),
 			});
-			return mapAndClearLastEventClosure(closure, selected.binding, retainedUntrackedSelections, cwd);
+			return withCorrectionTarget(mapAndClearLastEventClosure(closure, selected.binding, retainedUntrackedSelections, cwd));
 		} catch (error) {
 			return await reconcileUnknownReviewCaptureFailure(error, nativeReviewCli, cwd, selected.binding, retainedUntrackedSelections, route);
 		}
@@ -4573,7 +4581,7 @@ async function executeReviewCaptureOperation(
 		if (parameters.reviewerRunAcknowledged !== undefined || parameters.correctionLines !== undefined) {
 			return captureBindingRejected("reviewerRunAcknowledged and correctionLines are not valid for a provider role capture");
 		}
-		return await executeProviderRoleVectorCapture(providerRoleSlots[0]!, nativeReviewCli, cwd, selected.binding, retainedUntrackedSelections, route, signal);
+		return withCorrectionTarget(await executeProviderRoleVectorCapture(providerRoleSlots[0]!, nativeReviewCli, cwd, selected.binding, retainedUntrackedSelections, route, signal));
 	}
 	return captureBindingRejected(`unsupported provider capture operation: ${selected.input.captureOperation}`);
 }
@@ -5413,7 +5421,7 @@ function createGentleAiExtensionForTesting(
 		promptSnippet: "Use one exact current STATUS collectBinding for one ordinary native capture; call fresh STATUS before every additional capture.",
 		promptGuidelines: [
 			"Pass only lineageId, the JSON-serialized exact collectBinding from current STATUS, and the route-specific optional acknowledgement or correctionLines value. Never compose provider argument tokens, prompts, results, verdicts, or lens arrays.",
-			"A materialize reviewer slot first forecasts one model run; re-submit that same exact binding with reviewerRunAcknowledged: true to authorize one host relay. Correction-plan slots require correctionLines inside the provider-issued bounds. Refuter and validation vectors execute exactly once as provider-rendered.",
+			"A materialize reviewer slot first forecasts one model run; re-submit that same exact binding with reviewerRunAcknowledged: true to authorize one host relay. Correction-plan slots require correctionLines inside the provider-issued bounds, counted in diff lines (one replaced source line is one deletion plus one addition) — a different unit from the frozen logical correction budget. Refuter and validation vectors execute exactly once as provider-rendered.",
 			"A native terminal closure or nonterminal capture returns directly. Do not expect automatic STATUS, FINALIZE, receipt, delivery, or another capture; call fresh STATUS before any next capture.",
 		],
 		parameters: REVIEW_CAPTURE_PARAMETERS,
@@ -5453,7 +5461,7 @@ function createGentleAiExtensionForTesting(
 			"Inspect and recover review authority and start native ordinary review. Ordinary capture is available only through the separate gentle_review_capture tool. Review outcomes never authorize delivery: commit, push, pull-request, and release commands follow ordinary repository policy. RESET/RECOVER remain destructive and are executed by the audited native CLI.",
 		promptSnippet: "Inspect authority, then start native ordinary review; use gentle_review_capture for one current collect slot",
 		promptGuidelines: [
-			'Call {"operation":"inspect"} before START. New native ordinary START uses a JSON string such as "{\\"mode\\":\\"ordinary\\"}"; an explicit baseRef must be paired with committedOnly: true to request a committed range, while policyPath remains repository-local. policyHash is legacy compact-only. The controller derives lineage, Git/untracked scope, tier, lenses, authored lines, and budget.',
+			'Call {"operation":"inspect"} before START. New native ordinary START uses a JSON string such as "{\\"mode\\":\\"ordinary\\"}"; an explicit baseRef must be paired with committedOnly: true to request a committed range, while policyPath remains repository-local. policyHash is legacy compact-only. The controller derives lineage, Git/untracked scope, tier, lenses, authored lines, and budget; the frozen correction budget counts logical corrections, while correction-plan correctionLines count diff lines (one replaced source line is one deletion plus one addition).',
 			"Use RECONCILE_AUTHORITY only to quarantine one invalid native recovery successor. Supply exact predecessorLineage, expectedPredecessorRevision, successorLineage, expectedSuccessorRevision, actor, and reason values; Pi derives and displays the seven-line native authorization binding for fresh UI approval. The predecessor stays untouched, native returns the durable audit record, and Pi never falls back to RESET or RECOVER.",
 			"Use ABANDON or QUARANTINE_LEGACY only after an explicit user decision and with exact native inputs. ABANDON needs lineage, expectedRevision, snapshotIdentity, capturedLensResults, findingsPresent, evidenceRecordsPresent, actor, and reason; QUARANTINE_LEGACY accepts only the published malformed freeze-findings diagnostic/disposition. A dual reconciliation may supply only anomalies `unchanged_target,malformed_recovery_authorization` in that exact order. Use REPAIR_LEGACY_ALIAS only with lineage, actor, and reason: Pi freshly reads native inventory and derives repository, revision, diagnostic, disposition, and the exact eight-line binding before interactive approval. `review dispose-result` is unsupported pending design.",
 			"Lens, refuter, and validator verdicts are admitted natively, never Pi-authored. Use gentle_review_capture with exactly one current provider-owned collectBinding for ordinary native capture; it never follows another transition.",

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4879,6 +4879,9 @@ async function executeReviewControllerOperation(
 				...(signal === undefined ? {} : { signal }),
 			});
 			clearRetainedNativeUntrackedSelection(retainedUntrackedSelections, defaultCwd, parameters.lineageId);
+			// The registry owns restoring writability of its 0555 views before
+			// removal; a terminal approved cleanup keeps the lineage projection.
+			candidateViews?.cleanupTerminal(parameters.lineageId, "approved", defaultCwd);
 			return {
 				operation: parameters.operation,
 				status: "closed",

--- a/lib/sdd-status.ts
+++ b/lib/sdd-status.ts
@@ -101,6 +101,12 @@ export interface SddStatus {
 	relationships: SddRelationships;
 	collisions: SddDomainCollisionReport[];
 	legacyFlatSpec?: { path: string; hasDomainSpecs: boolean };
+	/**
+	 * Positive terminal projection: the change was archived. `path` is the
+	 * repo-relative archive folder (openspec/changes/archive/YYYY-MM-DD-<change>).
+	 * When set, `nextRecommended` is "archived" and no further phase is recommended.
+	 */
+	archived?: { path: string };
 	nextRecommended: string;
 	instructions?: SddPhaseInstructions;
 	blockedReasons: string[];
@@ -299,6 +305,31 @@ function emptyStatus(cwd: string, changeName: string | null, blockedReasons: str
 	};
 }
 
+/**
+ * Find the newest archive entry for a change. Archive folders are named
+ * `YYYY-MM-DD-<change>`; only an exact `-<change>` suffix after a full date
+ * prefix matches (change "foo-bar" never matches "2026-01-01-foo-bar-baz").
+ * safeDirectories sorts lexicographically, so the last match is the newest date.
+ */
+function findArchivedChangeEntry(root: string, changeName: string): string | undefined {
+	return safeDirectories(join(root, "openspec", "changes", "archive"))
+		.filter(
+			(entry) =>
+				/^\d{4}-\d{2}-\d{2}-$/.test(entry.slice(0, 11)) && entry.slice(11) === changeName,
+		)
+		.at(-1);
+}
+
+/** Positive terminal projection for a change whose folder moved to the archive. */
+function archivedStatus(cwd: string, changeName: string, archiveEntry: string, artifactStore: SddArtifactStore): SddStatus {
+	const status = emptyStatus(cwd, changeName, [], artifactStore);
+	status.applyState = "all_done";
+	status.dependencies = { apply: "all_done", verify: "all_done", sync: "all_done", archive: "all_done" };
+	status.archived = { path: join("openspec", "changes", "archive", archiveEntry) };
+	status.nextRecommended = "archived";
+	return status;
+}
+
 export function listActiveOpenSpecChanges(cwd: string): string[] {
 	return safeDirectories(join(cwd, "openspec", "changes")).filter(
 		(change) => change !== "archive",
@@ -462,6 +493,12 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 		// Pure openspec still blocks (legit "run sdd-new").
 		if (store === "hybrid") {
 			return nonAuthoritativeStatus(options.cwd, changeName, store, options.includeInstructions);
+		}
+		// Issue #535: an absent active folder may mean the change was archived.
+		// Project explicit completion instead of a false "run sdd-new" block.
+		const archiveEntry = findArchivedChangeEntry(root, changeName);
+		if (archiveEntry) {
+			return archivedStatus(root, changeName, archiveEntry, store);
 		}
 		return emptyStatus(root, changeName, [`Active change not found: ${changeName}.`], store);
 	}

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -223,6 +223,45 @@ test("public acknowledgement reports the burn from the review-acknowledged/v1 en
 		argumentTokens: [`--cwd=${process.cwd()}`, `--lineage=${lineageId}`, `--target=${SHA}`, `--expected-revision=${SHA}`, "--token=provider-issued-once"],
 		binding: { lineageId, targetIdentity: SHA, revision: SHA },
 	}]);
+});
+
+function candidateRepository(t: test.TestContext): string {
+	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-routing-"));
+	// The registry's views are 0555 dirs / 0444 files; restore writability before
+	// the fixture teardown so a surviving view never breaks rmSync.
+	t.after(() => { try { execFileSync("chmod", ["-R", "u+w", cwd]); } catch {} rmSync(cwd, { recursive: true, force: true }); });
+	const git = (...arguments_: string[]) => execFileSync("git", arguments_, { cwd, encoding: "utf8" });
+	git("init", "-b", "main");
+	writeFileSync(join(cwd, "tracked.txt"), "base\n");
+	git("add", "tracked.txt");
+	git("-c", "user.name=Routing Test", "-c", "user.email=routing@example.invalid", "commit", "-m", "base");
+	return realpathSync(cwd);
+}
+
+test("approved acknowledgement burn tears down the retained candidate view and keeps its projection", async (t) => {
+	const lineageId = "acknowledge-approved-view-teardown";
+	const contributorRoot = candidateRepository(t);
+	writeFileSync(join(contributorRoot, "tracked.txt"), "candidate\n");
+	const registry = new CandidateViewRegistry();
+	t.after(() => registry.cleanupAll());
+	const view = registry.create({ contributorRoot });
+	registry.retain(view.token, lineageId);
+	assert.ok(existsSync(view.root));
+	let approved = false;
+	const native = {
+		targetStatus: async () => approved ? approvedAcknowledgementStatus(lineageId, contributorRoot) : status(lineageId),
+		acknowledgeApproved: async () => {},
+	} as unknown as NativeReviewCli;
+
+	const blocked = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, contributorRoot, native, undefined, registry);
+	assert.equal(blocked.outcome, "native-approved-acknowledgement-not-current");
+	assert.ok(existsSync(view.root), "a refused acknowledgement proves no burn; the view must survive");
+
+	approved = true;
+	const completed = await __testing.executeReviewControllerOperation({ operation: "acknowledge-approved", lineageId }, contributorRoot, native, undefined, registry);
+	assert.equal(completed.outcome, "native-approved-acknowledgement-completed");
+	assert.equal(existsSync(view.root), false, "the burn must tear down the immutable candidate view worktree");
+	assert.ok(registry.hasProjection(lineageId, contributorRoot), "terminal approved cleanup keeps the lineage projection");
 });
 
 test("ambiguous acknowledgement reconciles STATUS once without replaying the provider vector", async () => {

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -922,6 +922,59 @@ test("targeted-validator provider vectors preserve their nonuniform native closu
 	const result = await __testing.executeReviewCaptureOperation({ lineageId: closureLineage, collectBinding: JSON.stringify(input) }, process.cwd(), native);
 	assert.equal(result.status, "closed");
 	assert.equal(result.outcome, "native-last-event-closure");
+	assert.equal("correction_target_identity" in result, false);
+});
+
+test("targeted-validator captures echo the distinct provider correction target identity", async () => {
+	const closureLineage = "review-validator-correction-target";
+	const correctionTarget = `sha256:${"d".repeat(64)}`;
+	const baseInput = collectInput(closureLineage);
+	const { submission: _submission, artifactSubject: _artifactSubject, ...roleInput } = baseInput;
+	void _submission;
+	void _artifactSubject;
+	const input = {
+		...roleInput,
+		name: "provider_targeted_validator",
+		schema: "https://gentle-ai.dev/schema/review/targeted-validator/v1",
+		captureOperation: "review.capture-validation",
+		arguments: [
+			{ name: "lineage", value: closureLineage, token: `--lineage=${closureLineage}` },
+			{ name: "target", value: correctionTarget, token: `--target=${correctionTarget}` },
+			{ name: "agent", value: "pi", token: "--agent=pi" },
+			{ name: "execute", value: "true", token: "--execute=true" },
+		],
+		validationRequest: { correctionTargetIdentity: correctionTarget },
+	} as unknown as ReviewCollectInputV3;
+	const roleStatus = { ...status(closureLineage), nextTransition: { kind: "collect", reasonCode: "provider_role_required", collect: { inputs: [input] } } } as ReviewStatusV3;
+	const native = {
+		targetStatus: async () => roleStatus,
+		captureProviderRole: async () => ({ schema: "gentle-ai.review-last-event-closure/v1", operation: "review/capture-validation", lineageId: closureLineage, state: "approved", storeRevision: SHA }),
+	} as unknown as NativeReviewCli;
+	const result = await __testing.executeReviewCaptureOperation({ lineageId: closureLineage, collectBinding: JSON.stringify(input) }, process.cwd(), native);
+	assert.equal(result.outcome, "native-last-event-closure");
+	assert.equal(result.correction_target_identity, correctionTarget);
+});
+
+test("capture schema and guidance name diff-line units apart from the frozen logical correction budget", () => {
+	const tools = new Map<string, { description: string; promptGuidelines?: readonly string[]; parameters: unknown }>();
+	createGentleAiExtension({ nativeReviewCli: null })({
+		on() {},
+		registerTool(definition: { name: string; description: string; promptGuidelines?: readonly string[]; parameters: unknown }) { tools.set(definition.name, definition); },
+		registerCommand() {},
+	} as unknown as ExtensionAPI);
+	const capture = tools.get("gentle_review_capture");
+	const controller = tools.get("gentle_review");
+	assert.ok(capture);
+	assert.ok(controller);
+	const schema = JSON.stringify(capture.parameters);
+	assert.match(schema, /diff lines/);
+	assert.match(schema, /logical correction budget/);
+	const captureGuidance = (capture.promptGuidelines ?? []).join("\n");
+	assert.match(captureGuidance, /diff lines/);
+	assert.match(captureGuidance, /logical correction budget/);
+	const controllerGuidance = (controller.promptGuidelines ?? []).join("\n");
+	assert.match(controllerGuidance, /logical correction/);
+	assert.match(controllerGuidance, /diff lines/);
 });
 
 test("correction-plan collection demands provider-bounded lines, then returns its terminal closure", async () => {

--- a/tests/review-relay-transport-agent.test.ts
+++ b/tests/review-relay-transport-agent.test.ts
@@ -244,6 +244,35 @@ test("a provider that refuses the pi transport blocks immediately without an age
 	assert.doesNotMatch(JSON.stringify(result), /"status":"(?:approved|allowed)"/);
 });
 
+test("a transport refusal names the runnable wrapper continuation, never a raw CLI command as the only exit", async (t) => {
+	// #535: a provider-printed raw `gentle-ai review ...` continuation is a dead
+	// end in this runtime — Pi is not in the provider's immutable review runtime
+	// list — so the refusal envelope itself must name the exit that runs in this
+	// surface: the gentle_review / gentle_review_capture wrapper tools. The
+	// provider's diagnostic stays intact as evidence alongside the runnable exit.
+	const captureCwd = repository(t);
+	const { native: captureNative } = transportAwareNative({ refusalCode: TRANSPORT_REFUSAL_CODE });
+	const capture = await runCapture(captureCwd, captureNative, "continuation-capture-lineage");
+	__testing.clearReviewTransportProbeForTesting(captureNative);
+	assert.equal(capture.outcome, "pi-host-relay-transport-unavailable");
+	const captureNextAction = String(capture.next_action);
+	assert.match(captureNextAction, /gentle_review \{"operation":"inspect"\}/, "the capture refusal re-enters negotiated STATUS through the wrapper controller");
+	assert.match(captureNextAction, /gentle_review_capture/, "the capture refusal names the wrapper resubmission, not a CLI command");
+	assert.doesNotMatch(captureNextAction, /gentle-ai review/, "a raw `gentle-ai review ...` invocation is not a runnable exit in this runtime");
+	assert.deepEqual(capture.wrapper_continuation, { tool: "gentle_review", operation: "inspect", then: "gentle_review_capture" });
+	assert.match(String((capture.relay_transport as { message: string }).message), /immutable review runtimes/i, "the provider diagnostic remains intact in the envelope");
+
+	const statusCwd = repository(t);
+	const { native: statusNative } = transportAwareNative({ refusalCode: TRANSPORT_REFUSAL_CODE });
+	const status = await runStatus(statusCwd, statusNative, "continuation-status-lineage");
+	__testing.clearReviewTransportProbeForTesting(statusNative);
+	assert.equal(status.outcome, "pi-host-relay-transport-unavailable");
+	const statusNextAction = String(status.next_action);
+	assert.match(statusNextAction, /gentle_review \{"operation":"inspect"\}/, "the controller refusal re-enters negotiated STATUS through the wrapper controller");
+	assert.doesNotMatch(statusNextAction, /gentle-ai review/, "a raw `gentle-ai review ...` invocation is not a runnable exit in this runtime");
+	assert.deepEqual(status.wrapper_continuation, { tool: "gentle_review", operation: "inspect" });
+});
+
 test("a remembered pi transport refusal remains blocked without re-probing or lifecycle continuation", async (t) => {
 	const cwd = repository(t);
 	const { native, agents } = transportAwareNative({ refusalCode: TRANSPORT_REFUSAL_CODE });

--- a/tests/sdd-agent-tools.test.ts
+++ b/tests/sdd-agent-tools.test.ts
@@ -123,6 +123,41 @@ test("generic non-SDD agents declare exact role tool allowlists", () => {
 	}
 });
 
+test("sdd-verify phase text carries the verify-result envelope and validate-before-persist rule", () => {
+	// gentle-pi#535 row 5: the phase must produce a natively admissible report
+	// on its first persistence attempt without hunting the format elsewhere.
+	const envelopeFields = [
+		"schema: gentle-ai.verify-result/v1",
+		"evidence_revision: sha256:",
+		"verdict:",
+		"blockers:",
+		"critical_findings:",
+		"requirements:",
+		"scenarios:",
+		"test_command:",
+		"test_exit_code:",
+		"test_output_hash: sha256:",
+		"build_command:",
+		"build_exit_code:",
+		"build_output_hash: sha256:",
+	];
+
+	const agentSource = readFileSync(join(assetsAgentsDir, "sdd-verify.md"), "utf8");
+	assert.match(agentSource, /```yaml\nschema: gentle-ai\.verify-result\/v1\n/);
+	for (const field of envelopeFields) {
+		assert.ok(agentSource.includes(field), `sdd-verify.md envelope must carry \`${field}\``);
+	}
+	assert.match(agentSource, /first non-empty content/);
+	assert.match(
+		agentSource,
+		/gentle-ai sdd-verify-validate --input <path\|-> --requirements <n> --scenarios <n>/,
+	);
+
+	const chainSource = readFileSync(join(repoRoot, "assets", "chains", "sdd-verify.chain.md"), "utf8");
+	assert.match(chainSource, /gentle-ai\.verify-result\/v1/);
+	assert.match(chainSource, /sdd-verify-validate/);
+});
+
 test("the retired Pi adversarial role agents are not packaged", () => {
 	// gentle-pi#311 P5: the refuter and targeted validator verdicts execute
 	// through Go-owned pi processes via provider-rendered self-contained

--- a/tests/sdd-status.test.ts
+++ b/tests/sdd-status.test.ts
@@ -659,6 +659,65 @@ test("resolveSddStatus openspec + named change missing still blocks", async () =
 	assert.notEqual(status.nextRecommended, "resolve-via-engram");
 });
 
+// Issue #535 — post-archive status exposes explicit completion and the archived artifact location
+test("resolveSddStatus projects archived terminal state when the change lives in the archive", async () => {
+	const cwd = await workspace();
+	mkdirSync(join(cwd, "openspec", "changes"), { recursive: true });
+	write(
+		join(cwd, "openspec", "changes", "archive", "2026-01-02-add-auth", "proposal.md"),
+		"# Proposal\n",
+	);
+
+	const status = resolveSddStatus({ cwd, changeName: "add-auth" });
+
+	assert.equal(status.changeName, "add-auth");
+	assert.equal(status.nextRecommended, "archived");
+	assert.deepEqual(status.archived, {
+		path: join("openspec", "changes", "archive", "2026-01-02-add-auth"),
+	});
+	assert.deepEqual(status.blockedReasons, []);
+	assert.equal(status.dependencies.archive, "all_done");
+	assert.doesNotMatch(status.nextRecommended, /sdd-new|Start an SDD change|not found/i);
+});
+
+test("resolveSddStatus archived projection prefers the newest archive date", async () => {
+	const cwd = await workspace();
+	mkdirSync(join(cwd, "openspec", "changes"), { recursive: true });
+	mkdirSync(join(cwd, "openspec", "changes", "archive", "2026-01-01-add-auth"), { recursive: true });
+	mkdirSync(join(cwd, "openspec", "changes", "archive", "2026-03-04-add-auth"), { recursive: true });
+
+	const status = resolveSddStatus({ cwd, changeName: "add-auth" });
+
+	assert.equal(status.nextRecommended, "archived");
+	assert.deepEqual(status.archived, {
+		path: join("openspec", "changes", "archive", "2026-03-04-add-auth"),
+	});
+});
+
+test("resolveSddStatus still blocks a change that never existed and has no archive entry", async () => {
+	const cwd = await workspace();
+	mkdirSync(join(cwd, "openspec", "changes"), { recursive: true });
+	mkdirSync(join(cwd, "openspec", "changes", "archive", "2026-01-01-unrelated"), { recursive: true });
+
+	const status = resolveSddStatus({ cwd, changeName: "ghost" });
+
+	assert.equal(status.archived, undefined);
+	assert.match(status.blockedReasons.join("\n"), /Active change not found/);
+	assert.notEqual(status.nextRecommended, "archived");
+});
+
+test("resolveSddStatus archive matching requires the exact change-name suffix", async () => {
+	const cwd = await workspace();
+	mkdirSync(join(cwd, "openspec", "changes"), { recursive: true });
+	mkdirSync(join(cwd, "openspec", "changes", "archive", "2026-01-01-foo-bar-baz"), { recursive: true });
+
+	const status = resolveSddStatus({ cwd, changeName: "foo-bar" });
+
+	assert.equal(status.archived, undefined);
+	assert.match(status.blockedReasons.join("\n"), /Active change not found/);
+	assert.notEqual(status.nextRecommended, "archived");
+});
+
 // Fix 4 render test — non-authoritative both status → dispatcher shows "both" not "Engram or none"
 test("renderSddDispatcherMarkdown for non-authoritative both status shows artifact store 'both'", async () => {
 	const cwd = await workspace();


### PR DESCRIPTION
Part of #535

## Summary

- Fixes the five gentle-pi-owned root causes from the #535 stop-and-recover cluster, one reviewable work-unit commit per root cause (rows 17, 8, 5, 13+15, 3).
- Deliberately does NOT close #535: the remaining rows are provider-owned (gentle-ai), superseded on main (`a217fbea` closed #502, covering rows 10/11), or out of repo (rows 1, 9, 12, 18). Follow-up gentle-ai issues still needed for: sync-before-archive routing drift, a positive native archived terminal state, candidate-view permission ownership after burn, and the bench injector's `archive_valid` dependency.

## PR type

- [x] Bug fix

## Work units (one commit each)

| Commit | Row | Change |
|--------|-----|--------|
| `348e6e54` | 17 | `CandidateViewRegistry.cleanupTerminal` had zero production callers; the approved acknowledgement burn now tears down the retained immutable candidate view (0555/0444) and keeps the lineage projection. |
| `0b7c7c49` | 8 | `lib/sdd-status.ts` projects an explicit `archived` terminal status with the archive path instead of "Active change not found" + `sdd-new` for archived changes. |
| `47f0adfb` | 5 | The installed `sdd-verify` phase now carries the mandatory leading `gentle-ai.verify-result/v1` YAML envelope and the `sdd-verify-validate`-before-persist rule, copied from the provider's report-format reference. |
| `d8cccbaf` | 13+15 | Correction units are named everywhere they surface (diff lines vs frozen logical budget), and capture results echo `correction_target_identity` instead of dropping it after matching against it. |
| `3a24a541` | 3 | All six transport-refusal paths (single factory) now name the runnable wrapper continuation (`gentle_review {"operation":"inspect"}` → `gentle_review_capture`) instead of relaying a raw CLI command Pi's shell cannot run. Sibling of #443. |

## Size exception

317 changed lines across 8 files — above the 400-line-per-unit guideline as a single PR, split into five ≤400-line work-unit commits by root cause. Labeled `size:exception`; review commit-by-commit.

## Test plan

- [x] Strict TDD per unit: every unit's test failed first for the right reason, then went green (failing-first evidence in each unit's development log).
- [x] Full suite: `pnpm test` → 1159 pass / 0 fail / 1 skip, provider-contract mirror check passed, runtime harness passed.
- [x] Native RDD review (receipt-driven): high tier, 4 lenses (risk, resilience, readability, reliability) over the frozen committed-only candidate `origin/main..HEAD`; **approved** with 0 blocking findings; acknowledgement burned (`gentle-ai.review-acknowledged/v1`, lineage `review-6b92b5cfcd8c68d2`).
- 24 advisory (non-blocking) findings were logged by the review — 13 WARNING / 11 SUGGESTION, e.g. archived-projection input validation, post-burn cleanup guard, verify-envelope literal-vs-placeholder wording. They are separate later work per the review contract and intentionally not folded into this PR.

## Contributor checklist

- [x] Linked an approved issue (`status:approved` on #535)
- [x] Exactly one `type:*` label (`type:bug`)
- [x] No shell scripts modified (shellcheck n/a)
- [x] Conventional commit format on every commit
- [x] No `Co-Authored-By` trailers
- [x] Docs/phase text updated where behavior changed (`assets/agents/sdd-verify.md`, chain)

https://claude.ai/code/session_01P9jxuSzTwn4HFmxRrZJYQd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Archived changes now display a completed terminal status, including their archive location and recommended next step.
  - Review results now include structured verification evidence, command outcomes, and output hashes.
  - Review tools provide a supported continuation path when the host transport is unavailable.
  - Review captures now preserve the provider’s correction target identity.

- **Bug Fixes**
  - Approved review acknowledgements now properly clean up retained working views.
  - Archive matching avoids incorrectly identifying similarly named changes.

- **Documentation**
  - Clarified the distinction between diff-line counts and logical correction budgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->