### PR TITLE
fix(review): record a session baseline at session_start so the agent_end reminder skips candidates that predate the session

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Findings surviving round two escalate; no third-round transition exists.
 
 Native review mode and candidate-scoped consent remain provider-owned lifecycle semantics. Pi relays the exact provider-owned lifecycle inputs and outputs; it does not create a clone-local consent latch or infer a delivery decision.
 
-When RDD is on and an agent loop ends with an unreviewed candidate, `gentle-pi` sends one read-only reminder pointing the agent back to `gentle_review {"operation":"inspect"}` before it reports completion. This nudge is idempotent (at most once per target identity per session), never fires for a headless session or a subagent's own loop, and never runs START or answers consent itself.
+When RDD is on and an agent loop ends with an unreviewed candidate, `gentle-pi` sends one read-only reminder pointing the agent back to `gentle_review {"operation":"inspect"}` before it reports completion. This nudge is idempotent (at most once per target identity per session), never fires for a headless session or a subagent's own loop, and never runs START or answers consent itself. At session start, `gentle-pi` records the current target identity as a baseline, so a candidate that already existed before the session began (the user's own prior work, not this session's output) never draws the reminder.
 
 Review outcomes and receipt state are informational; commit, push, pull-request, and release delivery follow ordinary repository policy. No one-shot command authorization, publication-target revalidation, or receipt gate is required for delivery, and Pi does not inspect RDD mode or native authority to decide a Bash delivery command.
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3732,6 +3732,13 @@ const processAgentEndSubagentDepth = new Map<PendingReviewConsentSessionKey, num
 // `agent_end` preflight reminder fires at most once per unreviewed candidate.
 const processAgentEndPreflightNudgedTargets = new Map<PendingReviewConsentSessionKey, Set<string>>();
 
+// gentle-pi#568: the target identity negotiated STATUS reported at
+// `session_start`, before this session touched the worktree. A candidate
+// already present at that point is the user's own pre-session work, not
+// something this session produced, so `agent_end` must not treat it as an
+// unreviewed candidate this session should be reminded about.
+const processAgentEndSessionBaseline = new Map<PendingReviewConsentSessionKey, string>();
+
 function pendingReviewConsentSessionKey(context: ExtensionContext | undefined, fallbackKey: symbol): PendingReviewConsentSessionKey {
 	try {
 		const sessionManager = (context as unknown as { sessionManager?: { getSessionId?: () => unknown } } | undefined)?.sessionManager;
@@ -4558,6 +4565,37 @@ async function negotiatedStatusForHostTransport(
 		const transport: ReviewTransportRefusal = { supported: false, code, message: error.message };
 		reviewTransportRefusalByProvider.set(provider, transport);
 		return { transport };
+	}
+}
+
+// gentle-pi#568: resolves the current negotiated review STATUS for a session,
+// under the exact guards `agent_end` uses to decide whether to nudge: a
+// native review CLI with both `reviewMode` and `targetStatus`, a UI-bearing
+// context, and RDD effectively on. Returns `undefined` on any missing guard,
+// an effective-off mode, or any STATUS error or transport refusal, so both
+// `session_start` (recording a baseline) and `agent_end` (deciding whether to
+// nudge) resolve the same target identity through the same path.
+async function resolveNegotiatedReviewStatusForSession(
+	nativeReviewCli: NativeReviewCli | null,
+	ctx: ExtensionContext,
+	sessionKey: PendingReviewConsentSessionKey,
+): Promise<ReviewStatusV3 | undefined> {
+	if (nativeReviewCli?.reviewMode === undefined || nativeReviewCli.targetStatus === undefined) return undefined;
+	if (ctx.hasUI !== true) return undefined;
+	let modeEffective: "on" | "off";
+	try {
+		const mode = await nativeReviewCli.reviewMode({ cwd: ctx.cwd, operation: NATIVE_REVIEW_MODE_OPERATION.STATUS });
+		modeEffective = mode.status.effective;
+	} catch {
+		return undefined;
+	}
+	if (modeEffective === "off") return undefined;
+	try {
+		const retainedSelections = ((key: PendingReviewConsentSessionKey) => processRetainedNativeStatusSelections.get(key) ?? processRetainedNativeStatusSelections.set(key, new Map()).get(key)!)(sessionKey);
+		const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, { cwd: ctx.cwd }, retainedSelections, ctx.cwd);
+		return negotiated.status;
+	} catch {
+		return undefined;
 	}
 }
 
@@ -5809,6 +5847,7 @@ function createGentleAiExtensionForTesting(
 		processRetainedNativeStatusSelections.delete(sessionKey);
 		processAgentEndSubagentDepth.delete(sessionKey);
 		processAgentEndPreflightNudgedTargets.delete(sessionKey);
+		processAgentEndSessionBaseline.delete(sessionKey);
 	});
 
 	pi.registerTool({
@@ -5998,6 +6037,19 @@ function createGentleAiExtensionForTesting(
 				);
 			}
 		}
+		// gentle-pi#568: record the target identity STATUS reports right now,
+		// before this session does anything, as the baseline `agent_end` skips
+		// later. Best-effort and silent: it never notifies and never lets a
+		// STATUS failure fail session start.
+		try {
+			const sessionKey = pendingReviewConsentSessionKey(ctx, pendingReviewConsentFallbackKey);
+			const status = await resolveNegotiatedReviewStatusForSession(nativeReviewCli, ctx, sessionKey);
+			if (status?.targetIdentity !== undefined) {
+				processAgentEndSessionBaseline.set(sessionKey, status.targetIdentity);
+			}
+		} catch {
+			// Baseline recording is best-effort only; never surface or throw.
+		}
 	});
 
 	pi.on("input", async (event, ctx) => {
@@ -6058,6 +6110,10 @@ function createGentleAiExtensionForTesting(
 	// handler is read-only and idempotent: it never runs START, never answers
 	// consent, and never writes a file. It only sends one turn-triggering
 	// reminder, at most once per unreviewed target identity per session.
+	// gentle-pi#568: a candidate matching the baseline `session_start`
+	// recorded predates this session's own work and is skipped rather than
+	// nudged, so a worktree already dirty from the user's own edits does not
+	// draw a reminder about work this session never produced.
 	pi.on("agent_end", async (_event, ctx) => {
 		if (nativeReviewCli?.reviewMode === undefined || nativeReviewCli.targetStatus === undefined) return;
 		if (ctx.hasUI !== true) return;
@@ -6067,25 +6123,11 @@ function createGentleAiExtensionForTesting(
 			processAgentEndSubagentDepth.set(sessionKey, subagentDepth - 1);
 			return;
 		}
-		let modeEffective: "on" | "off";
-		try {
-			const mode = await nativeReviewCli.reviewMode({ cwd: ctx.cwd, operation: NATIVE_REVIEW_MODE_OPERATION.STATUS });
-			modeEffective = mode.status.effective;
-		} catch {
-			return;
-		}
-		if (modeEffective === "off") return;
-		let status: ReviewStatusV3;
-		try {
-			const retainedSelections = ((key: PendingReviewConsentSessionKey) => processRetainedNativeStatusSelections.get(key) ?? processRetainedNativeStatusSelections.set(key, new Map()).get(key)!)(sessionKey);
-			const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, { cwd: ctx.cwd }, retainedSelections, ctx.cwd);
-			if (negotiated.status === undefined) return;
-			status = negotiated.status;
-		} catch {
-			return;
-		}
+		const status = await resolveNegotiatedReviewStatusForSession(nativeReviewCli, ctx, sessionKey);
+		if (status === undefined) return;
 		if (status.nextTransition?.kind !== "execute" || status.nextTransition.execute.operation !== "review.start") return;
 		const targetIdentity = status.targetIdentity;
+		if (processAgentEndSessionBaseline.get(sessionKey) === targetIdentity) return;
 		let nudged = processAgentEndPreflightNudgedTargets.get(sessionKey);
 		if (nudged === undefined) {
 			nudged = new Set<string>();

--- a/tests/review-agent-end-preflight.test.ts
+++ b/tests/review-agent-end-preflight.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
@@ -10,6 +13,14 @@ import type { ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 // preflight. These tests cover the read-only, idempotent `agent_end` nudge
 // that reminds the agent to call gentle_review before reporting completion,
 // without ever starting a review or answering consent itself.
+//
+// gentle-pi#568: `session_start` records the target identity STATUS reports
+// at session start as a baseline, so `agent_end` skips a candidate that
+// already existed before this session touched the worktree (the user's own
+// pre-session work, not this session's output). These tests point
+// `GENTLE_PI_AGENT_HOME` and the session `cwd` at fresh temp directories so
+// `session_start`'s real SDD asset install and model config sweep never
+// touch this machine's actual home directory.
 
 type AnyHandler = (event: unknown, ctx: ExtensionContext) => unknown;
 type SentMessage = { message: Record<string, unknown>; options: Record<string, unknown> };
@@ -42,6 +53,25 @@ function ctx(sessionId: string, hasUI = true, cwd = process.cwd()): ExtensionCon
 		ui: { notify() {} },
 		sessionManager: { getSessionId: () => sessionId },
 	} as unknown as ExtensionContext;
+}
+
+async function withSessionStartEnv<T>(callback: (cwd: string) => Promise<T>): Promise<T> {
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const previousConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
+	process.env.GENTLE_PI_AGENT_HOME = await mkdtemp(join(tmpdir(), "gentle-pi-session-baseline-agent-home-"));
+	// Isolates both the model-config sweep and the dev-binary registration
+	// lookup from this machine's real ~/.pi/gentle-ai, so `session_start`'s
+	// unrelated notifications never leak into these assertions.
+	process.env.GENTLE_PI_CONFIG_HOME = await mkdtemp(join(tmpdir(), "gentle-pi-session-baseline-config-home-"));
+	try {
+		const cwd = await mkdtemp(join(tmpdir(), "gentle-pi-session-baseline-cwd-"));
+		return await callback(cwd);
+	} finally {
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		if (previousConfigHome === undefined) delete process.env.GENTLE_PI_CONFIG_HOME;
+		else process.env.GENTLE_PI_CONFIG_HOME = previousConfigHome;
+	}
 }
 
 function onMode(effective: "on" | "off"): NativeReviewCli["reviewMode"] {
@@ -249,4 +279,130 @@ test("session_shutdown clears the nudged-target set for its session key", async 
 	await shutdown!({}, session);
 	await agentEnd!(agentEndEvent, session);
 	assert.equal(sent.length, 2, "shutdown clears the nudged set so the same identity nudges again");
+});
+
+test("session_start records the baseline target identity when RDD is on", async () => {
+	const targetIdentity = `sha256:${"2".repeat(64)}`;
+	const statusRequests: Array<{ agent?: string }> = [];
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async (request: { agent?: string }) => {
+			statusRequests.push(request);
+			return executeStartStatus(targetIdentity);
+		},
+	} as unknown as NativeReviewCli;
+	await withSessionStartEnv(async (cwd) => {
+		const { handlers, sent } = harness(native);
+		const sessionStart = handlers.get("session_start");
+		assert.equal(typeof sessionStart, "function");
+		const notifications: Array<{ message: string; severity: string }> = [];
+		const session = {
+			...ctx("session-baseline-record", true, cwd),
+			ui: { notify: (message: string, severity: string) => notifications.push({ message, severity }) },
+		};
+		await sessionStart!({}, session);
+		assert.equal(statusRequests[0]?.agent, "pi");
+		assert.deepEqual(sent, []);
+		assert.deepEqual(notifications, []);
+	});
+});
+
+test("agent_end skips the candidate that matches the session's recorded baseline, then nudges for a new one", async () => {
+	let targetIdentity = `sha256:${"3".repeat(64)}`;
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async () => executeStartStatus(targetIdentity),
+	} as unknown as NativeReviewCli;
+	await withSessionStartEnv(async (cwd) => {
+		const { handlers, sent } = harness(native);
+		const sessionStart = handlers.get("session_start");
+		const agentEnd = handlers.get("agent_end");
+		const session = ctx("session-baseline-skip", true, cwd);
+
+		await sessionStart!({}, session);
+		await agentEnd!(agentEndEvent, session);
+		assert.deepEqual(sent, [], "the baseline candidate predates the session and is not nudged");
+
+		targetIdentity = `sha256:${"4".repeat(64)}`;
+		await agentEnd!(agentEndEvent, session);
+		assert.equal(sent.length, 1, "a candidate identity different from the baseline still nudges");
+	});
+});
+
+test("session_start with RDD off records no baseline, so agent_end still reminds once", async () => {
+	const targetIdentity = `sha256:${"5".repeat(64)}`;
+	let mode: "on" | "off" = "off";
+	const statusRequests: unknown[] = [];
+	const native = {
+		reviewMode: async () => ({
+			operation: "status",
+			scope: "clone",
+			status: { global: "", cloneLocal: mode === "on" ? "on" : "", effective: mode, source: "clone_local" },
+		}),
+		targetStatus: async (request: unknown) => {
+			statusRequests.push(request);
+			if (mode === "off") throw new Error("targetStatus must not be called when RDD is off");
+			return executeStartStatus(targetIdentity);
+		},
+	} as unknown as NativeReviewCli;
+	await withSessionStartEnv(async (cwd) => {
+		const { handlers, sent } = harness(native);
+		const sessionStart = handlers.get("session_start");
+		const agentEnd = handlers.get("agent_end");
+		const session = ctx("session-baseline-rdd-off", true, cwd);
+
+		await sessionStart!({}, session);
+		assert.deepEqual(statusRequests, []);
+
+		mode = "on";
+		await agentEnd!(agentEndEvent, session);
+		assert.equal(sent.length, 1, "no baseline was recorded while RDD was off, so the first dirty candidate still reminds");
+	});
+});
+
+test("session_start whose targetStatus rejects records no baseline, so agent_end still reminds once", async () => {
+	const targetIdentity = `sha256:${"6".repeat(64)}`;
+	let shouldThrow = true;
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async () => {
+			if (shouldThrow) throw new Error("native status unavailable at session start");
+			return executeStartStatus(targetIdentity);
+		},
+	} as unknown as NativeReviewCli;
+	await withSessionStartEnv(async (cwd) => {
+		const { handlers, sent } = harness(native);
+		const sessionStart = handlers.get("session_start");
+		const agentEnd = handlers.get("agent_end");
+		const session = ctx("session-baseline-throws", true, cwd);
+
+		await assert.doesNotReject(async () => sessionStart!({}, session));
+
+		shouldThrow = false;
+		await agentEnd!(agentEndEvent, session);
+		assert.equal(sent.length, 1, "STATUS threw at session_start, so no baseline was recorded and the candidate still reminds");
+	});
+});
+
+test("session_shutdown clears the recorded baseline so the same identity reminds again", async () => {
+	const targetIdentity = `sha256:${"7".repeat(64)}`;
+	const native = {
+		reviewMode: onMode("on"),
+		targetStatus: async () => executeStartStatus(targetIdentity),
+	} as unknown as NativeReviewCli;
+	await withSessionStartEnv(async (cwd) => {
+		const { handlers, sent } = harness(native);
+		const sessionStart = handlers.get("session_start");
+		const agentEnd = handlers.get("agent_end");
+		const shutdown = handlers.get("session_shutdown");
+		const session = ctx("session-baseline-shutdown", true, cwd);
+
+		await sessionStart!({}, session);
+		await agentEnd!(agentEndEvent, session);
+		assert.deepEqual(sent, [], "the baseline candidate is skipped");
+
+		await shutdown!({}, session);
+		await agentEnd!(agentEndEvent, session);
+		assert.equal(sent.length, 1, "shutdown cleared the baseline, so the same identity reminds again in the next session");
+	});
 });


### PR DESCRIPTION
Closes #568. Pair of the Claude Code `SessionStart` baseline in Gentleman-Programming/gentle-ai#4071.

## Cause

The `agent_end` review preflight reminder (#558) deduplicates per session and target identity but has no notion of what the session started with, so a worktree already dirty from the user's own work gets one reminder at the first loop end even when the agent edited nothing.

## Fix

- `resolveNegotiatedReviewStatusForSession(nativeReviewCli, ctx, sessionKey)` factors the guards and the read-only STATUS call shared by both handlers (review CLI present, interactive session, switch on, same retained-selection map, same `--agent pi` route).
- `session_start` records `status.targetIdentity` as the session baseline in a module map, silently; any error or a switch that reads off records nothing.
- `agent_end` stays silent when the current identity equals the baseline (the candidate predates the session) and otherwise keeps the once-per-candidate behavior; the baseline is released at `session_shutdown`.
- README gains one sentence.

## Verification

- `pnpm test`: 1204 tests, 1203 pass, 1 pre-existing Windows skip; `check:provider-contract`, `test:harness`, and `scripts/verify-package-files.mjs` pass. The test env helper now isolates `GENTLE_PI_CONFIG_HOME` as well as `GENTLE_PI_AGENT_HOME` so the session_start path does not read the machine's model config or dev-binary override.
- Native review (gentle-ai, lineage `review-a9c2bb05ceeda0e8`, tier medium, one lens): approved on the last admitted event and acknowledged (`gentle-ai.review-acknowledged/v1`, authority burned). Consent was answered `granted` under the maintainer's standing authorization.

https://claude.ai/code/session_01WYGtotXyhPmbnEeAZAbSbj
