### PR TITLE
fix(review): remind the agent to preflight an unreviewed candidate when the loop ends with RDD enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ Findings surviving round two escalate; no third-round transition exists.
 
 Native review mode and candidate-scoped consent remain provider-owned lifecycle semantics. Pi relays the exact provider-owned lifecycle inputs and outputs; it does not create a clone-local consent latch or infer a delivery decision.
 
+When RDD is on and an agent loop ends with an unreviewed candidate, `gentle-pi` sends one read-only reminder pointing the agent back to `gentle_review {"operation":"inspect"}` before it reports completion. This nudge is idempotent (at most once per target identity per session), never fires for a headless session or a subagent's own loop, and never runs START or answers consent itself.
+
 Review outcomes and receipt state are informational; commit, push, pull-request, and release delivery follow ordinary repository policy. No one-shot command authorization, publication-target revalidation, or receipt gate is required for delivery, and Pi does not inspect RDD mode or native authority to decide a Bash delivery command.
 
 Dangerous-command safety remains independent and authoritative. Destructive-review-maintenance consent remains separate from delivery. Review operations, informational VALIDATE, and SDD perform no commit, push, pull-request, release, or publication operation.

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3621,6 +3621,16 @@ export class PendingReviewConsentRegistry {
 const processPendingReviewConsentRegistry = new PendingReviewConsentRegistry();
 const processRetainedNativeStatusSelections = new Map<PendingReviewConsentSessionKey, Map<string, RetainedNativeStatusSelection>>();
 
+// gentle-pi#556 / gentle-ai#4051: whether the most recent `before_agent_start`
+// event observed for a session named an agent (SDD phase executor or any
+// other named subagent). The `agent_end` preflight nudge fires only for the
+// primary session loop, never for a subagent's own loop end.
+const processAgentEndSubagentSessions = new Map<PendingReviewConsentSessionKey, boolean>();
+
+// Target identities already nudged once per session, so the read-only
+// `agent_end` preflight reminder fires at most once per unreviewed candidate.
+const processAgentEndPreflightNudgedTargets = new Map<PendingReviewConsentSessionKey, Set<string>>();
+
 function pendingReviewConsentSessionKey(context: ExtensionContext | undefined, fallbackKey: symbol): PendingReviewConsentSessionKey {
 	try {
 		const sessionManager = (context as unknown as { sessionManager?: { getSessionId?: () => unknown } } | undefined)?.sessionManager;
@@ -4443,6 +4453,14 @@ async function negotiatedStatusForHostTransport(
 		reviewTransportRefusalByProvider.set(provider, transport);
 		return { transport };
 	}
+}
+
+// gentle-pi#556 / gentle-ai#4051: the exact once-per-candidate reminder sent
+// through `agent_end`. It never runs START itself, so it names the one
+// supported continuation (gentle_review inspect) and defers the resulting
+// consent envelope to the human.
+function renderAgentEndReviewPreflightMessage(targetIdentity: string): string {
+	return `Receipt-driven development is enabled, and this worktree holds an unreviewed candidate (target ${targetIdentity}). By the review contract entry rule, run the review preflight before reporting completion.\n\nCall the gentle_review tool with {"operation":"inspect"} and follow the transition it returns; it currently offers review.start for this target. Relay the resulting gentle-ai.review-integration.consent/v3 envelope to the human losslessly, and never answer it on the human's behalf.\n\nThis extension never runs START itself. This reminder is sent once per candidate.`;
 }
 
 function canonicalReviewCaptureBinding(value: unknown): string {
@@ -5485,6 +5503,8 @@ function createGentleAiExtensionForTesting(
 		const sessionKey = pendingReviewConsentSessionKey(context, pendingReviewConsentFallbackKey);
 		cleanupAllPendingReviewConsents(pendingReviewConsentRegistry, sessionKey);
 		processRetainedNativeStatusSelections.delete(sessionKey);
+		processAgentEndSubagentSessions.delete(sessionKey);
+		processAgentEndPreflightNudgedTargets.delete(sessionKey);
 	});
 
 	pi.registerTool({
@@ -5655,6 +5675,10 @@ function createGentleAiExtensionForTesting(
 	pi.on("before_agent_start", async (event, ctx) => {
 		const isSddAgent = isSddAgentStartEvent(event);
 		const isNamedAgent = isNamedAgentStartEvent(event);
+		processAgentEndSubagentSessions.set(
+			pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey),
+			isSddAgent || isNamedAgent,
+		);
 		if (isSddAgent && !getSddPreflightPreferences(ctx)) {
 			await runSddPreflight(ctx);
 		}
@@ -5678,6 +5702,53 @@ function createGentleAiExtensionForTesting(
 		return {
 			systemPrompt: `${event.systemPrompt}${gentlePrompt}${sddPrompt}${nativeStatusPrompt}`,
 		};
+	});
+
+	// gentle-pi#556 / gentle-ai#4051: with RDD enabled, the agent could finish
+	// an authorized implementation and report completion without ever running
+	// the review STATUS preflight or offering the consent question. This
+	// handler is read-only and idempotent: it never runs START, never answers
+	// consent, and never writes a file. It only sends one turn-triggering
+	// reminder, at most once per unreviewed target identity per session.
+	pi.on("agent_end", async (_event, ctx) => {
+		if (nativeReviewCli?.reviewMode === undefined || nativeReviewCli.targetStatus === undefined) return;
+		if (ctx.hasUI !== true) return;
+		const sessionKey = pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey);
+		if (processAgentEndSubagentSessions.get(sessionKey) === true) return;
+		let modeEffective: "on" | "off";
+		try {
+			const mode = await nativeReviewCli.reviewMode({ cwd: ctx.cwd, operation: NATIVE_REVIEW_MODE_OPERATION.STATUS });
+			modeEffective = mode.status.effective;
+		} catch {
+			return;
+		}
+		if (modeEffective === "off") return;
+		let status: ReviewStatusV3;
+		try {
+			const retainedSelections = ((key: PendingReviewConsentSessionKey) => processRetainedNativeStatusSelections.get(key) ?? processRetainedNativeStatusSelections.set(key, new Map()).get(key)!)(sessionKey);
+			const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, { cwd: ctx.cwd }, retainedSelections, ctx.cwd);
+			if (negotiated.status === undefined) return;
+			status = negotiated.status;
+		} catch {
+			return;
+		}
+		if (status.nextTransition?.kind !== "execute" || status.nextTransition.execute.operation !== "review.start") return;
+		const targetIdentity = status.targetIdentity;
+		let nudged = processAgentEndPreflightNudgedTargets.get(sessionKey);
+		if (nudged === undefined) {
+			nudged = new Set<string>();
+			processAgentEndPreflightNudgedTargets.set(sessionKey, nudged);
+		}
+		if (nudged.has(targetIdentity)) return;
+		nudged.add(targetIdentity);
+		pi.sendMessage(
+			{
+				customType: "gentle-pi.review-preflight",
+				content: renderAgentEndReviewPreflightMessage(targetIdentity),
+				display: true,
+			},
+			{ triggerTurn: true, deliverAs: "followUp" },
+		);
 	});
 
 	pi.on("tool_call", async (event, ctx) => {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3621,11 +3621,13 @@ export class PendingReviewConsentRegistry {
 const processPendingReviewConsentRegistry = new PendingReviewConsentRegistry();
 const processRetainedNativeStatusSelections = new Map<PendingReviewConsentSessionKey, Map<string, RetainedNativeStatusSelection>>();
 
-// gentle-pi#556 / gentle-ai#4051: whether the most recent `before_agent_start`
-// event observed for a session named an agent (SDD phase executor or any
-// other named subagent). The `agent_end` preflight nudge fires only for the
-// primary session loop, never for a subagent's own loop end.
-const processAgentEndSubagentSessions = new Map<PendingReviewConsentSessionKey, boolean>();
+// gentle-pi#556 / gentle-ai#4051: nesting depth of named-agent (SDD phase
+// executor or other subagent) starts vs. ends for a session. Starts and
+// ends are paired so a subagent's own loop end never leaves the primary
+// loop's `agent_end` preflight suppressed for the rest of the session: a
+// named-agent start increments the depth, a matching end decrements it,
+// and a fresh primary-loop start resets it to 0.
+const processAgentEndSubagentDepth = new Map<PendingReviewConsentSessionKey, number>();
 
 // Target identities already nudged once per session, so the read-only
 // `agent_end` preflight reminder fires at most once per unreviewed candidate.
@@ -5503,7 +5505,7 @@ function createGentleAiExtensionForTesting(
 		const sessionKey = pendingReviewConsentSessionKey(context, pendingReviewConsentFallbackKey);
 		cleanupAllPendingReviewConsents(pendingReviewConsentRegistry, sessionKey);
 		processRetainedNativeStatusSelections.delete(sessionKey);
-		processAgentEndSubagentSessions.delete(sessionKey);
+		processAgentEndSubagentDepth.delete(sessionKey);
 		processAgentEndPreflightNudgedTargets.delete(sessionKey);
 	});
 
@@ -5675,10 +5677,12 @@ function createGentleAiExtensionForTesting(
 	pi.on("before_agent_start", async (event, ctx) => {
 		const isSddAgent = isSddAgentStartEvent(event);
 		const isNamedAgent = isNamedAgentStartEvent(event);
-		processAgentEndSubagentSessions.set(
-			pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey),
-			isSddAgent || isNamedAgent,
-		);
+		const subagentDepthKey = pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey);
+		if (isSddAgent || isNamedAgent) {
+			processAgentEndSubagentDepth.set(subagentDepthKey, (processAgentEndSubagentDepth.get(subagentDepthKey) ?? 0) + 1);
+		} else {
+			processAgentEndSubagentDepth.set(subagentDepthKey, 0);
+		}
 		if (isSddAgent && !getSddPreflightPreferences(ctx)) {
 			await runSddPreflight(ctx);
 		}
@@ -5714,7 +5718,11 @@ function createGentleAiExtensionForTesting(
 		if (nativeReviewCli?.reviewMode === undefined || nativeReviewCli.targetStatus === undefined) return;
 		if (ctx.hasUI !== true) return;
 		const sessionKey = pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey);
-		if (processAgentEndSubagentSessions.get(sessionKey) === true) return;
+		const subagentDepth = processAgentEndSubagentDepth.get(sessionKey) ?? 0;
+		if (subagentDepth > 0) {
+			processAgentEndSubagentDepth.set(sessionKey, subagentDepth - 1);
+			return;
+		}
 		let modeEffective: "on" | "off";
 		try {
 			const mode = await nativeReviewCli.reviewMode({ cwd: ctx.cwd, operation: NATIVE_REVIEW_MODE_OPERATION.STATUS });

--- a/tests/review-agent-end-preflight.test.ts
+++ b/tests/review-agent-end-preflight.test.ts
@@ -172,7 +172,7 @@ test("agent_end skips headless sessions before any native call", async () => {
 	assert.deepEqual(sent, []);
 });
 
-test("agent_end sends nothing for a session whose before_agent_start named an agent", async () => {
+test("agent_end pairs a named agent's start with its own end, then still nudges for the primary loop's end", async () => {
 	const targetIdentity = `sha256:${"f".repeat(64)}`;
 	const native = {
 		reviewMode: onMode("on"),
@@ -186,8 +186,28 @@ test("agent_end sends nothing for a session whose before_agent_start named an ag
 
 	await beforeAgentStart!({ agentName: "review-readability", systemPrompt: "" }, session);
 	await agentEnd!(agentEndEvent, session);
+	assert.deepEqual(sent, [], "the subagent's own loop end is suppressed");
 
-	assert.deepEqual(sent, []);
+	await agentEnd!(agentEndEvent, session);
+	assert.equal(sent.length, 1, "the primary loop's end still nudges once the subagent's end is paired off");
+});
+
+test("agent_end resets the subagent depth when a fresh primary loop starts", async () => {
+	const targetIdentity = `sha256:${"1".repeat(64)}`;
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async () => executeStartStatus(targetIdentity),
+	} as unknown as NativeReviewCli;
+	const { handlers, sent } = harness(native);
+	const beforeAgentStart = handlers.get("before_agent_start");
+	const agentEnd = handlers.get("agent_end");
+	const session = ctx("agent-end-subagent-reset");
+
+	await beforeAgentStart!({ agentName: "review-readability", systemPrompt: "" }, session);
+	await beforeAgentStart!({ systemPrompt: "" }, session);
+	await agentEnd!(agentEndEvent, session);
+
+	assert.equal(sent.length, 1, "a fresh primary-loop start resets the depth so its own end nudges");
 });
 
 test("agent_end handler exists but sends nothing when nativeReviewCli is null", async () => {

--- a/tests/review-agent-end-preflight.test.ts
+++ b/tests/review-agent-end-preflight.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import type { NativeReviewCli } from "../lib/native-review-cli.ts";
+import type { ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+
+// gentle-pi#556 / gentle-ai#4051: with RDD enabled, the agent finished an
+// implementation and reported completion without ever entering the review
+// preflight. These tests cover the read-only, idempotent `agent_end` nudge
+// that reminds the agent to call gentle_review before reporting completion,
+// without ever starting a review or answering consent itself.
+
+type AnyHandler = (event: unknown, ctx: ExtensionContext) => unknown;
+type SentMessage = { message: Record<string, unknown>; options: Record<string, unknown> };
+
+function harness(nativeReviewCli: NativeReviewCli | null): {
+	handlers: Map<string, AnyHandler>;
+	sent: SentMessage[];
+} {
+	const handlers = new Map<string, AnyHandler>();
+	const sent: SentMessage[] = [];
+	const pi = {
+		on(name: string, handler: AnyHandler) {
+			handlers.set(name, handler);
+		},
+		events: { emit() {} },
+		registerCommand() {},
+		registerTool() {},
+		sendMessage(message: Record<string, unknown>, options: Record<string, unknown> = {}) {
+			sent.push({ message, options });
+		},
+	} as unknown as ExtensionAPI;
+	createGentleAiExtension({ nativeReviewCli })(pi);
+	return { handlers, sent };
+}
+
+function ctx(sessionId: string, hasUI = true, cwd = process.cwd()): ExtensionContext {
+	return {
+		cwd,
+		hasUI,
+		ui: { notify() {} },
+		sessionManager: { getSessionId: () => sessionId },
+	} as unknown as ExtensionContext;
+}
+
+function onMode(effective: "on" | "off"): NativeReviewCli["reviewMode"] {
+	return async () => ({
+		operation: "status",
+		scope: "clone",
+		status: { global: "", cloneLocal: effective === "on" ? "on" : "", effective, source: "clone_local" },
+	});
+}
+
+function executeStartStatus(targetIdentity: string): ReviewStatusV3 {
+	return {
+		applicability: "unrelated",
+		action: "start",
+		targetIdentity,
+		nextTransition: { kind: "execute", execute: { operation: "review.start", arguments: [] } },
+	} as unknown as ReviewStatusV3;
+}
+
+function collectStatus(targetIdentity: string): ReviewStatusV3 {
+	return {
+		applicability: "unrelated",
+		action: "start",
+		targetIdentity,
+		nextTransition: { kind: "collect", collect: { inputs: [] } },
+	} as unknown as ReviewStatusV3;
+}
+
+function stopStatus(targetIdentity: string): ReviewStatusV3 {
+	return {
+		applicability: "unrelated",
+		action: "start",
+		targetIdentity,
+		nextTransition: { kind: "stop" },
+	} as unknown as ReviewStatusV3;
+}
+
+const agentEndEvent = { type: "agent_end", messages: [] };
+
+test("agent_end performs no STATUS call and sends nothing when RDD is off", async () => {
+	const statusRequests: unknown[] = [];
+	const native = {
+		reviewMode: onMode("off"),
+		targetStatus: async (request: unknown) => {
+			statusRequests.push(request);
+			throw new Error("targetStatus must not be called when RDD is off");
+		},
+	} as unknown as NativeReviewCli;
+	const { handlers, sent } = harness(native);
+	const agentEnd = handlers.get("agent_end");
+	assert.equal(typeof agentEnd, "function");
+	await agentEnd!(agentEndEvent, ctx("agent-end-rdd-off"));
+	assert.deepEqual(statusRequests, []);
+	assert.deepEqual(sent, []);
+});
+
+test("agent_end nudges exactly once when RDD is on and STATUS offers review.start", async () => {
+	const targetIdentity = `sha256:${"a".repeat(64)}`;
+	const statusRequests: Array<{ agent?: string }> = [];
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async (request: { agent?: string }) => {
+			statusRequests.push(request);
+			return executeStartStatus(targetIdentity);
+		},
+	} as unknown as NativeReviewCli;
+	const { handlers, sent } = harness(native);
+	const agentEnd = handlers.get("agent_end");
+	await agentEnd!(agentEndEvent, ctx("agent-end-execute"));
+
+	assert.equal(sent.length, 1);
+	const [entry] = sent;
+	assert.equal(entry?.message.customType, "gentle-pi.review-preflight");
+	const content = String(entry?.message.content);
+	assert.match(content, /gentle_review/);
+	assert.ok(content.includes(targetIdentity), "message must name the target identity");
+	assert.equal(entry?.options.triggerTurn, true);
+	assert.equal(statusRequests[0]?.agent, "pi");
+});
+
+test("agent_end nudges once per target identity and again for a fresh identity", async () => {
+	let targetIdentity = `sha256:${"b".repeat(64)}`;
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async () => executeStartStatus(targetIdentity),
+	} as unknown as NativeReviewCli;
+	const { handlers, sent } = harness(native);
+	const agentEnd = handlers.get("agent_end");
+	const session = ctx("agent-end-repeat");
+
+	await agentEnd!(agentEndEvent, session);
+	await agentEnd!(agentEndEvent, session);
+	assert.equal(sent.length, 1, "the same target identity nudges only once");
+
+	targetIdentity = `sha256:${"e".repeat(64)}`;
+	await agentEnd!(agentEndEvent, session);
+	assert.equal(sent.length, 2, "a different target identity nudges again");
+});
+
+test("agent_end sends nothing when STATUS offers collect or stop", async () => {
+	for (const [label, status] of [
+		["collect", collectStatus(`sha256:${"c".repeat(64)}`)],
+		["stop", stopStatus(`sha256:${"d".repeat(64)}`)],
+	] as const) {
+		const native = {
+			reviewMode: onMode("on"),
+			targetStatus: async () => status,
+		} as unknown as NativeReviewCli;
+		const { handlers, sent } = harness(native);
+		const agentEnd = handlers.get("agent_end");
+		await agentEnd!(agentEndEvent, ctx(`agent-end-${label}`));
+		assert.deepEqual(sent, [], label);
+	}
+});
+
+test("agent_end skips headless sessions before any native call", async () => {
+	const native = {
+		reviewMode: async () => {
+			throw new Error("reviewMode must not be called when hasUI is false");
+		},
+		targetStatus: async () => {
+			throw new Error("targetStatus must not be called when hasUI is false");
+		},
+	} as unknown as NativeReviewCli;
+	const { handlers, sent } = harness(native);
+	const agentEnd = handlers.get("agent_end");
+	await agentEnd!(agentEndEvent, ctx("agent-end-no-ui", false));
+	assert.deepEqual(sent, []);
+});
+
+test("agent_end sends nothing for a session whose before_agent_start named an agent", async () => {
+	const targetIdentity = `sha256:${"f".repeat(64)}`;
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async () => executeStartStatus(targetIdentity),
+	} as unknown as NativeReviewCli;
+	const { handlers, sent } = harness(native);
+	const beforeAgentStart = handlers.get("before_agent_start");
+	const agentEnd = handlers.get("agent_end");
+	assert.equal(typeof beforeAgentStart, "function");
+	const session = ctx("agent-end-subagent");
+
+	await beforeAgentStart!({ agentName: "review-readability", systemPrompt: "" }, session);
+	await agentEnd!(agentEndEvent, session);
+
+	assert.deepEqual(sent, []);
+});
+
+test("agent_end handler exists but sends nothing when nativeReviewCli is null", async () => {
+	const { handlers, sent } = harness(null);
+	const agentEnd = handlers.get("agent_end");
+	assert.equal(typeof agentEnd, "function");
+	await agentEnd!(agentEndEvent, ctx("agent-end-null-cli"));
+	assert.deepEqual(sent, []);
+});
+
+test("agent_end sends nothing and does not throw when target STATUS rejects", async () => {
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async () => {
+			throw new Error("native status unavailable");
+		},
+	} as unknown as NativeReviewCli;
+	const { handlers, sent } = harness(native);
+	const agentEnd = handlers.get("agent_end");
+	await assert.doesNotReject(async () => agentEnd!(agentEndEvent, ctx("agent-end-status-throws")));
+	assert.deepEqual(sent, []);
+});
+
+test("session_shutdown clears the nudged-target set for its session key", async () => {
+	const targetIdentity = `sha256:${"9".repeat(64)}`;
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async () => executeStartStatus(targetIdentity),
+	} as unknown as NativeReviewCli;
+	const { handlers, sent } = harness(native);
+	const agentEnd = handlers.get("agent_end");
+	const shutdown = handlers.get("session_shutdown");
+	assert.equal(typeof shutdown, "function");
+	const session = ctx("agent-end-shutdown");
+
+	await agentEnd!(agentEndEvent, session);
+	assert.equal(sent.length, 1);
+
+	await shutdown!({}, session);
+	await agentEnd!(agentEndEvent, session);
+	assert.equal(sent.length, 2, "shutdown clears the nudged set so the same identity nudges again");
+});


### PR DESCRIPTION
Closes #556. Upstream contract change: Gentleman-Programming/gentle-ai#4051 (merged in Gentleman-Programming/gentle-ai#4052).

## Cause

With receipt-driven development enabled, the agent finishes an authorized implementation and reports completion without running the review STATUS preflight or offering the consent question. The lifecycle text describes only how the atomic transaction runs; the entry condition used to be carried by the gentle-ai commit gate, which no longer exists. The extension subscribed to no end-of-loop event, so nothing pulled the agent into STATUS.

## Fix

A read-only, idempotent `agent_end` handler:

- Stays silent when the native review CLI is unavailable, the session is headless (`hasUI !== true`), the session is a subagent loop, the RDD switch reads off, the STATUS preflight does not offer `review.start`, or the target identity was already nudged in this session.
- Otherwise sends one turn-triggering custom message (`gentle-pi.review-preflight`) that names the target identity and the exact supported route: `gentle_review` with `{"operation":"inspect"}`, then relay the `gentle-ai.review-integration.consent/v3` envelope to the human. The extension never runs START, never answers consent, never writes a file.
- Subagent starts and ends are paired through a per-session depth counter (a named or SDD agent start increments, a primary-loop start resets, an `agent_end` while depth is positive decrements and returns), so a subagent's own loop end never leaves the primary loop suppressed.
- Nudged target identities and the depth are released at `session_shutdown`.

Tests: `tests/review-agent-end-preflight.test.ts` (10 cases: RDD off, review.start nudge with `agent: "pi"` on the STATUS request, once per identity and re-nudge on a new identity, collect and stop transitions, headless, subagent pairing, primary-loop reset, null CLI, throwing STATUS, shutdown cleanup). README gains one paragraph.

## Verification

- `pnpm test`: 1178 tests, 1177 pass, 1 pre-existing Windows skip, 0 fail; `check:provider-contract` and `test:harness` pass.
- Native review (gentle-ai, lineage `review-f90a2c8c0fac677a`, medium tier, one reliability lens): one CRITICAL finding (`R3-subagent-suppression-sticky`, the sticky subagent flag) was corrected in `f49eaeef` within budget. The targeted validator reported `original_criteria.passed: true` (finding addressed, both candidate tests cover it) and listed only affirming evidence under `correction_regression`, yet returned `correction_regression.passed: false` and the lineage escalated terminally. That contradiction is the open provider defect Gentleman-Programming/gentle-ai#4037 (occurrence comment added); the first validation attempt was refused on a stray validator field, reported as Gentleman-Programming/gentle-ai#4053. No receipt exists for this candidate; delivery follows ordinary repository policy.
- Validator follow-ups, recorded here and not treated as blockers: the depth decrement sits after the `hasUI` and CLI-availability early returns (those are constant within a session, so no residual depth accrues in practice), and a primary-loop start observed while a subagent is still in flight would reset the depth (no known Pi ordering produces that).

https://claude.ai/code/session_01WYGtotXyhPmbnEeAZAbSbj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only reminder when an RDD-enabled agent loop ends with an unreviewed candidate.
  - Reminders suggest running the review inspection command and appear at most once per candidate per session.
  - Reminders are suppressed for headless sessions and subagent loops and do not start a review or request consent.

- **Documentation**
  - Documented the new review-preflight reminder behavior.

- **Tests**
  - Added coverage for reminder eligibility, suppression, deduplication, session resets, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->