### PR TITLE
fix(skills): automate YAML issue form publication

### DIFF
--- a/skills/issue-creation/SKILL.md
+++ b/skills/issue-creation/SKILL.md
@@ -46,14 +46,14 @@ LABEL_ARGS+=(--label "$LABEL") # Repeat only for each permitted discovered label
    gh issue list --repo "$TARGET" --state all --search "$QUERY" --limit 1000
    ```
 
-   If results are saturated or completeness is uncertain, narrow the read-only search or stop. Comment on a confirmed duplicate instead of creating one.
+   If results are saturated or completeness is uncertain, narrow the read-only search or stop. Comment on a confirmed duplicate instead of creating one. Before commenting on a confirmed duplicate, perform the same privacy scan/redaction on the exact comment body as for publication.
 2. Select one repository-provided form only when its declared purpose matches. If multiple forms match and policy does not distinguish them, stop and request that decision.
-3. For a YAML form, read its schema and establish controls in declared order. Support only `input`, `textarea`, `dropdown`, and `checkboxes`; ignore `markdown` guidance. Fail closed before mutation on malformed, unsupported, missing, or ambiguous required structure or answers. Missing or ambiguous required answers fail closed: do not open a browser or mutate. For a malformed, unsupported, or unrepresentable form, report why automation is unsafe and stop; only when the user explicitly requests browser completion may the browser handoff below be used.
+3. For a YAML form, read its schema and establish controls in declared order. Support only `input`, `textarea`, `dropdown`, and `checkboxes`. Markdown controls are non-answer guidance: honor their visible instructions when collecting and materializing adjacent answers, but do not render them as response sections. Fail closed before mutation on malformed, unsupported, missing, or ambiguous required structure or answers. A malformed schema, or missing or ambiguous required answers, fail closed: do not open a browser or mutate. A browser handoff is available only when the user explicitly requests browser completion or a syntactically valid selected form cannot safely/faithfully be represented by the automated path; otherwise report why automation is unsafe and stop.
 
 | Control | Required handling |
 | --- | --- |
 | `input` / `textarea` | Preserve the visible label. Require an answer when `validations.required` is true; otherwise render `_No response_`. |
-| `dropdown` | Preserve visible labels and options. Require exact selected option text; single-select has one selection, and multi-select preserves selections in declared options order. A required dropdown needs at least one valid selection. |
+| `dropdown` | Preserve visible labels and options. Require exact selected option text; single-select has one selection, and multi-select preserves selections in declared options order. A required dropdown needs at least one valid selection; an optional dropdown with no selection renders `_No response_`. |
 | `checkboxes` | Preserve the visible label and every option as `- [x]` or `- [ ]` in declared order. Enforce individually required checkboxes and require explicit first-person affirmation for first-person option text. |
 
 For each answer, render `### <visible label>` followed by its materialized value. For `textarea.attributes.render`, fence the answer with the declared language and a fence long enough for its content. Never invent answers, selections, confirmations, or labels.
@@ -68,11 +68,20 @@ Create one owner-only temporary directory outside the repository for both privat
 
 ```bash
 umask 077
-TMP_DIR="$(mktemp -d)"
-chmod 700 "$TMP_DIR"
-BODY_FILE="$TMP_DIR/body.md"
-READBACK_FILE="$TMP_DIR/readback.json"
-trap 'rm -rf "$TMP_DIR"' EXIT
+REPO_ROOT="$(git rev-parse --show-toplevel)" || exit 1
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd -P)" || exit 1
+if [ "$REPO_ROOT" = "/" ]; then
+  printf '%s\n' "Temporary directory is inside the repository" >&2; exit 1
+fi
+TMP_DIR="$(TMPDIR=/tmp mktemp -d /tmp/gentle-ai-issue.XXXXXXXX)" || exit 1
+trap 'rm -rf -- "$TMP_DIR"' EXIT
+TMP_DIR_REAL="$(cd "$TMP_DIR" && pwd -P)" || exit 1
+case "$TMP_DIR_REAL/" in
+  "$REPO_ROOT/"*) printf '%s\n' "Temporary directory is inside the repository" >&2; exit 1 ;;
+esac
+chmod 700 "$TMP_DIR_REAL"
+BODY_FILE="$TMP_DIR_REAL/body.md"
+READBACK_FILE="$TMP_DIR_REAL/readback.json"
 ```
 
 Make one mutation attempt through the automated path and publish exactly once:
@@ -81,7 +90,7 @@ Make one mutation attempt through the automated path and publish exactly once:
 gh issue create --repo "$TARGET" --title "$TITLE" --body-file "$BODY_FILE" "${LABEL_ARGS[@]}"
 ```
 
-Only when the user explicitly requests browser completion may an optional, separate browser handoff open the repository form; it is never the default or a response to missing answers:
+When browser completion is available under the form decision above, an optional, separate browser handoff may open the repository form. It is never proof of publication and is never a response to malformed schemas or missing/ambiguous required answers:
 
 ```bash
 gh issue create --repo "$TARGET" --web

--- a/skills/issue-creation/SKILL.md
+++ b/skills/issue-creation/SKILL.md
@@ -4,18 +4,14 @@ description: "Create and triage GitHub issues from repository evidence. Trigger:
 license: Apache-2.0
 metadata:
   author: gentleman-programming
-  version: "1.2"
+  version: "1.3"
 ---
 
 # Issue Creation
 
-## When To Use
-
-Use this skill when creating, drafting, triaging, or approving an issue in the current GitHub repository.
-
 ## Core Rule
 
-Discover the repository's actual contribution workflow before proposing or publishing an issue. Templates, labels, approval gates, and Discussions support are repository policy, not universal GitHub behavior.
+Discover the target repository's contribution workflow before proposing or publishing. YAML Issue Forms are the format authority for the default automated path: materialize reviewed answers into a private `BODY_FILE` and publish with `--body-file`.
 
 ## Safe Discovery
 
@@ -27,123 +23,78 @@ REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 REPO_URL="$(gh repo view --json url -q .url)"
 HOST="${REPO_URL#*://}"
 HOST="${HOST%%/*}"
+TARGET="$HOST/$REPO"
 gh repo view --json nameWithOwner,url,hasDiscussionsEnabled,hasIssuesEnabled,isBlankIssuesEnabled
-git ls-files CONTRIBUTING.md CONTRIBUTING.* .github/CONTRIBUTING.md .github/ISSUE_TEMPLATE
+git ls-files README.md CONTRIBUTING.md CONTRIBUTING.* .github/CONTRIBUTING.md .github/ISSUE_TEMPLATE .github/ISSUE_TEMPLATE/config.yml
 gh api --hostname "$HOST" --paginate "repos/$REPO/labels?per_page=100" --jq '.[].name'
 ```
 
-Also inspect:
+Inspect `README.md`, contribution instructions, `.github/ISSUE_TEMPLATE/config.yml` contact links, forms, labels, and open and closed issues. For questions/support, follow repository-prescribed Discussions/contact routing when available; otherwise ask or stop. Complete target verification for `REPO`, `HOST`, and `TARGET`. Fail closed before mutation when authentication, target verification, issue availability, policy, form selection, or required metadata is missing or ambiguous. A blank fallback is allowed only when `isBlankIssuesEnabled` is explicitly true.
 
-- repository instructions such as `CONTRIBUTING.md` and `README.md`;
-- files under `.github/ISSUE_TEMPLATE`;
-- `.github/ISSUE_TEMPLATE/config.yml` when present;
-- issue forms, required fields, and labels declared by each template;
-- existing open and closed issues for duplicates and established wording.
-
-Stop and ask for repository context if authentication, repository resolution, verification that REPO and HOST are non-empty, required metadata is unavailable, hasIssuesEnabled is false, or policy discovery fails. Never continue from failed discovery into issue publication.
-
-A no-template fallback is allowed only when isBlankIssuesEnabled is explicitly true. Otherwise follow discovered contact links or stop and ask; never publish.
-
-After discovery and review, build optional label arguments using only labels that exist and repository policy permits the actor to apply:
+Build `LABEL_ARGS` only from reviewed labels that exist and policy permits the actor to apply:
 
 ```bash
 LABEL_ARGS=()
-# Repeat for each reviewed, permitted discovered label.
-LABEL_ARGS+=(--label "$LABEL")
+LABEL_ARGS+=(--label "$LABEL") # Repeat only for each permitted discovered label.
 ```
 
-An empty array applies no label; do not invent labels.
+## Duplicate And Form Decision
 
-## Workflow
-
-1. Describe the problem or request in one sentence and derive a short search query.
-2. Search open and closed issues:
+1. Describe the report in one sentence, derive `QUERY`, then complete one duplicate search across open and closed issues:
 
    ```bash
-   gh issue list --repo "$HOST/$REPO" --state all --search "$QUERY" --limit 1000
+   gh issue list --repo "$TARGET" --state all --search "$QUERY" --limit 1000
    ```
 
-   If 1000 results are returned or completeness remains uncertain, narrow the search, use read-only API discovery, or stop and ask before publishing.
+   If results are saturated or completeness is uncertain, narrow the read-only search or stop. Comment on a confirmed duplicate instead of creating one.
+2. Select one repository-provided form only when its declared purpose matches. If multiple forms match and policy does not distinguish them, stop and request that decision.
+3. For a YAML form, read its schema and establish controls in declared order. Support only `input`, `textarea`, `dropdown`, and `checkboxes`; ignore `markdown` guidance. Fail closed before mutation on malformed, unsupported, missing, or ambiguous required structure or answers. Missing or ambiguous required answers fail closed: do not open a browser or mutate. For a malformed, unsupported, or unrepresentable form, report why automation is unsafe and stop; only when the user explicitly requests browser completion may the browser handoff below be used.
 
-3. If an issue already covers the same behavior, comment there instead of creating a duplicate.
-4. Choose a repository-provided template only when its purpose matches the report.
-5. Fill every required template field from known evidence. Ask for missing facts rather than inventing them.
-6. Apply labels only when they exist and repository guidance establishes who should apply them.
-7. Publish only after the title, body, target repository, and selected template or fallback have been reviewed, and the pre-submission privacy review below has passed.
+| Control | Required handling |
+| --- | --- |
+| `input` / `textarea` | Preserve the visible label. Require an answer when `validations.required` is true; otherwise render `_No response_`. |
+| `dropdown` | Preserve visible labels and options. Require exact selected option text; single-select has one selection, and multi-select preserves selections in declared options order. A required dropdown needs at least one valid selection. |
+| `checkboxes` | Preserve the visible label and every option as `- [x]` or `- [ ]` in declared order. Enforce individually required checkboxes and require explicit first-person affirmation for first-person option text. |
 
-## Pre-submission Privacy Review
+For each answer, render `### <visible label>` followed by its materialized value. For `textarea.attributes.render`, fence the answer with the declared language and a fence long enough for its content. Never invent answers, selections, confirmations, or labels.
 
-Pre-submission privacy review is mandatory. Scan every issue body immediately before `gh issue create`. The scan replaces — never deletes — environment-specific data with explicit placeholders so the reproduction still teaches:
+A Markdown template may be completed only from known evidence into the same private `BODY_FILE`. If no matching template exists, use the reviewed structured blank fallback only when blank issues are explicitly enabled; otherwise stop without publishing.
 
-| Category | Replace with | Example (before → after) |
-|----------|---------------|---------------------------|
-| Private project names | `<project-name>` | `my-private-project-b` → `<project-name>` |
-| Usernames | `<user>` | `C:\Users\my-real-username\go\bin` → `C:\Users\<user>\go\bin` |
-| Hostnames | `<hostname>` | `devbox-macbook.local` → `<hostname>` |
-| Home paths | `/home/<user>` or `C:\Users\<user>` | (covered above) |
-| API keys, tokens, passwords | `<token>` / `<password>` | `ghp_abc123...` → `<token>` |
-| Internal ports / hostnames | `<host>:<port>` | `10.0.0.42:5432` → `<host>:<port>` |
+## Review And Publication
 
-Do NOT redact intentionally public identifiers: tool names (`gentle-ai`, `engram`, `go`, `node`, `python`), package names, public documentation URLs, generic example domains (`example.com`, `localhost`). Keep reproduction structure with placeholders — never redact an example into nothingness.
+Before the single create attempt, review the target, title, selected form or permitted fallback, exact body, and permitted labels. Perform a privacy scan immediately before publication: replace private project names, usernames, hostnames, home paths, credentials, and private network addresses with useful placeholders without removing reproduction structure.
 
-**Rule of thumb:** if the reader can run the reproduction step after you replace every identifier with its placeholder, the sanitization is correct. If a step becomes impossible (because the placeholder consumed a needed value), that step needs the value — and you should mark it `<value-required>` and explain in the body what the user should fill in.
-
-## Template Paths
-
-Do not guess a template filename. If multiple templates could apply and repository guidance does not distinguish them, stop and ask which one to use.
-
-- .yml and .yaml files are GitHub Issue Forms. Do not parse or render their schema. Open the web issue chooser and stop for human completion:
-
-  ```bash
-  gh issue create --repo "$HOST/$REPO" --web "${LABEL_ARGS[@]}"
-  ```
-
-- .md files are Markdown templates. Read the matching template, complete it from known evidence into a reviewed BODY_FILE, then publish it:
-
-  ```bash
-  gh issue create --repo "$HOST/$REPO" --title "$TITLE" --body-file "$BODY_FILE" "${LABEL_ARGS[@]}"
-  ```
-
-## No-Template Fallback
-
-When the repository permits issue creation, provides no matching template, and isBlankIssuesEnabled is explicitly true, prepare a structured body with these sections:
-
-- problem or requested outcome;
-- reproduction or motivating example;
-- expected behavior;
-- actual behavior or current limitation;
-- environment and relevant evidence;
-- alternatives or workarounds, when applicable.
-
-Publish the reviewed fallback explicitly:
+Create one owner-only temporary directory outside the repository for both private files; restrict it to the current user and clean up both files on every exit/outcome:
 
 ```bash
-gh issue create --repo "$HOST/$REPO" --title "$TITLE" --body "$BODY" "${LABEL_ARGS[@]}"
+umask 077
+TMP_DIR="$(mktemp -d)"
+chmod 700 "$TMP_DIR"
+BODY_FILE="$TMP_DIR/body.md"
+READBACK_FILE="$TMP_DIR/readback.json"
+trap 'rm -rf "$TMP_DIR"' EXIT
 ```
 
-If blank issues are not explicitly enabled, follow discovered contact links or stop and ask. Never publish a no-template fallback.
+Make one mutation attempt through the automated path and publish exactly once:
 
-## Labels And Approval
+```bash
+gh issue create --repo "$TARGET" --title "$TITLE" --body-file "$BODY_FILE" "${LABEL_ARGS[@]}"
+```
 
-Treat labels and approval gates as conditional:
+Only when the user explicitly requests browser completion may an optional, separate browser handoff open the repository form; it is never the default or a response to missing answers:
 
-- use only labels returned by repository discovery;
-- follow contribution guidance for who may apply each label;
-- wait when repository policy requires maintainer approval before implementation;
-- do not invent a status or priority taxonomy when none is documented.
+```bash
+gh issue create --repo "$TARGET" --web
+```
 
-## Questions And Discussions
+Do not retry a timeout, network failure, missing identity, or other uncertain result. Capture the returned issue number, then read it back from the verified target host before reporting success:
 
-Use Discussions only when `hasDiscussionsEnabled` is true and repository guidance routes the question there. Otherwise follow documented support/contact links or ask the user where the question belongs. Never link to another repository's Discussions page.
+```bash
+gh issue view "$NUMBER" --repo "$TARGET" --json number,url,title,body,state,labels >"$READBACK_FILE"
+```
 
-## Triage Decision
+Confirm that read-back identifies the target-host issue and that title and body match after only CRLF-to-LF and trailing-final-newline normalization. Report `confirmed` only after this target-host read-back. Otherwise report `no_write` when an authoritative rejection proves no issue was created, or `unknown` and stop all later mutations.
 
-Before approving or closing an issue, verify:
+## Triage
 
-- it describes a concrete bug or scoped improvement rather than an unsupported question;
-- it is not a duplicate;
-- the report contains enough evidence for an implementation decision;
-- the requested behavior is in repository scope;
-- labels and status changes follow the current repository's policy.
-
-If any point is uncertain, keep the issue in the repository's review state and request the smallest missing evidence.
+Before approving or closing an issue, verify it is concrete, non-duplicate, sufficiently evidenced, in scope, and consistent with repository label/status policy. If any point is uncertain, retain the repository review state and request the smallest missing evidence.

--- a/tests/issue-creation-skill.test.ts
+++ b/tests/issue-creation-skill.test.ts
@@ -6,8 +6,9 @@ import test from "node:test";
 const repoRoot = join(import.meta.dirname, "..");
 const skill = readFileSync(join(repoRoot, "skills", "issue-creation", "SKILL.md"), "utf8");
 
-test("preserves the prefixed skill identity and bumps metadata for automated Issue Forms", () => {
+test("preserves the prefixed skill identity and complete Issue Form metadata", () => {
 	assert.match(skill, /^name: gentle-ai-issue-creation$/m);
+	assert.match(skill, /^description: ".+"$/m);
 	assert.match(skill, /^  version: "1\.3"$/m);
 });
 
@@ -17,7 +18,10 @@ test("makes YAML Issue Forms the deterministic automated format authority", () =
 	assert.match(skill, /declared order/i);
 	assert.match(skill, /visible labels and options/i);
 	assert.match(skill, /multi-select.*declared options order/i);
-	assert.match(skill, /_No response_/);
+	assert.match(skill, /optional dropdown[\s\S]{0,180}_No response_/i);
+	assert.match(skill, /Markdown controls are non-answer guidance/i);
+	assert.match(skill, /visible instructions[\s\S]{0,180}adjacent answers/i);
+	assert.match(skill, /do not render them as response sections/i);
 	assert.match(skill, /individually required checkbox/i);
 	assert.match(skill, /explicit first-person affirmation/i);
 	assert.match(skill, /textarea\.attributes\.render/);
@@ -27,6 +31,7 @@ test("makes YAML Issue Forms the deterministic automated format authority", () =
 test("fails closed before publication for invalid required Issue Form data", () => {
 	assert.match(skill, /Fail closed before mutation/i);
 	assert.match(skill, /malformed, unsupported, missing, or ambiguous required structure or answers/i);
+	assert.match(skill, /malformed schema[\s\S]{0,200}do not open a browser/i);
 	assert.match(skill, /Never invent answers, selections, confirmations, or labels/i);
 });
 
@@ -35,6 +40,7 @@ test("publishes reviewed Issue Form bodies through a private body file", () => {
 	assert.match(skill, /gh issue create --repo "\$TARGET" --title "\$TITLE" --body-file "\$BODY_FILE"/);
 	assert.match(skill, /target verification/i);
 	assert.match(skill, /duplicate search/i);
+	assert.match(skill, /Before commenting on a confirmed duplicate[\s\S]{0,250}privacy scan\/redaction[\s\S]{0,250}exact comment body/i);
 	assert.match(skill, /privacy scan/i);
 	assert.match(skill, /permitted labels/i);
 	assert.match(skill, /one mutation attempt/i);
@@ -45,23 +51,32 @@ function assertBrowserContract(candidate: string) {
 	assert.match(candidate, /gh issue create --repo "\$TARGET" --title "\$TITLE" --body-file "\$BODY_FILE"/);
 	assert.match(
 		candidate,
-		/Only when the user explicitly requests browser completion[\s\S]{0,500}gh issue create --repo "\$TARGET" --web/,
+		/user explicitly requests browser completion[\s\S]{0,350}syntactically valid selected form cannot safely\/faithfully be represented by the automated path/i,
 	);
-	assert.match(candidate, /malformed, unsupported, or unrepresentable form[\s\S]{0,300}explicitly requests browser completion/i);
+	assert.match(candidate, /malformed schema[\s\S]{0,200}do not open a browser/i);
 	assert.match(candidate, /missing or ambiguous required[\s\S]{0,200}fail closed[\s\S]{0,200}do not open a browser/i);
+	assert.match(candidate, /browser handoff[\s\S]{0,160}never proof of publication/i);
 	assert.doesNotMatch(candidate, /Do not parse or render[\s\S]{0,300}stop for human completion/i);
 	assert.doesNotMatch(candidate, /(?:always|must|only)\s+(?:open|use|route to)\s+(?:the )?browser(?:\s+for)?\s+(?:Issue Forms?|YAML)/i);
+	assert.doesNotMatch(candidate, /YAML Issue Forms require human completion in the web issue chooser\./i);
+	assert.doesNotMatch(candidate, /Always route Issue Forms to the browser\./i);
 	assert.doesNotMatch(
 		candidate,
 		/\bfor\s+(?:YAML\s+)?Issue\s+Forms?\b[\s\S]{0,160}\b(?:open|use|route to|go to)\b[\s\S]{0,100}\b(?:browser|web issue chooser|web)\b/i,
 	);
 }
 
-test("keeps automated and explicitly requested browser Issue Form paths distinct", () => {
+test("keeps automated and conditional browser Issue Form paths distinct", () => {
 	assertBrowserContract(skill);
 
-	const unconditionalYamlBrowserGuidance = `${skill}\n\nFor YAML Issue Forms, open the web issue chooser and stop for human completion.`;
-	assert.throws(() => assertBrowserContract(unconditionalYamlBrowserGuidance));
+	const unsafeMutations = [
+		"For YAML Issue Forms, open the web issue chooser and stop for human completion.",
+		"YAML Issue Forms require human completion in the web issue chooser.",
+		"Always route Issue Forms to the browser.",
+	];
+	for (const mutation of unsafeMutations) {
+		assert.throws(() => assertBrowserContract(`${skill}\n\n${mutation}`), mutation);
+	}
 });
 
 test("discovers support routing and keeps all issue files private until cleanup", () => {
@@ -69,10 +84,20 @@ test("discovers support routing and keeps all issue files private until cleanup"
 	assert.match(skill, /\.github\/ISSUE_TEMPLATE\/config\.yml/);
 	assert.match(skill, /Discussions\/contact routing/i);
 	assert.match(skill, /questions\/support[\s\S]{0,250}(?:Discussions|contact)[\s\S]{0,250}otherwise ask or stop/i);
-	assert.match(skill, /TMP_DIR="\$\(mktemp -d\)"/);
-	assert.match(skill, /chmod 700 "\$TMP_DIR"/);
+	assert.doesNotMatch(skill, /TMP_DIR="\$\(mktemp -d\)"/);
+	assert.match(skill, /TMPDIR=\/tmp mktemp -d/);
+	assert.match(skill, /REPO_ROOT="\$\(git rev-parse --show-toplevel\)"/);
+	assert.match(skill, /REPO_ROOT="\$\(cd "\$REPO_ROOT" && pwd -P\)"/);
+	assert.match(skill, /if \[ "\$REPO_ROOT" = "\/" \]/);
+	assert.match(skill, /trap 'rm -rf -- "\$TMP_DIR"' EXIT/);
+	assert.match(skill, /TMP_DIR_REAL="\$\(cd "\$TMP_DIR" && pwd -P\)"/);
+	assert.match(skill, /case "\$TMP_DIR_REAL\/" in[\s\S]{0,200}"\$REPO_ROOT\/"\*/);
+	assert.match(skill, /if \[ "\$REPO_ROOT" = "\/" \][\s\S]{0,200}Temporary directory is inside the repository/);
+	assert.match(skill, /REPO_ROOT="\$\(cd "\$REPO_ROOT" && pwd -P\)"[\s\S]{0,200}TMPDIR=\/tmp mktemp -d/);
+	assert.match(skill, /TMPDIR=\/tmp mktemp -d[\s\S]{0,200}trap 'rm -rf -- "\$TMP_DIR"' EXIT/);
+	assert.match(skill, /chmod 700 "\$TMP_DIR_REAL"/);
 	assert.match(skill, /umask 077/);
-	assert.match(skill, /BODY_FILE="\$TMP_DIR\//);
-	assert.match(skill, /READBACK_FILE="\$TMP_DIR\//);
-	assert.match(skill, /trap '[^']*rm -rf "\$TMP_DIR"[^']*' EXIT/);
+	assert.match(skill, /BODY_FILE="\$TMP_DIR_REAL\//);
+	assert.match(skill, /READBACK_FILE="\$TMP_DIR_REAL\//);
+	assert.doesNotMatch(skill, /TMP_DIR="\$\(cd "\$TMP_DIR" && pwd -P\)"/);
 });

--- a/tests/issue-creation-skill.test.ts
+++ b/tests/issue-creation-skill.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const repoRoot = join(import.meta.dirname, "..");
+const skill = readFileSync(join(repoRoot, "skills", "issue-creation", "SKILL.md"), "utf8");
+
+test("preserves the prefixed skill identity and bumps metadata for automated Issue Forms", () => {
+	assert.match(skill, /^name: gentle-ai-issue-creation$/m);
+	assert.match(skill, /^  version: "1\.3"$/m);
+});
+
+test("makes YAML Issue Forms the deterministic automated format authority", () => {
+	assert.match(skill, /YAML Issue Forms are the format authority/i);
+	assert.match(skill, /`input`, `textarea`, `dropdown`, and `checkboxes`/);
+	assert.match(skill, /declared order/i);
+	assert.match(skill, /visible labels and options/i);
+	assert.match(skill, /multi-select.*declared options order/i);
+	assert.match(skill, /_No response_/);
+	assert.match(skill, /individually required checkbox/i);
+	assert.match(skill, /explicit first-person affirmation/i);
+	assert.match(skill, /textarea\.attributes\.render/);
+	assert.match(skill, /fence the answer with the declared language/i);
+});
+
+test("fails closed before publication for invalid required Issue Form data", () => {
+	assert.match(skill, /Fail closed before mutation/i);
+	assert.match(skill, /malformed, unsupported, missing, or ambiguous required structure or answers/i);
+	assert.match(skill, /Never invent answers, selections, confirmations, or labels/i);
+});
+
+test("publishes reviewed Issue Form bodies through a private body file", () => {
+	assert.match(skill, /private `BODY_FILE`/);
+	assert.match(skill, /gh issue create --repo "\$TARGET" --title "\$TITLE" --body-file "\$BODY_FILE"/);
+	assert.match(skill, /target verification/i);
+	assert.match(skill, /duplicate search/i);
+	assert.match(skill, /privacy scan/i);
+	assert.match(skill, /permitted labels/i);
+	assert.match(skill, /one mutation attempt/i);
+	assert.match(skill, /target-host read-back/i);
+});
+
+function assertBrowserContract(candidate: string) {
+	assert.match(candidate, /gh issue create --repo "\$TARGET" --title "\$TITLE" --body-file "\$BODY_FILE"/);
+	assert.match(
+		candidate,
+		/Only when the user explicitly requests browser completion[\s\S]{0,500}gh issue create --repo "\$TARGET" --web/,
+	);
+	assert.match(candidate, /malformed, unsupported, or unrepresentable form[\s\S]{0,300}explicitly requests browser completion/i);
+	assert.match(candidate, /missing or ambiguous required[\s\S]{0,200}fail closed[\s\S]{0,200}do not open a browser/i);
+	assert.doesNotMatch(candidate, /Do not parse or render[\s\S]{0,300}stop for human completion/i);
+	assert.doesNotMatch(candidate, /(?:always|must|only)\s+(?:open|use|route to)\s+(?:the )?browser(?:\s+for)?\s+(?:Issue Forms?|YAML)/i);
+	assert.doesNotMatch(
+		candidate,
+		/\bfor\s+(?:YAML\s+)?Issue\s+Forms?\b[\s\S]{0,160}\b(?:open|use|route to|go to)\b[\s\S]{0,100}\b(?:browser|web issue chooser|web)\b/i,
+	);
+}
+
+test("keeps automated and explicitly requested browser Issue Form paths distinct", () => {
+	assertBrowserContract(skill);
+
+	const unconditionalYamlBrowserGuidance = `${skill}\n\nFor YAML Issue Forms, open the web issue chooser and stop for human completion.`;
+	assert.throws(() => assertBrowserContract(unconditionalYamlBrowserGuidance));
+});
+
+test("discovers support routing and keeps all issue files private until cleanup", () => {
+	assert.match(skill, /README\.md/);
+	assert.match(skill, /\.github\/ISSUE_TEMPLATE\/config\.yml/);
+	assert.match(skill, /Discussions\/contact routing/i);
+	assert.match(skill, /questions\/support[\s\S]{0,250}(?:Discussions|contact)[\s\S]{0,250}otherwise ask or stop/i);
+	assert.match(skill, /TMP_DIR="\$\(mktemp -d\)"/);
+	assert.match(skill, /chmod 700 "\$TMP_DIR"/);
+	assert.match(skill, /umask 077/);
+	assert.match(skill, /BODY_FILE="\$TMP_DIR\//);
+	assert.match(skill, /READBACK_FILE="\$TMP_DIR\//);
+	assert.match(skill, /trap '[^']*rm -rf "\$TMP_DIR"[^']*' EXIT/);
+});


### PR DESCRIPTION
Closes #574

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Replace mandatory browser-only YAML Issue Form handling with deterministic reviewed body materialization.
- Keep browser completion available only after an explicit user request.
- Add regression coverage for supported controls, fail-closed behavior, private publication, and equivalent browser-only wording.

## Changes

| File | Change |
|------|--------|
| `skills/issue-creation/SKILL.md` | Define automated YAML Issue Form materialization and guarded publication through `--body-file`. |
| `tests/issue-creation-skill.test.ts` | Protect the publication contract, including a semantic browser-only mutation check. |

## Test Plan

- [x] `node --experimental-strip-types --test tests/issue-creation-skill.test.ts` — 6 passed
- [x] `node --experimental-strip-types --test tests/issue-creation-skill.test.ts tests/skill-collision-prefixes.test.ts` — 20 passed
- [x] `pnpm test` — 1209 passed, 1 skipped
- [x] `pnpm run check:runtime-modules` — 4 runtime modules match
- [x] `node scripts/verify-package-files.mjs` — 163 package resources verified
- [x] `git diff --check`

## Review

- Initial native RDD review approved target `sha256:147945664b9cae60fba8c259755f30012bd52d8b6aef5c770245271649f6d4b0` under lineage `review-e22e21f58628bbc4`.
- Correction RDD review approved target `sha256:c36cc2a9ed779e109f802970f5b0be9871ef9e9462d24bba922207353d7921da` under lineage `review-ddf6cbf0c33db70b`.
- The correction review recorded two informational warnings (`R3-markdown-guidance-ambiguity` and `R3-temp-behavior-unproved`); independent candidate-bound verification covered both behaviors and found no material defect.
- Final candidate size: 249 changed lines, below the 400-line review budget. All four review threads are resolved.

## Contributor Checklist

- [x] Linked approved issue #574 (`status:approved`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] No shell scripts changed; shellcheck is not applicable
- [x] Skill identity and target-agent collision behavior are covered by tests
- [x] User-visible workflow documentation is updated in the skill contract
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Issue creation now follows YAML Issue Forms as the authoritative format.
  - Required information is validated before publication, with fail-closed behavior when details are incomplete or uncertain.
  - Reviewed issue content is handled privately during automated creation.
  - Automated and browser-based issue creation paths are clearly separated; browser handoff occurs only when explicitly requested.
  - Creation results are verified on the target host before being reported.
  - Support guidance discovery now includes project documentation and issue-template configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
