### PR TITLE
feat(startup): compact HUD stats grid

### DIFF
--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -501,8 +501,12 @@ const WIDE_STATS_LABEL_WIDTH = 12;
 const WIDE_STATS_VALUE_WIDTH = 46;
 const WIDE_STATS_GUTTER = "   ";
 
+function sanitizeStartupStatValue(value: unknown): string {
+  return String(value ?? "").replace(/[\u0000-\u001f\u007f-\u009f]/g, "");
+}
+
 function fitStartupStatValue(value: unknown, width: number): string {
-  return String(value ?? "")
+  return sanitizeStartupStatValue(value)
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, width)
@@ -510,20 +514,24 @@ function fitStartupStatValue(value: unknown, width: number): string {
 }
 
 function buildStartupStatsGrid(width: number, stats: StartupStats): StartupStatsGrid {
+  const clean = (value: unknown) => sanitizeStartupStatValue(value);
   const narrowRows: StartupStat[] = [
-    { label: "PATH:", value: stats.path },
-    { label: "GIT:", value: stats.gitBranch },
-    { label: "MCP:", value: stats.mcp },
-    { label: "PLUGINS:", value: stats.plugins },
-    { label: "AGENTS:", value: stats.agents },
-    { label: "SKILLS:", value: stats.skills },
-    { label: "EXTENSIONS:", value: stats.extensions },
-    { label: "TOOLS:", value: stats.tools },
-    { label: "VER:", value: stats.version },
+    { label: "PATH:", value: clean(stats.path) },
+    { label: "GIT:", value: clean(stats.gitBranch) },
+    { label: "MCP:", value: clean(stats.mcp) },
+    { label: "PLUGINS:", value: clean(stats.plugins) },
+    { label: "AGENTS:", value: clean(stats.agents) },
+    { label: "SKILLS:", value: clean(stats.skills) },
+    { label: "EXTENSIONS:", value: clean(stats.extensions) },
+    { label: "TOOLS:", value: clean(stats.tools) },
+    { label: "VER:", value: clean(stats.version) },
   ];
 
   if (width < WIDE_STATS_MIN_WIDTH) {
-    const labelWidth = Math.max(...narrowRows.map(({ label }) => label.length));
+    const labelWidth = Math.min(
+      Math.max(...narrowRows.map(({ label }) => label.length)),
+      Math.max(0, width - 2),
+    );
     return {
       wide: false,
       labelWidth,
@@ -532,6 +540,7 @@ function buildStartupStatsGrid(width: number, stats: StartupStats): StartupStats
         Math.min(
           Math.max(...narrowRows.map(({ value }) => value.length)),
           Math.max(8, width - labelWidth - 4),
+          Math.max(0, width - labelWidth - 2),
         ),
       ),
       rows: narrowRows.map((left) => ({ left })),
@@ -559,12 +568,12 @@ function formatStartupStat(
   separator: string,
 ): string {
   if (!stat) return " ".repeat(labelWidth + separator.length + valueWidth);
-  return `${stat.label.padEnd(labelWidth)}${separator}${fitStartupStatValue(stat.value, valueWidth)}`;
+  return `${stat.label.slice(0, labelWidth).padEnd(labelWidth)}${separator}${fitStartupStatValue(stat.value, valueWidth)}`;
 }
 
 export function formatStartupStatsRows(width: number, stats: StartupStats): string[] {
   const grid = buildStartupStatsGrid(width, stats);
-  const separator = grid.wide ? " " : "  ";
+  const separator = grid.wide ? " " : " ".repeat(Math.min(2, Math.max(0, width)));
   return grid.rows.map(({ left, right }) => {
     const row = formatStartupStat(left, grid.labelWidth, grid.valueWidth, separator);
     return grid.wide

--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -477,6 +477,125 @@ const RESIZE_GRACE_PERIOD_MS = 300;
 
 type IntroMode = "full" | "minimal" | "skip";
 
+type StartupStats = {
+  gitBranch: string;
+  path: string;
+  mcp: string;
+  agents: string;
+  plugins: string;
+  skills: string;
+  extensions: string;
+  version: string;
+  tools: string;
+};
+type StartupStat = { label: string; value: string };
+type StartupStatsGrid = {
+  wide: boolean;
+  labelWidth: number;
+  valueWidth: number;
+  rows: Array<{ left: StartupStat; right?: StartupStat }>;
+};
+
+const WIDE_STATS_MIN_WIDTH = 122;
+const WIDE_STATS_LABEL_WIDTH = 12;
+const WIDE_STATS_VALUE_WIDTH = 46;
+const WIDE_STATS_GUTTER = "   ";
+
+function fitStartupStatValue(value: unknown, width: number): string {
+  return String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, width)
+    .padEnd(width);
+}
+
+function buildStartupStatsGrid(width: number, stats: StartupStats): StartupStatsGrid {
+  const narrowRows: StartupStat[] = [
+    { label: "PATH:", value: stats.path },
+    { label: "GIT:", value: stats.gitBranch },
+    { label: "MCP:", value: stats.mcp },
+    { label: "PLUGINS:", value: stats.plugins },
+    { label: "AGENTS:", value: stats.agents },
+    { label: "SKILLS:", value: stats.skills },
+    { label: "EXTENSIONS:", value: stats.extensions },
+    { label: "TOOLS:", value: stats.tools },
+    { label: "VER:", value: stats.version },
+  ];
+
+  if (width < WIDE_STATS_MIN_WIDTH) {
+    const labelWidth = Math.max(...narrowRows.map(({ label }) => label.length));
+    return {
+      wide: false,
+      labelWidth,
+      valueWidth: Math.max(
+        0,
+        Math.min(
+          Math.max(...narrowRows.map(({ value }) => value.length)),
+          Math.max(8, width - labelWidth - 4),
+        ),
+      ),
+      rows: narrowRows.map((left) => ({ left })),
+    };
+  }
+
+  return {
+    wide: true,
+    labelWidth: WIDE_STATS_LABEL_WIDTH,
+    valueWidth: WIDE_STATS_VALUE_WIDTH,
+    rows: [
+      { left: narrowRows[0], right: narrowRows[1] },
+      { left: narrowRows[2], right: narrowRows[3] },
+      { left: narrowRows[4], right: narrowRows[6] },
+      { left: narrowRows[5] },
+      { left: narrowRows[7], right: narrowRows[8] },
+    ],
+  };
+}
+
+function formatStartupStat(
+  stat: StartupStat | undefined,
+  labelWidth: number,
+  valueWidth: number,
+  separator: string,
+): string {
+  if (!stat) return " ".repeat(labelWidth + separator.length + valueWidth);
+  return `${stat.label.padEnd(labelWidth)}${separator}${fitStartupStatValue(stat.value, valueWidth)}`;
+}
+
+export function formatStartupStatsRows(width: number, stats: StartupStats): string[] {
+  const grid = buildStartupStatsGrid(width, stats);
+  const separator = grid.wide ? " " : "  ";
+  return grid.rows.map(({ left, right }) => {
+    const row = formatStartupStat(left, grid.labelWidth, grid.valueWidth, separator);
+    return grid.wide
+      ? `${row}${WIDE_STATS_GUTTER}${formatStartupStat(right, grid.labelWidth, grid.valueWidth, separator)}`
+      : row;
+  });
+}
+
+const STARTUP_STAT_LABEL_PATTERN =
+  /(?:^| {3})(?:PATH|GIT|MCP|PLUGINS|AGENTS|SKILLS|EXTENSIONS|TOOLS|VER):/g;
+
+function addFormattedStartupStatsRow(builder: LayoutBuilder, row: string): void {
+  const labelIndices = new Set<number>();
+  for (const match of row.matchAll(STARTUP_STAT_LABEL_PATTERN)) {
+    const label = match[0].trimStart();
+    const labelStart = match.index + match[0].length - label.length;
+    for (let index = labelStart; index < labelStart + label.length; index++) {
+      labelIndices.add(index);
+    }
+  }
+
+  builder.addRow();
+  for (let index = 0; index < row.length; index++) {
+    const char = row[index] ?? " ";
+    builder.add(
+      labelIndices.has(index) ? "label" : char === " " ? "none" : "value",
+      char,
+    );
+  }
+}
+
 function pickIntroMode(rows: number, cols: number): IntroMode {
   if (rows >= FULL_INTRO_MIN_ROWS && cols >= FULL_INTRO_MIN_COLS) return "full";
   if (rows >= MINIMAL_INTRO_MIN_ROWS && cols >= MINIMAL_INTRO_MIN_COLS) return "minimal";
@@ -758,10 +877,8 @@ export default function (pi: ExtensionAPI) {
             const frame = Math.floor(tick / 2);
 
             const sideBySideMinWidth = roseBase.width + 3 + logoBase.width + 4;
-            const wideStatsMinWidth = 122;
             const horizontal =
               state.mode === "full" && bannerConfig.showRose && bannerConfig.showTextLogo && width >= sideBySideMinWidth;
-            const wideStats = width >= wideStatsMinWidth;
 
             const b = new LayoutBuilder();
             b.addRow();
@@ -859,86 +976,20 @@ export default function (pi: ExtensionAPI) {
               b.addRow();
               b.center(width);
 
-              const fit = (v: unknown, w: number) =>
-                String(v ?? "")
-                  .replace(/\s+/g, " ")
-                  .trim()
-                  .slice(0, w)
-                  .padEnd(w);
-              const addWideRow = (
-                l1: string,
-                v1: string,
-                l2: string,
-                v2: string,
-              ) => {
-                b.addRow();
-                b.add("label", fit(l1, 10));
-                b.add("none", " ");
-                b.add("value", fit(v1, 48));
-                b.add("none", "   ");
-                b.add("label", fit(l2, 12));
-                b.add("none", " ");
-                b.add("value", fit(v2, 46));
+              const statsRows = formatStartupStatsRows(width, {
+                gitBranch,
+                path: ctx.cwd,
+                mcp: `${mcpServersCount} server(s)`,
+                agents: `${sddAgentsCount} phases`,
+                plugins: `${packagesCount} package(s)`,
+                skills: `${skills.length} loaded`,
+                extensions: `${extensionsCount} active`,
+                tools: `${customTools.length} custom`,
+                version: `v${VERSION}`,
+              });
+              for (const row of statsRows) {
+                addFormattedStartupStatsRow(b, row);
                 b.center(width);
-              };
-              const narrowRows: Array<[string, string]> = [
-                ["GIT:", gitBranch],
-                ["PATH:", ctx.cwd],
-                ["MCP:", `${mcpServersCount} server(s)`],
-                ["AGENTS:", `${sddAgentsCount} phases`],
-                ["PLUGINS:", `${packagesCount} package(s)`],
-                ["SKILLS:", `${skills.length} loaded`],
-                ["EXTENSIONS:", `${extensionsCount} active`],
-                ["VER:", `v${VERSION}`],
-                ["TOOLS:", `${customTools.length} custom`],
-              ];
-              const narrowLabelW = Math.max(...narrowRows.map(([l]) => l.length));
-              const narrowValueW = Math.max(
-                0,
-                Math.min(
-                  Math.max(...narrowRows.map(([, v]) => v.length)),
-                  Math.max(8, width - narrowLabelW - 4),
-                ),
-              );
-              const addNarrowRow = (label: string, value: string) => {
-                b.addRow();
-                b.add("label", label.padEnd(narrowLabelW));
-                b.add("none", "  ");
-                b.add("value", fit(value, narrowValueW));
-                b.center(width);
-              };
-
-              if (wideStats) {
-                addWideRow("GIT:", gitBranch, "PATH:", ctx.cwd);
-                addWideRow(
-                  "MCP:",
-                  `${mcpServersCount} server(s)`,
-                  "PLUGINS:",
-                  `${packagesCount} package(s)`,
-                );
-                addWideRow(
-                  "AGENTS:",
-                  `${sddAgentsCount} phases`,
-                  "EXTENSIONS:",
-                  `${extensionsCount} active`,
-                );
-                addWideRow(
-                  "SKILLS:",
-                  `${skills.length} loaded`,
-                  "TOOLS:",
-                  `${customTools.length} custom`,
-                );
-                addWideRow("VER:", `v${VERSION}`, "", "");
-              } else {
-                addNarrowRow("GIT:", gitBranch);
-                addNarrowRow("PATH:", ctx.cwd);
-                addNarrowRow("MCP:", `${mcpServersCount} server(s)`);
-                addNarrowRow("PLUGINS:", `${packagesCount} package(s)`);
-                addNarrowRow("AGENTS:", `${sddAgentsCount} phases`);
-                addNarrowRow("SKILLS:", `${skills.length} loaded`);
-                addNarrowRow("EXTENSIONS:", `${extensionsCount} active`);
-                addNarrowRow("VER:", `v${VERSION}`);
-                addNarrowRow("TOOLS:", `${customTools.length} custom`);
               }
 
               b.addRow();

--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -506,11 +506,10 @@ function sanitizeStartupStatValue(value: unknown): string {
 }
 
 function fitStartupStatValue(value: unknown, width: number): string {
-  return sanitizeStartupStatValue(value)
+  const normalizedValue = sanitizeStartupStatValue(value)
     .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, width)
-    .padEnd(width);
+    .trim();
+  return truncateToWidth(normalizedValue, width, "", true).replace(/\x1b\[0m$/, "");
 }
 
 function buildStartupStatsGrid(width: number, stats: StartupStats): StartupStatsGrid {

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -817,6 +817,52 @@ async function run() {
 	// (cancelled), and /gentle:banner -> Color row -> nested picker (cancelled).
 	// Also covers an invalid non-empty argument, which must still open the
 	// picker and treat its cancellation as a no-op.
+	// issue-375: all startup-stat rows must share one grid at the wide
+	// threshold. Long values must truncate within that grid rather than changing
+	// its columns or wrapping a terminal line.
+	{
+		const { formatStartupStatsRows } = await import(
+			`${pathToFileURL(join(ROOT, "extensions/startup-banner.ts")).href}?startup-stats-grid`,
+		);
+		const longStats = {
+			gitBranch: `On branch ${"branch-".repeat(12)}`,
+			path: `/${"workspace/".repeat(12)}`,
+			mcp: `${"9".repeat(70)} server(s)`,
+			agents: `${"8".repeat(70)} phases`,
+			plugins: `${"7".repeat(70)} package(s)`,
+			skills: `${"6".repeat(70)} loaded`,
+			extensions: `${"5".repeat(70)} active`,
+			version: `v${"4".repeat(70)}`,
+			tools: `${"3".repeat(70)} custom`,
+		};
+
+		const narrowRows = formatStartupStatsRows(80, longStats);
+		assert.deepEqual(
+			narrowRows.map((row) => row.match(/^(PATH:|GIT:|MCP:|PLUGINS:|AGENTS:|SKILLS:|EXTENSIONS:|TOOLS:|VER:)/)?.[1]),
+			["PATH:", "GIT:", "MCP:", "PLUGINS:", "AGENTS:", "SKILLS:", "EXTENSIONS:", "TOOLS:", "VER:"],
+			"narrow layout must show PATH before GIT and keep version visually secondary",
+		);
+		assert.ok(narrowRows.every((row) => row.length <= 80 && !row.includes("\n")), "narrow rows must not wrap or clip");
+
+		const thresholdRows = formatStartupStatsRows(122, longStats);
+		assert.equal(thresholdRows.length, 5, "wide layout must compact stats into five paired grid rows");
+		assert.ok(thresholdRows.every((row) => row.length === 121 && !row.includes("\n")), "122-column grid must fit without wrapping or clipping");
+		assert.deepEqual(
+			thresholdRows.map((row) => row.indexOf("GIT:") >= 0 ? row.indexOf("GIT:") : row.indexOf("PLUGINS:") >= 0 ? row.indexOf("PLUGINS:") : row.indexOf("EXTENSIONS:") >= 0 ? row.indexOf("EXTENSIONS:") : row.indexOf("VER:")),
+			[62, 62, 62, -1, 62],
+			"wide second-column stats must retain the same origin",
+		);
+		assert.equal(thresholdRows[0].slice(13, 59), longStats.path.slice(0, 46), "PATH must retain 46 characters at 122 columns");
+		assert.match(thresholdRows[4], /TOOLS:.*VER:/, "version must share the wide grid with another stat");
+
+		const largerRows = formatStartupStatsRows(160, longStats);
+		assert.deepEqual(largerRows, thresholdRows, "larger widths must preserve the stable wide grid geometry");
+		assert.ok(
+			thresholdRows.every((row) => row.length <= 122 && !row.includes("\n")),
+			"long path, branch, version, and count values must stay inside the 122-column grid",
+		);
+	}
+
 	const cancelPickerCwd = await tempWorkspace();
 	try {
 		const bannerConfigPath = join(globalConfigHome, "banner.json");

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -7,7 +7,7 @@ import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { discoverAndLoadExtensions } from "@earendil-works/pi-coding-agent";
-import { matchesKey } from "@earendil-works/pi-tui";
+import { matchesKey, visibleWidth } from "@earendil-works/pi-tui";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 import { domainHashV1 } from "../lib/review-canonical.ts";
@@ -852,13 +852,18 @@ async function run() {
 			["PATH:", "GIT:", "MCP:", "PLUGINS:", "AGENTS:", "SKILLS:", "EXTENSIONS:", "TOOLS:", "VER:"],
 			"narrow layout must show PATH before GIT and keep version visually secondary",
 		);
-		assert.ok(narrowRows.every((row) => row.length <= 80 && !row.includes("\n")), "narrow rows must not wrap or clip");
+		assert.ok(narrowRows.every((row) => visibleWidth(row) <= 80 && !row.includes("\n")), "narrow rows must not wrap or clip");
 
 		const thresholdRows = formatStartupStatsRows(122, longStats);
 		assert.equal(thresholdRows.length, 5, "wide layout must compact stats into five paired grid rows");
-		assert.ok(thresholdRows.every((row) => row.length === 121 && !row.includes("\n")), "122-column grid must fit without wrapping or clipping");
+		assert.ok(thresholdRows.every((row) => visibleWidth(row) === 121 && !row.includes("\n")), "122-column grid must fit without wrapping or clipping");
 		assert.deepEqual(
-			thresholdRows.map((row) => row.indexOf("GIT:") >= 0 ? row.indexOf("GIT:") : row.indexOf("PLUGINS:") >= 0 ? row.indexOf("PLUGINS:") : row.indexOf("EXTENSIONS:") >= 0 ? row.indexOf("EXTENSIONS:") : row.indexOf("VER:")),
+			thresholdRows.map((row) => {
+				const rightLabelIndex = ["GIT:", "PLUGINS:", "EXTENSIONS:", "VER:"]
+					.map((label) => row.indexOf(label))
+					.find((index) => index >= 0);
+				return rightLabelIndex === undefined ? -1 : visibleWidth(row.slice(0, rightLabelIndex));
+			}),
 			[62, 62, 62, -1, 62],
 			"wide second-column stats must retain the same origin",
 		);
@@ -868,8 +873,25 @@ async function run() {
 		const largerRows = formatStartupStatsRows(160, longStats);
 		assert.deepEqual(largerRows, thresholdRows, "larger widths must preserve the stable wide grid geometry");
 		assert.ok(
-			thresholdRows.every((row) => row.length <= 122 && !row.includes("\n")),
+			thresholdRows.every((row) => visibleWidth(row) <= 122 && !row.includes("\n")),
 			"long path, branch, version, and count values must stay inside the 122-column grid",
+		);
+
+		const unicodeStats = {
+			gitBranch: "plain",
+			path: "👩‍💻".repeat(7),
+			mcp: "plain",
+			agents: "plain",
+			plugins: "plain",
+			skills: "plain",
+			extensions: "界".repeat(7),
+			version: "plain",
+			tools: "plain",
+		};
+		const unicodeRows = formatStartupStatsRows(20, unicodeStats);
+		assert.ok(
+			unicodeRows.every((row) => visibleWidth(row) === 20),
+			"wide and grapheme values must truncate and pad to the terminal display width",
 		);
 
 		// PR #571: every rendered banner row must fit narrow widths, and runtime
@@ -896,7 +918,7 @@ async function run() {
 			);
 			for (const width of [1, 2, 5, 10, 19, 20]) {
 				assert.ok(
-					formatStartupStatsRows(width, longStats).every((row) => row.length <= Math.max(1, width)),
+					formatStartupStatsRows(width, longStats).every((row) => visibleWidth(row) <= Math.max(1, width)),
 					`startup stats must fit a ${width}-column terminal before rendering`,
 				);
 			}
@@ -912,7 +934,7 @@ async function run() {
 				tools: unsafePath,
 			};
 			for (const row of formatStartupStatsRows(80, unsafeStats)) {
-				assert.doesNotMatch(row, /[\x00-\x1f\x7f-\x9f]/, "startup stats must sanitize controls before layout");
+				assert.doesNotMatch(stripAnsi(row), /[\x00-\x1f\x7f-\x9f]/, "startup stats must sanitize controls before layout");
 			}
 
 			const renderPath = unsafePath.replace(/\u0000/g, "");

--- a/tests/runtime-harness.mjs
+++ b/tests/runtime-harness.mjs
@@ -122,11 +122,11 @@ function createPi() {
 		},
 		getAllTools() {
 			return [
-				{ name: "read" },
-				{ name: "bash" },
-				{ name: "edit" },
-				{ name: "write" },
-				{ name: "mem_save" },
+				{ name: "read", sourceInfo: { source: "builtin" } },
+				{ name: "bash", sourceInfo: { source: "builtin" } },
+				{ name: "edit", sourceInfo: { source: "builtin" } },
+				{ name: "write", sourceInfo: { source: "builtin" } },
+				{ name: "mem_save", sourceInfo: { source: "builtin" } },
 			];
 		},
 	};
@@ -137,9 +137,19 @@ function createPi() {
 function createUi() {
 	const notifications = [];
 	const selections = [];
+	let header;
 	return {
 		notifications,
 		selections,
+		get header() {
+			return header;
+		},
+		setHeader(factory) {
+			header = factory(
+				{ requestRender() {} },
+				{ fg(_name, text) { return text; } },
+			);
+		},
 		notify(message, level = "info") {
 			notifications.push({ message, level });
 		},
@@ -861,6 +871,76 @@ async function run() {
 			thresholdRows.every((row) => row.length <= 122 && !row.includes("\n")),
 			"long path, branch, version, and count values must stay inside the 122-column grid",
 		);
+
+		// PR #571: every rendered banner row must fit narrow widths, and runtime
+		// values must never introduce terminal controls. The harness uses ctx.cwd as
+		// the nearest real dynamic input seam because control bytes are not portable
+		// process-environment values.
+		const bannerConfigPath = join(globalConfigHome, "banner.json");
+		const originalRows = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		const originalColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+		const originalWrite = process.stdout.write;
+		const unsafePath = `safe\u0000\u0001\u007f\u009b31m\x1b]8;;https://example.invalid\u0007link\x1b]8;;\x1b\\tail`;
+		const restoreTerminalDimensions = () => {
+			if (originalRows) Object.defineProperty(process.stdout, "rows", originalRows);
+			else delete process.stdout.rows;
+			if (originalColumns) Object.defineProperty(process.stdout, "columns", originalColumns);
+			else delete process.stdout.columns;
+		};
+		try {
+			Object.defineProperty(process.stdout, "rows", { configurable: true, value: 30 });
+			Object.defineProperty(process.stdout, "columns", { configurable: true, value: 80 });
+			await writeFile(
+				bannerConfigPath,
+				'{"showRose":false,"showTextLogo":false,"color":"pink"}\n',
+			);
+			for (const width of [1, 2, 5, 10, 19, 20]) {
+				assert.ok(
+					formatStartupStatsRows(width, longStats).every((row) => row.length <= Math.max(1, width)),
+					`startup stats must fit a ${width}-column terminal before rendering`,
+				);
+			}
+			const unsafeStats = {
+				gitBranch: unsafePath,
+				path: unsafePath,
+				mcp: unsafePath,
+				agents: unsafePath,
+				plugins: unsafePath,
+				skills: unsafePath,
+				extensions: unsafePath,
+				version: unsafePath,
+				tools: unsafePath,
+			};
+			for (const row of formatStartupStatsRows(80, unsafeStats)) {
+				assert.doesNotMatch(row, /[\x00-\x1f\x7f-\x9f]/, "startup stats must sanitize controls before layout");
+			}
+
+			const renderPath = unsafePath.replace(/\u0000/g, "");
+			const bannerCtx = createCtx(renderPath, true, "startup-banner-safety");
+			process.stdout.write = () => true;
+			await hooks.get("session_start").at(-1)({ reason: "startup" }, bannerCtx);
+			await new Promise((resolve) => setTimeout(resolve, 60));
+			assert.ok(bannerCtx.ui.header, "startup banner must register a header renderer");
+
+			for (const width of [20, 40, 80, 122, 160]) {
+				const lines = bannerCtx.ui.header.render(width);
+				assert.ok(lines.length > 0, `startup banner must render at width ${width}`);
+				assert.ok(
+					lines.every((line) => stripAnsi(line).length <= width),
+					`ANSI-stripped startup-banner rows must fit width ${width}`,
+				);
+				for (const line of lines) {
+					const withoutTrustedStyles = line.replace(/\x1b\[(?:\d+(?:;\d+)*)?m/g, "");
+					assert.doesNotMatch(withoutTrustedStyles, /[\x00-\x1a\x1c-\x1f\x7f-\x9f]/, "dynamic values must not emit terminal controls");
+					assert.doesNotMatch(withoutTrustedStyles, /\x1b/, "only trusted SGR styling may remain");
+				}
+			}
+			bannerCtx.ui.header.invalidate();
+		} finally {
+			process.stdout.write = originalWrite;
+			restoreTerminalDimensions();
+			await rm(bannerConfigPath, { force: true });
+		}
 	}
 
 	const cancelPickerCwd = await tempWorkspace();


### PR DESCRIPTION
Closes #375

## Type

- [x] New feature

## Summary

- render wide startup stats through one stable column grid at the 122-column threshold and above
- preserve 46-character PATH capacity, move version into the wide grid, and order PATH before GIT in narrow layouts
- add regression coverage for narrow, threshold, wide, and long-value rendering through the same formatter used by production
- keep every stats row within the requested terminal display width and strip terminal control characters from dynamic stat values before layout

## Context

This implements the rework requested from the layout approach in #36. It does not modify or close that contributor PR.

## Changes

| File | Change |
|------|--------|
| `extensions/startup-banner.ts` | Centralize narrow/wide formatting, clamp values by terminal display width, sanitize dynamic values, and render production stats through the tested formatter. |
| `tests/runtime-harness.mjs` | Cover stable geometry, tiny/narrow/wide boundaries, CJK/emoji display width, dynamic control sanitization, and the production render seam. |

## Test plan

- [x] `git diff --check`
- [x] `pnpm run test:harness` — passed
- [x] `pnpm test` — 1214 passed, 0 failed, 1 skipped; provider contract check passed
- [x] `pnpm run check:runtime-modules` — 4 runtime mirrors match
- [x] Package verification — 162 files; packed-package E2E passed
- [x] Cortex Test Runner and Adversarial Tester passed on the frozen corrected diff
- [x] `gentle-pi-dev` visual dogfooding passed in wide and narrow layouts
- [x] Verified exactly 122 columns and wider layouts retain stable alignment and PATH capacity
- [x] Verified only the two approved files changed

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck not applicable; no shell scripts changed
- [x] Skills not affected
- [x] Documentation not required; user-facing behavior is covered by runtime regression tests
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved startup banner statistics layout across different terminal widths.
  - Added clearer display of `PATH` and `TOOLS` statistics where space allows.
  - Preserved readable alignment and prevented wrapping or clipping of long values in narrow and wide layouts.
  - Sanitized unusual characters and normalized long values to keep startup statistics clean and readable.
  - Improved handling of wide characters for more accurate terminal alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

