### PR TITLE
feat(todo): Gentle Todo, an own todo that stays current

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ research.md
 progress.md
 meta-prompt.md
 tmp/
+
+# CodeGraph index (recreated by pi on session start)
+.codegraph/

--- a/README.md
+++ b/README.md
@@ -653,7 +653,27 @@ Gentle notices are drawn as cards: the same rounded frame as the prompt, with th
 - Every call into the gentle-ai binary and every `gentle_review` tool renders as a card under the rose, `🌹︎ Gentle AI`: the rail is amber while it runs, green when it finished, red when it failed; the expand key sits in the top rule once the tool finished, and the collapsed result shows only its line count. Reviewer captures name their lens (`review capture · risk`; the group lists all four).
 - The review preflight reminder renders as a card in the transcript with the expand key in its top rule.
 - An active dev-binary override shows above the editor at startup, in amber, naming the binary and its digest, and leaves with the first prompt; an invalid override shows in red with the reason.
-- Todo and subagent widgets belong to their own packages and keep their rendering.
+- Subagent widgets belong to their own package and keep their rendering.
+
+### Gentle Todo
+
+The `todo` tool and its card replace the third-party todo extension (remove `npm:@juicesharp/rpiv-todo` from your pi packages; sessions written by it replay into the new card).
+
+```text
+╭─ ❀ Todos · 1 of 3 ──────────────────────────────────────╮
+│ ✓ Add quiet tool rendering                              │
+│ ◐ Fix quiet tools conflict · fixing conflict            │
+│ ○ Show git bash tails                                   │
+╰─────────────────────────────────────────────────────────╯
+```
+
+Three things keep the list current, which a static tool description cannot:
+
+- `write` replaces the whole list in one call, so the model rewrites the plan instead of patching it; `add`, `update`, `clear`, and `list` remain for single moves.
+- Every turn's system prompt carries the open tasks and the rules: in_progress before starting, done right after finishing, update before ending the turn.
+- A list that goes two turns untouched while tasks stay open turns amber with `stale · N turns`, and the prompt says so, so the model brings it up to date.
+
+A finished list stays on screen for the turn it finished in and clears at the next. `ctrl+shift+t` collapses the card to the task in progress (`GENTLE_PI_TODO_KEY` rebinds it, `off` disables it); `GENTLE_PI_TODO=0` disables the tool and the card.
 
 Set `GENTLE_PI_SHELL=0` to keep pi's built-in footer and editor.
 

--- a/extensions/gentle-todo.ts
+++ b/extensions/gentle-todo.ts
@@ -1,0 +1,195 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import {
+	applyTodo,
+	emptyTodo,
+	renderTodoCard,
+	replayTodo,
+	staleTurns,
+	TODO_DETAILS_KEY,
+	TODO_GLYPH,
+	TODO_TOOL_NAME,
+	todoPromptBlock,
+	todoSummary,
+	type TodoParams,
+	type TodoState,
+} from "../lib/shell-todo.ts";
+
+// Gentle Todo: the task list the model keeps while it works, drawn as a
+// Gentle Shell card above the editor. Three things keep it current that a
+// static tool description cannot: `write` replaces the whole list in one
+// call, every turn's system prompt carries the open tasks and the rules, and
+// a list that goes untouched while tasks stay open is marked stale for both
+// the human and the model.
+
+const WIDGET_KEY = "gentle-todo";
+const COLLAPSE_KEY_DEFAULT = "ctrl+shift+t";
+const TOOL_PARAMETERS = {
+	type: "object",
+	additionalProperties: false,
+	required: ["action"],
+	properties: {
+		action: { type: "string", enum: ["write", "add", "update", "clear", "list"], description: "write replaces the whole list; add appends one task; update changes one task by id; clear empties the list; list reports it." },
+		tasks: {
+			type: "array",
+			description: "For write: the complete ordered list. Keep the id of tasks that already exist so their history survives; omit it for new ones.",
+			items: {
+				type: "object",
+				additionalProperties: false,
+				required: ["title"],
+				properties: {
+					id: { type: "integer", description: "Existing task id to keep." },
+					title: { type: "string", description: "Short imperative title, e.g. 'Write the parser'." },
+					status: { type: "string", enum: ["pending", "in_progress", "done"], description: "Defaults to pending." },
+					note: { type: "string", description: "What is happening right now, shown while in_progress, e.g. 'writing tests'." },
+				},
+			},
+		},
+		id: { type: "integer", description: "Task id for update." },
+		title: { type: "string", description: "Title for add, or a new title for update." },
+		status: { type: "string", enum: ["pending", "in_progress", "done"], description: "Status for add or update." },
+		note: { type: "string", description: "Note for add or update." },
+	},
+} as const;
+
+export function todoEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	const value = env.GENTLE_PI_TODO?.trim().toLowerCase();
+	return !(value === "0" || value === "false" || value === "off");
+}
+
+export function todoCollapseKey(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	const value = env.GENTLE_PI_TODO_KEY?.trim();
+	if (value === undefined) return COLLAPSE_KEY_DEFAULT;
+	return value === "" || value.toLowerCase() === "off" ? undefined : value;
+}
+
+interface TodoSession {
+	state: TodoState;
+	turn: number;
+	collapsed: boolean;
+	/** A finished list stays on screen for the turn it finished in, then clears. */
+	clearOnNextTurn: boolean;
+	ui: ExtensionContext["ui"] | undefined;
+	host: { requestRender(): void } | undefined;
+}
+
+function sessionKey(ctx: ExtensionContext): string {
+	return ctx.sessionManager.getSessionId() ?? "";
+}
+
+export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = process.env): void {
+	if (!todoEnabled(env)) return;
+	const sessions = new Map<string, TodoSession>();
+	const collapseKey = todoCollapseKey(env);
+
+	const session = (ctx: ExtensionContext): TodoSession => {
+		const key = sessionKey(ctx);
+		let current = sessions.get(key);
+		if (!current) {
+			current = { state: emptyTodo(), turn: 0, collapsed: false, clearOnNextTurn: false, ui: undefined, host: undefined };
+			sessions.set(key, current);
+		}
+		return current;
+	};
+
+	const show = (current: TodoSession) => {
+		if (!current.ui) return;
+		if (current.state.tasks.length === 0) {
+			current.ui.setWidget(WIDGET_KEY, undefined);
+			return;
+		}
+		const snapshot = current;
+		current.ui.setWidget(WIDGET_KEY, (tui, theme) => {
+			snapshot.host = tui;
+			return {
+				render(width: number) {
+					const lines = renderTodoCard(snapshot.state, theme, width, { collapsed: snapshot.collapsed, staleTurns: staleTurns(snapshot.state, snapshot.turn), collapseKey });
+					return lines.length === 0 ? [] : [...lines, ""];
+				},
+				invalidate() {},
+			};
+		});
+	};
+
+	pi.registerTool({
+		name: TODO_TOOL_NAME,
+		label: "Todo",
+		description: "Plan and track multi-step work. Use write to set the whole list, update to move one task, add for a new one, clear to reset, list to read it back.",
+		promptSnippet: "Track multi-step work; rewrite the whole list as the plan changes",
+		promptGuidelines: [
+			"Use todo for work with three or more steps or when the user hands you a list. Skip it for single trivial requests.",
+			"Mark a task in_progress before starting it and done right after finishing it; keep exactly one task in_progress.",
+			"Prefer write with the complete list whenever the plan changes; keep ids of tasks that already exist.",
+			"Never mark a task done while tests fail or the work is partial; add a task for the blocker instead.",
+		],
+		parameters: TOOL_PARAMETERS,
+		executionMode: "sequential",
+		renderCall(args, theme) {
+			const params = args as TodoParams;
+			return new Text(theme.fg("toolTitle", `${TODO_GLYPH} todo · ${params.action}`), 0, 0);
+		},
+		renderResult(result, options, theme) {
+			const text = result.content.map((part) => (part.type === "text" ? part.text : "")).join("\n");
+			return new Text(options.expanded ? text : theme.fg("muted", text.split("\n")[0] ?? ""), 0, 0);
+		},
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			const current = session(ctx);
+			const result = applyTodo(current.state, params as TodoParams, current.turn);
+			if (!result.error) {
+				current.state = result.state;
+				current.clearOnNextTurn = false;
+			}
+			return {
+				content: [{ type: "text", text: result.text }],
+				details: { [TODO_DETAILS_KEY]: result.state, ...(result.error ? { error: result.error } : {}) },
+			};
+		},
+	});
+
+	if (collapseKey) {
+		pi.registerShortcut(collapseKey as Parameters<ExtensionAPI["registerShortcut"]>[0], {
+			description: "Collapse or expand the todo list",
+			handler: async (ctx) => {
+				const current = session(ctx);
+				current.collapsed = !current.collapsed;
+				current.host?.requestRender();
+			},
+		});
+	}
+
+	pi.on("session_start", (_event, ctx) => {
+		const current = session(ctx);
+		current.state = replayTodo(ctx.sessionManager.getBranch());
+		current.turn = ctx.sessionManager.getBranch().filter((entry) => (entry as { type?: string }).type === "message" && (entry as { message?: { role?: string } }).message?.role === "user").length;
+		current.ui = ctx.hasUI ? ctx.ui : undefined;
+		show(current);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		sessions.delete(sessionKey(ctx));
+	});
+
+	pi.on("before_agent_start", (event, ctx) => {
+		const current = session(ctx);
+		current.turn += 1;
+		if (current.clearOnNextTurn) {
+			current.state = { ...current.state, tasks: [] };
+			current.clearOnNextTurn = false;
+			show(current);
+		}
+		const block = todoPromptBlock(current.state, staleTurns(current.state, current.turn));
+		if (!block) return undefined;
+		return { systemPrompt: `${event.systemPrompt}\n\n${block}` };
+	});
+
+	pi.on("tool_execution_end", (event, ctx) => {
+		if (event.toolName !== TODO_TOOL_NAME) return;
+		show(session(ctx));
+	});
+
+	pi.on("agent_end", (_event, ctx) => {
+		const current = session(ctx);
+		if (current.state.tasks.length > 0 && todoSummary(current.state).open === 0) current.clearOnNextTurn = true;
+		show(current);
+	});
+}

--- a/lib/shell-todo.ts
+++ b/lib/shell-todo.ts
@@ -1,0 +1,264 @@
+import { CARD_TONE, renderCard, type CardTheme } from "./shell-card.ts";
+import { sanitizeTerminalText } from "./terminal-theme.ts";
+
+// Gentle Todo: the task list the model keeps while it works. Everything here
+// is pure. The state lives in the session branch (every tool result carries
+// the full snapshot), and staleness is how many turns passed since the last
+// write while tasks are still open.
+
+export const TODO_STATUS = {
+	PENDING: "pending",
+	IN_PROGRESS: "in_progress",
+	DONE: "done",
+} as const;
+
+export type TodoStatus = (typeof TODO_STATUS)[keyof typeof TODO_STATUS];
+
+export const TODO_ACTION = {
+	WRITE: "write",
+	ADD: "add",
+	UPDATE: "update",
+	CLEAR: "clear",
+	LIST: "list",
+} as const;
+
+export type TodoAction = (typeof TODO_ACTION)[keyof typeof TODO_ACTION];
+
+export interface TodoTask {
+	id: number;
+	title: string;
+	status: TodoStatus;
+	note?: string;
+}
+
+export interface TodoState {
+	tasks: TodoTask[];
+	nextId: number;
+	/** Turn index of the last write, or null before the first one. */
+	updatedTurn: number | null;
+}
+
+export interface TodoTaskInput {
+	id?: number;
+	title?: string;
+	status?: string;
+	note?: string;
+}
+
+export interface TodoParams {
+	action: string;
+	tasks?: TodoTaskInput[];
+	id?: number;
+	title?: string;
+	status?: string;
+	note?: string;
+}
+
+export interface TodoResult {
+	state: TodoState;
+	text: string;
+	error?: string;
+}
+
+export interface TodoSummary {
+	done: number;
+	total: number;
+	open: number;
+}
+
+export interface TodoTheme extends CardTheme {
+	strikethrough(text: string): string;
+}
+
+export interface TodoRenderOptions {
+	collapsed: boolean;
+	staleTurns: number;
+	collapseKey?: string;
+}
+
+/** Tool results carry the snapshot under this key; the old rpiv-todo shape is read too. */
+export const TODO_DETAILS_KEY = "gentleTodo";
+export const TODO_TOOL_NAME = "todo";
+export const TODO_GLYPH = "❀";
+const STATUS_ALIASES: Record<string, TodoStatus> = { completed: TODO_STATUS.DONE, complete: TODO_STATUS.DONE, doing: TODO_STATUS.IN_PROGRESS, todo: TODO_STATUS.PENDING };
+const STATUS_GLYPH: Record<TodoStatus, string> = { [TODO_STATUS.PENDING]: "○", [TODO_STATUS.IN_PROGRESS]: "◐", [TODO_STATUS.DONE]: "✓" };
+const STATUS_ROLE: Record<TodoStatus, string> = { [TODO_STATUS.PENDING]: "text", [TODO_STATUS.IN_PROGRESS]: "accent", [TODO_STATUS.DONE]: "dim" };
+const GLYPH_ROLE: Record<TodoStatus, string> = { [TODO_STATUS.PENDING]: "muted", [TODO_STATUS.IN_PROGRESS]: "accent", [TODO_STATUS.DONE]: "success" };
+const NOTE_ROLE = "muted";
+const STALE_AFTER_TURNS = 2;
+
+export function emptyTodo(): TodoState {
+	return { tasks: [], nextId: 1, updatedTurn: null };
+}
+
+function cleanText(value: unknown): string {
+	return typeof value === "string" ? sanitizeTerminalText(value).replace(/\s+/g, " ").trim() : "";
+}
+
+function parseStatus(value: unknown): TodoStatus | undefined {
+	if (value === undefined || value === null || value === "") return TODO_STATUS.PENDING;
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+	if ((Object.values(TODO_STATUS) as string[]).includes(normalized)) return normalized as TodoStatus;
+	return STATUS_ALIASES[normalized];
+}
+
+export function todoSummary(state: TodoState): TodoSummary {
+	const done = state.tasks.filter((task) => task.status === TODO_STATUS.DONE).length;
+	return { done, total: state.tasks.length, open: state.tasks.length - done };
+}
+
+export function staleTurns(state: TodoState, currentTurn: number): number {
+	if (state.updatedTurn === null || todoSummary(state).open === 0) return 0;
+	return Math.max(0, currentTurn - state.updatedTurn);
+}
+
+function summaryText(state: TodoState): string {
+	const { done, total } = todoSummary(state);
+	const inProgress = state.tasks.filter((task) => task.status === TODO_STATUS.IN_PROGRESS).length;
+	return `${total} ${total === 1 ? "task" : "tasks"} · ${done} done · ${inProgress} in progress`;
+}
+
+function taskLine(task: TodoTask): string {
+	return `[${task.status}] #${task.id} ${task.title}${task.note ? ` — ${task.note}` : ""}`;
+}
+
+function buildTask(input: TodoTaskInput, id: number): TodoTask | string {
+	const title = cleanText(input.title);
+	if (title.length === 0) return "title is required";
+	const status = parseStatus(input.status);
+	if (status === undefined) return `unknown status "${input.status}" (use pending, in_progress, or done)`;
+	const note = cleanText(input.note);
+	return { id, title, status, ...(note ? { note } : {}) };
+}
+
+function write(state: TodoState, inputs: TodoTaskInput[], turn: number): TodoResult {
+	const tasks: TodoTask[] = [];
+	let nextId = state.nextId;
+	for (const input of inputs) {
+		const keepId = typeof input.id === "number" && Number.isInteger(input.id) && input.id > 0 && !tasks.some((task) => task.id === input.id);
+		const id = keepId ? (input.id as number) : nextId++;
+		nextId = Math.max(nextId, id + 1);
+		const built = buildTask(input, id);
+		if (typeof built === "string") return { state, text: `Error: ${built}`, error: built };
+		tasks.push(built);
+	}
+	const next = { tasks, nextId, updatedTurn: turn };
+	return { state: next, text: `Todo list written: ${summaryText(next)}` };
+}
+
+function update(state: TodoState, params: TodoParams, turn: number): TodoResult {
+	const task = state.tasks.find((candidate) => candidate.id === params.id);
+	if (!task) {
+		const error = `no task #${params.id}`;
+		return { state, text: `Error: ${error}`, error };
+	}
+	if (params.status === undefined && params.title === undefined && params.note === undefined) {
+		const error = "nothing to update: pass status, title, or note";
+		return { state, text: `Error: ${error}`, error };
+	}
+	const built = buildTask({ id: task.id, title: params.title ?? task.title, status: params.status ?? task.status, note: params.note ?? task.note }, task.id);
+	if (typeof built === "string") return { state, text: `Error: ${built}`, error: built };
+	const next = { ...state, tasks: state.tasks.map((candidate) => (candidate.id === task.id ? built : candidate)), updatedTurn: turn };
+	const change = task.status === built.status ? "updated" : `→ ${built.status}`;
+	return { state: next, text: `#${built.id} ${built.title} ${change}` };
+}
+
+export function applyTodo(state: TodoState, params: TodoParams, turn: number): TodoResult {
+	switch (params.action) {
+		case TODO_ACTION.WRITE:
+			return write(state, Array.isArray(params.tasks) ? params.tasks : [], turn);
+		case TODO_ACTION.ADD: {
+			const built = buildTask({ title: params.title, status: params.status, note: params.note }, state.nextId);
+			if (typeof built === "string") return { state, text: `Error: ${built}`, error: built };
+			const next = { tasks: [...state.tasks, built], nextId: state.nextId + 1, updatedTurn: turn };
+			return { state: next, text: `Added #${built.id} ${built.title} (${built.status})` };
+		}
+		case TODO_ACTION.UPDATE:
+			return update(state, params, turn);
+		case TODO_ACTION.CLEAR:
+			return { state: { ...emptyTodo(), updatedTurn: turn }, text: `Cleared ${state.tasks.length} ${state.tasks.length === 1 ? "task" : "tasks"}` };
+		case TODO_ACTION.LIST:
+			return { state, text: state.tasks.length === 0 ? "No tasks." : state.tasks.map(taskLine).join("\n") };
+		default: {
+			const error = `unknown action "${params.action}" (use write, add, update, clear, or list)`;
+			return { state, text: `Error: ${error}`, error };
+		}
+	}
+}
+
+interface ReplayEntry {
+	type?: string;
+	message?: { role?: string; toolName?: string; isError?: boolean; details?: unknown };
+}
+
+interface RpivTask {
+	id?: number;
+	subject?: string;
+	status?: string;
+	activeForm?: string;
+}
+
+function fromRpiv(details: { tasks?: RpivTask[]; nextId?: number }): TodoState {
+	const tasks: TodoTask[] = [];
+	for (const raw of details.tasks ?? []) {
+		if (raw.status === "deleted" || typeof raw.id !== "number") continue;
+		const built = buildTask({ id: raw.id, title: raw.subject, status: raw.status, note: raw.status === TODO_STATUS.IN_PROGRESS ? raw.activeForm : undefined }, raw.id);
+		if (typeof built !== "string") tasks.push(built);
+	}
+	return { tasks, nextId: typeof details.nextId === "number" ? details.nextId : tasks.reduce((max, task) => Math.max(max, task.id), 0) + 1, updatedTurn: null };
+}
+
+// The last successful `todo` result on the branch is the state: ours carries
+// the snapshot under `gentleTodo`; rpiv-todo carried `tasks` + `nextId` at the top.
+export function replayTodo(entries: readonly unknown[]): TodoState {
+	let state = emptyTodo();
+	for (const entry of entries as ReplayEntry[]) {
+		const message = entry?.message;
+		if (entry?.type !== "message" || message?.role !== "toolResult" || message.toolName !== TODO_TOOL_NAME || message.isError === true) continue;
+		const details = message.details as Record<string, unknown> | undefined;
+		if (!details || typeof details !== "object") continue;
+		const ours = details[TODO_DETAILS_KEY] as TodoState | undefined;
+		if (ours && Array.isArray(ours.tasks)) state = { tasks: ours.tasks, nextId: ours.nextId, updatedTurn: ours.updatedTurn ?? null };
+		else if (Array.isArray(details.tasks)) state = fromRpiv(details as { tasks?: RpivTask[]; nextId?: number });
+	}
+	return state;
+}
+
+export function todoPromptBlock(state: TodoState, stale: number): string | undefined {
+	if (todoSummary(state).open === 0) return undefined;
+	const lines = state.tasks.map((task, index) => `${index + 1}. [${task.status}] ${task.title}${task.note ? ` — ${task.note}` : ""}`);
+	const staleLine = stale >= STALE_AFTER_TURNS ? `\n(stale: ${stale} turns without an update — bring the list up to date now)` : "";
+	return [
+		"## Todo list",
+		"Keep it current with the `todo` tool: mark a task in_progress before starting it, done right after finishing it, and rewrite the whole list with `write` whenever the plan changes. Update it before you end the turn.",
+		...lines,
+	].join("\n") + staleLine;
+}
+
+function taskRow(task: TodoTask, theme: TodoTheme): string {
+	const title = task.status === TODO_STATUS.DONE ? theme.strikethrough(task.title) : task.title;
+	const note = task.status === TODO_STATUS.IN_PROGRESS && task.note ? ` ${theme.fg(NOTE_ROLE, "·")} ${theme.fg(NOTE_ROLE, task.note)}` : "";
+	return `${theme.fg(GLYPH_ROLE[task.status], STATUS_GLYPH[task.status])} ${theme.fg(STATUS_ROLE[task.status], title)}${note}`;
+}
+
+function collapsedRow(state: TodoState, theme: TodoTheme): string {
+	const active = state.tasks.find((task) => task.status === TODO_STATUS.IN_PROGRESS);
+	if (active) return taskRow(active, theme);
+	const { open } = todoSummary(state);
+	return `${theme.fg(GLYPH_ROLE[TODO_STATUS.PENDING], STATUS_GLYPH[TODO_STATUS.PENDING])} ${theme.fg(NOTE_ROLE, `${open} open`)}`;
+}
+
+export function renderTodoCard(state: TodoState, theme: TodoTheme, width: number, options: TodoRenderOptions): string[] {
+	if (state.tasks.length === 0) return [];
+	const { done, total } = todoSummary(state);
+	const stale = options.staleTurns >= STALE_AFTER_TURNS;
+	const hint = stale ? `stale · ${options.staleTurns} turns` : options.collapsed && options.collapseKey ? `${options.collapseKey} expand` : undefined;
+	const body = options.collapsed ? [collapsedRow(state, theme)] : state.tasks.map((task) => taskRow(task, theme));
+	return renderCard(
+		{ title: "Todos", subtitle: `${done} of ${total}`, body, tone: stale ? CARD_TONE.WARNING : CARD_TONE.INFO, glyph: TODO_GLYPH },
+		theme,
+		width,
+		{ expanded: true, hint },
+	);
+}

--- a/tests/gentle-todo.test.ts
+++ b/tests/gentle-todo.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import gentleTodo, { todoCollapseKey, todoEnabled } from "../extensions/gentle-todo.ts";
+import { stripAnsi } from "../lib/terminal-theme.ts";
+
+// The Gentle Todo extension: the `todo` tool, the card above the editor,
+// the per-turn prompt block, and the staleness signal, driven by fakes.
+
+type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+interface Registered {
+	execute(toolCallId: string, params: unknown, signal: undefined, onUpdate: undefined, ctx: ExtensionContext): Promise<{ content: Array<{ type: string; text: string }>; details: Record<string, unknown> }>;
+	renderCall(args: unknown, theme: unknown): { render(width: number): string[] };
+	renderResult(result: unknown, options: { expanded: boolean }, theme: unknown): { render(width: number): string[] };
+}
+
+const plainTheme = {
+	fg(_color: string, text: string) {
+		return text;
+	},
+	strikethrough(text: string) {
+		return `~${text}~`;
+	},
+};
+const fakeTui = { requestRender() {} };
+
+function fakePi() {
+	const handlers = new Map<string, Handler[]>();
+	const tools = new Map<string, Registered>();
+	const shortcuts = new Map<string, { handler(ctx: ExtensionContext): Promise<void> }>();
+	const pi = {
+		on(event: string, handler: Handler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerTool(tool: Registered & { name: string }) {
+			tools.set(tool.name, tool);
+		},
+		registerShortcut(key: string, registration: { handler(ctx: ExtensionContext): Promise<void> }) {
+			shortcuts.set(key, registration);
+		},
+	} as unknown as ExtensionAPI;
+	const fire = async (event: string, ctx: ExtensionContext, payload: unknown = {}) => {
+		let last: unknown;
+		for (const handler of handlers.get(event) ?? []) last = await handler(payload, ctx);
+		return last;
+	};
+	return { pi, tools, shortcuts, fire };
+}
+
+function fakeContext(branch: unknown[] = [], hasUI = true) {
+	const widgets = new Map<string, (tui: unknown, theme: unknown) => { render(width: number): string[] }>();
+	const ctx = {
+		hasUI,
+		sessionManager: { getSessionId: () => "s1", getBranch: () => branch },
+		ui: {
+			setWidget(key: string, content: ((tui: unknown, theme: unknown) => { render(width: number): string[] }) | undefined) {
+				if (content === undefined) widgets.delete(key);
+				else widgets.set(key, content);
+			},
+		},
+	} as unknown as ExtensionContext;
+	const widget = () => {
+		const factory = widgets.get("gentle-todo");
+		return factory ? factory(fakeTui, plainTheme).render(70).map(stripAnsi) : undefined;
+	};
+	return { ctx, widgets, widget };
+}
+
+test("todoEnabled and todoCollapseKey read their environment flags", () => {
+	assert.equal(todoEnabled({}), true);
+	assert.equal(todoEnabled({ GENTLE_PI_TODO: "0" }), false);
+	assert.equal(todoCollapseKey({}), "ctrl+shift+t");
+	assert.equal(todoCollapseKey({ GENTLE_PI_TODO_KEY: "alt+t" }), "alt+t");
+	assert.equal(todoCollapseKey({ GENTLE_PI_TODO_KEY: "off" }), undefined);
+	const off = fakePi();
+	gentleTodo(off.pi, { GENTLE_PI_TODO: "off" });
+	assert.equal(off.tools.size, 0);
+});
+
+test("the todo tool writes the list, shows the card after the call, and carries the snapshot in details", async () => {
+	const { pi, tools, fire } = fakePi();
+	gentleTodo(pi, {});
+	const { ctx, widget } = fakeContext();
+	await fire("session_start", ctx);
+	assert.equal(widget(), undefined, "no card without tasks");
+
+	const tool = tools.get("todo")!;
+	const result = await tool.execute("c1", { action: "write", tasks: [{ title: "Write the parser", status: "in_progress", note: "parsing" }, { title: "Add tests" }] }, undefined, undefined, ctx);
+	assert.match(result.content[0].text, /2 tasks · 0 done · 1 in progress/);
+	assert.equal((result.details.gentleTodo as { tasks: unknown[] }).tasks.length, 2);
+	await fire("tool_execution_end", ctx, { toolName: "todo" });
+	const lines = widget()!;
+	assert.match(lines[0], /^╭─ ❀ Todos · 0 of 2 ─+╮$/);
+	assert.match(lines[1], /◐ Write the parser · parsing/);
+	assert.match(lines[2], /○ Add tests/);
+	assert.equal(lines[lines.length - 1], "", "a blank line keeps the card off the prompt");
+
+	const bad = await tool.execute("c2", { action: "update", id: 9, status: "done" }, undefined, undefined, ctx);
+	assert.match(bad.content[0].text, /Error: no task #9/);
+	assert.equal(bad.details.error, "no task #9");
+	assert.match(tool.renderCall({ action: "write" }, plainTheme).render(40).join(""), /❀ todo · write/);
+	assert.equal(tool.renderResult({ content: [{ type: "text", text: "a\nb" }] }, { expanded: false }, plainTheme).render(40).join("|").trimEnd(), "a");
+});
+
+test("every turn carries the open tasks in the system prompt and the card goes stale after two silent turns", async () => {
+	const { pi, tools, fire } = fakePi();
+	gentleTodo(pi, {});
+	const { ctx, widget } = fakeContext();
+	await fire("session_start", ctx);
+	await fire("before_agent_start", ctx, { systemPrompt: "base" });
+	await tools.get("todo")!.execute("c1", { action: "write", tasks: [{ title: "Fix the bug" }] }, undefined, undefined, ctx);
+	await fire("tool_execution_end", ctx, { toolName: "todo" });
+
+	const withTasks = (await fire("before_agent_start", ctx, { systemPrompt: "base" })) as { systemPrompt: string };
+	assert.match(withTasks.systemPrompt, /^base\n\n## Todo list/);
+	assert.match(withTasks.systemPrompt, /1\. \[pending\] Fix the bug/);
+	assert.doesNotMatch(widget()![0], /stale/);
+
+	const stale = (await fire("before_agent_start", ctx, { systemPrompt: "base" })) as { systemPrompt: string };
+	assert.match(stale.systemPrompt, /stale: 2 turns without an update/);
+	assert.match(widget()![0], /stale · 2 turns/);
+
+	await tools.get("todo")!.execute("c2", { action: "update", id: 1, status: "in_progress", note: "on it" }, undefined, undefined, ctx);
+	await fire("tool_execution_end", ctx, { toolName: "todo" });
+	assert.doesNotMatch(widget()![0], /stale/);
+});
+
+test("a finished list stays for its turn and clears at the next, and the collapse key folds the card", async () => {
+	const { pi, tools, shortcuts, fire } = fakePi();
+	gentleTodo(pi, {});
+	const { ctx, widget } = fakeContext();
+	await fire("session_start", ctx);
+	await tools.get("todo")!.execute("c1", { action: "write", tasks: [{ title: "A", status: "in_progress" }, { title: "B" }] }, undefined, undefined, ctx);
+	await fire("tool_execution_end", ctx, { toolName: "todo" });
+	await shortcuts.get("ctrl+shift+t")!.handler(ctx);
+	assert.equal(widget()!.length, 4, "collapsed: top, one row, bottom, spacer");
+	assert.match(widget()![1], /◐ A/);
+	await shortcuts.get("ctrl+shift+t")!.handler(ctx);
+	assert.equal(widget()!.length, 5);
+
+	await tools.get("todo")!.execute("c2", { action: "write", tasks: [{ id: 1, title: "A", status: "done" }, { id: 2, title: "B", status: "done" }] }, undefined, undefined, ctx);
+	await fire("tool_execution_end", ctx, { toolName: "todo" });
+	await fire("agent_end", ctx);
+	assert.match(widget()![0], /Todos · 2 of 2/, "the finished list is still visible at the end of its turn");
+	const next = await fire("before_agent_start", ctx, { systemPrompt: "base" });
+	assert.equal(next, undefined, "nothing open, nothing to add to the prompt");
+	assert.equal(widget(), undefined, "the card clears at the next turn");
+});
+
+test("session_start replays the list from the branch, rpiv-todo results included, and counts past turns", async () => {
+	const { pi, fire } = fakePi();
+	gentleTodo(pi, {});
+	const branch = [
+		{ type: "message", message: { role: "user", content: "hi" } },
+		{ type: "message", message: { role: "toolResult", toolName: "todo", isError: false, details: { action: "create", params: {}, tasks: [{ id: 1, subject: "Old task", status: "in_progress", activeForm: "still going" }], nextId: 2 } } },
+		{ type: "message", message: { role: "user", content: "again" } },
+	];
+	const { ctx, widget } = fakeContext(branch);
+	await fire("session_start", ctx);
+	const lines = widget()!;
+	assert.match(lines[0], /Todos · 0 of 1/);
+	assert.match(lines[1], /◐ Old task · still going/);
+	const headless = fakeContext(branch, false);
+	await fire("session_start", headless.ctx);
+	assert.equal(headless.widget(), undefined);
+});

--- a/tests/shell-todo.test.ts
+++ b/tests/shell-todo.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	applyTodo,
+	emptyTodo,
+	renderTodoCard,
+	replayTodo,
+	staleTurns,
+	TODO_STATUS,
+	todoPromptBlock,
+	todoSummary,
+	type TodoState,
+} from "../lib/shell-todo.ts";
+import { stripAnsi } from "../lib/terminal-theme.ts";
+
+// Gentle Todo: a task list the model rewrites as it works. The reducer is
+// pure, the state replays from the session branch, and staleness is derived
+// from how many turns passed since the last write while tasks stay open.
+
+const plainTheme = {
+	fg(_color: string, text: string) {
+		return text;
+	},
+	strikethrough(text: string) {
+		return `~${text}~`;
+	},
+};
+
+function seeded(): TodoState {
+	return applyTodo(
+		emptyTodo(),
+		{ action: "write", tasks: [{ title: "Add quiet tool rendering", status: "done" }, { title: "Fix quiet tools conflict", status: "in_progress", note: "fixing conflict" }, { title: "Show git bash tails" }] },
+		3,
+	).state;
+}
+
+test("applyTodo write replaces the list, assigns ids, defaults to pending, and records the turn", () => {
+	const { state, text, error } = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "First" }, { title: "Second", status: "in_progress", note: "working" }] }, 2);
+	assert.equal(error, undefined);
+	assert.deepEqual(state.tasks, [
+		{ id: 1, title: "First", status: TODO_STATUS.PENDING },
+		{ id: 2, title: "Second", status: TODO_STATUS.IN_PROGRESS, note: "working" },
+	]);
+	assert.equal(state.nextId, 3);
+	assert.equal(state.updatedTurn, 2);
+	assert.match(text, /2 tasks · 0 done · 1 in progress/);
+});
+
+test("applyTodo write keeps ids the model passes back and drops the rest", () => {
+	const first = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "A" }, { title: "B" }] }, 1).state;
+	const second = applyTodo(first, { action: "write", tasks: [{ id: 2, title: "B", status: "done" }, { title: "C" }] }, 2).state;
+	assert.deepEqual(second.tasks.map((task) => `${task.id}:${task.title}:${task.status}`), ["2:B:done", "3:C:pending"]);
+});
+
+test("applyTodo add, update, and clear mutate one task at a time and validate ids", () => {
+	let state = applyTodo(emptyTodo(), { action: "add", title: "Write tests" }, 1).state;
+	assert.equal(state.tasks[0].id, 1);
+	const updated = applyTodo(state, { action: "update", id: 1, status: "in_progress", note: "writing tests" }, 2);
+	assert.equal(updated.error, undefined);
+	assert.equal(updated.state.tasks[0].status, TODO_STATUS.IN_PROGRESS);
+	assert.equal(updated.state.tasks[0].note, "writing tests");
+	assert.match(updated.text, /#1 Write tests → in_progress/);
+	const missing = applyTodo(updated.state, { action: "update", id: 9, status: "done" }, 2);
+	assert.match(missing.error ?? "", /no task #9/);
+	assert.strictEqual(missing.state, updated.state);
+	const noField = applyTodo(updated.state, { action: "update", id: 1 }, 2);
+	assert.match(noField.error ?? "", /nothing to update/);
+	state = applyTodo(updated.state, { action: "clear" }, 3).state;
+	assert.deepEqual(state.tasks, []);
+	assert.equal(state.nextId, 1);
+});
+
+test("applyTodo accepts completed as an alias of done, rejects unknown statuses, and sanitizes text", () => {
+	const alias = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "X", status: "completed" }] }, 1);
+	assert.equal(alias.state.tasks[0].status, TODO_STATUS.DONE);
+	const bad = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "X", status: "later" }] }, 1);
+	assert.match(bad.error ?? "", /unknown status "later"/);
+	const dirty = applyTodo(emptyTodo(), { action: "add", title: "Evil\x1b[31m title\n" }, 1).state;
+	assert.equal(dirty.tasks[0].title, "Evil title");
+	const empty = applyTodo(emptyTodo(), { action: "add", title: "   " }, 1);
+	assert.match(empty.error ?? "", /title is required/);
+});
+
+test("applyTodo list reports the state without changing it", () => {
+	const state = seeded();
+	const listed = applyTodo(state, { action: "list" }, 5);
+	assert.strictEqual(listed.state, state);
+	assert.match(listed.text, /\[done\] #1 Add quiet tool rendering/);
+	assert.match(listed.text, /\[in_progress\] #2 Fix quiet tools conflict — fixing conflict/);
+	assert.match(listed.text, /\[pending\] #3 Show git bash tails/);
+});
+
+test("todoSummary and staleTurns describe progress and how long the list went untouched", () => {
+	const state = seeded();
+	assert.deepEqual(todoSummary(state), { done: 1, total: 3, open: 2 });
+	assert.equal(staleTurns(state, 3), 0);
+	assert.equal(staleTurns(state, 5), 2);
+	const allDone = applyTodo(state, { action: "write", tasks: state.tasks.map((task) => ({ ...task, status: "done" })) }, 4).state;
+	assert.equal(staleTurns(allDone, 9), 0, "a finished list never goes stale");
+	assert.equal(staleTurns(emptyTodo(), 9), 0);
+});
+
+test("replayTodo rebuilds the latest state from Gentle and rpiv tool results alike", () => {
+	const gentle = { type: "message", message: { role: "toolResult", toolName: "todo", isError: false, details: { gentleTodo: { tasks: [{ id: 4, title: "Ours", status: "pending" }], nextId: 5, updatedTurn: 7 } } } };
+	const rpiv = { type: "message", message: { role: "toolResult", toolName: "todo", isError: false, details: { action: "update", params: {}, tasks: [{ id: 1, subject: "Theirs", status: "completed", activeForm: "done" }, { id: 2, subject: "Gone", status: "deleted" }, { id: 3, subject: "Now", status: "in_progress", activeForm: "doing it" }], nextId: 4 } } };
+	const other = { type: "message", message: { role: "toolResult", toolName: "bash", details: { tasks: [] } } };
+	assert.deepEqual(replayTodo([other, rpiv]).tasks, [
+		{ id: 1, title: "Theirs", status: TODO_STATUS.DONE },
+		{ id: 3, title: "Now", status: TODO_STATUS.IN_PROGRESS, note: "doing it" },
+	]);
+	assert.equal(replayTodo([other, rpiv]).nextId, 4);
+	assert.equal(replayTodo([rpiv, gentle]).tasks[0].title, "Ours", "the last write wins");
+	assert.equal(replayTodo([rpiv, gentle]).updatedTurn, 7);
+	assert.deepEqual(replayTodo([]), emptyTodo());
+});
+
+test("todoPromptBlock lists open work with the rules, and stays silent when there is nothing open", () => {
+	const block = todoPromptBlock(seeded(), 0);
+	assert.ok(block);
+	assert.match(block, /^## Todo list/m);
+	assert.match(block, /mark a task in_progress before starting/);
+	assert.match(block, /1\. \[done\] Add quiet tool rendering/);
+	assert.match(block, /2\. \[in_progress\] Fix quiet tools conflict — fixing conflict/);
+	assert.match(block, /3\. \[pending\] Show git bash tails/);
+	assert.doesNotMatch(block, /stale/);
+	assert.match(todoPromptBlock(seeded(), 2) ?? "", /stale: 2 turns without an update/);
+	assert.equal(todoPromptBlock(emptyTodo(), 0), undefined);
+	const allDone = applyTodo(seeded(), { action: "write", tasks: [{ title: "A", status: "done" }] }, 1).state;
+	assert.equal(todoPromptBlock(allDone, 0), undefined);
+});
+
+test("renderTodoCard draws the framed list with status glyphs and keeps every line at width", () => {
+	const lines = renderTodoCard(seeded(), plainTheme, 60, { collapsed: false, staleTurns: 0, collapseKey: "ctrl+shift+t" });
+	for (const line of lines) assert.equal(visibleWidth(line), 60, `"${stripAnsi(line)}" is not 60 wide`);
+	const plain = lines.map(stripAnsi);
+	assert.match(plain[0], /^╭─ ❀ Todos · 1 of 3 ─+╮$/);
+	assert.match(plain[1], /^│ ✓ ~Add quiet tool rendering~ +│$/);
+	assert.match(plain[2], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
+	assert.match(plain[3], /^│ ○ Show git bash tails +│$/);
+	assert.match(plain[4], /^╰─+╯$/);
+});
+
+test("renderTodoCard marks a stale list in the top rule and collapses to the task in progress", () => {
+	const stale = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
+	assert.match(stale[0], /^╭─ ❀ Todos · 1 of 3 ─+ stale · 2 turns ╮$/);
+	const collapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
+	assert.equal(collapsed.length, 3);
+	assert.match(collapsed[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
+	assert.match(collapsed[1], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
+	const idle = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "Only pending" }] }, 1).state;
+	assert.match(renderTodoCard(idle, plainTheme, 70, { collapsed: true, staleTurns: 0 }).map(stripAnsi)[1], /^│ ○ 1 open +│$/);
+	assert.deepEqual(renderTodoCard(emptyTodo(), plainTheme, 70, { collapsed: false, staleTurns: 0 }), []);
+});


### PR DESCRIPTION
Closes #603

## PR type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds Gentle Todo: the `todo` tool and its card above the editor, replacing `@juicesharp/rpiv-todo` (its session results replay into the new card).
- Keeps the list current with three mechanisms the old extension lacked: `write` with the complete list, the open tasks and rules in every turn's system prompt, and a `stale · N turns` marker after two silent turns.
- Also ignores the CodeGraph index pi recreates on session start, which otherwise blocks the review preflight. Delivered as one `size:exception` PR at the maintainer's request;  6 files changed, 804 insertions(+), 1 deletion(-), three work-unit commits.

## Changes

| File | Change |
|------|--------|
| `lib/shell-todo.ts` | Pure model: reducer, replay from the session branch (Gentle and rpiv shapes), staleness, prompt block, card renderer |
| `extensions/gentle-todo.ts` | The `todo` tool, the card widget, per-turn prompt injection, collapse key, finished-list clearing |
| `tests/shell-todo.test.ts`, `tests/gentle-todo.test.ts` | Coverage for the model and the wiring |
| `README.md` | Gentle Todo section and migration note |
| `.gitignore` | Ignore `.codegraph/` |

## Test plan

- [x] `pnpm test`: 1317 pass, 0 fail
- [x] Manually tested in pi: the card, the collapse key, and the list following the agent across turns

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified
- [x] Extension tested in pi
- [x] Docs updated
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gentle Todo, an integrated task list displayed above the editor.
  * Supports creating, adding, updating, listing, and clearing tasks.
  * Preserves task state across sessions and includes open tasks in model context.
  * Adds stale-list warnings, completion clearing, collapse/expand controls, and environment-based configuration.
  * Supports migration of task state from the previous todo format.

* **Documentation**
  * Updated the README with Gentle Todo behavior, controls, configuration, and subagent widget details.

* **Tests**
  * Added coverage for task operations, persistence, rendering, configuration, stale states, and legacy state replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->