### PR TITLE
docs(readme): link the Gentle-AI ecosystem sites from the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![SDD/OpenSpec](https://img.shields.io/badge/SDD-OpenSpec-00ADD8)](#sddopenspec-flow)
 [![Subagents](https://img.shields.io/badge/Pi-subagents-brightgreen)](#what-it-adds)
 
+**[Gentle-AI website](https://gentle-ai.gentlemanprogramming.com/)** &bull; **[Gentle-AI wiki](https://gentle-ai-wiki.gentlemanprogramming.com/)** &bull; **[Engram](https://engram.gentlemanprogramming.com/)**
+
 <div align="center">
 
 <!--


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #566

---

## 🏷️ PR Type

- [x] `type:chore` — Documentation only (this repo has no `type:docs` label)

## 📝 Summary

- Adds a link row to the README header so a reader landing on the repository has a path to the project sites.
- All three URLs were requested live and returned `200` with no redirect.

## 📂 Changes

| File | Change |
|------|--------|
| `README.md` | Link row added to the header block |

## 🧪 Test Plan

Documentation-only change; no code, build inputs, or runtime behavior is touched.

- [x] Unit tests pass locally — not affected by this change
- [x] Manually tested the affected functionality — every added URL resolves `200`

---

## ✅ Contributor Checklist

- [x] I linked an approved issue above
- [x] I added the appropriate `type:*` label to this PR
- [x] Docs updated (if behavior changed)
- [x] Commits follow [conventional commits](https://www.conventionalcommits.org/) format
- [x] No `Co-Authored-By` trailers in commits

https://claude.ai/code/session_015hDNaNWqutTp8CMrBeFRge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added quick-access links to the Gentle-AI website, Gentle-AI wiki, and Engram site in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->