### PR TITLE
fix(subagents): honor PI_CODING_AGENT_DIR for assets

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -159,7 +159,7 @@ const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const ASSETS_DIR = join(PACKAGE_ROOT, "assets");
 
 function gentlePiAgentHome(): string {
-	return process.env.GENTLE_PI_AGENT_HOME ?? join(homedir(), ".pi", "agent");
+	return process.env.GENTLE_PI_AGENT_HOME ?? process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
 }
 
 function sddGlobalAssetDriftCount(): number {

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -29,6 +29,7 @@ import type {
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
 import { matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
+import { resolveGentlePiAgentHome } from "../lib/agent-home.ts";
 import {
 	ensureSddPreflight,
 	getSddPreflightPreferences,
@@ -159,7 +160,7 @@ const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const ASSETS_DIR = join(PACKAGE_ROOT, "assets");
 
 function gentlePiAgentHome(): string {
-	return process.env.GENTLE_PI_AGENT_HOME ?? process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+	return resolveGentlePiAgentHome();
 }
 
 function sddGlobalAssetDriftCount(): number {

--- a/lib/agent-home.ts
+++ b/lib/agent-home.ts
@@ -1,6 +1,8 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+// Pi Subagents resolves its global directory as `PI_CODING_AGENT_DIR || ~/.pi/agent`,
+// so an empty value must fall through here too or the two homes diverge again.
 export function resolveGentlePiAgentHome(env: NodeJS.ProcessEnv = process.env): string {
-	return env.GENTLE_PI_AGENT_HOME ?? env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+	return env.GENTLE_PI_AGENT_HOME || env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
 }

--- a/lib/agent-home.ts
+++ b/lib/agent-home.ts
@@ -1,0 +1,6 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function resolveGentlePiAgentHome(env: NodeJS.ProcessEnv = process.env): string {
+	return env.GENTLE_PI_AGENT_HOME ?? env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+}

--- a/lib/sdd-preflight.ts
+++ b/lib/sdd-preflight.ts
@@ -19,7 +19,7 @@ const LEGACY_MANAGED_ASSET_MANIFESTS = Object.freeze([
 ]);
 
 function gentlePiAgentHome(): string {
-	return process.env.GENTLE_PI_AGENT_HOME ?? join(homedir(), ".pi", "agent");
+	return process.env.GENTLE_PI_AGENT_HOME ?? process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
 }
 
 export type SddExecutionMode = "interactive" | "auto";

--- a/lib/sdd-preflight.ts
+++ b/lib/sdd-preflight.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { resolveGentlePiAgentHome } from "./agent-home.ts";
 import type { SddArtifactStore } from "./sdd-status.ts";
 
 export type { SddArtifactStore };
@@ -19,7 +19,7 @@ const LEGACY_MANAGED_ASSET_MANIFESTS = Object.freeze([
 ]);
 
 function gentlePiAgentHome(): string {
-	return process.env.GENTLE_PI_AGENT_HOME ?? process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+	return resolveGentlePiAgentHome();
 }
 
 export type SddExecutionMode = "interactive" | "auto";

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1071,6 +1071,73 @@ test("installSddAssets installs gentle-ai-worker with a loader-compatible scoped
 	);
 });
 
+test("asset installation uses PI_CODING_AGENT_DIR as the Pi agent home when no explicit Gentle override is set", () => {
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const temporaryPiAgentDir = mkdtempSync(join(tmpdir(), "gentle-pi-agent-dir-"));
+	const explicitGentleHome = mkdtempSync(join(tmpdir(), "gentle-pi-explicit-home-"));
+
+	try {
+		delete process.env.GENTLE_PI_AGENT_HOME;
+		process.env.PI_CODING_AGENT_DIR = temporaryPiAgentDir;
+
+		installSddAssets(PACKAGE_ROOT, true);
+
+		const installedPath = join(temporaryPiAgentDir, "agents", "gentle-ai-explore.md");
+		assert.ok(existsSync(installedPath), "managed agents must install where Pi Subagents reads global definitions");
+		assert.deepEqual(readAgentDefinition(installedPath).tools, MANAGED_EXEMPLAR_TOOLS);
+		assert.ok(
+			!existsSync(join(explicitGentleHome, "agents", "gentle-ai-explore.md")),
+			"the explicit override fixture must still be untouched before it is selected",
+		);
+
+		process.env.GENTLE_PI_AGENT_HOME = explicitGentleHome;
+		installSddAssets(PACKAGE_ROOT, true);
+		assert.ok(
+			existsSync(join(explicitGentleHome, "agents", "gentle-ai-explore.md")),
+			"GENTLE_PI_AGENT_HOME remains the explicit test/operator override",
+		);
+	} finally {
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		if (previousPiAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
+		rmSync(temporaryPiAgentDir, { recursive: true, force: true });
+		rmSync(explicitGentleHome, { recursive: true, force: true });
+	}
+});
+
+test("global model routing uses PI_CODING_AGENT_DIR for package-installed agents", () => {
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const temporaryPiAgentDir = mkdtempSync(join(tmpdir(), "gentle-pi-model-agent-dir-"));
+	const temporaryProject = mkdtempSync(join(tmpdir(), "gentle-pi-model-project-"));
+
+	try {
+		delete process.env.GENTLE_PI_AGENT_HOME;
+		process.env.PI_CODING_AGENT_DIR = temporaryPiAgentDir;
+		installSddAssets(PACKAGE_ROOT, true);
+
+		const result = applyModelConfig(temporaryProject, {
+			"gentle-ai-explore": { model: "provider/model", thinking: "high" },
+		});
+
+		assert.equal(result.updated, 2);
+		const config = JSON.parse(readFileSync(join(temporaryPiAgentDir, "subagents.json"), "utf8"));
+		assert.deepEqual(config.model_profiles["gentle-ai-explore"], {
+			model: "provider/model",
+			effort: "high",
+		});
+	} finally {
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		if (previousPiAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+		else process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
+		rmSync(temporaryPiAgentDir, { recursive: true, force: true });
+		rmSync(temporaryProject, { recursive: true, force: true });
+	}
+});
+
 test("normal and forced installation copy generic agents with complete role contracts", () => {
 	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
 	const expectedTools = {

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -9,11 +9,12 @@ import {
 	rmSync,
 	writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { applyModelConfig } from "../extensions/gentle-ai.ts";
+import { resolveGentlePiAgentHome } from "../lib/agent-home.ts";
 import { installSddAssets } from "../lib/sdd-preflight.ts";
 
 const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -1069,6 +1070,26 @@ test("installSddAssets installs gentle-ai-worker with a loader-compatible scoped
 		!existsSync(temporaryAgentHome),
 		"the integration test must delete only its temporary agent home",
 	);
+});
+
+test("agent home resolver centralizes Gentle and Pi agent-dir precedence", () => {
+	const explicitGentleHome = mkdtempSync(join(tmpdir(), "gentle-pi-resolver-explicit-"));
+	const piAgentDir = mkdtempSync(join(tmpdir(), "gentle-pi-resolver-pi-dir-"));
+
+	try {
+		assert.equal(
+			resolveGentlePiAgentHome({
+				GENTLE_PI_AGENT_HOME: explicitGentleHome,
+				PI_CODING_AGENT_DIR: piAgentDir,
+			}),
+			explicitGentleHome,
+		);
+		assert.equal(resolveGentlePiAgentHome({ PI_CODING_AGENT_DIR: piAgentDir }), piAgentDir);
+		assert.equal(resolveGentlePiAgentHome({}), join(homedir(), ".pi", "agent"));
+	} finally {
+		rmSync(explicitGentleHome, { recursive: true, force: true });
+		rmSync(piAgentDir, { recursive: true, force: true });
+	}
 });
 
 test("asset installation uses PI_CODING_AGENT_DIR as the Pi agent home when no explicit Gentle override is set", () => {

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1086,6 +1086,16 @@ test("agent home resolver centralizes Gentle and Pi agent-dir precedence", () =>
 		);
 		assert.equal(resolveGentlePiAgentHome({ PI_CODING_AGENT_DIR: piAgentDir }), piAgentDir);
 		assert.equal(resolveGentlePiAgentHome({}), join(homedir(), ".pi", "agent"));
+		assert.equal(
+			resolveGentlePiAgentHome({ GENTLE_PI_AGENT_HOME: "", PI_CODING_AGENT_DIR: piAgentDir }),
+			piAgentDir,
+			"an empty explicit override falls through like Pi Subagents does",
+		);
+		assert.equal(
+			resolveGentlePiAgentHome({ PI_CODING_AGENT_DIR: "" }),
+			join(homedir(), ".pi", "agent"),
+			"an empty PI_CODING_AGENT_DIR falls through like Pi Subagents does",
+		);
 	} finally {
 		rmSync(explicitGentleHome, { recursive: true, force: true });
 		rmSync(piAgentDir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #575

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Align Gentle Pi package-owned agent home resolution with Pi Subagents by honoring `PI_CODING_AGENT_DIR`.
- Preserve `GENTLE_PI_AGENT_HOME` as the explicit override for tests/operators.
- Cover package asset installation and global model routing so `gentle-ai-explore` remains visible with its `codegraph` allowlist.

## Changes

| File | Change |
|------|--------|
| `lib/sdd-preflight.ts` | Install managed agents into `GENTLE_PI_AGENT_HOME ?? PI_CODING_AGENT_DIR ?? ~/.pi/agent`. |
| `extensions/gentle-ai.ts` | Discover/package-route global agents from the same agent home. |
| `tests/package-manifest.test.ts` | Add regression coverage for `PI_CODING_AGENT_DIR` installation and model routing. |

## Test Plan

- [x] Focused tests: `pnpm exec node --experimental-strip-types --test tests/package-manifest.test.ts tests/sdd-preflight.test.ts` (`57 pass, 0 fail` on clean PR worktree)
- [x] Dogfood reload: `/reload` made `gentle-ai-explore` visible with `tools: read, grep, find, codegraph`
- [x] Dogfood subagent run: `gentle-ai-explore` successfully called `codegraph` and found `gentlePiAgentHome` in `extensions/gentle-ai.ts` and `lib/sdd-preflight.ts`
- [x] Full suite attempted: `pnpm test` on clean PR worktree currently fails only in `background-subagents` capability/status tests because this dogfood machine has Pi Subagents installed globally; no failures were observed in the #575 focused coverage.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (N/A, no shell scripts modified)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed (N/A, internal path resolution fix)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Agent-related features now use the configured coding-agent directory when no Gentle-specific directory is provided.
  - Gentle-specific directory settings continue to take priority when configured.
  - Asset installation and model configuration now consistently follow the selected agent directory, improving setup reliability across supported configurations.

- **Tests**
  - Added coverage for directory selection, installed agent contents, and generated model configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
