### PR TITLE
docs: document review-mode and align command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,8 @@ Legacy string entries are still accepted and treated as `model`-only config.
 | -------------------------------- | ------------------------------------------------------------------- |
 | `/gentle:status`              | Shows package, SDD asset, OpenSpec, and global model config status. |
 | `/gentle:doctor`              | Runs read-only diagnostics for SDD assets, model/persona config, memory tools, and safety guards. |
+| `/gentle:sdd-preflight`       | Runs or reuses the lazy SDD preflight for this Pi session.          |
+| `/gentle:review-mode`         | Shows or sets the Gentle AI review-driven-development kill switch (`status\|disable\|enable`). |
 | `/gentle:models`                 | Opens global model + effort assignment UI. Press `x` to export and `r` to restore saved routing. |
 | `/gentle:persona`                | Switches global persona mode, with project override support.        |
 | `/gentle:background-subagents`   | Shows or sets the managed background-subagents policy (`status\|enable\|disable`), naming the source that decided it. |


### PR DESCRIPTION
Closes #300

Adds the two currently-registered missing commands to the README Commands table:
- /gentle:sdd-preflight
- /gentle:review-mode (status|disable|enable)

Note: #300 also mentions /gentle:commit-status and /gentle:commit-abort, but those do not exist on current main (verified via grep registerCommand in extensions/gentle-ai.ts), so they were intentionally not documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `/gentle:sdd-preflight` to the command reference.
  - Added `/gentle:review-mode` for viewing or changing review-driven development settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->