### PR TITLE
test: make the suite pass on macOS by canonicalizing temp roots and fixing the prompt budget root length

### DIFF
--- a/tests/codegraph-tools.test.ts
+++ b/tests/codegraph-tools.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -11,14 +11,14 @@ import codeGraphTools, {
 } from "../extensions/codegraph-tools.ts";
 
 function workspace(t: test.TestContext): string {
-	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-codegraph-"));
+	const cwd = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-codegraph-")));
 	execFileSync("git", ["init", "-b", "main"], { cwd, stdio: "ignore" });
 	t.after(() => rmSync(cwd, { recursive: true, force: true }));
 	return cwd;
 }
 
 test("CodeGraph tool rejects non-project, nested-project, HOME, and temporary workspaces before init", async (t) => {
-	const nonProject = mkdtempSync(join(tmpdir(), "gentle-pi-codegraph-non-project-"));
+	const nonProject = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-codegraph-non-project-")));
 	t.after(() => rmSync(nonProject, { recursive: true, force: true }));
 	const root = workspace(t);
 	const nested = join(root, "nested");

--- a/tests/native-review-parity-runtime.test.ts
+++ b/tests/native-review-parity-runtime.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import baseTest from "node:test";
@@ -22,7 +22,7 @@ import { requireNativeBinary } from "./support/native-binary-gate.ts";
 
 const execFileAsync = promisify(execFile);
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
-const pinnedBinaryHome = mkdtempSync(join(tmpdir(), "gentle-pi-pinned-runtime-home-"));
+const pinnedBinaryHome = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-pinned-runtime-home-")));
 const pinnedBinaryEnvironment: GentleAiDevBinaryEnvironment = {
 	env: { ...process.env },
 	home: pinnedBinaryHome,
@@ -77,8 +77,8 @@ interface RegisteredController {
 // intentionally have clone-local mode off, which must never participate in the
 // fixture's lifecycle.
 async function reviewEnabledHome(t: baseTest.TestContext): Promise<string> {
-	const home = await mkdtemp(join(tmpdir(), "gentle-pi-review-home-"));
-	const lifecycleCwd = await mkdtemp(join(tmpdir(), "gentle-pi-review-lifecycle-"));
+	const home = await realpath(await mkdtemp(join(tmpdir(), "gentle-pi-review-home-")));
+	const lifecycleCwd = await realpath(await mkdtemp(join(tmpdir(), "gentle-pi-review-lifecycle-")));
 	const xdgConfigHome = join(home, ".config");
 	const xdgDataHome = join(home, ".local", "share");
 	const xdgCacheHome = join(home, ".cache");
@@ -140,7 +140,7 @@ test("generated runtime decoder consumes the captured terminal closure directly"
 
 test("registered gentle_review surfaces the package-pinned Pi transport refusal before native START for a safe internal symlink candidate", async (t) => {
 	await reviewEnabledHome(t);
-	const workspace = await mkdtemp(join(tmpdir(), "gentle-pi-v215-symlink-candidate-"));
+	const workspace = await realpath(await mkdtemp(join(tmpdir(), "gentle-pi-v215-symlink-candidate-")));
 	const repository = join(workspace, "repository");
 	t.after(async () => {
 		// Candidate views are intentionally read-only. Restore test-workspace write

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -131,7 +131,7 @@ test("current review mode keeps canonical reach values and rejects unrecognized 
 		(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE,
 	);
 	if (process.platform !== "win32") {
-		const root = mkdtempSync(join(tmpdir(), "gentle-pi-review-mode-"));
+		const root = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-review-mode-")));
 		const alias = `${root}-alias`;
 		const { symlinkSync } = await import("node:fs");
 		symlinkSync(root, alias, "dir");
@@ -208,7 +208,7 @@ function parityRuntime(nativeReviewCli: NativeReviewCli | null, options: ParityR
 }
 
 function repository(t: test.TestContext): string {
-	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-parity-"));
+	const cwd = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-native-parity-")));
 	t.after(() => {
 		try { execFileSync("chmod", ["-R", "u+w", cwd], { stdio: "ignore" }); } catch { /* best effort */ }
 		rmSync(cwd, { recursive: true, force: true });

--- a/tests/orchestrator-budget.test.ts
+++ b/tests/orchestrator-budget.test.ts
@@ -58,13 +58,29 @@ const { __testing } = await import("../extensions/gentle-ai.ts");
 // canonical budget independently of the checkout or installed-package path.
 // The child-process measurement keeps production cache behavior separate from
 // fixture measurements.
+// The root is built to one exact length rather than "tmpdir plus a long
+// suffix". The prompt declares the absolute root once, so it grows one byte
+// per root character, and a 48-character macOS tmpdir pushed the previous
+// construction to 164 characters where a 4-character Linux /tmp gave 121.
+// A fixed length makes every platform measure the same budget claim.
+const CONTROLLED_LONG_ASSETS_ROOT_CHARS = 128;
 const controlledLongBaseDir = mkdtempSync(join(tmpdir(), "gp-long-"));
+const controlledLongSegmentChars = CONTROLLED_LONG_ASSETS_ROOT_CHARS - join(controlledLongBaseDir, "x", "assets").length + 1;
+assert.ok(
+	controlledLongSegmentChars >= 1,
+	`tmpdir ${tmpdir()} is too long to build a ${CONTROLLED_LONG_ASSETS_ROOT_CHARS}-char controlled assets root`,
+);
 const controlledLongAssetsDir = join(
 	controlledLongBaseDir,
-	"path-independent-prompt-budget-".repeat(3),
+	"path-independent-prompt-budget-".repeat(Math.ceil(controlledLongSegmentChars / 31)).slice(0, controlledLongSegmentChars),
 	"assets",
 );
 mkdirSync(controlledLongAssetsDir, { recursive: true });
+assert.equal(
+	controlledLongAssetsDir.length,
+	CONTROLLED_LONG_ASSETS_ROOT_CHARS,
+	`controlled long assets root is ${controlledLongAssetsDir.length} chars, want exactly ${CONTROLLED_LONG_ASSETS_ROOT_CHARS}`,
+);
 assert.ok(
 	controlledLongAssetsDir.length >= MIN_CONTROLLED_LONG_ASSETS_ROOT_CHARS,
 	`controlled long assets root is only ${controlledLongAssetsDir.length} chars, need >= ${MIN_CONTROLLED_LONG_ASSETS_ROOT_CHARS}`,

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { realpathSync } from "node:fs";
 import test from "node:test";
 import { initTheme, keyHint } from "@earendil-works/pi-coding-agent";
 import { imageFallback, visibleWidth } from "@earendil-works/pi-tui";
@@ -180,7 +181,8 @@ test("quiet tool rendering registers noisy built-in tools", () => {
 test("quiet tool execution uses the tool-call cwd", async () => {
 	const tool = registeredQuietTools().get("bash");
 	const output = extractTextContent(await tool.execute("tool-call", { command: "pwd" }, new AbortController().signal, undefined, { cwd: "/tmp" })).trim();
-	assert.equal(output, "/tmp");
+	// pwd prints the physical directory: on macOS /tmp is a symlink to /private/tmp.
+	assert.equal(output, realpathSync("/tmp"));
 	assert.notEqual(output, process.cwd());
 });
 

--- a/tests/review-controller-lock-status.test.ts
+++ b/tests/review-controller-lock-status.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -47,7 +47,7 @@ function context(cwd: string): ExtensionContext {
 }
 
 function repository(t: test.TestContext): string {
-	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-lock-status-"));
+	const cwd = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-lock-status-")));
 	t.after(() => rmSync(cwd, { recursive: true, force: true }));
 	execFileSync("git", ["init", "-b", "main"], { cwd });
 	writeFileSync(join(cwd, "app.ts"), "export const value = 1;\n");

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -226,7 +226,7 @@ test("public acknowledgement reports the burn from the review-acknowledged/v1 en
 });
 
 function candidateRepository(t: test.TestContext): string {
-	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-routing-"));
+	const cwd = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-native-routing-")));
 	// The registry's views are 0555 dirs / 0444 files; restore writability before
 	// the fixture teardown so a surviving view never breaks rmSync.
 	t.after(() => { try { execFileSync("chmod", ["-R", "u+w", cwd]); } catch {} rmSync(cwd, { recursive: true, force: true }); });
@@ -624,7 +624,7 @@ test("public INSPECT and STATUS publish the exact pi-bound binding that capture 
 });
 
 function repository(t: test.TestContext): string {
-	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-native-routing-"));
+	const cwd = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-native-routing-")));
 	t.after(() => {
 		execFileSync("chmod", ["-R", "u+rwx", cwd], { stdio: "ignore" });
 		chmodSync(cwd, 0o700);

--- a/tests/review-controller-workspace-root.test.ts
+++ b/tests/review-controller-workspace-root.test.ts
@@ -55,7 +55,7 @@ function context(cwd: string): ExtensionContext {
 }
 
 function repository(t: test.TestContext, prefix = "gentle-pi-workspace-root-"): string {
-	const cwd = mkdtempSync(join(tmpdir(), prefix));
+	const cwd = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
 	t.after(() => {
 		if (process.platform !== "win32") {
 			try { execFileSync("chmod", ["-R", "u+w", cwd], { stdio: "ignore" }); } catch { /* best effort */ }
@@ -70,7 +70,7 @@ function repository(t: test.TestContext, prefix = "gentle-pi-workspace-root-"): 
 }
 
 function addWorktree(t: test.TestContext, cwd: string, branch: string): string {
-	const parent = mkdtempSync(join(tmpdir(), "gentle-pi-workspace-worktrees-"));
+	const parent = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-workspace-worktrees-")));
 	t.after(() => {
 		try { execFileSync("git", ["worktree", "remove", "--force", join(parent, branch)], { cwd }); } catch {}
 		rmSync(parent, { recursive: true, force: true });
@@ -389,7 +389,7 @@ test("an explicit foreign workspace root works when the Pi session cwd is not a 
 	const target = repository(t, "gentle-pi-target-b-non-git-session-");
 	const nested = join(target, "nested");
 	mkdirSync(nested);
-	const nonGit = mkdtempSync(join(tmpdir(), "gentle-pi-non-git-session-"));
+	const nonGit = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-non-git-session-")));
 	t.after(() => rmSync(nonGit, { recursive: true, force: true }));
 	const observed: string[] = [];
 	const { controller } = runtime(fakeNative({
@@ -433,7 +433,7 @@ test("omitted workspaceRoot fails closed for the same lineage bound to two targe
 test("workspaceRoot fails closed before any native call for invalid target paths", async (t) => {
 	const sessionCwd = repository(t);
 	const worktree = addWorktree(t, sessionCwd, "feat-guard");
-	const nonGit = mkdtempSync(join(tmpdir(), "gentle-pi-non-git-"));
+	const nonGit = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-non-git-")));
 	t.after(() => rmSync(nonGit, { recursive: true, force: true }));
 	const filePath = join(worktree, "app.ts");
 	let nativeCalls = 0;

--- a/tests/review-controller.test.ts
+++ b/tests/review-controller.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -120,7 +120,7 @@ function git(repository: string, ...args: string[]): string {
 }
 
 function createRepository(t: test.TestContext): RepositoryFixture {
-	const parent = mkdtempSync(join(tmpdir(), "gentle-pi-review-controller-"));
+	const parent = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-review-controller-")));
 	const repository = join(parent, "repo");
 	mkdirSync(repository);
 	t.after(() => rmSync(parent, { recursive: true, force: true }));

--- a/tests/review-host-relay-restart-parity.test.ts
+++ b/tests/review-host-relay-restart-parity.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -117,7 +117,7 @@ function collectStatus(lineageId, inputs) {
 }
 
 function repository(t) {
-	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-relay-restart-"));
+	const cwd = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-relay-restart-")));
 	t.after(() => rmSync(cwd, { recursive: true, force: true }));
 	execFileSync("git", ["init", "-b", "main"], { cwd });
 	writeFileSync(join(cwd, "app.ts"), "export const value = 1;\n");
@@ -204,7 +204,7 @@ await writeFile(outFile, JSON.stringify({ result, inspectResult, captureBinding,
 }
 
 function runWorker(t, cwd, statuses, mode) {
-	const scratch = mkdtempSync(join(tmpdir(), "gentle-pi-relay-restart-run-"));
+	const scratch = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-relay-restart-run-")));
 	t.after(() => rmSync(scratch, { recursive: true, force: true }));
 	const statusFile = join(scratch, "statuses.json");
 	const outFile = join(scratch, "out.json");

--- a/tests/review-host-relay.test.ts
+++ b/tests/review-host-relay.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -118,7 +118,7 @@ interface RelayHarness {
 }
 
 function harness(t: test.TestContext, overrides: Record<string, string> = {}): RelayHarness {
-	const directory = mkdtempSync(join(tmpdir(), "gentle-pi-relay-harness-"));
+	const directory = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-relay-harness-")));
 	t.after(() => rmSync(directory, { recursive: true, force: true }));
 	const gentleAi = join(directory, "gentle-ai");
 	const pi = join(directory, "pi");
@@ -404,7 +404,7 @@ test("the production relay path resolves the reviewer bound from the environment
 
 test("a relay Pi timeout keeps its typed mapping and timing evidence when opaque scratch cleanup also fails", async (t) => {
 	const fixture = harness(t, { RELAY_FAKE_PI_MODE: "hang", RELAY_FAKE_PI_BREAK_CLEANUP: "true" });
-	const scratchParent = mkdtempSync(join(tmpdir(), "gentle-pi-relay-pi-primary-failure-"));
+	const scratchParent = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-relay-pi-primary-failure-")));
 	const originalTmpdir = process.env.TMPDIR;
 	process.env.TMPDIR = scratchParent;
 	try {
@@ -509,7 +509,7 @@ test("a submission the fake admits with the expected subject still completes", a
 
 test("submission refusal preserves its primary evidence when result staging cleanup also fails", async (t) => {
 	const fixture = harness(t, { RELAY_FAKE_SUBMIT_MODE: "refuse-cleanup-fail" });
-	const scratchParent = mkdtempSync(join(tmpdir(), "gentle-pi-relay-primary-failure-"));
+	const scratchParent = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-relay-primary-failure-")));
 	const originalTmpdir = process.env.TMPDIR;
 	process.env.TMPDIR = scratchParent;
 	try {
@@ -542,7 +542,7 @@ test("relay scratch and staging directories are removed after failures too", asy
 
 test("a result staging cleanup failure remains a typed submit failure", async (t) => {
 	const fixture = harness(t, { RELAY_FAKE_SUBMIT_MODE: "cleanup-fail" });
-	const scratchParent = mkdtempSync(join(tmpdir(), "gentle-pi-relay-cleanup-"));
+	const scratchParent = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-relay-cleanup-")));
 	const originalTmpdir = process.env.TMPDIR;
 	process.env.TMPDIR = scratchParent;
 	try {

--- a/tests/review-snapshot.test.ts
+++ b/tests/review-snapshot.test.ts
@@ -2,9 +2,10 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
 	existsSync,
-	mkdtempSync,
 	mkdirSync,
+	mkdtempSync,
 	readFileSync,
+	realpathSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -60,7 +61,7 @@ function createRepository(t: test.TestContext): {
 	repository: string;
 	git: (...args: string[]) => string;
 } {
-	const parent = mkdtempSync(join(tmpdir(), "gentle-pi-snapshot-"));
+	const parent = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-snapshot-")));
 	const repository = join(parent, "repo");
 	mkdirSync(repository);
 	t.after(() => rmSync(parent, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

Twenty-two tests failed on macOS and passed on Linux CI; all twenty-two were test defects, none production.

- **Twenty-one uncanonicalized temp roots.** Tests built expected paths from `mkdtemp(join(tmpdir(), …))` without `realpath`, while production answers with the physical path: `git rev-parse`, `pwd`, and the gentle-ai binary resolve `/var` to `/private/var`, and gentle-ai's secure lock walk refuses a symlinked HOME or cwd component outright (`review store lock could not be acquired: not a directory`), which is what broke the runtime parity helper's sandbox HOME. Every temp root in the affected files is now `realpathSync(mkdtempSync(…))` / `await realpath(await mkdtemp(…))`, and the quiet-tools cwd test compares against `realpathSync("/tmp")`.
- **One tmpdir-length-dependent budget.** `tests/orchestrator-budget.test.ts` built its "controlled long assets root" on top of `tmpdir()`: a 48-character macOS tmpdir made the root 164 characters where Linux `/tmp` made it 121. The prompt declares the root once and grows one byte per root character (8107 B at a 60-character root), so the same claim measured 8211 B on macOS and under the 8192 B budget on Linux. The root is now built to an exact 128 characters on every platform, so CI and a laptop measure the same thing.

Worth knowing, not changed here: the always-on orchestrator prompt exceeds its 8192 B budget for any assets root longer than about 145 characters. That is a property of the prompt, not of this test.

## Files

`tests/codegraph-tools.test.ts`, `tests/native-review-parity.test.ts`, `tests/native-review-parity-runtime.test.ts`, `tests/quiet-tool-rendering.test.ts`, `tests/review-controller-lock-status.test.ts`, `tests/review-controller-native-routing.test.ts`, `tests/review-controller-workspace-root.test.ts`, `tests/review-controller.test.ts`, `tests/review-host-relay-restart-parity.test.ts`, `tests/review-host-relay.test.ts`, `tests/review-snapshot.test.ts`, `tests/orchestrator-budget.test.ts`.

## Verification

- `pnpm test` on macOS (arm64): 1162 tests, 1161 pass, 0 fail, 1 expected skip; provider contract mirror check passed; runtime harness passed. On clean `main` the same machine fails 22.
- No production file changes.

https://claude.ai/code/session_01434g6iQJNsDdvBTUNiC9yw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability across platforms by consistently resolving temporary and workspace paths to their canonical locations.
  - Updated path-related checks to account for environments where standard temporary directories use symlinks.
  - Strengthened coverage for workspace validation, repository handling, review workflows, and tool output.
  - Made long-path budget testing enforce the intended path length consistently across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->