### PR TITLE
fix(agents): expose CodeGraph to sdd-explore

### DIFF
--- a/assets/agents/sdd-explore.md
+++ b/assets/agents/sdd-explore.md
@@ -5,6 +5,7 @@ tools:
   - read
   - grep
   - find
+  - codegraph
   - edit
   - write
   - mem_save

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -895,6 +895,22 @@ test("jd-fix-agent packaged allowlist includes write tools", () => {
 	}
 });
 
+test("sdd-explore packages its CodeGraph-enabled exploration allowlist", () => {
+	const agentPath = join(PACKAGE_ROOT, "assets", "agents", "sdd-explore.md");
+	const { name, tools } = readAgentDefinition(agentPath);
+
+	assert.equal(name, "sdd-explore");
+	assert.deepEqual(tools, [
+		"read",
+		"grep",
+		"find",
+		"codegraph",
+		"edit",
+		"write",
+		"mem_save",
+	]);
+});
+
 test("gentle-ai-worker packages the exact scoped writer contract", () => {
 	const agentsDir = join(PACKAGE_ROOT, "assets", "agents");
 	const agentPath = join(agentsDir, "gentle-ai-worker.md");


### PR DESCRIPTION
Closes #584

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Exposes the constrained direct `codegraph` tool to `sdd-explore`.
- Adds an exact ordered-allowlist regression test.
- Avoids granting the broader `mcp` gateway to the exploration phase.

## Changes

| File | Change |
|------|--------|
| `assets/agents/sdd-explore.md` | Adds `codegraph` after `find`. |
| `tests/package-manifest.test.ts` | Pins the exact CodeGraph-enabled tool allowlist. |

## Test plan

- [x] `git diff --check`
- [x] `node --experimental-strip-types --test tests/package-manifest.test.ts` — 34 passed
- [x] `node scripts/verify-package-files.mjs` — 163 files and 68 byte-pinned artifacts verified
- [x] Native Gentle AI reliability review approved

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck not applicable; no shell scripts changed
- [x] Agent tool contract covered by a focused regression test
- [x] Documentation impact assessed; no user-facing documentation change required
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the `sdd-explore` agent to use the `codegraph` tool alongside its existing tools.

* **Tests**
  * Added coverage to verify the agent’s name and approved tool list in packaged distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->