### PR TITLE
docs(readme): add a star history chart to the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@
 [![SDD/OpenSpec](https://img.shields.io/badge/SDD-OpenSpec-00ADD8)](#sddopenspec-flow)
 [![Subagents](https://img.shields.io/badge/Pi-subagents-brightgreen)](#what-it-adds)
 
+<div align="center">
+
+<!--
+  sealed_token is a GitHub fine-grained token encrypted against Star History's
+  public key, so only the encrypted value is published here. It is required
+  because GitHub restricted the stargazers API to a repository's admins and
+  collaborators on 2026-06-30; without it the chart renders an error placeholder.
+  Regenerate it at https://www.star-history.com/?repos=Gentleman-Programming%2Fgentle-pi&type=date&legend=top-left
+-->
+
+<a href="https://www.star-history.com/?repos=Gentleman-Programming%2Fgentle-pi&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Gentleman-Programming%2Fgentle-pi&type=date&theme=dark&legend=top-left&sealed_token=zwrd_DfwYZeJU7nhGYNtREEheKWYEslW_uzrqORlZ36v-JSMepdqGLkKExp1M-xbNq6t-ebVS5iM3WoPDO26tXbSGkjXC2Jo3kHQ3uNzlRkCrWoqRHkPVQXvosKciY109ObiwGV1z8aajyedcloppmekCGrvVKJb6KWxGLXW_mHcRAVIBZUOa4SzW75D" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Gentleman-Programming%2Fgentle-pi&type=date&legend=top-left&sealed_token=zwrd_DfwYZeJU7nhGYNtREEheKWYEslW_uzrqORlZ36v-JSMepdqGLkKExp1M-xbNq6t-ebVS5iM3WoPDO26tXbSGkjXC2Jo3kHQ3uNzlRkCrWoqRHkPVQXvosKciY109ObiwGV1z8aajyedcloppmekCGrvVKJb6KWxGLXW_mHcRAVIBZUOa4SzW75D" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Gentleman-Programming%2Fgentle-pi&type=date&legend=top-left&sealed_token=zwrd_DfwYZeJU7nhGYNtREEheKWYEslW_uzrqORlZ36v-JSMepdqGLkKExp1M-xbNq6t-ebVS5iM3WoPDO26tXbSGkjXC2Jo3kHQ3uNzlRkCrWoqRHkPVQXvosKciY109ObiwGV1z8aajyedcloppmekCGrvVKJb6KWxGLXW_mHcRAVIBZUOa4SzW75D" />
+  </picture>
+</a>
+
+</div>
+
 **Turn Pi from a powerful coding agent into a controlled development harness.**
 
 `gentle-pi` installs **el Gentleman** in Pi: a senior-architect operating layer for Spec-Driven Development, focused subagents, strict TDD evidence, reviewable work units, safety guards, project/user skill discovery, and bounded native review.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #562

---

## 🏷️ PR Type

- [x] `type:chore` — Documentation only (this repo has no `type:docs` label)

---

## 📝 Summary

- Adds a Star History chart to the README header so the growth curve is visible without scrolling.
- Uses star-history's current embed contract: the `/chart` endpoint, `type=date`, `legend=top-left`, and a `<picture>` element so the chart follows the reader's light/dark preference.
- Carries an encrypted `sealed_token`, with an inline comment explaining why it exists and how to regenerate it.

GitHub [restricted the stargazers API](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) on 2026-06-30 to a repository's admins and collaborators, to curb scraping of star data for spam. Every token-less star-history embed — for any repository — now returns a placeholder SVG reading "GitHub restricted access to star data", so the sealed token is what makes the chart render at all.

## 📂 Changes

| File | Change |
|------|--------|
| `README.md` | Star History chart added to the header block, with a theme-aware `<picture>` embed and an explanatory comment |

## 🧪 Test Plan

Documentation-only change; no code, build inputs, or runtime behavior is touched.

- [x] Unit tests pass locally — not affected by this change
- [x] Manually tested the affected functionality — exercised the embed URL live

Verification performed:

- Confirmed the legacy `api.star-history.com/svg` path `301`-redirects and that `/chart` is the endpoint the site itself emits today. The query contract (`repos`, `type`, `theme`, `logscale`, `legend`, `sealed_token`) was read out of star-history's own frontend bundle rather than copied from a blog snippet.
- Reimplemented star-history's client-side sealing (X25519 + XSalsa20-Poly1305, nonce derived as `SHA-512(ephemeral_pub || server_pub)[0..24]`, output `base64url(ephemeral_pub || ciphertext)`) so the raw GitHub token never had to be pasted into a third-party web form.
- Used the response shape as a diagnostic. A deliberately fake sealed token returns `401 The provided GitHub access token is invalid or expired`; a valid token missing `Contents: Read and write` returns the generic 60125-byte placeholder; a correctly scoped token returns the chart. That distinction is what identified the permission problem on the first token.
- Requested the final embed URL live and confirmed it returns real data, not a placeholder and not a `401`.

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above
- [x] I added exactly **one** `type:*` label to this PR
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

---

## 💬 Notes for Reviewers

One thing worth stating plainly, because it is easy to wave through: **the published sealed value wraps a token that can write to this repository.**

That is not star-history asking for more than it needs. GitHub's fine-grained token model exposes no "prove you are a collaborator" permission, and on a public repository read access proves nothing because everyone already has it. A write grant can only be issued by someone who already holds write, so `Contents: Read and write` is the only permission that doubles as proof of collaborator status — read-only is rejected outright. The classic-token alternative (`public_repo`) is also a write scope and reaches every repository in every org, so the fine-grained token is the tighter of the two.

The token is scoped to this owner's repositories only and is used for nothing else. Its confidentiality rests on star-history's private key: the value here is a NaCl sealed envelope only their server can open. If star-history ever reports a key compromise, revoke the token and regenerate the embed.

https://claude.ai/code/session_015hDNaNWqutTp8CMrBeFRge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Star History chart to the README, with support for light and dark themes.
  * Included a fallback image and links to the Star History site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->