### PR TITLE
feat(review): split concurrent reviewer transport

### DIFF
--- a/lib/review-host-relay.ts
+++ b/lib/review-host-relay.ts
@@ -284,7 +284,18 @@ export interface ReviewHostRelayResult {
 	readonly submission: string;
 }
 
+/** Opaque materialize-and-review result, not yet submitted to the provider. */
+export interface ReviewHostRelayPreparedResult {
+	/** Copy-safe request snapshot captured before materialization starts. */
+	readonly request: ReviewHostRelayRequest;
+	readonly promptByteLength: number;
+	readonly resultByteLength: number;
+	readonly resultBytes: Buffer;
+}
+
 export type ReviewHostRelayRunner = (request: ReviewHostRelayRequest) => Promise<ReviewHostRelayResult>;
+export type ReviewHostRelayPreparationRunner = (request: ReviewHostRelayRequest) => Promise<ReviewHostRelayPreparedResult>;
+export type ReviewHostRelaySubmissionRunner = (prepared: ReviewHostRelayPreparedResult) => Promise<ReviewHostRelayResult>;
 
 const DEFAULT_GENTLE_AI_TIMEOUT_MS = 120_000;
 
@@ -442,38 +453,54 @@ function assertTokens(name: string, tokens: readonly string[]): void {
 	}
 }
 
-/**
- * Runs one complete host-relay capture for one provider-bound slot:
- * materialize → opaque Pi adapter → submit. Throws a typed
- * {@link ReviewHostRelayError} on every failure leg and submits nothing after
- * a failure; the caller re-queries negotiated STATUS instead of retrying.
- */
-export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): Promise<ReviewHostRelayResult> {
+function snapshotReviewHostRelayRequest(request: ReviewHostRelayRequest): ReviewHostRelayRequest {
 	assertTokens("capture", request.captureArgumentTokens);
-	// The completing form is validated before any process launches: a
-	// materialize slot without a provider-owned submission is a typed
-	// contract mismatch, never a synthesized invocation.
-	const submissionBinding = resolveReviewHostRelaySubmission(request.submission);
-	const gentleAi = request.gentleAiExecutable ?? resolveGentleAiBinary();
-	if (!isAbsolute(gentleAi)) throw new TypeError("Pi host relay requires an absolute gentle-ai executable path");
-	const baseEnvironment = request.environment ?? process.env;
-	// Every gentle-ai invocation the relay makes carries the handshake; the
-	// pi subprocess environment stays exactly as the user configured it.
-	const gentleAiEnvironment = { ...baseEnvironment, [GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV]: GENTLE_PI_REVIEW_RELAY_CONTRACT };
-	const gentleAiTimeoutMs = request.gentleAiTimeoutMs ?? DEFAULT_GENTLE_AI_TIMEOUT_MS;
-	const targetCwd = request.targetCwd ?? process.cwd();
+	// The completing form is validated before any process launches: a materialize
+	// slot without a provider-owned submission is a typed contract mismatch,
+	// never a synthesized invocation.
+	resolveReviewHostRelaySubmission(request.submission);
+	const gentleAiExecutable = request.gentleAiExecutable ?? resolveGentleAiBinary();
+	if (!isAbsolute(gentleAiExecutable)) throw new TypeError("Pi host relay requires an absolute gentle-ai executable path");
+	const environment = Object.freeze({ ...(request.environment ?? process.env) }) as NodeJS.ProcessEnv;
+	const submission = request.submission === undefined ? undefined : Object.freeze({
+		operationToken: request.submission.operationToken,
+		argumentTokens: Object.freeze([...request.submission.argumentTokens]),
+		values: Object.freeze(request.submission.values.map((value) => Object.freeze({ ...value }))),
+	});
+	return Object.freeze({
+		...request,
+		captureArgumentTokens: Object.freeze([...request.captureArgumentTokens]),
+		...(submission === undefined ? {} : { submission }),
+		gentleAiExecutable,
+		environment,
+		gentleAiTimeoutMs: request.gentleAiTimeoutMs ?? DEFAULT_GENTLE_AI_TIMEOUT_MS,
+		targetCwd: request.targetCwd ?? process.cwd(),
+	});
+}
 
-	// (a) Materialize the Go-issued opaque prompt. This invocation is also the
-	// capability detection: an old binary's unknown-flag refusal proves the
-	// relay surface is absent, and the provider's handshake refusal surfaces
-	// verbatim. No version sniffing.
+/**
+ * Materializes one provider-bound reviewer prompt and runs its opaque Pi
+ * subprocess. It does not submit anything, so independent reviewer work can
+ * finish before the caller performs provider-ordered admission.
+ */
+export async function prepareReviewHostRelaySlot(
+	request: ReviewHostRelayRequest,
+	reviewer: typeof runOpaquePiReviewer = runOpaquePiReviewer,
+): Promise<ReviewHostRelayPreparedResult> {
+	// Copy mutable transport configuration before the first async boundary. The
+	// supplied AbortSignal intentionally stays live across materialize, reviewer,
+	// and submit, preserving the established cancellation behavior.
+	const preparedRequest = snapshotReviewHostRelayRequest(request);
+
+	// The provider materializes the opaque prompt and detects whether this relay
+	// surface is available. No version sniffing or prompt reconstruction occurs.
 	let materialized: ProcessCapture;
 	try {
-		materialized = await collectGentleAiProcess(gentleAi, ["review", "capture-result", ...request.captureArgumentTokens], {
-			cwd: targetCwd,
-			env: gentleAiEnvironment,
-			timeoutMs: gentleAiTimeoutMs,
-			...(request.signal === undefined ? {} : { signal: request.signal }),
+		materialized = await collectGentleAiProcess(preparedRequest.gentleAiExecutable!, ["review", "capture-result", ...preparedRequest.captureArgumentTokens], {
+			cwd: preparedRequest.targetCwd!,
+			env: { ...preparedRequest.environment!, [GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV]: GENTLE_PI_REVIEW_RELAY_CONTRACT },
+			timeoutMs: preparedRequest.gentleAiTimeoutMs!,
+			...(preparedRequest.signal === undefined ? {} : { signal: preparedRequest.signal }),
 		});
 	} catch (error) {
 		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.MATERIALIZE_FAILED, "materialize", `gentle-ai prompt materialization could not start: ${error instanceof Error ? error.message : String(error)}`);
@@ -481,45 +508,88 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 	if (materialized.exitCode !== 0 || materialized.timedOut) {
 		const stderr = materialized.stderr.toString("utf8");
 		const refusal = classifyReviewHostRelayRefusal(stderr);
-		const timing = { elapsedMs: materialized.elapsedMs, timeoutMs: gentleAiTimeoutMs };
+		const timing = { elapsedMs: materialized.elapsedMs, timeoutMs: preparedRequest.gentleAiTimeoutMs! };
 		if (refusal === "unknown-flag") {
-			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE, "materialize", REVIEW_HOST_RELAY_UNAVAILABLE_MESSAGE, { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut, ...timing });
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.RELAY_UNAVAILABLE, "materialize", REVIEW_HOST_RELAY_UNAVAILABLE_MESSAGE, {
+				exitCode: materialized.exitCode,
+				stderr,
+				timedOut: materialized.timedOut,
+				...timing,
+			});
 		}
 		if (refusal === "handshake") {
-			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.HANDSHAKE_REFUSED, "materialize", stderr, { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut, ...timing });
+			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.HANDSHAKE_REFUSED, "materialize", stderr, {
+				exitCode: materialized.exitCode,
+				stderr,
+				timedOut: materialized.timedOut,
+				...timing,
+			});
 		}
 		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.MATERIALIZE_FAILED, "materialize", materialized.timedOut
-			? `gentle-ai prompt materialization exceeded its ${gentleAiTimeoutMs}ms bound after ${materialized.elapsedMs}ms`
+			? `gentle-ai prompt materialization exceeded its ${preparedRequest.gentleAiTimeoutMs!}ms bound after ${materialized.elapsedMs}ms`
 			: "gentle-ai prompt materialization failed", { exitCode: materialized.exitCode, stderr, timedOut: materialized.timedOut, ...timing });
 	}
 	const promptBytes = materialized.stdout;
 	if (promptBytes.length === 0) {
-		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.EMPTY_PROMPT, "materialize", "gentle-ai prompt materialization produced no bytes", { exitCode: 0, stderr: materialized.stderr.toString("utf8"), elapsedMs: materialized.elapsedMs, timeoutMs: gentleAiTimeoutMs });
+		throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.EMPTY_PROMPT, "materialize", "gentle-ai prompt materialization produced no bytes", {
+			exitCode: 0,
+			stderr: materialized.stderr.toString("utf8"),
+			elapsedMs: materialized.elapsedMs,
+			timeoutMs: preparedRequest.gentleAiTimeoutMs!,
+		});
 	}
 	// The reviewer bound is derived from the prompt the provider actually
-	// materialized, so it can only be resolved here. An explicit request
-	// timeout (the test seam) still wins over both the override and the scale.
-	const piTimeoutMs = request.piTimeoutMs ?? resolveReviewHostRelayPiTimeoutMs(promptBytes.length, baseEnvironment);
+	// materialized. The explicit request timeout is a test seam that wins over
+	// both the user-owned environment override and the scale-derived bound.
+	const piTimeoutMs = preparedRequest.piTimeoutMs ?? resolveReviewHostRelayPiTimeoutMs(promptBytes.length, preparedRequest.environment);
 
-	// (b) The pure adapter owns the fresh isolated Pi process. Its input and
-	// output are opaque bytes; this coordinator only maps transport failures to
-	// the established relay boundary.
+	// The pure adapter owns the fresh isolated Pi process. Its input and output
+	// are opaque bytes; this coordinator only maps transport failures.
 	let piResult: OpaquePiReviewerResult;
 	try {
-		piResult = await runOpaquePiReviewer(promptBytes, {
-			...(request.piExecutable === undefined ? {} : { piExecutable: request.piExecutable }),
-			environment: baseEnvironment,
+		piResult = await reviewer(promptBytes, {
+			...(preparedRequest.piExecutable === undefined ? {} : { piExecutable: preparedRequest.piExecutable }),
+			environment: preparedRequest.environment,
 			timeoutMs: piTimeoutMs,
-			...(request.signal === undefined ? {} : { signal: request.signal }),
+			...(preparedRequest.signal === undefined ? {} : { signal: preparedRequest.signal }),
 		});
 	} catch (error) {
 		throw relayPiTransportError(error, promptBytes.length, piTimeoutMs);
 	}
-	const resultBytes = piResult.stdout;
+	return {
+		request: preparedRequest,
+		promptByteLength: promptBytes.length,
+		resultByteLength: piResult.stdoutByteLength,
+		resultBytes: Buffer.from(piResult.stdout),
+	};
+}
 
-	// (c) Submit the raw final bytes untouched through the provider-owned
-	// completing form: its exact operation and argument tokens, with only the
-	// artifact path substituted into the declared {{value}} slot.
+/**
+ * Starts every reviewer before awaiting any result. If one or more reviewers
+ * fail, it rejects only after every started transport has settled and reports
+ * the earliest failed request in provider order.
+ */
+export async function runReviewHostRelayReviewerGroup(
+	requests: readonly ReviewHostRelayRequest[],
+	prepare: ReviewHostRelayPreparationRunner = prepareReviewHostRelaySlot,
+): Promise<readonly ReviewHostRelayPreparedResult[]> {
+	if (requests.length === 0) {
+		throw new TypeError("Pi host relay reviewer group requires at least one provider-bound request");
+	}
+	const settled = await Promise.allSettled(requests.map(async (request) => await prepare(request)));
+	const failed = settled.find((result) => result.status === "rejected");
+	if (failed?.status === "rejected") throw failed.reason;
+	return settled.map((result) => (result as PromiseFulfilledResult<ReviewHostRelayPreparedResult>).value);
+}
+
+/**
+ * Submits one already-reviewed opaque result through the exact provider-owned
+ * completing form. Only the provider-declared artifact slot is substituted.
+ */
+export async function submitReviewHostRelayPreparedResult(prepared: ReviewHostRelayPreparedResult): Promise<ReviewHostRelayResult> {
+	const { request, resultBytes } = prepared;
+	assertTokens("capture", request.captureArgumentTokens);
+	const submissionBinding = resolveReviewHostRelaySubmission(request.submission);
 	const stagingDirectory = await mkdtemp(join(tmpdir(), "gentle-pi-host-relay-result-"));
 	let primaryFailure = false;
 	try {
@@ -528,14 +598,16 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 		await writeFile(resultFile, resultBytes, { mode: 0o600 });
 		await chmod(resultFile, 0o600);
 		const submitTokens = submissionBinding.argumentTokens.map((token, index) =>
-			index === submissionBinding.substitutionLocation ? token.split(REVIEW_HOST_RELAY_SUBMISSION_VALUE_SLOT).join(resultFile) : token,
+			index === submissionBinding.substitutionLocation
+				? token.split(REVIEW_HOST_RELAY_SUBMISSION_VALUE_SLOT).join(resultFile)
+				: token,
 		);
 		let submission: ProcessCapture;
 		try {
-			submission = await collectGentleAiProcess(gentleAi, ["review", submissionBinding.operationToken, ...submitTokens], {
-				cwd: targetCwd,
-				env: gentleAiEnvironment,
-				timeoutMs: gentleAiTimeoutMs,
+			submission = await collectGentleAiProcess(request.gentleAiExecutable!, ["review", submissionBinding.operationToken, ...submitTokens], {
+				cwd: request.targetCwd!,
+				env: { ...request.environment!, [GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV]: GENTLE_PI_REVIEW_RELAY_CONTRACT },
+				timeoutMs: request.gentleAiTimeoutMs!,
 				...(request.signal === undefined ? {} : { signal: request.signal }),
 			});
 		} catch (error) {
@@ -543,20 +615,22 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 		}
 		if (submission.exitCode !== 0 || submission.timedOut || submission.stdout.length === 0) {
 			const stderr = submission.stderr.toString("utf8");
-			const details = { exitCode: submission.exitCode, stderr, timedOut: submission.timedOut, elapsedMs: submission.elapsedMs, timeoutMs: gentleAiTimeoutMs };
-			// A typed admission refusal is a proven non-mutation whose reason is
-			// the refusal text itself; everything else that launched (timeout,
-			// signal, untyped exit) stays unknown pending STATUS.
+			const details = { exitCode: submission.exitCode, stderr, timedOut: submission.timedOut, elapsedMs: submission.elapsedMs, timeoutMs: request.gentleAiTimeoutMs! };
+			// A typed admission refusal proves the provider consumed no slot.
+			// Every other launched submission stays unknown pending fresh STATUS.
 			if (isReviewHostRelayAdmissionRefusal(submission, stderr)) {
-				throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", stderr.trim(), { ...details, mutationOutcome: "none" });
+				throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", stderr.trim(), {
+					...details,
+					mutationOutcome: "none",
+				});
 			}
 			throw new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit", submission.timedOut
-				? `gentle-ai capture submission exceeded its ${gentleAiTimeoutMs}ms bound after ${submission.elapsedMs}ms`
+				? `gentle-ai capture submission exceeded its ${request.gentleAiTimeoutMs!}ms bound after ${submission.elapsedMs}ms`
 				: "gentle-ai refused the relayed capture submission", details);
 		}
 		return {
-			promptByteLength: promptBytes.length,
-			resultByteLength: piResult.stdoutByteLength,
+			promptByteLength: prepared.promptByteLength,
+			resultByteLength: prepared.resultByteLength,
 			submission: submission.stdout.toString("utf8"),
 		};
 	} catch (error) {
@@ -575,4 +649,12 @@ export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): P
 			}
 		}
 	}
+}
+
+/**
+ * Compatibility one-binding path: materialize → opaque Pi adapter → submit.
+ * It preserves the established API and its typed failure behavior exactly.
+ */
+export async function runReviewHostRelaySlot(request: ReviewHostRelayRequest): Promise<ReviewHostRelayResult> {
+	return await submitReviewHostRelayPreparedResult(await prepareReviewHostRelaySlot(request));
 }

--- a/lib/review-host-relay.ts
+++ b/lib/review-host-relay.ts
@@ -290,8 +290,9 @@ export interface ReviewHostRelayPreparedResult {
 	readonly request: ReviewHostRelayRequest;
 	readonly promptByteLength: number;
 	readonly resultByteLength: number;
-	readonly resultBytes: Buffer;
 }
+
+const preparedResultBytes = new WeakMap<ReviewHostRelayPreparedResult, Buffer>();
 
 export type ReviewHostRelayRunner = (request: ReviewHostRelayRequest) => Promise<ReviewHostRelayResult>;
 export type ReviewHostRelayPreparationRunner = (request: ReviewHostRelayRequest) => Promise<ReviewHostRelayPreparedResult>;
@@ -556,12 +557,13 @@ export async function prepareReviewHostRelaySlot(
 	} catch (error) {
 		throw relayPiTransportError(error, promptBytes.length, piTimeoutMs);
 	}
-	return {
+	const prepared = Object.freeze({
 		request: preparedRequest,
 		promptByteLength: promptBytes.length,
 		resultByteLength: piResult.stdoutByteLength,
-		resultBytes: Buffer.from(piResult.stdout),
-	};
+	});
+	preparedResultBytes.set(prepared, Buffer.from(piResult.stdout));
+	return prepared;
 }
 
 /**
@@ -587,7 +589,9 @@ export async function runReviewHostRelayReviewerGroup(
  * completing form. Only the provider-declared artifact slot is substituted.
  */
 export async function submitReviewHostRelayPreparedResult(prepared: ReviewHostRelayPreparedResult): Promise<ReviewHostRelayResult> {
-	const { request, resultBytes } = prepared;
+	const resultBytes = preparedResultBytes.get(prepared);
+	if (resultBytes === undefined) throw new TypeError("Pi host relay requires a recognized prepared result");
+	const { request } = prepared;
 	assertTokens("capture", request.captureArgumentTokens);
 	const submissionBinding = resolveReviewHostRelaySubmission(request.submission);
 	const stagingDirectory = await mkdtemp(join(tmpdir(), "gentle-pi-host-relay-result-"));

--- a/tests/review-host-relay.test.ts
+++ b/tests/review-host-relay.test.ts
@@ -383,7 +383,7 @@ test("preparation snapshots mutable submission tokens and values before material
 	assert.deepEqual(readFileSync(fixture.submitCapturePath), PI_OUTPUT_BYTES);
 });
 
-test("preparation detaches reviewer bytes before deferred submission", async (t) => {
+test("preparation keeps reviewer bytes private through deferred submission", async (t) => {
 	const fixture = harness(t);
 	const reviewerBytes = Buffer.from(PI_OUTPUT_BYTES);
 	const prepared = await prepareReviewHostRelaySlot(relayRequest(fixture), async () => ({
@@ -392,8 +392,15 @@ test("preparation detaches reviewer bytes before deferred submission", async (t)
 		stdoutByteLength: reviewerBytes.length,
 	}));
 	reviewerBytes.fill(0);
+	const mutablePrepared = prepared as unknown as { resultBytes?: Buffer };
+	mutablePrepared.resultBytes?.fill(0);
+	assert.throws(() => { mutablePrepared.resultBytes = Buffer.from("fabricated"); }, TypeError);
 	await submitReviewHostRelayPreparedResult(prepared);
 	assert.deepEqual(readFileSync(fixture.submitCapturePath), PI_OUTPUT_BYTES);
+
+	const fabricated = { ...prepared, resultBytes: Buffer.from("fabricated") } as unknown as ReviewHostRelayPreparedResult;
+	await assert.rejects(submitReviewHostRelayPreparedResult(fabricated), /recognized prepared result/);
+	assert.equal(readLog(fixture.logPath).length, 2, "unrecognized results must not launch provider submission");
 });
 
 test("the supplied AbortSignal stays live through deferred submission", async (t) => {
@@ -438,7 +445,6 @@ test("four reviewer results retain provider order when their preparation resolve
 			request,
 			promptByteLength: index + 1,
 			resultByteLength: index + 1,
-			resultBytes: Buffer.from(REVIEWER_GROUP_LENSES[index]!),
 		}));
 	}));
 
@@ -446,7 +452,7 @@ test("four reviewer results retain provider order when their preparation resolve
 	for (const finish of [...complete].reverse()) finish();
 	const prepared = await group;
 
-	assert.deepEqual(prepared.map((result) => result.resultBytes.toString("utf8")), REVIEWER_GROUP_LENSES);
+	assert.deepEqual(prepared.map((result) => result.resultByteLength), [1, 2, 3, 4]);
 });
 
 test("partial reviewer failures wait for a later pending transport and report the first provider-ordered error", async (t) => {
@@ -468,7 +474,6 @@ test("partial reviewer failures wait for a later pending transport and report th
 					request,
 					promptByteLength: index + 1,
 					resultByteLength: index + 1,
-					resultBytes: Buffer.from(REVIEWER_GROUP_LENSES[index]!),
 				});
 			});
 		}
@@ -476,7 +481,6 @@ test("partial reviewer failures wait for a later pending transport and report th
 			request,
 			promptByteLength: index + 1,
 			resultByteLength: index + 1,
-			resultBytes: Buffer.from(REVIEWER_GROUP_LENSES[index]!),
 		});
 	});
 	void group.then(() => { groupSettled = true; }, () => { groupSettled = true; });

--- a/tests/review-host-relay.test.ts
+++ b/tests/review-host-relay.test.ts
@@ -18,7 +18,12 @@ import {
 	resolveReviewHostRelayPiTimeoutMs,
 	resolveReviewHostRelaySubmission,
 	reviewHostRelaySlots,
+	prepareReviewHostRelaySlot,
+	runReviewHostRelayReviewerGroup,
 	runReviewHostRelaySlot,
+	submitReviewHostRelayPreparedResult,
+	type ReviewHostRelayPreparedResult,
+	type ReviewHostRelayRequest,
 } from "../lib/review-host-relay.ts";
 import { GENTLE_PI_REVIEW_RELAY_CONTRACT, GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV } from "../lib/review-relay-contract.ts";
 import { decodeReviewNextTransitionV3, type ReviewCaptureSubmissionV1, type ReviewCollectInputV3 } from "../lib/review-integration-v2.ts";
@@ -47,6 +52,8 @@ const inputToken = argv.find((token) => token === "--input" || token.startsWith(
 if (inputToken !== undefined) {
 	const mode = process.env.RELAY_FAKE_SUBMIT_MODE || "ok";
 	const inputPath = inputToken.startsWith("--input=") ? inputToken.slice("--input=".length) : argv[argv.indexOf("--input") + 1];
+	const submitDelayMs = Number(process.env.RELAY_FAKE_SUBMIT_DELAY_MS || "0");
+	if (Number.isSafeInteger(submitDelayMs) && submitDelayMs > 0) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, submitDelayMs);
 	if (mode === "ok" || mode === "cleanup-fail") {
 		const bytes = fs.readFileSync(inputPath);
 		if (process.env.RELAY_FAKE_SUBMIT_CAPTURE) fs.writeFileSync(process.env.RELAY_FAKE_SUBMIT_CAPTURE, bytes);
@@ -95,13 +102,32 @@ process.stdin.on("data", (chunk) => chunks.push(chunk));
 process.stdin.on("end", () => {
 	const stdin = Buffer.concat(chunks);
 	if (process.env.RELAY_FAKE_PI_STDIN_CAPTURE) fs.writeFileSync(process.env.RELAY_FAKE_PI_STDIN_CAPTURE, stdin);
-	const mode = process.env.RELAY_FAKE_PI_MODE || "ok";
-	if (process.env.RELAY_FAKE_PI_BREAK_CLEANUP === "true") fs.chmodSync(path.dirname(process.cwd()), 0o500);
-	if (mode === "ok") { process.stdout.write(Buffer.from(process.env.RELAY_FAKE_PI_OUTPUT_B64 || "", "base64")); process.exit(0); }
-	if (mode === "empty") process.exit(0);
-	if (mode === "hang") { setTimeout(() => process.exit(0), 10_000); return; }
-	process.stderr.write("pi exploded\\n");
-	process.exit(4);
+	const finish = () => {
+		const mode = process.env.RELAY_FAKE_PI_MODE || "ok";
+		if (process.env.RELAY_FAKE_PI_BREAK_CLEANUP === "true") fs.chmodSync(path.dirname(process.cwd()), 0o500);
+		if (mode === "ok") { process.stdout.write(Buffer.from(process.env.RELAY_FAKE_PI_OUTPUT_B64 || "", "base64")); process.exit(0); }
+		if (mode === "empty") process.exit(0);
+		if (mode === "hang") { setTimeout(() => process.exit(0), 10_000); return; }
+		process.stderr.write("pi exploded\\n");
+		process.exit(4);
+	};
+	const barrierDirectory = process.env.RELAY_FAKE_PI_BARRIER_DIR;
+	if (barrierDirectory === undefined) { finish(); return; }
+	fs.mkdirSync(barrierDirectory, { recursive: true });
+	fs.writeFileSync(path.join(barrierDirectory, String(process.pid)), "started");
+	const expected = Number(process.env.RELAY_FAKE_PI_BARRIER_COUNT || "4");
+	const deadline = Date.now() + 1_000;
+	const releaseFile = process.env.RELAY_FAKE_PI_RELEASE_FILE;
+	const waitForGroup = () => {
+		if (fs.readdirSync(barrierDirectory).length < expected) {
+			if (Date.now() >= deadline) { process.stderr.write("reviewer barrier timed out\\n"); process.exit(5); return; }
+			setTimeout(waitForGroup, 10);
+			return;
+		}
+		if (releaseFile !== undefined && !fs.existsSync(releaseFile)) { setTimeout(waitForGroup, 10); return; }
+		finish();
+	};
+	waitForGroup();
 });
 `;
 
@@ -151,6 +177,14 @@ function readLog(path: string): Array<{ argv: string[]; contract: string | null;
 	return readFileSync(path, "utf8").split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line));
 }
 
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (condition()) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+	}
+	throw new Error(message);
+}
+
 const BINDING_TOKENS = Object.freeze([
 	"--lineage=review-1d5aadacc600e167",
 	`--expected-revision=sha256:${"c".repeat(64)}`,
@@ -161,6 +195,7 @@ const BINDING_TOKENS = Object.freeze([
 	`--subject-hash=sha256:${"a".repeat(64)}`,
 ]);
 const CAPTURE_TOKENS = Object.freeze([...BINDING_TOKENS, "--agent=pi", "--materialize=true"]);
+const REVIEWER_GROUP_LENSES = ["review-risk", "review-resilience", "review-readability", "review-reliability"] as const;
 
 // The provider-owned completing form: exact operation and argument tokens
 // with one declared {{value}} substitution slot for the artifact path.
@@ -199,6 +234,20 @@ function relayRequest(fixture: RelayHarness, overrides: Record<string, unknown> 
 		...overrides,
 	};
 }
+
+function reviewerGroupRequests(fixture: RelayHarness): ReviewHostRelayRequest[] {
+	return REVIEWER_GROUP_LENSES.map((lens, order) => relayRequest(fixture, {
+		captureArgumentTokens: CAPTURE_TOKENS.map((token) => token === "--lens=review-reliability"
+			? `--lens=${lens}`
+			: token === "--order=0" ? `--order=${order}` : token),
+		environment: {
+			...fixture.environment,
+			RELAY_FAKE_PROMPT_B64: PROMPT_BYTES.toString("base64"),
+			RELAY_FAKE_PI_OUTPUT_B64: PI_OUTPUT_BYTES.toString("base64"),
+		},
+	}));
+}
+
 
 async function rejectsWithRelayError(promise: Promise<unknown>, kind: string, stage: string): Promise<ReviewHostRelayError> {
 	let caught: ReviewHostRelayError | undefined;
@@ -303,6 +352,141 @@ test("the pi lockdown argv is pinned exactly with no model or provider selection
 	assert.deepEqual([...REVIEW_HOST_RELAY_PI_ARGV], expected);
 	assert.deepEqual(piCalls[0]!.argv, expected);
 	assert.equal(piCalls[0]!.argv.some((token) => token.startsWith("--model") || token.startsWith("--provider") || token.startsWith("--profile")), false);
+});
+
+test("preparation snapshots mutable submission tokens and values before materialization", async (t) => {
+	const fixture = harness(t);
+	const barrierDirectory = join(fixture.directory, "submission-snapshot-barrier");
+	const releaseFile = join(fixture.directory, "submission-snapshot-release");
+	const submissionTokens = [...SUBMISSION.argumentTokens];
+	const submissionValues = SUBMISSION.values.map((value) => ({ ...value }));
+	const submission: ReviewCaptureSubmissionV1 = { ...SUBMISSION, argumentTokens: submissionTokens, values: submissionValues };
+	const prepared = prepareReviewHostRelaySlot(relayRequest(fixture, {
+		submission,
+		environment: {
+			...fixture.environment,
+			RELAY_FAKE_PROMPT_B64: PROMPT_BYTES.toString("base64"),
+			RELAY_FAKE_PI_OUTPUT_B64: PI_OUTPUT_BYTES.toString("base64"),
+			RELAY_FAKE_PI_BARRIER_DIR: barrierDirectory,
+			RELAY_FAKE_PI_BARRIER_COUNT: "1",
+			RELAY_FAKE_PI_RELEASE_FILE: releaseFile,
+		},
+	}));
+	await waitFor(() => readLog(fixture.piLogPath).length === 1, "reviewer did not reach the snapshot barrier");
+	submissionTokens[submissionTokens.length - 1] = "--input=mutated";
+	submissionValues[0]!.slot = "mutated";
+	writeFileSync(releaseFile, "release");
+
+	const result = await prepared;
+	assert.deepEqual(result.request.submission, SUBMISSION);
+	await submitReviewHostRelayPreparedResult(result);
+	assert.deepEqual(readFileSync(fixture.submitCapturePath), PI_OUTPUT_BYTES);
+});
+
+test("preparation detaches reviewer bytes before deferred submission", async (t) => {
+	const fixture = harness(t);
+	const reviewerBytes = Buffer.from(PI_OUTPUT_BYTES);
+	const prepared = await prepareReviewHostRelaySlot(relayRequest(fixture), async () => ({
+		stdout: reviewerBytes,
+		promptByteLength: PROMPT_BYTES.length,
+		stdoutByteLength: reviewerBytes.length,
+	}));
+	reviewerBytes.fill(0);
+	await submitReviewHostRelayPreparedResult(prepared);
+	assert.deepEqual(readFileSync(fixture.submitCapturePath), PI_OUTPUT_BYTES);
+});
+
+test("the supplied AbortSignal stays live through deferred submission", async (t) => {
+	const fixture = harness(t, { RELAY_FAKE_SUBMIT_DELAY_MS: "1000" });
+	const controller = new AbortController();
+	const prepared = await prepareReviewHostRelaySlot(relayRequest(fixture, { signal: controller.signal }));
+	const submission = submitReviewHostRelayPreparedResult(prepared);
+	await waitFor(() => readLog(fixture.logPath).length === 2, "submission did not start");
+	controller.abort();
+	await rejectsWithRelayError(submission, REVIEW_HOST_RELAY_FAILURE.SUBMISSION_REFUSED, "submit");
+});
+
+test("four reviewers cross a shared barrier before any result submission can begin", async (t) => {
+	const fixture = harness(t);
+	const barrierDirectory = join(fixture.directory, "reviewer-barrier");
+	const requests = reviewerGroupRequests(fixture).map((request) => ({
+		...request,
+		environment: {
+			...request.environment,
+			RELAY_FAKE_PI_BARRIER_DIR: barrierDirectory,
+			RELAY_FAKE_PI_BARRIER_COUNT: String(REVIEWER_GROUP_LENSES.length),
+		},
+	}));
+
+	const prepared = await runReviewHostRelayReviewerGroup(requests);
+
+	assert.equal(prepared.length, REVIEWER_GROUP_LENSES.length);
+	assert.ok(prepared.every((result) => result.resultByteLength === PI_OUTPUT_BYTES.length));
+	assert.equal(readLog(fixture.piLogPath).length, REVIEWER_GROUP_LENSES.length);
+	assert.equal(readLog(fixture.logPath).length, REVIEWER_GROUP_LENSES.length, "preparation materializes only; it does not submit");
+});
+
+test("four reviewer results retain provider order when their preparation resolves in reverse", async (t) => {
+	const requests = reviewerGroupRequests(harness(t));
+	const started: number[] = [];
+	const complete: Array<() => void> = [];
+	const group = runReviewHostRelayReviewerGroup(requests, (request) => new Promise<ReviewHostRelayPreparedResult>((resolve) => {
+		const index = requests.indexOf(request);
+		assert.notEqual(index, -1);
+		started.push(index);
+		complete.push(() => resolve({
+			request,
+			promptByteLength: index + 1,
+			resultByteLength: index + 1,
+			resultBytes: Buffer.from(REVIEWER_GROUP_LENSES[index]!),
+		}));
+	}));
+
+	assert.deepEqual(started, [0, 1, 2, 3], "every reviewer starts before the group waits");
+	for (const finish of [...complete].reverse()) finish();
+	const prepared = await group;
+
+	assert.deepEqual(prepared.map((result) => result.resultBytes.toString("utf8")), REVIEWER_GROUP_LENSES);
+});
+
+test("partial reviewer failures wait for a later pending transport and report the first provider-ordered error", async (t) => {
+	const requests = reviewerGroupRequests(harness(t));
+	const started: number[] = [];
+	let groupSettled = false;
+	let releaseLaterReviewer: (() => void) | undefined, rejectFirstProvider: ((reason?: unknown) => void) | undefined;
+	const firstProviderError = new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_FAILED, "pi", "first provider error");
+
+	const group = runReviewHostRelayReviewerGroup(requests, (request) => {
+		const index = requests.indexOf(request);
+		assert.notEqual(index, -1);
+		started.push(index);
+		if (index === 1) return new Promise<ReviewHostRelayPreparedResult>((_resolve, reject) => { rejectFirstProvider = reject; });
+		if (index === 2) return Promise.reject(new ReviewHostRelayError(REVIEW_HOST_RELAY_FAILURE.PI_FAILED, "pi", "later provider error"));
+		if (index === 3) {
+			return new Promise<ReviewHostRelayPreparedResult>((resolve) => {
+				releaseLaterReviewer = () => resolve({
+					request,
+					promptByteLength: index + 1,
+					resultByteLength: index + 1,
+					resultBytes: Buffer.from(REVIEWER_GROUP_LENSES[index]!),
+				});
+			});
+		}
+		return Promise.resolve({
+			request,
+			promptByteLength: index + 1,
+			resultByteLength: index + 1,
+			resultBytes: Buffer.from(REVIEWER_GROUP_LENSES[index]!),
+		});
+	});
+	void group.then(() => { groupSettled = true; }, () => { groupSettled = true; });
+
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.deepEqual(started, [0, 1, 2, 3], "one failed reviewer does not prevent later reviewers from starting");
+	rejectFirstProvider!(firstProviderError); await new Promise<void>((resolve) => setImmediate(resolve));
+	assert.equal(groupSettled, false, "the group must remain pending until the later reviewer settles");
+	releaseLaterReviewer!();
+	await assert.rejects(group, (error: unknown) => error === firstProviderError);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #533

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Splits reviewer process execution from native result submission.
- Runs independent reviewer preparation concurrently while preserving provider-ordered admission.
- Protects detached reviewer output behind unforgeable prepared-result identity.

## Changes

| File | Change |
|------|--------|
| `lib/review-host-relay.ts` | Adds concurrent preparation, ordered submission, cancellation, and private result storage. |
| `tests/review-host-relay.test.ts` | Covers overlap, ordering, failures, detachment, cancellation, and fabricated-result refusal. |

## Test Plan

- [x] `node --experimental-strip-types --test tests/review-host-relay.test.ts`
- [x] TypeScript syntax checks passed
- [x] `git diff --check` passed
- [x] Native high-risk RDD review approved

## Contributor Checklist

- [x] Linked approved issue #533
- [x] Added exactly one `type:*` label
- [x] Shellcheck not applicable; no shell scripts changed
- [x] Runtime behavior covered in the Pi host relay tests
- [x] Documentation is deferred to the orchestration slice
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Issue #533 concurrent 4R reviewers |
| Tracker PR | Not needed |
| Position | 1 of 2 |
| Base | `main` |
| Depends on | None |
| Follow-up | Public grouped orchestration PR |
| Review budget | 408 / 400 (`size:exception`) |
| Starts at | Existing sequential host-relay transport |
| Ends with | Standalone concurrent reviewer preparation and ordered submission primitives |

### Size Exception

This slice is eight lines over the standard limit exclusively because the native RDD review required a security correction that prevents callers from mutating or fabricating prepared reviewer bytes.

### Chain Overview

```text
main
 └── 📍 PR 1: concurrent reviewer transport
      └── PR 2: grouped public orchestration
```

### Scope

- Includes: host-relay transport primitives and focused tests.
- Excludes: public grouped tool registration, STATUS orchestration, runtime harness coverage, and ledger documentation.

### Autonomy

- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests cover this unit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review processing can now prepare multiple provider reviews concurrently before submitting results.
  - Prepared reviews retain request details and result size information for reliable deferred submission.
  - Review groups preserve provider order and report failures consistently after all reviews finish.

- **Bug Fixes**
  - Improved handling of mutable submission data by capturing its values during review preparation.
  - Review operations now honor cancellation signals during processing.

- **Compatibility**
  - Existing single-review behavior remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->