### PR TITLE
fix(skill-registry): discover category-nested skills

### DIFF
--- a/extensions/skill-registry.ts
+++ b/extensions/skill-registry.ts
@@ -94,6 +94,11 @@ function projectSkillDirs(cwd: string): string[] {
 	];
 }
 
+function isMissingSkillFileError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null || !("code" in error)) return false;
+	return error.code === "ENOENT" || error.code === "ENOTDIR";
+}
+
 async function findSkillFiles(root: string): Promise<string[]> {
 	if (!(await pathExists(root))) return [];
 	let entries;
@@ -103,7 +108,8 @@ async function findSkillFiles(root: string): Promise<string[]> {
 		return [];
 	}
 
-	const out: string[] = [];
+	const directSkills: string[] = [];
+	const nestedSkills: string[] = [];
 	for (const entry of entries) {
 		const skillDir = join(root, entry.name);
 		let dirInfo;
@@ -117,13 +123,12 @@ async function findSkillFiles(root: string): Promise<string[]> {
 		const candidate = join(skillDir, "SKILL.md");
 		try {
 			const skillInfo = await stat(candidate);
-			if (skillInfo.isFile()) {
-				out.push(candidate);
-				continue;
-			}
-		} catch {
-			// A non-skill child may be a category; inspect exactly one level deeper.
+			if (skillInfo.isFile()) directSkills.push(candidate);
+			continue;
+		} catch (error) {
+			if (!isMissingSkillFileError(error)) continue;
 		}
+		if (entry.isSymbolicLink() || isExcluded(entry.name)) continue;
 
 		let nestedEntries;
 		try {
@@ -132,6 +137,7 @@ async function findSkillFiles(root: string): Promise<string[]> {
 			continue;
 		}
 		for (const nestedEntry of nestedEntries) {
+			if (nestedEntry.isSymbolicLink()) continue;
 			const nestedSkillDir = join(skillDir, nestedEntry.name);
 			let nestedDirInfo;
 			try {
@@ -144,13 +150,13 @@ async function findSkillFiles(root: string): Promise<string[]> {
 			const nestedCandidate = join(nestedSkillDir, "SKILL.md");
 			try {
 				const nestedSkillInfo = await stat(nestedCandidate);
-				if (nestedSkillInfo.isFile()) out.push(nestedCandidate);
+				if (nestedSkillInfo.isFile()) nestedSkills.push(nestedCandidate);
 			} catch {
 				// Missing or unreadable skill files are ignored; the registry is best-effort.
 			}
 		}
 	}
-	return out.sort();
+	return [...directSkills.sort(), ...nestedSkills.sort()];
 }
 
 function parseFrontmatter(source: string): { name?: string; description?: string; body: string } {
@@ -555,6 +561,7 @@ export const __testing = {
 	projectSkillDirs,
 	userSkillDirs,
 	findSkillFiles,
+	isMissingSkillFileError,
 	uniqueExistingDirs,
 	dedupeBySkillName,
 	scopeForPath,

--- a/extensions/skill-registry.ts
+++ b/extensions/skill-registry.ts
@@ -117,9 +117,37 @@ async function findSkillFiles(root: string): Promise<string[]> {
 		const candidate = join(skillDir, "SKILL.md");
 		try {
 			const skillInfo = await stat(candidate);
-			if (skillInfo.isFile()) out.push(candidate);
+			if (skillInfo.isFile()) {
+				out.push(candidate);
+				continue;
+			}
 		} catch {
-			// Missing or unreadable skill files are ignored; the registry is best-effort.
+			// A non-skill child may be a category; inspect exactly one level deeper.
+		}
+
+		let nestedEntries;
+		try {
+			nestedEntries = await readdir(skillDir, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const nestedEntry of nestedEntries) {
+			const nestedSkillDir = join(skillDir, nestedEntry.name);
+			let nestedDirInfo;
+			try {
+				nestedDirInfo = await stat(nestedSkillDir);
+			} catch {
+				continue;
+			}
+			if (!nestedDirInfo.isDirectory()) continue;
+
+			const nestedCandidate = join(nestedSkillDir, "SKILL.md");
+			try {
+				const nestedSkillInfo = await stat(nestedCandidate);
+				if (nestedSkillInfo.isFile()) out.push(nestedCandidate);
+			} catch {
+				// Missing or unreadable skill files are ignored; the registry is best-effort.
+			}
 		}
 	}
 	return out.sort();

--- a/tests/skill-registry.test.ts
+++ b/tests/skill-registry.test.ts
@@ -114,16 +114,19 @@ test("uniqueExistingDirs normalizes duplicates and ignores missing roots", async
 	);
 });
 
-test("findSkillFiles scans one skill directory level only", async () => {
+test("findSkillFiles scans flat skills and category-nested skills without descending further", async () => {
 	const root = join(tmpdir(), `gentle-pi-shallow-${Date.now()}`);
 	const skillPath = join(root, "docs", "SKILL.md");
 	const nestedSkillPath = join(root, "fixtures", "nested", "SKILL.md");
+	const deeperSkillPath = join(root, "fixtures", "nested", "deeper", "SKILL.md");
 	mkdirSync(dirname(skillPath), { recursive: true });
 	mkdirSync(dirname(nestedSkillPath), { recursive: true });
+	mkdirSync(dirname(deeperSkillPath), { recursive: true });
 	writeFileSync(skillPath, "---\nname: docs\ndescription: Docs.\n---\n");
 	writeFileSync(nestedSkillPath, "---\nname: nested\ndescription: Nested fixture.\n---\n");
+	writeFileSync(deeperSkillPath, "---\nname: deeper\ndescription: Deeper fixture.\n---\n");
 
-	assert.deepEqual(await __testing.findSkillFiles(root), [skillPath]);
+	assert.deepEqual(await __testing.findSkillFiles(root), [skillPath, nestedSkillPath]);
 });
 
 test("findSkillFiles follows symlinked skill directories", async (t) => {

--- a/tests/skill-registry.test.ts
+++ b/tests/skill-registry.test.ts
@@ -129,22 +129,58 @@ test("findSkillFiles scans flat skills and category-nested skills without descen
 	assert.deepEqual(await __testing.findSkillFiles(root), [skillPath, nestedSkillPath]);
 });
 
-test("findSkillFiles follows symlinked skill directories", async (t) => {
+test("findSkillFiles keeps direct skills ahead of alphabetically earlier nested collisions", async () => {
+	const cwd = join(tmpdir(), `gentle-pi-precedence-${Date.now()}`);
+	const directSkillPath = join(cwd, "skills", "zeta", "SKILL.md");
+	const nestedSkillPath = join(cwd, "skills", "alpha", "duplicate", "SKILL.md");
+	mkdirSync(dirname(directSkillPath), { recursive: true });
+	mkdirSync(dirname(nestedSkillPath), { recursive: true });
+	writeFileSync(directSkillPath, "---\nname: duplicate\ndescription: Direct skill.\n---\n");
+	writeFileSync(nestedSkillPath, "---\nname: duplicate\ndescription: Nested skill.\n---\n");
+
+	await __testing.regenerateRegistry(cwd, true);
+	const registry = readFileSync(join(cwd, ".atl", "skill-registry.md"), "utf8");
+	assert.match(registry, new RegExp(directSkillPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+	assert.doesNotMatch(registry, new RegExp(nestedSkillPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("findSkillFiles does not descend into excluded categories", async () => {
+	const root = join(tmpdir(), `gentle-pi-excluded-category-${Date.now()}`);
+	for (const category of ["_shared", "skill-registry", "sdd-fixtures"]) {
+		const nestedSkillPath = join(root, category, "hidden", "SKILL.md");
+		mkdirSync(dirname(nestedSkillPath), { recursive: true });
+		writeFileSync(nestedSkillPath, "---\nname: hidden\ndescription: Hidden skill.\n---\n");
+	}
+
+	assert.deepEqual(await __testing.findSkillFiles(root), []);
+});
+
+test("findSkillFiles follows direct symlinked skills but not symlinked categories", async (t) => {
 	const root = join(tmpdir(), `gentle-pi-symlink-root-${Date.now()}`);
 	const realSkillDir = join(tmpdir(), `gentle-pi-symlink-target-${Date.now()}`);
+	const categoryTarget = join(tmpdir(), `gentle-pi-symlink-category-${Date.now()}`);
 	const linkedSkillDir = join(root, "linked");
 	const skillPath = join(linkedSkillDir, "SKILL.md");
 	mkdirSync(root, { recursive: true });
 	mkdirSync(realSkillDir, { recursive: true });
+	mkdirSync(join(categoryTarget, "nested"), { recursive: true });
 	writeFileSync(join(realSkillDir, "SKILL.md"), "---\nname: linked\ndescription: Linked skill.\n---\n");
+	writeFileSync(join(categoryTarget, "nested", "SKILL.md"), "---\nname: nested\ndescription: Nested skill.\n---\n");
 	try {
 		symlinkSync(realSkillDir, linkedSkillDir, "dir");
+		symlinkSync(categoryTarget, join(root, "category"), "dir");
 	} catch (error) {
 		t.skip(`symlink creation unavailable: ${error instanceof Error ? error.message : String(error)}`);
 		return;
 	}
 
 	assert.deepEqual(await __testing.findSkillFiles(root), [skillPath]);
+});
+
+test("only missing skill-file errors allow category scanning", () => {
+	assert.equal(__testing.isMissingSkillFileError({ code: "ENOENT" }), true);
+	assert.equal(__testing.isMissingSkillFileError({ code: "ENOTDIR" }), true);
+	assert.equal(__testing.isMissingSkillFileError({ code: "EACCES" }), false);
 });
 
 test("skill registry watchers close on shutdown", async () => {


### PR DESCRIPTION
Closes #304

## Type

- [x] Bug fix

## Summary

- discover skills organized as `<root>/<category>/<skill>/SKILL.md`
- preserve the existing flat `<root>/<skill>/SKILL.md` fast path
- keep traversal intentionally bounded to one category level, matching the approved issue scope

## Changes

| File | Change |
|------|--------|
| `extensions/skill-registry.ts` | Inspect one additional category level while preserving flat precedence, reserved-category exclusions, symlink trust boundaries, and best-effort error handling. |
| `tests/skill-registry.test.ts` | Cover bounded nesting, flat precedence, reserved categories, symlink behavior, and filesystem error classification. |

## Test plan

- [x] `git diff --check`
- [x] `node --experimental-strip-types --test tests/skill-registry.test.ts` — 20 passed, 0 failed
- [x] `pnpm test` — 1206 passed, 0 failed, 1 skipped
- [x] `node scripts/verify-package-files.mjs` — 163 files and 68 byte-pinned artifacts verified
- [x] Verified only the two approved files changed

## Scope

This intentionally does not add generic recursion, watcher behavior, cache schema changes, locale changes, or unrelated npm/EACCES handling. Direct reserved-directory semantics remain unchanged and outside #304.

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck not applicable; no shell scripts changed
- [x] Focused and full tests passed
- [x] Documentation not required; existing flat layouts remain compatible
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill discovery now supports skills nested one directory below a category folder.
  * Direct skills are prioritized over nested skills with the same name.
  * Results are returned in a consistent order.
  * Deeper nested directories remain excluded from discovery.
  * Excluded and symlinked category folders are not scanned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->