### PR TITLE
fix(orchestrator): validate spaced writer surfaces

### DIFF
--- a/assets/orchestrator-delegation.md
+++ b/assets/orchestrator-delegation.md
@@ -159,7 +159,8 @@ The bounded writer refuses to write outside the exact allowed edit surfaces and 
 
 Before launching a bounded writer (`gentle-ai-worker`, a user-configured `worker`, or the native `Agent` fallback), derive the allowed edit surface from the task being delegated — the files the planned change must touch, plus the directories where the task authorizes new files — and pass it in the delegated prompt under an `## Allowed edit surfaces` heading, in the same exact-path form as `## Skills to load before work`:
 
-- exact repository-relative paths or narrow globs, one per line; never `.` and never a bare repository root;
+- exact repository-relative paths or narrow globs, one per line; never `.` and never a bare repository root; paths containing whitespace require whole-entry backticks (for example, `` `Directory With Spaces/note.md` `` or ``- `Directory With Spaces/note.md` ``); a list marker alone does not permit whitespace;
+- the section ends only at the next canonical ATX Markdown heading of any level (zero to three leading ASCII spaces, one to six `#`, then an ASCII space); every non-empty line before that heading must be a valid surface entry, so put explanatory prose under a following heading;
 - pre-existing untracked targets the writer may write, listed explicitly;
 - the directories where new files are authorized, when the task requires new files;
 - nothing beyond the delegated task — a surface wider than the task is the same defect as no surface at all.

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -516,9 +516,10 @@ function readSurfaceEntry(line: string): AllowedEditSurfaceEntry {
  * A prose line cannot terminate this section: it must fail validation instead.
  */
 function readAllowedEditSurfaceEntries(following: string): AllowedEditSurfaceEntry[] {
-	const lines = following.split(/\r?\n/).map((line) => line.replace(/ +$/g, ""));
+	const lines = following.split(/\r?\n/);
 	const headingIndex = lines.findIndex((line) => MARKDOWN_HEADING_LINE.test(line));
 	return (headingIndex === -1 ? lines : lines.slice(0, headingIndex))
+		.map((line) => line.replace(/ +$/g, ""))
 		.filter((line) => line.length > 0)
 		.map((line) => readSurfaceEntry(line.replace(/^ {0,3}/, "")));
 }

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -461,17 +461,19 @@ const SUBAGENTS_PACKAGE_NAMES = ["pi-subagents-j0k3r", "pi-subagents"] as const;
 const SUBAGENT_RUN_TOOL = "subagent_run";
 const BOUNDED_WRITER_AGENT_NAMES = ["gentle-ai-worker", "worker"] as const;
 const ALLOWED_EDIT_SURFACES_HEADING = /^## Allowed edit surfaces[ \t]*$/gim;
-const MARKDOWN_HEADING_LINE = /^#{1,6}\s/;
-const MARKDOWN_LIST_MARKER = /^(?:[-*+]|\d+[.)])\s+/;
+const MARKDOWN_HEADING_LINE = /^ {0,3}#{1,6} /;
+const MARKDOWN_LIST_MARKER = /^(?:[-*+]|\d+[.)]) +/;
 const WRITER_EDIT_SURFACE_REJECTION =
-	"Writer tasks must include the exact Markdown heading `## Allowed edit surfaces` with narrow repository-relative paths or narrow globs, one per line. The parent must derive or map that canonical block from the delegated task and relaunch the writer; do not accept aliases, and do not ask the human to author paths or globs.";
+	"Writer tasks must include the exact Markdown heading `## Allowed edit surfaces` with narrow repository-relative paths or narrow globs, one per line. Every non-empty line belongs to the section until the next canonical Markdown heading and must be a valid surface entry. Paths containing whitespace require whole-entry backticks; begin explanatory prose under the next Markdown heading. The parent must derive or map that canonical block from the delegated task and relaunch the writer; do not accept aliases, and do not ask the human to author paths or globs.";
 
-function isTaskScopedRepositoryRelativePath(value: string): boolean {
+function isTaskScopedRepositoryRelativePath(value: string, isWholeEntryBackticked: boolean): boolean {
 	const normalized = value.replace(/\\/g, "/");
 	if (
 		normalized.length === 0 ||
 		isAbsolute(value) ||
-		/^(?:[A-Za-z]:|\/|~)/.test(normalized)
+		/^(?:[A-Za-z]:|\/|~)/.test(normalized) ||
+		/\p{Cc}|\p{Zl}|\p{Zp}/u.test(normalized) ||
+		(/\p{White_Space}/u.test(normalized) && !isWholeEntryBackticked)
 	) {
 		return false;
 	}
@@ -481,7 +483,6 @@ function isTaskScopedRepositoryRelativePath(value: string): boolean {
 		withoutCurrentDirectory.length === 0 ||
 		withoutCurrentDirectory === "." ||
 		withoutCurrentDirectory.startsWith("/") ||
-		/\s/.test(withoutCurrentDirectory) ||
 		withoutCurrentDirectory.split("/").some((segment) => segment === "..")
 	) {
 		return false;
@@ -490,56 +491,36 @@ function isTaskScopedRepositoryRelativePath(value: string): boolean {
 	return !/[?*\[\]{}]/.test(withoutCurrentDirectory.split("/")[0]);
 }
 
-/** Strips a list marker and surrounding backticks off one surface line. */
-function readSurfaceEntry(line: string): string {
-	const entry = line.replace(MARKDOWN_LIST_MARKER, "");
-	return entry.match(/^`(.+)`$/)?.[1] ?? entry;
-}
+type AllowedEditSurfaceEntry = {
+	source: string;
+	value: string;
+	isWholeEntryBackticked: boolean;
+	isValidMarkdownSyntax: boolean;
+};
 
-/** A line still reads as a surface entry when nothing but a bare path is left. */
-function looksLikeSurfaceEntry(line: string): boolean {
-	return line.length > 0 && !MARKDOWN_HEADING_LINE.test(line) && !/\s/.test(readSurfaceEntry(line));
+/** Reads one entry and records whether backticks delimit the whole path. */
+function readSurfaceEntry(line: string): AllowedEditSurfaceEntry {
+	const withoutListMarker = line.replace(MARKDOWN_LIST_MARKER, "");
+	const backticked = withoutListMarker.match(/^`([^`]+)`$/);
+	return {
+		source: line,
+		value: backticked?.[1] ?? withoutListMarker,
+		isWholeEntryBackticked: backticked !== null,
+		isValidMarkdownSyntax:
+			!/^(?:[-*+]|\d+[.)])$/.test(line) && (!withoutListMarker.includes("`") || backticked !== null),
+	};
 }
 
 /**
- * Reads the surface list that follows an `## Allowed edit surfaces` heading.
- *
- * A delegated `task` is a whole prompt: the list is normally followed by deeper
- * headings (`### Validation commands`, `#### Return`) and by ordinary prose.
- * Ending the section only at `#`/`##` swallowed all of that, turned prose into
- * surface entries, and rejected valid authorizations (issue #484). A `context`
- * value carrying just the heading and its lines had nothing following it, which
- * is why the identical surfaces were accepted there.
- *
- * So the section ends at the next heading of ANY level, and prose closes the
- * list inside it. Blank lines never close it: an entry is only ever dropped
- * when nothing below it still reads as a surface entry. A line that a caller
- * could pass off as a path stays under validation instead of being discarded,
- * because discarding is what would let `/etc/passwd` sit under a blank line or
- * a paragraph and reach an accepted dispatch.
+ * Reads every non-empty line until the next Markdown heading as an edit surface.
+ * A prose line cannot terminate this section: it must fail validation instead.
  */
-function readAllowedEditSurfaceEntries(following: string): string[] {
-	const lines = following.split(/\r?\n/).map((line) => line.trim());
+function readAllowedEditSurfaceEntries(following: string): AllowedEditSurfaceEntry[] {
+	const lines = following.split(/\r?\n/).map((line) => line.replace(/ +$/g, ""));
 	const headingIndex = lines.findIndex((line) => MARKDOWN_HEADING_LINE.test(line));
-	const section = headingIndex === -1 ? lines : lines.slice(0, headingIndex);
-	const entries: string[] = [];
-
-	for (const [index, line] of section.entries()) {
-		if (line.length === 0) continue;
-		const entry = readSurfaceEntry(line);
-		if (/\s/.test(entry)) {
-			// Prose closes the list only when it is genuinely trailing. Anything
-			// below it that still reads as a path makes the section ambiguous, so
-			// every non-empty line is validated and the ambiguity is rejected.
-			if (section.slice(index + 1).some(looksLikeSurfaceEntry)) {
-				return section.filter((candidate) => candidate.length > 0).map(readSurfaceEntry);
-			}
-			break;
-		}
-		entries.push(entry);
-	}
-
-	return entries;
+	return (headingIndex === -1 ? lines : lines.slice(0, headingIndex))
+		.filter((line) => line.length > 0)
+		.map((line) => readSurfaceEntry(line.replace(/^ {0,3}/, "")));
 }
 
 function hasTaskScopedAllowedEditSurfaces(...values: unknown[]): boolean {
@@ -553,9 +534,19 @@ function hasTaskScopedAllowedEditSurfaces(...values: unknown[]): boolean {
 		for (const heading of headings) {
 			const bodyStart = (heading.index ?? 0) + heading[0].length;
 			const entries = readAllowedEditSurfaceEntries(value.slice(bodyStart));
-			if (entries.length === 0 || !entries.every(isTaskScopedRepositoryRelativePath)) return false;
+			if (
+				entries.length === 0 ||
+				!entries.every(
+					(entry) =>
+						entry.isValidMarkdownSyntax &&
+						!/\p{Cc}|\p{Zl}|\p{Zp}/u.test(entry.source) &&
+						isTaskScopedRepositoryRelativePath(entry.value, entry.isWholeEntryBackticked),
+				)
+			) {
+				return false;
+			}
 
-			const uniqueEntries = [...new Set(entries)].sort();
+			const uniqueEntries = [...new Set(entries.map((entry) => entry.value))].sort();
 			if (
 				expectedEntries &&
 				(expectedEntries.length !== uniqueEntries.length ||

--- a/tests/writer-edit-surface-scope.test.ts
+++ b/tests/writer-edit-surface-scope.test.ts
@@ -117,6 +117,21 @@ test("canonical headings close the surface section with up to three ASCII spaces
 	}
 });
 
+test("canonical empty headings with trailing spaces close the surface section", async () => {
+	for (const indentation of ["", "   "]) {
+		await assertAccepted({
+			agent: "gentle-ai-worker",
+			mode: "task",
+			task: [
+				"## Allowed edit surfaces",
+				"- `lib/sdd-status.ts`",
+				`${indentation}### `,
+				"Ordinary prose after an empty heading is not a surface entry.",
+			].join("\n"),
+		}, `${JSON.stringify(indentation)} indentation closes at an empty heading`);
+	}
+});
+
 test("pseudo-headings remain inside the surface section and reject dangerous paths", async () => {
 	for (const [label, heading] of [
 		["four-space indentation", "    ### Validation"],

--- a/tests/writer-edit-surface-scope.test.ts
+++ b/tests/writer-edit-surface-scope.test.ts
@@ -15,18 +15,18 @@ import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
 // The guard reads the `## Allowed edit surfaces` section out of the delegated
 // `subagent_run` prompt. A delegated task is a full prompt: the surfaces list
 // is followed by deeper headings (`### Validation`, `#### Return`) and by
-// ordinary prose. The section must end where the list ends, so that following
-// content is never parsed as a surface entry and never turned into a false
-// rejection. A `context` value carrying only the heading and its lines had
-// nothing following it, which is why the same surfaces were accepted there and
-// rejected in `task`.
+// ordinary prose. The section remains fail-closed through ordinary prose until
+// the next canonical Markdown heading, so following content is always parsed as
+// a surface entry rather than silently discarded. A `context` value carrying
+// only the heading and its lines had nothing following it, which is why the same
+// surfaces were accepted there and rejected in `task`.
 //
 // Every case below runs through the real `tool_call` hook with the exact
 // `subagent_run` input shape, because that is the boundary that rejected.
 // ---------------------------------------------------------------------------
 
 const REJECTION =
-	"Writer tasks must include the exact Markdown heading `## Allowed edit surfaces` with narrow repository-relative paths or narrow globs, one per line. The parent must derive or map that canonical block from the delegated task and relaunch the writer; do not accept aliases, and do not ask the human to author paths or globs.";
+	"Writer tasks must include the exact Markdown heading `## Allowed edit surfaces` with narrow repository-relative paths or narrow globs, one per line. Every non-empty line belongs to the section until the next canonical Markdown heading and must be a valid surface entry. Paths containing whitespace require whole-entry backticks; begin explanatory prose under the next Markdown heading. The parent must derive or map that canonical block from the delegated task and relaunch the writer; do not accept aliases, and do not ask the human to author paths or globs.";
 
 type ToolCallHandler = (
 	event: { toolName: string; input: unknown },
@@ -89,8 +89,8 @@ test("task-scoped surfaces are accepted ahead of a deeper heading", async () => 
 	}, "a delegated task ends its surfaces list at the next heading of any level");
 });
 
-test("task-scoped surfaces are accepted ahead of trailing prose", async () => {
-	await assertAccepted({
+test("task-scoped surfaces reject trailing prose before the next heading", async () => {
+	await assertRejected({
 		agent: "gentle-ai-worker",
 		mode: "task",
 		task: [
@@ -99,7 +99,71 @@ test("task-scoped surfaces are accepted ahead of trailing prose", async () => {
 			"",
 			"Then run the focused test file and report the outcome.",
 		].join("\n"),
-	}, "prose after the list is not a surface entry");
+	}, "trailing prose must begin under a following Markdown heading");
+});
+
+test("canonical headings close the surface section with up to three ASCII spaces", async () => {
+	for (const indentation of ["", " ", "  ", "   "]) {
+		await assertAccepted({
+			agent: "gentle-ai-worker",
+			mode: "task",
+			task: [
+				"## Allowed edit surfaces",
+				"- `lib/sdd-status.ts`",
+				`${indentation}### Validation`,
+				"node --test",
+			].join("\n"),
+		}, `${JSON.stringify(indentation)} indentation closes the section`);
+	}
+});
+
+test("pseudo-headings remain inside the surface section and reject dangerous paths", async () => {
+	for (const [label, heading] of [
+		["four-space indentation", "    ### Validation"],
+		["seven hashes", "####### Validation"],
+		["bare marker", "###"],
+		["missing heading separator", "###Validation"],
+		["tab", "###\tValidation"],
+		["vertical tab", "###\vValidation"],
+		["form feed", "###\fValidation"],
+		["bare carriage return", "###\rValidation"],
+		["NBSP", "###\u00a0Validation"],
+		["em space", "###\u2003Validation"],
+		["Ogham space", "###\u1680Validation"],
+		["line separator", "###\u2028Validation"],
+		["paragraph separator", "###\u2029Validation"],
+	] as const) {
+		await assertRejected({
+			agent: "gentle-ai-worker",
+			mode: "task",
+			task: [
+				"## Allowed edit surfaces",
+				"- `lib/sdd-status.ts`",
+				heading,
+				"/etc/passwd",
+			].join("\n"),
+		}, `${label} pseudo-heading cannot close the surface section`);
+	}
+});
+
+test("only ASCII spaces may separate Markdown list markers from entries", async () => {
+	for (const [label, separator] of [
+		["NBSP", "\u00a0"],
+		["em space", "\u2003"],
+		["Ogham space", "\u1680"],
+		["tab", "\t"],
+	] as const) {
+		await assertRejected({
+			agent: "gentle-ai-worker",
+			mode: "task",
+			task: ["## Allowed edit surfaces", `-${separator}\`lib/sdd-status.ts\``].join("\n"),
+		}, `${label} cannot separate a list marker and entry`);
+	}
+	await assertAccepted({
+		agent: "gentle-ai-worker",
+		mode: "task",
+		task: ["## Allowed edit surfaces", "- `lib/sdd-status.ts`", "1. tests/sdd-status.test.ts"].join("\n"),
+	}, "ASCII-space bullets and numbered entries remain accepted");
 });
 
 test("the documented task shape from issue #484 is accepted", async () => {
@@ -134,6 +198,14 @@ test("bullet, backtick and plain-line surfaces reach the same decision", async (
 		{ agent: "gentle-ai-worker", mode: "task", task: bulleted, context: plain },
 		"the same surfaces in both fields are accepted",
 	);
+	await assertAccepted(
+		{
+			agent: "gentle-ai-worker",
+			mode: "task",
+			task: ["## Allowed edit surfaces", "extensions/**/*.ts", "tests/*.test.ts"].join("\n"),
+		},
+		"narrow no-space globs remain accepted",
+	);
 });
 
 test("a list broken by a blank line still validates every entry", async () => {
@@ -165,17 +237,66 @@ test("an entry hidden below a paragraph is validated, not discarded", async () =
 			"Also authorize the following path.",
 			"- `/etc/passwd`",
 		].join("\n"),
-	}, "prose does not close the list while a path still follows it");
+	}, "prose cannot close the section while a path still follows it");
+});
+
+test("whitespace-bearing surfaces require whole-entry backticks", async () => {
+	const backtickedSpaced = [
+		"## Allowed edit surfaces",
+		"- `Directory With Spaces/note.md`",
+		"`Directory\u00a0With\u2003Spaces/unicode.md`",
+	];
+	const equivalentBacktickedSpaced = [
+		"## Allowed edit surfaces",
+		"`Directory With Spaces/note.md`",
+		"- `Directory\u00a0With\u2003Spaces/unicode.md`",
+	];
+
+	await assertAccepted(
+		{ agent: "gentle-ai-worker", mode: "task", task: backtickedSpaced.join("\n") },
+		"whole-entry backticked ASCII and Unicode space-separator paths are accepted",
+	);
+	await assertAccepted(
+		{ agent: "gentle-ai-worker", mode: "task", task: backtickedSpaced.join("\n"), context: equivalentBacktickedSpaced.join("\n") },
+		"task and context compare equivalent backticked whitespace-bearing paths by value",
+	);
 	await assertAccepted({
 		agent: "gentle-ai-worker",
 		mode: "task",
-		task: [
-			"## Allowed edit surfaces",
-			"- `lib/sdd-status.ts`",
-			"",
-			"Then run the focused test file and report the outcome.",
-		].join("\n"),
-	}, "genuinely trailing prose still closes the list");
+		task: [...backtickedSpaced, "### Validation", "node --test"].join("\n"),
+	}, "the next Markdown heading closes a backticked whitespace-bearing surface section");
+
+	for (const [label, entry] of [
+		["bare spaced path", "Directory With Spaces/note.md"],
+		["bare bulleted spaced path", "- Directory With Spaces/note.md"],
+		["bare NBSP path", "Directory\u00a0With Spaces/note.md"],
+		["bare em-space path", "Directory\u2003With Spaces/note.md"],
+		["U+0085 control path", "`Directory\u0085With Spaces/note.md`"],
+		["U+0085 list separator", "-\u0085`lib/sdd-status.ts`"],
+		["U+2028 line-separator path", "`Directory\u2028With Spaces/note.md`"],
+		["U+2029 paragraph-separator path", "`Directory\u2029With Spaces/note.md`"],
+		["list-marked prose", "- Then run the focused test file."],
+		["marker-only hyphen", "-"],
+		["empty backticks", "``"],
+		["unclosed backticks", "`lib/sdd-status.ts"],
+		["partially backticked path", "`lib/sdd-status.ts` trailing"],
+		["absolute spaced path", "/tmp/Outside Directory/file.md"],
+		["parent spaced path", "../Other Directory/file.md"],
+		["home spaced path", "~/Private Directory/file.md"],
+		["Windows spaced path", "C:\\Outside Directory\\file.md"],
+		["dangerous backticked bullet", "- `/tmp/Outside Directory/file.md`"],
+	] as const) {
+		await assertRejected({
+			agent: "gentle-ai-worker",
+			mode: "task",
+			task: ["## Allowed edit surfaces", "lib/sdd-status.ts", entry].join("\n"),
+		}, `${label} after a valid entry is rejected`);
+		await assertRejected({
+			agent: "gentle-ai-worker",
+			mode: "task",
+			task: ["## Allowed edit surfaces", entry, "lib/sdd-status.ts"].join("\n"),
+		}, `${label} before a valid entry is rejected`);
+	}
 });
 
 test("out-of-scope and empty surfaces stay rejected", async () => {


### PR DESCRIPTION
Closes Gentleman-Programming/gentle-pi#549

## Summary

- accepts repository-relative edit surfaces containing whitespace when the complete path is backtick-delimited
- validates every non-empty surface line until a canonical ATX heading instead of silently truncating at prose or ambiguous whitespace
- hardens heading and list parsing against Unicode/control separators, indented code blocks, malformed Markdown, and dangerous path ordering

## Root cause and security impact

The writer-surface parser treated whitespace-bearing lines as trailing prose. A single legitimate path containing spaces was rejected, but a valid no-space prefix followed by a terminal spaced entry was admitted after validating only the prefix. The original unchanged prompt then reached a worker that treats the full `## Allowed edit surfaces` section as authoritative.

This change makes the parser fail closed. Paths containing whitespace require whole-entry backticks, every non-empty line remains in scope until the next canonical heading, and absolute, traversal, home-relative, Windows-drive, UNC, malformed, and control-bearing entries remain rejected.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Implements fail-closed surface parsing and canonical Markdown boundaries. |
| `tests/writer-edit-surface-scope.test.ts` | Adds spaced-path, Unicode, malformed syntax, ordering, and pseudo-heading regression coverage. |
| `assets/orchestrator-delegation.md` | Documents the canonical backtick and heading requirements. |

## Test plan

- [x] `node --experimental-strip-types --test tests/writer-edit-surface-scope.test.ts` — 13/13 passed
- [x] Real registered-hook matrix — 1,584/1,584 cases passed
- [x] `pnpm test` — 1,158 passed, 10 expected skips, 0 failed
- [x] `pnpm run check:provider-contract`
- [x] `pnpm run test:harness`
- [x] `pnpm run check:runtime-modules`
- [x] `git diff --check`

## Review workload

269 changed lines across three files. This is one cohesive parser contract, documentation, and regression-test work unit; no chained PR is needed.

## Contributor checklist

- [x] Linked approved issue #549
- [x] Exactly one `type:*` label: `type:bug`
- [x] Tests and documentation are included with the behavior change
- [x] Shellcheck is not applicable; no shell scripts changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of allowed edit-surface entries.
  * Entries containing whitespace must now be wrapped in backticks.
  * Invalid formatting, prose, control characters, and unsupported list markers are rejected.
  * Sections now end only at the next canonical Markdown heading.
  * List markers require supported spacing and formatting.
  * Added clearer rejection messages and expanded coverage for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->