### PR TITLE
feat(agents): Gentle Agents, an own subagents runtime that keeps the terminal free

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,10 @@ The latest RDD package installs Gentle AI only into its private `.gentle-ai/` di
 Recommended companion packages:
 
 ```bash
-pi install npm:pi-subagents-j0k3r
 pi install npm:pi-intercom
 pi install npm:gentle-engram
 pi install npm:pi-web-access
 pi install npm:pi-lens
-pi install npm:@juicesharp/rpiv-todo
 pi install npm:@juicesharp/rpiv-ask-user-question
 ```
 
@@ -172,7 +170,7 @@ The goal is not ceremony. The goal is to avoid accidental chaos. Once a task sto
 
 ### Delegation triggers
 
-`gentle-pi` keeps the parent session thin and delegates at the narrowest useful point. When the Pi Subagents extension is installed, the preferred runtime is the `subagent_*` tool family because it runs the user's configured project/global subagent definitions and preserves history/background behavior. Use waiting/task mode when the parent must consume the result and continue the workflow; use background mode only for independent work where parent continuation is not required. If those tools are unavailable, the parent should fall back to Pi's native `Agent` tool or another available delegation mechanism. The requirement is delegation; the runtime is capability-dependent.
+`gentle-pi` keeps the parent session thin and delegates at the narrowest useful point. When the Pi Subagents extension is installed, the preferred runtime is the `subagent_*` tool family because it runs the user's configured project/global subagent definitions and preserves history/background behavior. With the background policy on, delegations default to background mode: the terminal stays free and each result comes back as a message that starts a new turn; task mode is reserved for delegations that must ask the user something mid-flight. If those tools are unavailable, the parent should fall back to Pi's native `Agent` tool or another available delegation mechanism. The requirement is delegation; the runtime is capability-dependent.
 
 | Trigger                                                                                                                     | Required behavior                                                             |
 | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
@@ -543,8 +541,7 @@ A project can still override the global default with:
 The modal discovers:
 
 - project agents in `.pi/subagents/`, `.pi/agents/`, and `.agents/`;
-- user agents in `~/.pi/agent/subagents/`, `~/.pi/agent/agents/`, and `~/.agents/`;
-- built-in agents from `pi-subagents-j0k3r` when present.
+- user agents in `~/.pi/agent/subagents/`, `~/.pi/agent/agents/`, and `~/.agents/`.
 
 When applying routing, project agents write runtime profiles to `.pi/subagents.json`; global and built-in agents write profiles to `~/.pi/agent/subagents.json`.
 
@@ -624,7 +621,7 @@ Working-tree changes show up below the editor as soon as a file differs from HEA
 
 `/gentle:changes` or `alt+g` opens the changes as an overlay: files on the left, the selected file's diff on the right.
 
-- `j`/`k` or the arrows move between files, `pgup`/`pgdn` scroll the diff, `esc` or `q` closes.
+- `j`/`k` or the arrows move between files, `ctrl+j`/`ctrl+k` or `pgdn`/`pgup` scroll the diff, `esc` or `q` closes.
 - While the overlay is open, git is polled every 2 seconds, so edits made from nvim, another agent, or a checkout show up in place. The selection sticks to the file, and a diff reloads only when its counts move.
 - `GENTLE_PI_SHELL_CHANGES_KEY` rebinds the shortcut (pi key syntax, for example `ctrl+shift+g`); `off` disables it. On macOS, `alt+g` needs the terminal to send Option as Meta.
 - `o` (or `enter`) opens the selected file in `$VISUAL` or `$EDITOR` and returns to pi when the editor exits, so a jump into nvim and back never leaves the session.
@@ -653,7 +650,26 @@ Gentle notices are drawn as cards: the same rounded frame as the prompt, with th
 - Every call into the gentle-ai binary and every `gentle_review` tool renders as a card under the rose, `🌹︎ Gentle AI`: the rail is amber while it runs, green when it finished, red when it failed; the expand key sits in the top rule once the tool finished, and the collapsed result shows only its line count. Reviewer captures name their lens (`review capture · risk`; the group lists all four).
 - The review preflight reminder renders as a card in the transcript with the expand key in its top rule.
 - An active dev-binary override shows above the editor at startup, in amber, naming the binary and its digest, and leaves with the first prompt; an invalid override shows in red with the reason.
-- Subagent widgets belong to their own package and keep their rendering.
+- Subagents draw their own card; see Gentle Agents below.
+
+### Gentle Agents
+
+The `subagent_*` tools and the agents card replace the third-party subagents package (remove `npm:pi-subagents-j0k3r` from your pi packages; while it is still installed the tools stay unregistered and a warning says so at startup). Agent definitions and settings are the ones you already have: markdown agents in `~/.pi/agent/agents/`, `~/.pi/agent/subagents/`, `<cwd>/.pi/agents/`, `<cwd>/.pi/subagents/` (project beats global, `subagents/` beats `agents/`), and `subagents.json` at the global and project level (`default_model`, `default_effort`, `default_mode`, `model_profiles`, `timeout_ms`, `stall_timeout_ms`, `max_concurrency`, `history_max_tasks`).
+
+```text
+╭─ ❀ Agents · 1 active · 1 done ─────────────────────────────── 1m24s ╮
+│ ✓  sdd-explore  map footer data sources    gpt-5.6-terra · 34k · $0.27 · 25s │
+│ ◐  sdd-apply    write gentle-shell footer  gpt-5.6-terra · 12k · $0.09 · 41s │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+Every subagent is its own `pi --mode rpc` child process, so the terminal never runs subagent work: the host reads JSON lines, applies each one as a small delta to a bounded per-task thread, and notifies only the listeners of that task. A task-mode child's question (`ctx.ui.select`, `confirm`, `input`, `editor`) reaches you as an ordinary pi dialog; a background child's question is dismissed. Each task has a total timeout and a stall watchdog. Closing pi stops the children that are still running.
+
+- `subagent_list_agents`, `subagent_run` (`agent`, `task`, `label?`, `context?`, `mode?` task or background), `subagent_status`, `subagent_result`, `subagent_list_tasks`, `subagent_cancel`, `subagent_send_message` (steer a running child), `subagent_continue` (resume a finished task in its own session).
+- A background task's result comes back to the model as a `gentle-agents.result` message, drawn as a rose card, and starts a new turn when the agent is idle; the model never polls.
+- `/gentle:agents` or `alt+a` opens the overlay: tasks on the left, the selected task's thread on the right. `j`/`k` move, `ctrl+j`/`ctrl+k` or `pgdn`/`pgup` scroll (`f` follows the tail again), `c` cancels, `o` opens a markdown transcript of the task's session in `$EDITOR` (written under `~/.pi/agent/gentle-agents/transcripts/`), `esc` closes. Only the selected task is subscribed while it is open.
+- Finished tasks are written to `~/.pi/agent/gentle-agents/tasks/` (one JSON per task, newest `history_max_tasks` kept, default 200) and come back on demand for `subagent_result`, `subagent_continue`, and the overlay. Child sessions live under `~/.pi/agent/gentle-agents/sessions/`.
+- `ctrl+shift+a` collapses the card to its first row (`GENTLE_PI_AGENTS_KEY`), `GENTLE_PI_AGENTS_VIEW_KEY` rebinds the overlay, `GENTLE_PI_AGENTS_PI` overrides the pi command used for children, and `GENTLE_PI_AGENTS=0` disables the tools and the card.
 
 ### Gentle Todo
 
@@ -719,7 +735,7 @@ Four sources can decide the policy, and the first hit wins:
 
 Both files use the strict shape `{"schema":"gentle-pi.background-subagents/v1","policy":"on"}`. A file that is present but malformed fails closed to `off` and is **not** skipped in favor of a lower-priority source, so a typo in the project file disables background subagents rather than silently handing the decision to the global file. The command reports that case as a warning instead of an ordinary `off`.
 
-Because the project file outranks the global one, `enable` still writes the global file but reports plainly when a project file keeps the effective policy unchanged. The resolved capability (`ready` or `absent`) reports whether `subagent_run` is actually callable in this session; a policy of `on` with capability `absent` means the subagents package is not installed.
+Because the project file outranks the global one, `enable` still writes the global file but reports plainly when a project file keeps the effective policy unchanged. The resolved capability (`ready` or `absent`) reports whether `subagent_run` is actually callable in this session; a policy of `on` with capability `absent` means Gentle Agents is disabled or the retired subagents package is still installed.
 
 Startup banner settings are global and default to the current pink rose + text logo. Supported color presets are `pink`, `cyan`, `yellow`, and `green`.
 

--- a/assets/orchestrator-delegation.md
+++ b/assets/orchestrator-delegation.md
@@ -137,12 +137,11 @@ Background execution is policy-gated: the always-on orchestrator prompt renders 
 
 When the policy is on and `subagent_run` is available:
 
-- Use `subagent_run` `mode: "background"` ONLY for independent, read-only exploration or audit work where the parent can continue non-overlapping work.
-- At the parent level, allow no more than 2 concurrent background tasks.
-- Completion notifications only: do not poll, sleep, run status checks, or proactively read for completion.
-- Use foreground `mode: "task"` when the result is needed before the next action, and always for user decisions, SDD apply or other writers, dependent verification evidence, archive, dependent phases, and any delegated work whose output determines the next action.
-- Do not duplicate launches or work, and do not overlap files or topics. Never run parallel writers in one worktree.
-- Background jobs are process-local and non-durable. A restart loses them; make no recovery claim.
+- Default to `subagent_run` `mode: "background"`. It returns a task id at once; the terminal stays free and the human keeps typing. Pass a `label` of three to six words naming the work.
+- When a background task finishes, its result arrives as a message in this session (custom type `gentle-agents.result`, one per task) and starts a new turn if you are idle. Wait for it: end the turn once launches and any non-overlapping work are done. Never poll, sleep, or call `subagent_status`/`subagent_result` for completion.
+- Use `mode: "task"` only when the subagent must ask the human something mid-flight (task-mode dialogs reach the human; background dialogs are dismissed) or when the human asked to wait.
+- Launch as many independent tasks as the work has; the runner queues beyond `max_concurrency`. Do not duplicate launches or work, and do not overlap files or topics. Never run parallel writers in one worktree.
+- Finished tasks persist across restarts; running ones are stopped when pi exits and must be relaunched, never claimed as recovered.
 <!-- /gentle-pi:background-subagents -->
 
 For generic non-SDD exploration and mapping, first attempt the installed package-owned `gentle-ai-explore`. If that individual role is missing or unusable, fall back to Pi's native `Agent` with the same read-only mapping constraints and report the fallback.

--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -1,0 +1,452 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import { keyHint, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { AGENT_MODE, discoverAgents, loadAgentsConfig, resolveAgentProfile, type AgentDefinition, type AgentMode } from "../lib/agents-config.ts";
+import { isFinished, TaskStore, type AskRequest, type TaskRecord } from "../lib/agents-protocol.ts";
+import { AgentRunner, piCommand, type AskAnswer, type RunnerDeps, type TaskRequest } from "../lib/agents-runner.ts";
+import { historyDir, loadHistory, loadStoredTask, pruneHistory, saveTask } from "../lib/agents-history.ts";
+import { sessionToMarkdown } from "../lib/agents-transcript.ts";
+import { AgentsView } from "../lib/agents-view.ts";
+import { AGENTS_GLYPH, renderAgentsCard } from "../lib/agents-widget.ts";
+import { CARD_TONE, renderCard } from "../lib/shell-card.ts";
+import { openInExternalEditor } from "./gentle-shell.ts";
+
+// Gentle Agents: subagents as isolated `pi --mode rpc` children, a task
+// store that notifies per task, and a Gentle Shell card above the editor.
+// The tool names match the retired pi-subagents package so prompts, skills,
+// and gentle-ai's delegation rules keep working unchanged.
+
+export const AGENTS_WIDGET_KEY = "gentle-agents";
+export const AGENTS_COMMAND_NAME = "gentle:agents";
+export const AGENTS_RESULT_TYPE = "gentle-agents.result";
+const COLLAPSE_KEY_DEFAULT = "ctrl+shift+a";
+const VIEW_KEY_DEFAULT = "alt+a";
+const OVERLAY_HEIGHT_RATIO = 0.8;
+const OVERLAY_MIN_ROWS = 12;
+const RENDER_COALESCE_MS = 400;
+const CLOCK_TICK_MS = 1000;
+const TOOL_PREFIX = "subagent_";
+
+export interface AgentsDeps extends RunnerDeps {
+	home: string;
+	env: NodeJS.ProcessEnv;
+}
+
+interface ToolText {
+	content: Array<{ type: "text"; text: string }>;
+	details: Record<string, unknown>;
+}
+
+const defaultDeps = (env: NodeJS.ProcessEnv): AgentsDeps => ({
+	spawn: (command, args, options) => spawn(command, args, { cwd: options.cwd, env: options.env, stdio: ["pipe", "pipe", "pipe"] }),
+	now: () => Date.now(),
+	schedule: (fn, ms) => {
+		const timer = setTimeout(fn, ms);
+		timer.unref?.();
+		return () => clearTimeout(timer);
+	},
+	pi: piCommand(),
+	home: os.homedir(),
+	env,
+});
+
+export function agentsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (env.GENTLE_PI_AGENTS_CHILD === "1") return false;
+	const value = env.GENTLE_PI_AGENTS?.trim().toLowerCase();
+	return !(value === "0" || value === "false" || value === "off");
+}
+
+// The retired pi-subagents package registers the same tool names. While it
+// is still installed we stay out of the way and say how to switch.
+export const LEGACY_SUBAGENTS_PACKAGE = "pi-subagents-j0k3r";
+
+export function legacySubagentsInstalled(home: string): boolean {
+	const settingsPath = join(home, ".pi", "agent", "settings.json");
+	if (!existsSync(settingsPath)) return false;
+	try {
+		const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as { packages?: unknown };
+		return Array.isArray(settings.packages) && settings.packages.some((entry) => typeof entry === "string" && entry.includes(LEGACY_SUBAGENTS_PACKAGE));
+	} catch {
+		return false;
+	}
+}
+
+export function agentsViewKey(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	const value = env.GENTLE_PI_AGENTS_VIEW_KEY?.trim();
+	if (value === undefined) return VIEW_KEY_DEFAULT;
+	return value === "" || value.toLowerCase() === "off" ? undefined : value;
+}
+
+export function agentsCollapseKey(env: NodeJS.ProcessEnv = process.env): string | undefined {
+	const value = env.GENTLE_PI_AGENTS_KEY?.trim();
+	if (value === undefined) return COLLAPSE_KEY_DEFAULT;
+	return value === "" || value.toLowerCase() === "off" ? undefined : value;
+}
+
+function text(value: string, details: Record<string, unknown> = {}): ToolText {
+	return { content: [{ type: "text", text: value }], details };
+}
+
+function taskDetails(task: TaskRecord): Record<string, unknown> {
+	return { gentleAgents: { taskId: task.id, agent: task.agent, status: task.status, mode: task.mode } };
+}
+
+export function describeTask(task: TaskRecord): string {
+	const head = `${task.id} · ${task.agent} · ${task.status} · ${task.mode}`;
+	const detail = task.error ? `\n${task.error}` : "";
+	return `${head} · ${task.turns} turns · ${task.toolCalls} tool calls · last: ${task.lastStep}${detail}`;
+}
+
+function finishedText(task: TaskRecord): string {
+	if (task.status === "completed") return task.result ?? "(the subagent returned no text)";
+	return `Subagent ${task.agent} ${task.status}${task.error ? `: ${task.error}` : ""}${task.result ? `\n\nLast answer:\n${task.result}` : ""}`;
+}
+
+// pi's keybinding hint needs a live theme; outside one (tests, headless) the
+// plain words still tell the reader what the key does.
+function expandHint(expanded: boolean): string {
+	try {
+		return keyHint("app.tools.expand", expanded ? "collapse" : "expand");
+	} catch {
+		return expanded ? "collapse" : "expand";
+	}
+}
+
+// What the model reads when a background task ends: the outcome first, then
+// the answer itself. The card renderer shows the same text.
+export function completionText(task: TaskRecord): string {
+	const outcome = task.status === "completed" ? "finished" : task.status.replace("_", " ");
+	return `Subagent ${task.agent} (task ${task.id}, "${task.label}") ${outcome}.\n\n${finishedText(task)}`;
+}
+
+// Host-side answer to a child's dialog: the same ctx.ui the human already
+// uses, so a subagent's question looks like any other pi dialog.
+export async function answerThroughUi(ui: ExtensionContext["ui"] | undefined, ask: AskRequest, raw: Record<string, unknown>): Promise<AskAnswer> {
+	if (!ui) return { cancelled: true };
+	const title = `${AGENTS_GLYPH} ${ask.title}`;
+	switch (ask.method) {
+		case "select": {
+			const options = Array.isArray(raw.options) ? raw.options.map(String) : [];
+			const value = await ui.select(title, options);
+			return value === undefined ? { cancelled: true } : { value };
+		}
+		case "confirm":
+			return { confirmed: await ui.confirm(title, typeof raw.message === "string" ? raw.message : "") };
+		case "input": {
+			const value = await ui.input(title, typeof raw.placeholder === "string" ? raw.placeholder : undefined);
+			return value === undefined ? { cancelled: true } : { value };
+		}
+		case "editor": {
+			const value = await ui.editor(title, typeof raw.prefill === "string" ? raw.prefill : undefined);
+			return value === undefined ? { cancelled: true } : { value };
+		}
+		default:
+			return { cancelled: true };
+	}
+}
+
+export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = process.env, overrides: Partial<AgentsDeps> = {}): void {
+	if (!agentsEnabled(env)) return;
+	const deps: AgentsDeps = { ...defaultDeps(env), ...overrides };
+	if (legacySubagentsInstalled(deps.home)) {
+		pi.on("session_start", (_event, ctx) => {
+			if (ctx.hasUI) ctx.ui.notify(`${AGENTS_GLYPH} Gentle Agents is waiting: remove the old package first with "pi remove npm:${LEGACY_SUBAGENTS_PACKAGE}"`, "warning");
+		});
+		return;
+	}
+	const collapseKey = agentsCollapseKey(env);
+	const viewKey = agentsViewKey(env);
+	const store = new TaskStore();
+	const tasksDir = historyDir(deps.home);
+	let ui: ExtensionContext["ui"] | undefined;
+	let host: { requestRender(): void } | undefined;
+	let collapsed = false;
+	let renderQueued = false;
+	let cancelClock: (() => void) | undefined;
+
+	const requestRender = () => {
+		if (renderQueued) return;
+		renderQueued = true;
+		deps.schedule(() => {
+			renderQueued = false;
+			host?.requestRender();
+		}, RENDER_COALESCE_MS);
+	};
+
+	// The elapsed column ticks once a second, and only while something runs.
+	const tickClock = () => {
+		cancelClock?.();
+		cancelClock = undefined;
+		if (store.list().some((task) => !isFinished(task.status))) {
+			cancelClock = deps.schedule(() => {
+				requestRender();
+				tickClock();
+			}, CLOCK_TICK_MS);
+		}
+	};
+
+	// A finished task goes to disk once, after its child is gone; the history
+	// is then trimmed to the configured size. Failures never reach the TUI.
+	const persist = (task: TaskRecord) => {
+		void saveTask(tasksDir, task, store.thread(task.id))
+			.then(() => pruneHistory(tasksDir, loadAgentsConfig({ cwd: task.cwd, home: deps.home }).historyMaxTasks))
+			.catch(() => {});
+	};
+
+	// A background result is delivered as a message: queued behind the current
+	// turn if the model is busy, or starting a turn right away if it is idle.
+	const deliver = (task: TaskRecord) => {
+		pi.sendMessage({ customType: AGENTS_RESULT_TYPE, content: completionText(task), display: true, details: taskDetails(task) }, { deliverAs: "followUp", triggerTurn: true });
+	};
+
+	const runner = new AgentRunner(store, loadAgentsConfig({ cwd: process.cwd(), home: deps.home }), deps, {
+		askUser: (_taskId, ask, raw) => answerThroughUi(ui, ask, raw),
+		onFinish: (task) => {
+			requestRender();
+			persist(task);
+			if (task.mode === AGENT_MODE.BACKGROUND) deliver(task);
+		},
+	});
+
+	pi.registerMessageRenderer(AGENTS_RESULT_TYPE, (message, options, theme) => {
+		const details = (message.details as { gentleAgents?: { agent?: string; status?: string } } | undefined)?.gentleAgents;
+		const content = message.content as string | Array<{ type: string; text?: string }>;
+		const body = (typeof content === "string" ? content : content.map((part) => (part.type === "text" ? (part.text ?? "") : "")).join("\n")).split("\n");
+		const tone = details?.status === "completed" ? CARD_TONE.SUCCESS : CARD_TONE.ERROR;
+		const hint = expandHint(options.expanded);
+		return {
+			render(width: number) {
+				return renderCard({ title: "Agent result", subtitle: details?.agent, body, tone, glyph: AGENTS_GLYPH }, theme, width, { expanded: options.expanded, hint });
+			},
+			invalidate() {},
+		};
+	});
+
+	// Tasks from earlier sessions come back from disk on demand.
+	const resolveTask = async (id: string): Promise<TaskRecord | undefined> => {
+		const live = store.get(id);
+		if (live) return live;
+		const stored = await loadStoredTask(tasksDir, id);
+		if (stored) store.restore(stored.task, stored.thread);
+		return stored?.task;
+	};
+
+	const openOverlay = async (ctx: ExtensionContext) => {
+		if (!ctx.hasUI) return;
+		for (const stored of await loadHistory(tasksDir)) store.restore(stored.task, stored.thread);
+		let view: AgentsView | undefined;
+		let overlayHost: { requestRender(force?: boolean): void; stop(): void; start(): void } | undefined;
+		const chosen = await ctx.ui.custom<TaskRecord | null>(
+			(tui, theme, _keybindings, done) => {
+				overlayHost = tui;
+				view = new AgentsView({
+					theme,
+					rows: Math.max(OVERLAY_MIN_ROWS, Math.floor(tui.terminal.rows * OVERLAY_HEIGHT_RATIO)),
+					store,
+					now: () => deps.now(),
+					onCancel: (task) => runner.cancel(task.id),
+					onOpen: (task) => done(task),
+					onClose: () => done(null),
+					requestRender: () => tui.requestRender(),
+				});
+				return view;
+			},
+			{ overlay: true, overlayOptions: { width: "92%", anchor: "center" } },
+		);
+		view?.dispose();
+		if (!chosen || !overlayHost) return;
+		if (!chosen.sessionPath) {
+			ctx.ui.notify("This task has no session file yet.", "warning");
+			return;
+		}
+		// The child's session is JSONL; the reader gets a markdown transcript.
+		let transcriptPath: string;
+		try {
+			transcriptPath = await writeTranscript(chosen);
+		} catch (error) {
+			ctx.ui.notify(`Could not read the task's session: ${error instanceof Error ? error.message : String(error)}`, "warning");
+			return;
+		}
+		if (!openInExternalEditor(overlayHost, transcriptPath)) ctx.ui.notify("No editor configured. Set $VISUAL or $EDITOR.", "warning");
+	};
+
+	const writeTranscript = async (task: TaskRecord): Promise<string> => {
+		const dir = join(deps.home, ".pi", "agent", "gentle-agents", "transcripts");
+		await mkdir(dir, { recursive: true });
+		const markdown = sessionToMarkdown(await readFile(task.sessionPath ?? "", "utf8"), { title: `${task.agent} · ${task.label} · ${task.status}` });
+		const path = join(dir, `${task.id}.md`);
+		await writeFile(path, markdown, "utf8");
+		return path;
+	};
+	// A status change is worth a frame right away; deltas inside a task are
+	// coalesced so a chatty child cannot flood the terminal.
+	store.subscribeSummary(() => {
+		host?.requestRender();
+		tickClock();
+	});
+
+	const showWidget = (ctx: ExtensionContext) => {
+		ui = ctx.hasUI ? ctx.ui : undefined;
+		ui?.setWidget(AGENTS_WIDGET_KEY, (tui, theme) => {
+			host = tui;
+			return {
+				render(width: number) {
+					const lines = renderAgentsCard(store.list(), theme, width, deps.now(), { collapsed, collapseKey });
+					return lines.length === 0 ? [] : [...lines, ""];
+				},
+				invalidate() {},
+			};
+		});
+	};
+
+	const roots = (ctx: ExtensionContext) => ({ cwd: ctx.sessionManager.getCwd(), home: deps.home });
+
+	const buildRequest = (ctx: ExtensionContext, agent: AgentDefinition, prompt: string, label: string | undefined, context: string | undefined, mode: AgentMode, resume?: string): TaskRequest => {
+		const config = loadAgentsConfig(roots(ctx));
+		const profile = resolveAgentProfile(agent, config);
+		const sessionDir = join(deps.home, ".pi", "agent", "gentle-agents", "sessions");
+		mkdirSync(sessionDir, { recursive: true });
+		return {
+			agent,
+			prompt,
+			label,
+			context,
+			mode,
+			cwd: ctx.sessionManager.getCwd(),
+			parentSessionId: ctx.sessionManager.getSessionId() ?? "",
+			model: profile.model,
+			thinking: profile.thinking,
+			sessionDir,
+			resumeSessionPath: resume,
+			env: deps.env,
+		};
+	};
+
+	const launch = async (ctx: ExtensionContext, request: TaskRequest): Promise<ToolText> => {
+		const task = runner.run(request);
+		store.subscribe(task.id, () => requestRender());
+		if (request.mode === AGENT_MODE.BACKGROUND) return text(`Started ${task.agent} in the background as task ${task.id}. Use subagent_status or subagent_result with that id.`, taskDetails(task));
+		const finished = await runner.waitFor(task.id);
+		return text(finishedText(finished), taskDetails(finished));
+	};
+
+	const tool = (name: string, description: string, parameters: Record<string, unknown>, execute: (params: Record<string, unknown>, ctx: ExtensionContext) => Promise<ToolText>) => {
+		pi.registerTool({
+			name: `${TOOL_PREFIX}${name}`,
+			label: `Agent ${name.replace(/_/g, " ")}`,
+			description,
+			parameters: { type: "object", additionalProperties: false, ...parameters } as never,
+			renderCall(args, theme) {
+				const params = args as { agent?: string; task_id?: string };
+				return new Text(theme.fg("toolTitle", `${AGENTS_GLYPH} agent ${name.replace(/_/g, " ")}${params.agent ? ` · ${params.agent}` : params.task_id ? ` · ${params.task_id}` : ""}`), 0, 0);
+			},
+			renderResult(result, options, theme) {
+				const body = result.content.map((part) => (part.type === "text" ? part.text : "")).join("\n");
+				return new Text(options.expanded ? body : theme.fg("muted", body.split("\n")[0] ?? ""), 0, 0);
+			},
+			async execute(_id, params, _signal, _onUpdate, ctx) {
+				return execute(params as Record<string, unknown>, ctx);
+			},
+		});
+	};
+
+	tool("list_agents", "List the subagents defined for this project and user, with their descriptions.", { properties: {} }, async (_params, ctx) => {
+		const { agents, errors } = discoverAgents(roots(ctx));
+		const lines = agents.map((agent) => `- ${agent.name} (${agent.scope}): ${agent.description || "no description"}`);
+		const problems = errors.map((error) => `! ${error}`);
+		return text(lines.length === 0 ? "No subagents defined." : [...lines, ...problems].join("\n"));
+	});
+
+	tool(
+		"run",
+		"Delegate a task to a named subagent. Task mode waits for the answer; background mode returns a task id immediately.",
+		{
+			required: ["agent", "task"],
+			properties: {
+				agent: { type: "string", description: "Subagent name from subagent_list_agents." },
+				task: { type: "string", description: "What the subagent must do, self-contained." },
+				label: { type: "string", description: "Three to six words naming the work, shown on the agents card, e.g. 'map footer data sources'." },
+				context: { type: "string", description: "Optional extra context appended to the task." },
+				mode: { type: "string", enum: ["task", "background"], description: "task waits for the result (default); background returns immediately." },
+			},
+		},
+		async (params, ctx) => {
+			const { agents } = discoverAgents(roots(ctx));
+			const agent = agents.find((candidate) => candidate.name === params.agent);
+			if (!agent) return text(`Error: no subagent named "${String(params.agent)}". Known: ${agents.map((candidate) => candidate.name).join(", ") || "none"}`, { error: "unknown agent" });
+			const mode = (params.mode as AgentMode | undefined) ?? agent.mode ?? loadAgentsConfig(roots(ctx)).defaultMode;
+			return launch(ctx, buildRequest(ctx, agent, String(params.task ?? ""), typeof params.label === "string" ? params.label : undefined, typeof params.context === "string" ? params.context : undefined, mode));
+		},
+	);
+
+	tool("status", "Report the status of one subagent task.", { required: ["task_id"], properties: { task_id: { type: "string" } } }, async (params) => {
+		const task = await resolveTask(String(params.task_id));
+		return task ? text(describeTask(task), taskDetails(task)) : text(`Error: no task ${String(params.task_id)}`, { error: "unknown task" });
+	});
+
+	tool("result", "Return the final answer of a finished subagent task, or its current state if it is still running.", { required: ["task_id"], properties: { task_id: { type: "string" } } }, async (params) => {
+		const task = await resolveTask(String(params.task_id));
+		if (!task) return text(`Error: no task ${String(params.task_id)}`, { error: "unknown task" });
+		return text(isFinished(task.status) ? finishedText(task) : `Task ${task.id} is still ${task.status} (last: ${task.lastStep}).`, taskDetails(task));
+	});
+
+	tool("list_tasks", "List the subagent tasks of this session, newest first.", { properties: {} }, async (_params, ctx) => {
+		const tasks = store.list(ctx.sessionManager.getSessionId() ?? "");
+		return text(tasks.length === 0 ? "No subagent tasks in this session." : tasks.map(describeTask).join("\n"));
+	});
+
+	tool("cancel", "Cancel a queued or running subagent task.", { required: ["task_id"], properties: { task_id: { type: "string" } } }, async (params) => {
+		const id = String(params.task_id);
+		return runner.cancel(id) ? text(`Cancelled task ${id}.`) : text(`Error: task ${id} is not running.`, { error: "not running" });
+	});
+
+	tool("send_message", "Steer a running subagent with a message delivered before its next model call.", { required: ["task_id", "message"], properties: { task_id: { type: "string" }, message: { type: "string" } } }, async (params) => {
+		const id = String(params.task_id);
+		return runner.steer(id, String(params.message ?? "")) ? text(`Message queued for task ${id}.`) : text(`Error: task ${id} is not running.`, { error: "not running" });
+	});
+
+	tool(
+		"continue",
+		"Resume a finished subagent task in its own session with a follow-up prompt.",
+		{ required: ["task_id", "prompt"], properties: { task_id: { type: "string" }, prompt: { type: "string" }, label: { type: "string", description: "Three to six words naming the follow-up." }, mode: { type: "string", enum: ["task", "background"] } } },
+		async (params, ctx) => {
+			const previous = await resolveTask(String(params.task_id));
+			if (!previous) return text(`Error: no task ${String(params.task_id)}`, { error: "unknown task" });
+			if (!isFinished(previous.status) || !previous.sessionPath) return text(`Error: task ${previous.id} cannot be continued yet (${previous.status}).`, { error: "not continuable" });
+			const agent = discoverAgents(roots(ctx)).agents.find((candidate) => candidate.name === previous.agent);
+			if (!agent) return text(`Error: subagent "${previous.agent}" is no longer defined.`, { error: "unknown agent" });
+			const mode = (params.mode as AgentMode | undefined) ?? (previous.mode as AgentMode);
+			return launch(ctx, buildRequest(ctx, agent, String(params.prompt ?? ""), typeof params.label === "string" ? params.label : undefined, undefined, mode, previous.sessionPath));
+		},
+	);
+
+	if (collapseKey) {
+		pi.registerShortcut(collapseKey as Parameters<ExtensionAPI["registerShortcut"]>[0], {
+			description: "Collapse or expand the agents card",
+			handler: async () => {
+				collapsed = !collapsed;
+				host?.requestRender();
+			},
+		});
+	}
+
+	pi.registerCommand(AGENTS_COMMAND_NAME, {
+		description: "Show the subagents of this and earlier sessions with their threads. Press o to open a task's session in $EDITOR.",
+		handler: async (_args, ctx) => openOverlay(ctx),
+	});
+	if (viewKey) {
+		pi.registerShortcut(viewKey as Parameters<ExtensionAPI["registerShortcut"]>[0], {
+			description: "Show the subagents overlay",
+			handler: async (ctx) => openOverlay(ctx),
+		});
+	}
+
+	pi.on("session_start", (_event, ctx) => showWidget(ctx));
+	pi.on("session_shutdown", () => {
+		runner.cancelAll();
+	});
+}

--- a/extensions/gentle-todo.ts
+++ b/extensions/gentle-todo.ts
@@ -160,7 +160,10 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 
 	pi.on("session_start", (_event, ctx) => {
 		const current = session(ctx);
-		current.state = replayTodo(ctx.sessionManager.getBranch());
+		// A list that was already finished when the session was left is history,
+		// not work: it would otherwise sit on screen until two more turns pass.
+		const replayed = replayTodo(ctx.sessionManager.getBranch());
+		current.state = replayed.tasks.length > 0 && todoSummary(replayed).open === 0 ? { ...replayed, tasks: [] } : replayed;
 		current.turn = ctx.sessionManager.getBranch().filter((entry) => (entry as { type?: string }).type === "message" && (entry as { message?: { role?: string } }).message?.role === "user").length;
 		current.ui = ctx.hasUI ? ctx.ui : undefined;
 		show(current);

--- a/extensions/gentle-todo.ts
+++ b/extensions/gentle-todo.ts
@@ -53,6 +53,7 @@ const TOOL_PARAMETERS = {
 } as const;
 
 export function todoEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (env.GENTLE_PI_AGENTS_CHILD === "1") return false;
 	const value = env.GENTLE_PI_TODO?.trim().toLowerCase();
 	return !(value === "0" || value === "false" || value === "off");
 }

--- a/lib/agents-config.ts
+++ b/lib/agents-config.ts
@@ -1,0 +1,313 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+// Gentle Agents configuration. Agent definitions are markdown files with YAML
+// frontmatter (the format gentle-ai installs) and runtime settings come from
+// subagents.json at the global and project level. Everything here is pure
+// apart from the discovery helpers, which take their roots as arguments.
+
+export const AGENT_MODE = {
+	TASK: "task",
+	BACKGROUND: "background",
+} as const;
+
+export type AgentMode = (typeof AGENT_MODE)[keyof typeof AGENT_MODE];
+
+export const THINKING_LEVEL = {
+	OFF: "off",
+	MINIMAL: "minimal",
+	LOW: "low",
+	MEDIUM: "medium",
+	HIGH: "high",
+	XHIGH: "xhigh",
+} as const;
+
+export type ThinkingLevel = (typeof THINKING_LEVEL)[keyof typeof THINKING_LEVEL];
+
+export const AGENT_SCOPE = {
+	GLOBAL: "global",
+	PROJECT: "project",
+} as const;
+
+export type AgentScope = (typeof AGENT_SCOPE)[keyof typeof AGENT_SCOPE];
+
+export const PROFILE_SOURCE = {
+	PROFILE: "profile",
+	DEFINITION: "definition",
+	DEFAULT: "default",
+	UNRESOLVED: "unresolved",
+} as const;
+
+export type ProfileSource = (typeof PROFILE_SOURCE)[keyof typeof PROFILE_SOURCE];
+
+export interface ModelRef {
+	provider: string | undefined;
+	id: string;
+}
+
+export interface AgentDefinition {
+	name: string;
+	description: string;
+	filePath: string;
+	scope: AgentScope;
+	instructions: string;
+	model: ModelRef | undefined;
+	thinking: ThinkingLevel | undefined;
+	mode: AgentMode | undefined;
+	tools: string[];
+}
+
+export interface AgentDefinitionError {
+	filePath: string;
+	error: string;
+}
+
+export interface ModelProfile {
+	model: ModelRef | undefined;
+	thinking: ThinkingLevel | undefined;
+}
+
+export interface AgentsConfig {
+	defaultModel: ModelRef | undefined;
+	defaultThinking: ThinkingLevel | undefined;
+	defaultMode: AgentMode;
+	modelProfiles: Record<string, ModelProfile>;
+	timeoutMs: number;
+	stallTimeoutMs: number;
+	maxConcurrency: number;
+	historyMaxTasks: number;
+}
+
+export interface ProfileSources {
+	model: ProfileSource;
+	thinking: ProfileSource;
+}
+
+export interface ResolvedProfile {
+	model: ModelRef | undefined;
+	thinking: ThinkingLevel | undefined;
+	source: ProfileSources;
+}
+
+export interface DiscoveryRoots {
+	cwd: string;
+	home: string;
+}
+
+export interface DiscoveryResult {
+	agents: AgentDefinition[];
+	errors: string[];
+}
+
+export type FrontmatterValue = string | string[];
+
+export interface Frontmatter {
+	data: Record<string, FrontmatterValue>;
+	body: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 20 * 60_000;
+const DEFAULT_STALL_TIMEOUT_MS = 4 * 60_000;
+const DEFAULT_MAX_CONCURRENCY = 5;
+const DEFAULT_HISTORY_MAX_TASKS = 200;
+const THINKING_LEVELS = Object.values(THINKING_LEVEL) as string[];
+const AGENT_MODES = Object.values(AGENT_MODE) as string[];
+
+function unquote(value: string): string {
+	const trimmed = value.trim();
+	const quoted = (trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"));
+	return quoted && trimmed.length >= 2 ? trimmed.slice(1, -1) : trimmed;
+}
+
+function parseInlineList(value: string): string[] {
+	return value.slice(1, -1).split(",").map(unquote).filter((item) => item.length > 0);
+}
+
+// Just enough YAML for agent frontmatter: `key: scalar`, `key: [a, b]`, and
+// `key:` followed by `- item` lines. Anything else stays a plain string.
+export function parseFrontmatter(text: string): Frontmatter {
+	const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(text);
+	if (!match) return { data: {}, body: text.trim() };
+	const data: Record<string, FrontmatterValue> = {};
+	let listKey: string | undefined;
+	for (const raw of match[1].split(/\r?\n/)) {
+		const item = /^\s*-\s+(.*)$/.exec(raw);
+		if (item && listKey) {
+			(data[listKey] as string[]).push(unquote(item[1]));
+			continue;
+		}
+		const pair = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(raw);
+		if (!pair) continue;
+		const [, key, value] = pair;
+		const trimmed = value.trim();
+		if (trimmed.length === 0) {
+			data[key] = [];
+			listKey = key;
+			continue;
+		}
+		listKey = undefined;
+		data[key] = trimmed.startsWith("[") && trimmed.endsWith("]") ? parseInlineList(trimmed) : unquote(trimmed);
+	}
+	return { data, body: match[2].trim() };
+}
+
+export function parseModelRef(value: unknown): ModelRef | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	if (trimmed.length === 0) return undefined;
+	const slash = trimmed.indexOf("/");
+	if (slash <= 0) return { provider: undefined, id: trimmed };
+	return { provider: trimmed.slice(0, slash), id: trimmed.slice(slash + 1) };
+}
+
+function parseThinking(value: unknown): ThinkingLevel | undefined | string {
+	if (value === undefined) return undefined;
+	const normalized = String(value).trim().toLowerCase();
+	return THINKING_LEVELS.includes(normalized) ? (normalized as ThinkingLevel) : `thinking "${value}" is not one of ${THINKING_LEVELS.join(", ")}`;
+}
+
+function parseMode(value: unknown): AgentMode | undefined | string {
+	if (value === undefined) return undefined;
+	const normalized = String(value).trim().toLowerCase();
+	return AGENT_MODES.includes(normalized) ? (normalized as AgentMode) : `mode "${value}" is not one of ${AGENT_MODES.join(", ")}`;
+}
+
+function parseTools(value: FrontmatterValue | undefined): string[] {
+	if (value === undefined) return [];
+	const items = Array.isArray(value) ? value : value.split(",");
+	return items.map((item) => item.trim()).filter((item) => item.length > 0);
+}
+
+function scalar(value: FrontmatterValue | undefined): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+export function parseAgentDefinition(text: string, filePath: string, scope: AgentScope): AgentDefinition | AgentDefinitionError {
+	const { data, body } = parseFrontmatter(text);
+	const thinking = parseThinking(scalar(data.thinking) ?? scalar(data.effort) ?? scalar(data.thinking_level));
+	if (thinking !== undefined && !THINKING_LEVELS.includes(thinking)) return { filePath, error: thinking };
+	const mode = parseMode(scalar(data.subagent_mode) ?? scalar(data.mode));
+	if (mode !== undefined && !AGENT_MODES.includes(mode)) return { filePath, error: mode };
+	if (body.length === 0) return { filePath, error: "no instructions after the frontmatter" };
+	const name = scalar(data.name)?.trim() || basename(filePath).replace(/\.md$/i, "");
+	return {
+		name,
+		description: scalar(data.description)?.trim() ?? "",
+		filePath,
+		scope,
+		instructions: body,
+		model: parseModelRef(data.model),
+		thinking: thinking as ThinkingLevel | undefined,
+		mode: mode as AgentMode | undefined,
+		tools: parseTools(data.tools),
+	};
+}
+
+// Discovery order is precedence order: a later directory replaces an earlier
+// definition with the same name, so project beats global and `subagents/`
+// beats `agents/` within each scope.
+export function agentDirectories(roots: DiscoveryRoots): Array<{ dir: string; scope: AgentScope }> {
+	return [
+		{ dir: join(roots.home, ".pi", "agent", "agents"), scope: AGENT_SCOPE.GLOBAL },
+		{ dir: join(roots.home, ".pi", "agent", "subagents"), scope: AGENT_SCOPE.GLOBAL },
+		{ dir: join(roots.cwd, ".pi", "agents"), scope: AGENT_SCOPE.PROJECT },
+		{ dir: join(roots.cwd, ".pi", "subagents"), scope: AGENT_SCOPE.PROJECT },
+	];
+}
+
+export function discoverAgents(roots: DiscoveryRoots): DiscoveryResult {
+	const agents = new Map<string, AgentDefinition>();
+	const errors: string[] = [];
+	for (const { dir, scope } of agentDirectories(roots)) {
+		if (!existsSync(dir)) continue;
+		for (const file of readdirSync(dir).filter((entry) => entry.toLowerCase().endsWith(".md")).sort()) {
+			const filePath = join(dir, file);
+			const parsed = parseAgentDefinition(readFileSync(filePath, "utf8"), filePath, scope);
+			if ("error" in parsed) errors.push(`${filePath}: ${parsed.error}`);
+			else agents.set(parsed.name, parsed);
+		}
+	}
+	return { agents: [...agents.values()].sort((a, b) => a.name.localeCompare(b.name)), errors };
+}
+
+type RawConfig = Record<string, unknown> | undefined;
+
+function positiveInteger(value: unknown, fallback: number): number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function parseProfiles(value: unknown): Record<string, ModelProfile> {
+	const profiles: Record<string, ModelProfile> = {};
+	if (!value || typeof value !== "object") return profiles;
+	for (const [name, raw] of Object.entries(value as Record<string, unknown>)) {
+		if (!raw || typeof raw !== "object") continue;
+		const entry = raw as Record<string, unknown>;
+		const thinking = parseThinking(entry.effort ?? entry.thinking);
+		profiles[name] = { model: parseModelRef(entry.model), thinking: thinking !== undefined && THINKING_LEVELS.includes(thinking) ? (thinking as ThinkingLevel) : undefined };
+	}
+	return profiles;
+}
+
+function mergeProfiles(base: Record<string, ModelProfile>, override: Record<string, ModelProfile>): Record<string, ModelProfile> {
+	const merged = { ...base };
+	for (const [name, profile] of Object.entries(override)) {
+		merged[name] = { model: profile.model ?? base[name]?.model, thinking: profile.thinking ?? base[name]?.thinking };
+	}
+	return merged;
+}
+
+// Project settings override global ones field by field; model profiles merge
+// per agent so a project can change one effort without repeating the model.
+export function parseAgentsConfig(global: RawConfig, project: RawConfig): AgentsConfig {
+	const merged: Record<string, unknown> = { ...(global ?? {}), ...(project ?? {}) };
+	const thinking = parseThinking(merged.default_effort ?? merged.default_thinking_level ?? merged.default_thinking);
+	const mode = parseMode(merged.default_mode);
+	return {
+		defaultModel: parseModelRef(merged.default_model),
+		defaultThinking: thinking !== undefined && THINKING_LEVELS.includes(thinking) ? (thinking as ThinkingLevel) : undefined,
+		defaultMode: mode !== undefined && AGENT_MODES.includes(mode) ? (mode as AgentMode) : AGENT_MODE.TASK,
+		modelProfiles: mergeProfiles(parseProfiles(global?.model_profiles), parseProfiles(project?.model_profiles)),
+		timeoutMs: positiveInteger(merged.timeout_ms, DEFAULT_TIMEOUT_MS),
+		stallTimeoutMs: positiveInteger(merged.stall_timeout_ms, DEFAULT_STALL_TIMEOUT_MS),
+		maxConcurrency: positiveInteger(merged.max_concurrency, DEFAULT_MAX_CONCURRENCY),
+		historyMaxTasks: positiveInteger(merged.history_max_tasks, DEFAULT_HISTORY_MAX_TASKS),
+	};
+}
+
+function readJson(path: string): RawConfig {
+	if (!existsSync(path)) return undefined;
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function loadAgentsConfig(roots: DiscoveryRoots): AgentsConfig {
+	return parseAgentsConfig(readJson(join(roots.home, ".pi", "agent", "subagents.json")), readJson(join(roots.cwd, ".pi", "subagents.json")));
+}
+
+function pick<T>(candidates: Array<[T | undefined, ProfileSource]>): [T | undefined, ProfileSource] {
+	return candidates.find(([value]) => value !== undefined) ?? [undefined, PROFILE_SOURCE.UNRESOLVED];
+}
+
+export function resolveAgentProfile(agent: AgentDefinition, config: AgentsConfig): ResolvedProfile {
+	const profile = config.modelProfiles[agent.name];
+	const [model, modelSource] = pick<ModelRef>([
+		[profile?.model, PROFILE_SOURCE.PROFILE],
+		[agent.model, PROFILE_SOURCE.DEFINITION],
+		[config.defaultModel, PROFILE_SOURCE.DEFAULT],
+	]);
+	const [thinking, thinkingSource] = pick<ThinkingLevel>([
+		[profile?.thinking, PROFILE_SOURCE.PROFILE],
+		[agent.thinking, PROFILE_SOURCE.DEFINITION],
+		[config.defaultThinking, PROFILE_SOURCE.DEFAULT],
+	]);
+	return { model, thinking, source: { model: modelSource, thinking: thinkingSource } };
+}
+
+export function formatModelRef(model: ModelRef | undefined): string {
+	if (!model) return "default";
+	return model.provider ? `${model.provider}/${model.id}` : model.id;
+}

--- a/lib/agents-history.ts
+++ b/lib/agents-history.ts
@@ -1,0 +1,80 @@
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { emptyThread, type TaskRecord, type TaskThread } from "./agents-protocol.ts";
+
+// Gentle Agents history: one JSON file per finished task, written by the
+// host after the child is gone and read back lazily when the overlay opens
+// or a tool asks for a task from an earlier session. Everything is async so
+// the terminal never waits on disk.
+
+export interface StoredTask {
+	task: TaskRecord;
+	thread: TaskThread;
+}
+
+const FILE_SUFFIX = ".json";
+const SAFE_ID = /^[a-z0-9-]+$/i;
+
+export function historyDir(home: string): string {
+	return join(home, ".pi", "agent", "gentle-agents", "tasks");
+}
+
+function fileFor(dir: string, id: string): string {
+	if (!SAFE_ID.test(id)) throw new Error(`invalid task id: ${id}`);
+	return join(dir, `${id}${FILE_SUFFIX}`);
+}
+
+function isRecord(value: unknown): value is TaskRecord {
+	const task = value as Partial<TaskRecord> | undefined;
+	return typeof task?.id === "string" && typeof task.agent === "string" && typeof task.status === "string" && typeof task.createdAt === "number";
+}
+
+function parseStored(text: string): StoredTask | undefined {
+	try {
+		const parsed = JSON.parse(text) as Partial<StoredTask>;
+		if (!isRecord(parsed.task)) return undefined;
+		const thread = parsed.thread && Array.isArray(parsed.thread.items) ? parsed.thread : emptyThread();
+		return { task: parsed.task, thread: { ...emptyThread(), ...thread } };
+	} catch {
+		return undefined;
+	}
+}
+
+export async function saveTask(dir: string, task: TaskRecord, thread: TaskThread): Promise<void> {
+	await mkdir(dir, { recursive: true });
+	const target = fileFor(dir, task.id);
+	const temp = `${target}.${process.pid}-${Math.random().toString(36).slice(2, 8)}.tmp`;
+	await writeFile(temp, JSON.stringify({ task, thread }), "utf8");
+	await rename(temp, target);
+}
+
+export async function loadStoredTask(dir: string, id: string): Promise<StoredTask | undefined> {
+	if (!SAFE_ID.test(id)) return undefined;
+	try {
+		return parseStored(await readFile(fileFor(dir, id), "utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
+async function listFiles(dir: string): Promise<string[]> {
+	try {
+		return (await readdir(dir)).filter((name) => name.endsWith(FILE_SUFFIX));
+	} catch {
+		return [];
+	}
+}
+
+export async function loadHistory(dir: string): Promise<StoredTask[]> {
+	const files = await listFiles(dir);
+	const stored = await Promise.all(files.map(async (name) => parseStored(await readFile(join(dir, name), "utf8").catch(() => ""))));
+	return stored.filter((entry): entry is StoredTask => entry !== undefined).sort((a, b) => b.task.createdAt - a.task.createdAt);
+}
+
+// Keep the newest `maxTasks` files; the rest go. Returns how many were removed.
+export async function pruneHistory(dir: string, maxTasks: number): Promise<number> {
+	const stored = await loadHistory(dir);
+	const extra = stored.slice(Math.max(0, maxTasks));
+	await Promise.all(extra.map((entry) => rm(fileFor(dir, entry.task.id), { force: true })));
+	return extra.length;
+}

--- a/lib/agents-protocol.ts
+++ b/lib/agents-protocol.ts
@@ -1,0 +1,412 @@
+import { sanitizeTerminalText } from "./terminal-theme.ts";
+
+// Gentle Agents protocol. A child pi process streams RPC events; the host
+// turns each one into a small typed delta, applies it to an append-only,
+// bounded thread, and tells only the listeners of that task. Nothing here
+// rebuilds a transcript, re-validates a whole snapshot, or fans out globally.
+
+export const TASK_STATUS = {
+	QUEUED: "queued",
+	RUNNING: "running",
+	WAITING: "waiting",
+	COMPLETED: "completed",
+	FAILED: "failed",
+	CANCELLED: "cancelled",
+	TIMED_OUT: "timed_out",
+} as const;
+
+export type TaskStatus = (typeof TASK_STATUS)[keyof typeof TASK_STATUS];
+
+export const FINISHED_STATUSES: readonly TaskStatus[] = [TASK_STATUS.COMPLETED, TASK_STATUS.FAILED, TASK_STATUS.CANCELLED, TASK_STATUS.TIMED_OUT];
+
+export const TASK_EVENT = {
+	TEXT: "text",
+	THINKING: "thinking",
+	TOOL_START: "tool_start",
+	TOOL_UPDATE: "tool_update",
+	TOOL_END: "tool_end",
+	TURN_END: "turn_end",
+	AGENT_END: "agent_end",
+	ERROR: "error",
+	ASK: "ask",
+	NOTE: "note",
+	USAGE: "usage",
+} as const;
+
+export type TaskEventType = (typeof TASK_EVENT)[keyof typeof TASK_EVENT];
+
+export const THREAD_ITEM = {
+	TEXT: "text",
+	THINKING: "thinking",
+	TOOL: "tool",
+	NOTE: "note",
+} as const;
+
+export type ThreadItemKind = (typeof THREAD_ITEM)[keyof typeof THREAD_ITEM];
+
+export interface AskRequest {
+	id: string;
+	method: string;
+	title: string;
+}
+
+export interface TextEvent { type: typeof TASK_EVENT.TEXT; text: string }
+export interface ThinkingEvent { type: typeof TASK_EVENT.THINKING; text: string }
+export interface ToolStartEvent { type: typeof TASK_EVENT.TOOL_START; callId: string; name: string; args: Record<string, unknown> }
+export interface ToolUpdateEvent { type: typeof TASK_EVENT.TOOL_UPDATE; callId: string; output: string }
+export interface ToolEndEvent { type: typeof TASK_EVENT.TOOL_END; callId: string; output: string; isError: boolean }
+export interface TurnEndEvent { type: typeof TASK_EVENT.TURN_END }
+export interface AgentEndEvent { type: typeof TASK_EVENT.AGENT_END; text: string }
+export interface ErrorEvent { type: typeof TASK_EVENT.ERROR; message: string }
+export interface AskEvent { type: typeof TASK_EVENT.ASK; request: AskRequest }
+export interface NoteEvent { type: typeof TASK_EVENT.NOTE; text: string }
+export interface UsageEvent { type: typeof TASK_EVENT.USAGE; tokens: number; cost: number }
+
+export type TaskEvent = TextEvent | ThinkingEvent | ToolStartEvent | ToolUpdateEvent | ToolEndEvent | TurnEndEvent | AgentEndEvent | ErrorEvent | AskEvent | NoteEvent | UsageEvent;
+
+export interface TextItem { kind: typeof THREAD_ITEM.TEXT; text: string }
+export interface ThinkingItem { kind: typeof THREAD_ITEM.THINKING; text: string }
+export interface ToolItem { kind: typeof THREAD_ITEM.TOOL; callId: string; name: string; args: Record<string, unknown>; output: string; running: boolean; isError: boolean }
+export interface NoteItem { kind: typeof THREAD_ITEM.NOTE; text: string }
+
+export type ThreadItem = TextItem | ThinkingItem | ToolItem | NoteItem;
+
+export interface ThreadLimits {
+	maxItems: number;
+	maxOutputChars: number;
+}
+
+export interface TaskThread {
+	items: ThreadItem[];
+	dropped: number;
+	version: number;
+	limits: ThreadLimits;
+}
+
+export interface TaskRecord {
+	id: string;
+	agent: string;
+	mode: string;
+	prompt: string;
+	/** One line for the card: what the subagent is doing. */
+	label: string;
+	cwd: string;
+	parentSessionId: string;
+	status: TaskStatus;
+	createdAt: number;
+	startedAt: number | null;
+	endedAt: number | null;
+	model: string;
+	thinking: string | undefined;
+	sessionPath: string | null;
+	error: string | null;
+	result: string | null;
+	lastStep: string;
+	lastActivityAt: number;
+	turns: number;
+	toolCalls: number;
+	tokens: number;
+	cost: number;
+}
+
+export interface TaskSummary {
+	running: number;
+	queued: number;
+	waiting: number;
+	finished: number;
+}
+
+export type TaskListener = (task: TaskRecord, thread: TaskThread) => void;
+export type SummaryListener = (summary: TaskSummary) => void;
+
+const DEFAULT_LIMITS: ThreadLimits = { maxItems: 400, maxOutputChars: 4000 };
+/** Child UI requests that block on an answer; everything else (notify, setStatus, setWidget) is noise here. */
+export const DIALOG_METHODS: ReadonlySet<string> = new Set(["select", "confirm", "input", "editor"]);
+const LABEL_MAX = 72;
+const TEXT_CAP = 20_000;
+const ELLIPSIS = "…";
+
+function clean(value: unknown): string {
+	return typeof value === "string" ? sanitizeTerminalText(value) : "";
+}
+
+function contentText(content: unknown): string {
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((part) => (part && typeof part === "object" && (part as { type?: string }).type === "text" ? clean((part as { text?: unknown }).text) : ""))
+		.filter((text) => text.length > 0)
+		.join("\n");
+}
+
+function keepTail(text: string, max: number): string {
+	return text.length <= max ? text : `${ELLIPSIS}${text.slice(text.length - max + 1)}`;
+}
+
+function lastAssistantText(messages: unknown): string {
+	if (!Array.isArray(messages)) return "";
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index] as { role?: string; content?: unknown };
+		if (message?.role === "assistant") {
+			const text = contentText(message.content);
+			if (text.length > 0) return text;
+		}
+	}
+	return "";
+}
+
+type Raw = Record<string, unknown>;
+
+function askRequest(raw: Raw): AskRequest {
+	const title = clean(raw.title) || clean(raw.message) || clean(raw.method);
+	return { id: String(raw.id ?? ""), method: String(raw.method ?? ""), title };
+}
+
+// One RPC line in, zero or more deltas out. Streaming deltas carry only the
+// chunk; whole-message payloads that pi repeats on every update are ignored.
+export function normalizeRpcEvent(raw: unknown): TaskEvent[] {
+	if (!raw || typeof raw !== "object") return [];
+	const event = raw as Raw;
+	switch (event.type) {
+		case "message_update": {
+			const inner = event.assistantMessageEvent as Raw | undefined;
+			if (!inner) return [];
+			if (inner.type === "text_delta") return [{ type: TASK_EVENT.TEXT, text: clean(inner.delta) }];
+			if (inner.type === "thinking_delta") return [{ type: TASK_EVENT.THINKING, text: clean(inner.delta) }];
+			if (inner.type === "error") {
+				const error = inner.error as Raw | undefined;
+				return [{ type: TASK_EVENT.ERROR, message: clean(error?.message) || clean(inner.reason) || "unknown error" }];
+			}
+			return [];
+		}
+		case "tool_execution_start":
+			return [{ type: TASK_EVENT.TOOL_START, callId: String(event.toolCallId ?? ""), name: clean(event.toolName), args: (event.args as Record<string, unknown>) ?? {} }];
+		case "tool_execution_update":
+			return [{ type: TASK_EVENT.TOOL_UPDATE, callId: String(event.toolCallId ?? ""), output: contentText((event.partialResult as Raw | undefined)?.content) }];
+		case "tool_execution_end":
+			return [{ type: TASK_EVENT.TOOL_END, callId: String(event.toolCallId ?? ""), output: contentText((event.result as Raw | undefined)?.content), isError: event.isError === true }];
+		case "message_end": {
+			const message = event.message as Raw | undefined;
+			const usage = message?.role === "assistant" ? (message.usage as Raw | undefined) : undefined;
+			if (!usage) return [];
+			const cost = usage.cost as Raw | undefined;
+			return [{ type: TASK_EVENT.USAGE, tokens: Number(usage.totalTokens ?? 0) || 0, cost: Number(cost?.total ?? 0) || 0 }];
+		}
+		case "turn_end":
+			return [{ type: TASK_EVENT.TURN_END }];
+		case "agent_end":
+			return [{ type: TASK_EVENT.AGENT_END, text: lastAssistantText(event.messages) }];
+		case "extension_ui_request":
+			return DIALOG_METHODS.has(String(event.method)) ? [{ type: TASK_EVENT.ASK, request: askRequest(event) }] : [];
+		case "auto_retry_start":
+			return [{ type: TASK_EVENT.NOTE, text: `retrying (${String(event.attempt ?? "?")}/${String(event.maxAttempts ?? "?")})` }];
+		case "extension_error":
+			return [{ type: TASK_EVENT.NOTE, text: `extension error: ${clean(event.error)}` }];
+		default:
+			return [];
+	}
+}
+
+// The card shows one line per task: an explicit label, or the first sentence
+// of the prompt clipped to a readable length.
+export function taskLabel(prompt: string, label?: string): string {
+	const explicit = clean(label).replace(/\s+/g, " ").trim();
+	if (explicit.length > 0) return explicit.length > LABEL_MAX ? `${explicit.slice(0, LABEL_MAX - 1)}…` : explicit;
+	const firstLine = clean(prompt).split("\n").map((line) => line.trim()).find((line) => line.length > 0) ?? "";
+	const sentence = firstLine.split(/(?<=[.!?])\s/)[0] ?? firstLine;
+	const compact = sentence.replace(/\s+/g, " ").replace(/[.:]$/, "");
+	return compact.length > LABEL_MAX ? `${compact.slice(0, LABEL_MAX - 1)}…` : compact;
+}
+
+export function emptyThread(limits: Partial<ThreadLimits> = {}): TaskThread {
+	return { items: [], dropped: 0, version: 0, limits: { ...DEFAULT_LIMITS, ...limits } };
+}
+
+function withItems(thread: TaskThread, items: ThreadItem[], dropped = thread.dropped): TaskThread {
+	return { ...thread, items, dropped, version: thread.version + 1 };
+}
+
+function push(thread: TaskThread, item: ThreadItem): TaskThread {
+	const items = [...thread.items, item];
+	const overflow = Math.max(0, items.length - thread.limits.maxItems);
+	return withItems(thread, overflow > 0 ? items.slice(overflow) : items, thread.dropped + overflow);
+}
+
+function appendText(thread: TaskThread, kind: typeof THREAD_ITEM.TEXT | typeof THREAD_ITEM.THINKING, raw: string): TaskThread {
+	const text = clean(raw);
+	if (text.length === 0) return thread;
+	const last = thread.items[thread.items.length - 1];
+	if (last && last.kind === kind) {
+		const merged = { ...last, text: keepTail(last.text + text, TEXT_CAP) };
+		return withItems(thread, [...thread.items.slice(0, -1), merged]);
+	}
+	return push(thread, { kind, text } as ThreadItem);
+}
+
+function updateTool(thread: TaskThread, callId: string, patch: Partial<ToolItem>): TaskThread {
+	const index = thread.items.findIndex((item) => item.kind === THREAD_ITEM.TOOL && item.callId === callId);
+	if (index < 0) return thread;
+	const current = thread.items[index] as ToolItem;
+	const next: ToolItem = { ...current, ...patch, output: keepTail(patch.output === undefined ? current.output : clean(patch.output), thread.limits.maxOutputChars) };
+	const items = [...thread.items];
+	items[index] = next;
+	return withItems(thread, items);
+}
+
+export function askNote(request: AskRequest): string {
+	return `asked: ${request.title}`;
+}
+
+export function applyTaskEvent(thread: TaskThread, event: TaskEvent): TaskThread {
+	switch (event.type) {
+		case TASK_EVENT.TEXT:
+			return appendText(thread, THREAD_ITEM.TEXT, event.text);
+		case TASK_EVENT.THINKING:
+			return appendText(thread, THREAD_ITEM.THINKING, event.text);
+		case TASK_EVENT.TOOL_START:
+			return push(thread, { kind: THREAD_ITEM.TOOL, callId: event.callId, name: event.name, args: event.args, output: "", running: true, isError: false });
+		case TASK_EVENT.TOOL_UPDATE:
+			return updateTool(thread, event.callId, { output: event.output });
+		case TASK_EVENT.TOOL_END:
+			return updateTool(thread, event.callId, { output: event.output, running: false, isError: event.isError });
+		case TASK_EVENT.ERROR:
+			return push(thread, { kind: THREAD_ITEM.NOTE, text: `error: ${event.message}` });
+		case TASK_EVENT.ASK:
+			return push(thread, { kind: THREAD_ITEM.NOTE, text: askNote(event.request) });
+		case TASK_EVENT.NOTE:
+			return push(thread, { kind: THREAD_ITEM.NOTE, text: clean(event.text) });
+		default:
+			return thread;
+	}
+}
+
+export function isFinished(status: TaskStatus): boolean {
+	return FINISHED_STATUSES.includes(status);
+}
+
+// What a task event means for the record itself: the step label the widget
+// shows, the counters, and the waiting/running flip around user questions.
+function recordPatch(task: TaskRecord, event: TaskEvent): Partial<TaskRecord> {
+	const resumed = task.status === TASK_STATUS.WAITING && event.type !== TASK_EVENT.ASK ? { status: TASK_STATUS.RUNNING } : {};
+	switch (event.type) {
+		case TASK_EVENT.TOOL_START:
+			return { ...resumed, lastStep: event.name, toolCalls: task.toolCalls + 1 };
+		case TASK_EVENT.TURN_END:
+			return { ...resumed, turns: task.turns + 1 };
+		case TASK_EVENT.AGENT_END:
+			return { ...resumed, result: event.text.length > 0 ? event.text : task.result, lastStep: "responded" };
+		case TASK_EVENT.ERROR:
+			return { ...resumed, lastStep: `error: ${event.message}` };
+		case TASK_EVENT.ASK:
+			return { status: TASK_STATUS.WAITING, lastStep: askNote(event.request) };
+		case TASK_EVENT.TEXT:
+			return { ...resumed, lastStep: task.lastStep === "queued" || task.lastStep === "starting" ? "writing" : task.lastStep };
+		case TASK_EVENT.USAGE:
+			return { ...resumed, tokens: task.tokens + event.tokens, cost: task.cost + event.cost };
+		default:
+			return resumed;
+	}
+}
+
+export function summarize(tasks: Iterable<TaskRecord>): TaskSummary {
+	const summary: TaskSummary = { running: 0, queued: 0, waiting: 0, finished: 0 };
+	for (const task of tasks) {
+		if (task.status === TASK_STATUS.RUNNING) summary.running += 1;
+		else if (task.status === TASK_STATUS.QUEUED) summary.queued += 1;
+		else if (task.status === TASK_STATUS.WAITING) summary.waiting += 1;
+		else summary.finished += 1;
+	}
+	return summary;
+}
+
+export class TaskStore {
+	private readonly tasks = new Map<string, TaskRecord>();
+	private readonly threads = new Map<string, TaskThread>();
+	private readonly listeners = new Map<string, Set<TaskListener>>();
+	private readonly summaryListeners = new Set<SummaryListener>();
+	private readonly limits: Partial<ThreadLimits>;
+
+	constructor(limits: Partial<ThreadLimits> = {}) {
+		this.limits = limits;
+	}
+
+	add(task: TaskRecord): void {
+		this.tasks.set(task.id, task);
+		this.threads.set(task.id, emptyThread(this.limits));
+		this.notifySummary();
+	}
+
+	// Bring a task back from disk with its thread; a live task is never
+	// overwritten by a stored copy.
+	restore(task: TaskRecord, thread: TaskThread): boolean {
+		if (this.tasks.has(task.id)) return false;
+		this.tasks.set(task.id, task);
+		this.threads.set(task.id, { ...thread, limits: { ...DEFAULT_LIMITS, ...this.limits } });
+		this.notifySummary();
+		return true;
+	}
+
+	get(id: string): TaskRecord | undefined {
+		return this.tasks.get(id);
+	}
+
+	thread(id: string): TaskThread {
+		return this.threads.get(id) ?? emptyThread(this.limits);
+	}
+
+	list(parentSessionId?: string): TaskRecord[] {
+		return [...this.tasks.values()]
+			.filter((task) => parentSessionId === undefined || task.parentSessionId === parentSessionId)
+			.sort((a, b) => b.lastActivityAt - a.lastActivityAt || b.createdAt - a.createdAt);
+	}
+
+	summary(parentSessionId?: string): TaskSummary {
+		return summarize(this.list(parentSessionId));
+	}
+
+	// A status change is the only thing the summary cares about; everything
+	// that happens inside a task stays with that task's listeners.
+	update(id: string, patch: Partial<TaskRecord>): TaskRecord | undefined {
+		const current = this.tasks.get(id);
+		if (!current) return undefined;
+		const next = { ...current, ...patch };
+		this.tasks.set(id, next);
+		this.notifyTask(next);
+		if (next.status !== current.status) this.notifySummary();
+		return next;
+	}
+
+	apply(id: string, event: TaskEvent, at: number): TaskRecord | undefined {
+		const current = this.tasks.get(id);
+		if (!current) return undefined;
+		this.threads.set(id, applyTaskEvent(this.thread(id), event));
+		return this.update(id, { ...recordPatch(current, event), lastActivityAt: at });
+	}
+
+	subscribe(id: string, listener: TaskListener): () => void {
+		const set = this.listeners.get(id) ?? new Set<TaskListener>();
+		set.add(listener);
+		this.listeners.set(id, set);
+		return () => {
+			set.delete(listener);
+			if (set.size === 0) this.listeners.delete(id);
+		};
+	}
+
+	subscribeSummary(listener: SummaryListener): () => void {
+		this.summaryListeners.add(listener);
+		return () => this.summaryListeners.delete(listener);
+	}
+
+	private notifyTask(task: TaskRecord): void {
+		const set = this.listeners.get(task.id);
+		if (!set) return;
+		const thread = this.thread(task.id);
+		for (const listener of set) listener(task, thread);
+	}
+
+	private notifySummary(): void {
+		if (this.summaryListeners.size === 0) return;
+		const summary = this.summary();
+		for (const listener of this.summaryListeners) listener(summary);
+	}
+}

--- a/lib/agents-runner.ts
+++ b/lib/agents-runner.ts
@@ -1,0 +1,362 @@
+import type { Readable, Writable } from "node:stream";
+import { formatModelRef, type AgentDefinition, type AgentMode, type ModelRef } from "./agents-config.ts";
+import { isFinished, normalizeRpcEvent, TASK_EVENT, TASK_STATUS, taskLabel, type AskRequest, type TaskRecord, type TaskStore } from "./agents-protocol.ts";
+
+// Gentle Agents runner. Every subagent is its own `pi --mode rpc` process:
+// the host never runs subagent work on the TUI thread. It writes JSON
+// commands, reads JSON lines, applies deltas to the store, answers dialogs,
+// and enforces a total timeout plus a stall watchdog per task.
+
+export interface ChildLike {
+	pid: number | undefined;
+	stdin: Writable;
+	stdout: Readable;
+	stderr: Readable | null | undefined;
+	kill(signal?: NodeJS.Signals): boolean;
+	on(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+	on(event: "error", listener: (error: Error) => void): unknown;
+}
+
+export interface SpawnOptions {
+	cwd: string;
+	env: NodeJS.ProcessEnv;
+}
+
+export type Spawn = (command: string, args: string[], options: SpawnOptions) => ChildLike;
+
+export interface PiCommand {
+	command: string;
+	args: string[];
+}
+
+export interface RunnerDeps {
+	spawn: Spawn;
+	now(): number;
+	schedule(fn: () => void, ms: number): () => void;
+	pi: PiCommand;
+}
+
+export interface RunnerLimits {
+	maxConcurrency: number;
+	timeoutMs: number;
+	stallTimeoutMs: number;
+}
+
+export interface AskAnswer {
+	value?: string;
+	confirmed?: boolean;
+	cancelled?: boolean;
+}
+
+export interface RunnerHooks {
+	askUser(taskId: string, request: AskRequest, raw: Record<string, unknown>): Promise<AskAnswer>;
+	onFinish?(task: TaskRecord): void;
+}
+
+export interface TaskRequest {
+	agent: AgentDefinition;
+	prompt: string;
+	label: string | undefined;
+	context: string | undefined;
+	mode: AgentMode;
+	cwd: string;
+	parentSessionId: string;
+	model: ModelRef | undefined;
+	thinking: string | undefined;
+	sessionDir: string;
+	resumeSessionPath: string | undefined;
+	env: NodeJS.ProcessEnv;
+}
+
+interface ProcessLike {
+	execPath: string;
+	argv: string[];
+	env: NodeJS.ProcessEnv;
+}
+
+interface Pending {
+	resolve(value: Record<string, unknown>): void;
+}
+
+interface LiveTask {
+	child: ChildLike;
+	pending: Map<string, Pending>;
+	cancelTimeout: () => void;
+	cancelStall: () => void;
+	cancelling: boolean;
+	nextId: number;
+}
+
+const CHILD_MARKER = "GENTLE_PI_AGENTS_CHILD";
+const DEFAULT_TOOLS: readonly string[] = [];
+
+export function childArguments(request: TaskRequest): string[] {
+	const args = ["--mode", "rpc", "--session-dir", request.sessionDir];
+	if (request.resumeSessionPath) args.push("--session", request.resumeSessionPath);
+	if (request.model) args.push("--model", request.thinking ? `${formatModelRef(request.model)}:${request.thinking}` : formatModelRef(request.model));
+	else if (request.thinking) args.push("--thinking", request.thinking);
+	const tools = request.agent.tools.length > 0 ? request.agent.tools : DEFAULT_TOOLS;
+	if (tools.length > 0) args.push("--tools", tools.join(","));
+	if (request.agent.instructions.length > 0) args.push("--append-system-prompt", request.agent.instructions);
+	return args;
+}
+
+// The child is the same pi that is running us: node plus its cli entry.
+// GENTLE_PI_AGENTS_PI overrides it with a command line.
+export function piCommand(proc: ProcessLike = process): PiCommand {
+	const override = proc.env.GENTLE_PI_AGENTS_PI?.trim();
+	if (override) {
+		const [command, ...args] = override.split(/\s+/);
+		return { command, args };
+	}
+	const entry = proc.argv[1];
+	if (entry && /(^|[\\/])cli\.js$/.test(entry)) return { command: proc.execPath, args: [entry] };
+	return { command: "pi", args: [] };
+}
+
+// RPC framing is strict JSONL: LF only, optional CR. Lines that do not parse
+// are dropped (pi's own parse errors arrive as responses anyway).
+export class JsonLines {
+	private buffer = "";
+	private readonly onValue: (value: unknown) => void;
+
+	constructor(onValue: (value: unknown) => void) {
+		this.onValue = onValue;
+	}
+
+	push(chunk: string): void {
+		this.buffer += chunk;
+		const lines = this.buffer.split("\n");
+		this.buffer = lines.pop() ?? "";
+		for (const raw of lines) {
+			const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+			if (line.length === 0) continue;
+			try {
+				this.onValue(JSON.parse(line));
+			} catch {
+				// not JSON: ignore
+			}
+		}
+	}
+}
+
+export function promptText(request: TaskRequest): string {
+	return request.context ? `${request.prompt}\n\n## Context\n${request.context}` : request.prompt;
+}
+
+export class AgentRunner {
+	private readonly store: TaskStore;
+	private readonly limits: RunnerLimits;
+	private readonly deps: RunnerDeps;
+	private readonly hooks: RunnerHooks;
+	private readonly queue: Array<{ task: TaskRecord; request: TaskRequest }> = [];
+	private readonly live = new Map<string, LiveTask>();
+	private readonly waiters = new Map<string, Array<(task: TaskRecord) => void>>();
+	private counter = 0;
+
+	constructor(store: TaskStore, limits: RunnerLimits, deps: RunnerDeps, hooks: RunnerHooks) {
+		this.store = store;
+		this.limits = limits;
+		this.deps = deps;
+		this.hooks = hooks;
+	}
+
+	run(request: TaskRequest): TaskRecord {
+		const now = this.deps.now();
+		this.counter += 1;
+		const task: TaskRecord = {
+			id: `${now.toString(36)}-${this.counter.toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+			agent: request.agent.name,
+			mode: request.mode,
+			prompt: request.prompt,
+			label: taskLabel(request.prompt, request.label),
+			cwd: request.cwd,
+			parentSessionId: request.parentSessionId,
+			status: TASK_STATUS.QUEUED,
+			createdAt: now,
+			startedAt: null,
+			endedAt: null,
+			model: formatModelRef(request.model),
+			thinking: request.thinking,
+			sessionPath: request.resumeSessionPath ?? null,
+			error: null,
+			result: null,
+			lastStep: "queued",
+			lastActivityAt: now,
+			turns: 0,
+			toolCalls: 0,
+			tokens: 0,
+			cost: 0,
+		};
+		this.store.add(task);
+		this.queue.push({ task, request });
+		queueMicrotask(() => this.pump());
+		return task;
+	}
+
+	waitFor(id: string): Promise<TaskRecord> {
+		const current = this.store.get(id);
+		if (!current) return Promise.reject(new Error(`no task ${id}`));
+		if (isFinished(current.status)) return Promise.resolve(current);
+		return new Promise((resolve) => {
+			const list = this.waiters.get(id) ?? [];
+			list.push(resolve);
+			this.waiters.set(id, list);
+		});
+	}
+
+	cancel(id: string): boolean {
+		const queued = this.queue.findIndex((entry) => entry.task.id === id);
+		if (queued >= 0) {
+			this.queue.splice(queued, 1);
+			this.finish(id, TASK_STATUS.CANCELLED, "cancelled before start");
+			return true;
+		}
+		const live = this.live.get(id);
+		if (!live) return false;
+		live.cancelling = true;
+		void this.send(id, { type: "abort" });
+		this.finish(id, TASK_STATUS.CANCELLED, "cancelled");
+		return true;
+	}
+
+	cancelAll(): number {
+		const ids = [...this.queue.map((entry) => entry.task.id), ...this.live.keys()];
+		return ids.filter((id) => this.cancel(id)).length;
+	}
+
+	steer(id: string, message: string): boolean {
+		if (!this.live.has(id)) return false;
+		void this.send(id, { type: "steer", message });
+		this.store.apply(id, { type: TASK_EVENT.NOTE, text: `steered: ${message}` }, this.deps.now());
+		return true;
+	}
+
+	private pump(): void {
+		while (this.live.size < this.limits.maxConcurrency && this.queue.length > 0) {
+			const entry = this.queue.shift();
+			if (entry) this.launch(entry.task.id, entry.request);
+		}
+	}
+
+	// A child that cannot start (missing pi, bad cwd) fails only its task:
+	// spawn exceptions, the process error event, and stdin errors all settle
+	// through finish() instead of surfacing as uncaught errors in the host.
+	private launch(id: string, request: TaskRequest): void {
+		const env = { ...request.env, [CHILD_MARKER]: "1" };
+		let child: ChildLike;
+		try {
+			child = this.deps.spawn(this.deps.pi.command, [...this.deps.pi.args, ...childArguments(request)], { cwd: request.cwd, env });
+		} catch (error) {
+			this.store.update(id, { status: TASK_STATUS.RUNNING, startedAt: this.deps.now(), lastStep: "starting" });
+			this.finish(id, TASK_STATUS.FAILED, `could not start pi: ${error instanceof Error ? error.message : String(error)}`);
+			return;
+		}
+		const live: LiveTask = { child, pending: new Map(), cancelTimeout: () => {}, cancelStall: () => {}, cancelling: false, nextId: 0 };
+		this.live.set(id, live);
+		this.store.update(id, { status: TASK_STATUS.RUNNING, startedAt: this.deps.now(), lastStep: "starting" });
+		child.on("error", (error) => this.finish(id, TASK_STATUS.FAILED, `could not start pi: ${error.message}`));
+		child.stdin.on("error", () => {});
+		live.cancelTimeout = this.deps.schedule(() => this.finish(id, TASK_STATUS.TIMED_OUT, `timed out after ${Math.round(this.limits.timeoutMs / 60_000)} min`), this.limits.timeoutMs);
+		this.armStall(id, live);
+		const lines = new JsonLines((value) => this.receive(id, request, value));
+		child.stdout.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => lines.push(chunk));
+		child.stderr?.on("data", () => {});
+		child.on("exit", (code) => {
+			if (!this.live.has(id)) return;
+			const current = this.store.get(id);
+			if (current && !isFinished(current.status)) this.finish(id, live.cancelling ? TASK_STATUS.CANCELLED : TASK_STATUS.FAILED, `pi exited with code ${code ?? "unknown"}`);
+		});
+		void this.send(id, { type: "get_state" }).then((response) => {
+			const data = response.data as { sessionFile?: string } | undefined;
+			if (data?.sessionFile) this.store.update(id, { sessionPath: data.sessionFile });
+		});
+		void this.send(id, { type: "prompt", message: promptText(request) }).then((response) => {
+			if (response.success === false) this.finish(id, TASK_STATUS.FAILED, String(response.error ?? "prompt rejected"));
+		});
+	}
+
+	private armStall(id: string, live: LiveTask): void {
+		live.cancelStall();
+		live.cancelStall = this.deps.schedule(() => this.finish(id, TASK_STATUS.TIMED_OUT, `stalled for ${Math.round(this.limits.stallTimeoutMs / 60_000)} min`), this.limits.stallTimeoutMs);
+	}
+
+	private send(id: string, command: Record<string, unknown>): Promise<Record<string, unknown>> {
+		const live = this.live.get(id);
+		if (!live) return Promise.resolve({ success: false, error: "task is not running" });
+		live.nextId += 1;
+		const requestId = `r${live.nextId}`;
+		return new Promise((resolve) => {
+			live.pending.set(requestId, { resolve });
+			this.write(live, { id: requestId, ...command });
+		});
+	}
+
+	private write(live: LiveTask, payload: Record<string, unknown>): void {
+		try {
+			live.child.stdin.write(`${JSON.stringify(payload)}\n`);
+		} catch {
+			// the child is gone; the exit handler settles the task
+		}
+	}
+
+	private receive(id: string, request: TaskRequest, value: unknown): void {
+		const live = this.live.get(id);
+		if (!live || !value || typeof value !== "object") return;
+		const raw = value as Record<string, unknown>;
+		if (raw.type === "response") {
+			const pending = typeof raw.id === "string" ? live.pending.get(raw.id) : undefined;
+			if (pending) {
+				live.pending.delete(raw.id as string);
+				pending.resolve(raw);
+			}
+			return;
+		}
+		this.armStall(id, live);
+		for (const event of normalizeRpcEvent(raw)) {
+			this.store.apply(id, event, this.deps.now());
+			if (event.type === TASK_EVENT.ASK) void this.answer(id, request, live, event.request, raw);
+			if (event.type === TASK_EVENT.AGENT_END) this.finish(id, TASK_STATUS.COMPLETED, null);
+		}
+	}
+
+	// Task-mode subagents may ask the human through the host; background ones
+	// get their dialog cancelled so they never block on nobody.
+	private async answer(id: string, request: TaskRequest, live: LiveTask, ask: AskRequest, raw: Record<string, unknown>): Promise<void> {
+		let answer: AskAnswer = { cancelled: true };
+		if (request.mode === "task") {
+			try {
+				answer = await this.hooks.askUser(id, ask, raw);
+			} catch {
+				answer = { cancelled: true };
+			}
+		}
+		this.write(live, { type: "extension_ui_response", id: ask.id, ...answer });
+		const current = this.store.get(id);
+		if (current?.status === TASK_STATUS.WAITING) this.store.update(id, { status: TASK_STATUS.RUNNING, lastStep: answer.cancelled ? "question dismissed" : "answered" });
+	}
+
+	private finish(id: string, status: TaskRecord["status"], error: string | null): void {
+		const current = this.store.get(id);
+		if (!current || isFinished(current.status)) return;
+		const live = this.live.get(id);
+		if (live) {
+			live.cancelTimeout();
+			live.cancelStall();
+			this.live.delete(id);
+			try {
+				live.child.kill("SIGTERM");
+			} catch {
+				// already gone
+			}
+		}
+		const finished = this.store.update(id, { status, endedAt: this.deps.now(), error, lastStep: error ?? "done" });
+		if (finished) {
+			this.hooks.onFinish?.(finished);
+			for (const resolve of this.waiters.get(id) ?? []) resolve(finished);
+			this.waiters.delete(id);
+		}
+		queueMicrotask(() => this.pump());
+	}
+}

--- a/lib/agents-transcript.ts
+++ b/lib/agents-transcript.ts
@@ -1,0 +1,87 @@
+import { sanitizeTerminalText } from "./terminal-theme.ts";
+
+// Gentle Agents transcript: a child's session JSONL rendered as markdown a
+// human can read in an editor. Thinking is left out; tool output keeps a tail.
+
+export interface TranscriptOptions {
+	title: string;
+	maxOutputLines: number;
+}
+
+interface Part {
+	type?: string;
+	text?: string;
+	name?: string;
+	arguments?: Record<string, unknown>;
+}
+
+interface Entry {
+	type?: string;
+	message?: { role?: string; content?: Part[] | string; toolName?: string; isError?: boolean };
+}
+
+const DEFAULT_OPTIONS: TranscriptOptions = { title: "Subagent transcript", maxOutputLines: 40 };
+
+function clean(value: unknown): string {
+	return typeof value === "string" ? sanitizeTerminalText(value) : "";
+}
+
+function parts(content: Part[] | string | undefined): Part[] {
+	if (typeof content === "string") return [{ type: "text", text: content }];
+	return Array.isArray(content) ? content : [];
+}
+
+function argsSummary(args: Record<string, unknown> | undefined): string {
+	if (!args) return "";
+	const first = Object.values(args).find((value) => typeof value === "string") as string | undefined;
+	return first ? clean(first).replace(/\s+/g, " ").trim() : JSON.stringify(args);
+}
+
+function tail(text: string, max: number): string {
+	const lines = text.split("\n");
+	if (lines.length <= max) return text;
+	return [`… ${lines.length - max} earlier lines omitted`, ...lines.slice(-max)].join("\n");
+}
+
+function fence(text: string): string {
+	const ticks = /`{3,}/.test(text) ? "````" : "```";
+	return `${ticks}\n${text}\n${ticks}`;
+}
+
+export function sessionToMarkdown(jsonl: string, options: Partial<TranscriptOptions> = {}): string {
+	const { title, maxOutputLines } = { ...DEFAULT_OPTIONS, ...options };
+	const out: string[] = [`# ${title}`, ""];
+	for (const raw of jsonl.split("\n")) {
+		if (raw.trim().length === 0) continue;
+		let entry: Entry;
+		try {
+			entry = JSON.parse(raw) as Entry;
+		} catch {
+			continue;
+		}
+		if (entry.type !== "message" || !entry.message) continue;
+		const { role, content, toolName, isError } = entry.message;
+		if (role === "user") {
+			const text = parts(content).map((part) => clean(part.text)).filter((text) => text.length > 0).join("\n");
+			if (text) out.push("## User", "", text, "");
+		} else if (role === "assistant") {
+			let opened = false;
+			for (const part of parts(content)) {
+				if (part.type === "text" && clean(part.text).trim().length > 0) {
+					if (!opened) {
+						out.push("## Assistant", "");
+						opened = true;
+					}
+					out.push(clean(part.text).trim(), "");
+				} else if (part.type === "toolCall") {
+					out.push(`### ▸ ${clean(part.name) || "tool"} ${argsSummary(part.arguments)}`.trimEnd(), "");
+				}
+			}
+		} else if (role === "toolResult") {
+			const text = parts(content).map((part) => clean(part.text)).filter((text) => text.length > 0).join("\n");
+			const label = isError ? `${clean(toolName) || "tool"} error` : (clean(toolName) || "tool");
+			out.push(`<!-- ${label} -->`, fence(tail(text.length > 0 ? text : "(no output)", maxOutputLines)), "");
+		}
+	}
+	return `${out.join("\n").trimEnd()}\n`;
+}

--- a/lib/agents-view.ts
+++ b/lib/agents-view.ts
@@ -1,0 +1,276 @@
+import { Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { isFinished, TASK_STATUS, THREAD_ITEM, type TaskRecord, type TaskStore, type TaskThread, type ThreadItem, type ToolItem } from "./agents-protocol.ts";
+import { formatElapsed } from "./agents-widget.ts";
+import { formatTokens } from "./shell-bar.ts";
+
+// Gentle Agents overlay: tasks on the left, the selected task's thread on
+// the right. Only the selected task is subscribed, thread items are rendered
+// once each (they are immutable until replaced), and the viewport shows the
+// tail unless the human scrolls up.
+
+export interface AgentsViewTheme {
+	fg(color: string, text: string): string;
+}
+
+export interface AgentsViewDeps {
+	theme: AgentsViewTheme;
+	rows: number;
+	store: TaskStore;
+	now(): number;
+	onCancel(task: TaskRecord): void;
+	onOpen(task: TaskRecord): void;
+	onClose(): void;
+	requestRender(): void;
+}
+
+const ROLE = {
+	FRAME: "border",
+	TITLE: "customMessageLabel",
+	SELECTED: "accent",
+	NAME: "text",
+	NAME_IDLE: "muted",
+	META: "dim",
+	TEXT: "text",
+	THINKING: "dim",
+	TOOL: "accent",
+	TOOL_ERROR: "error",
+	OUTPUT: "muted",
+	NOTE: "muted",
+	NOTE_ERROR: "warning",
+	KEY: "accent",
+	KEY_TEXT: "dim",
+	EMPTY: "dim",
+} as const;
+
+const GLYPH: Record<string, string> = {
+	[TASK_STATUS.QUEUED]: "○",
+	[TASK_STATUS.RUNNING]: "◐",
+	[TASK_STATUS.WAITING]: "?",
+	[TASK_STATUS.COMPLETED]: "✓",
+	[TASK_STATUS.FAILED]: "✗",
+	[TASK_STATUS.CANCELLED]: "–",
+	[TASK_STATUS.TIMED_OUT]: "✗",
+};
+const GLYPH_ROLE: Record<string, string> = {
+	[TASK_STATUS.QUEUED]: "muted",
+	[TASK_STATUS.RUNNING]: "accent",
+	[TASK_STATUS.WAITING]: "warning",
+	[TASK_STATUS.COMPLETED]: "success",
+	[TASK_STATUS.FAILED]: "error",
+	[TASK_STATUS.CANCELLED]: "dim",
+	[TASK_STATUS.TIMED_OUT]: "error",
+};
+const LIST_MAX_WIDTH = 34;
+const LIST_RATIO = 0.32;
+const CHROME_ROWS = 3;
+const MIN_BODY_ROWS = 1;
+const OUTPUT_TAIL_LINES = 8;
+const EMPTY_LIST = "no tasks yet";
+const EMPTY_THREAD = "waiting for the first event";
+const KEYS = [
+	["j/k", "task"],
+	["ctrl+j/k", "scroll"],
+	["f", "follow"],
+	["c", "cancel"],
+	["o", "open session"],
+	["esc", "close"],
+] as const;
+
+function rule(length: number): string {
+	return "─".repeat(Math.max(0, length));
+}
+
+function fit(text: string, width: number): string {
+	const clipped = truncateToWidth(text, width, "…");
+	return clipped + " ".repeat(Math.max(0, width - visibleWidth(clipped)));
+}
+
+function argsSummary(item: ToolItem): string {
+	const values = Object.values(item.args).filter((value) => typeof value === "string") as string[];
+	return (values[0] ?? "").replace(/\s+/g, " ").trim();
+}
+
+function toolLines(item: ToolItem, theme: AgentsViewTheme, width: number): string[] {
+	const role = item.isError ? ROLE.TOOL_ERROR : ROLE.TOOL;
+	const head = truncateToWidth(`▸ ${item.name} ${argsSummary(item)}`, width, "…");
+	const lines = [theme.fg(role, head)];
+	const output = item.output.split("\n").filter((line) => line.length > 0);
+	for (const line of output.slice(-OUTPUT_TAIL_LINES)) lines.push(theme.fg(ROLE.OUTPUT, truncateToWidth(`  ${line}`, width, "…")));
+	if (item.running) lines.push(theme.fg(ROLE.META, "  …"));
+	return lines;
+}
+
+export function itemLines(item: ThreadItem, theme: AgentsViewTheme, width: number): string[] {
+	switch (item.kind) {
+		case THREAD_ITEM.TEXT:
+			return wrapTextWithAnsi(item.text, width).map((line) => theme.fg(ROLE.TEXT, line));
+		case THREAD_ITEM.THINKING:
+			return [theme.fg(ROLE.THINKING, truncateToWidth(`∴ ${item.text.split("\n")[0] ?? ""}`, width, "…"))];
+		case THREAD_ITEM.TOOL:
+			return toolLines(item, theme, width);
+		case THREAD_ITEM.NOTE:
+			return [theme.fg(item.text.startsWith("error") ? ROLE.NOTE_ERROR : ROLE.NOTE, truncateToWidth(`· ${item.text}`, width, "…"))];
+		default:
+			return [];
+	}
+}
+
+export function taskHeader(task: TaskRecord, now: number): string {
+	const parts = [task.agent, task.status, task.model, task.tokens > 0 ? formatTokens(task.tokens) : "", task.cost > 0 ? `$${task.cost.toFixed(2)}` : "", task.startedAt === null ? "" : formatElapsed((task.endedAt ?? now) - task.startedAt)];
+	return parts.filter((part) => part.length > 0).join(" · ");
+}
+
+export class AgentsView {
+	private readonly deps: AgentsViewDeps;
+	private tasks: TaskRecord[] = [];
+	private selected = 0;
+	private scroll = 0;
+	private follow = true;
+	private unsubscribeTask: (() => void) | undefined;
+	private readonly unsubscribeSummary: () => void;
+	private cache = new WeakMap<ThreadItem, string[]>();
+	private cacheWidth = -1;
+
+	constructor(deps: AgentsViewDeps) {
+		this.deps = deps;
+		this.refreshTasks();
+		this.unsubscribeSummary = deps.store.subscribeSummary(() => {
+			this.refreshTasks();
+			this.deps.requestRender();
+		});
+		this.subscribeSelected();
+	}
+
+	dispose(): void {
+		this.unsubscribeTask?.();
+		this.unsubscribeSummary();
+	}
+
+	selectedTask(): TaskRecord | undefined {
+		return this.tasks[this.selected];
+	}
+
+	handleInput(data: string): void {
+		if (matchesKey(data, Key.escape) || data === "q") {
+			this.deps.onClose();
+			return;
+		}
+		const task = this.selectedTask();
+		if (data === "j" || matchesKey(data, Key.down)) this.select(this.selected + 1);
+		else if (data === "k" || matchesKey(data, Key.up)) this.select(this.selected - 1);
+		else if (matchesKey(data, Key.pageDown) || matchesKey(data, Key.ctrl("j"))) this.scrollBy(this.pageRows());
+		else if (matchesKey(data, Key.pageUp) || matchesKey(data, Key.ctrl("k"))) this.scrollBy(-this.pageRows());
+		else if (data === "f") {
+			this.follow = true;
+			this.deps.requestRender();
+		} else if (data === "c" && task && !isFinished(task.status)) this.deps.onCancel(task);
+		else if ((data === "o" || matchesKey(data, Key.enter)) && task) this.deps.onOpen(task);
+	}
+
+	render(width: number): string[] {
+		const theme = this.deps.theme;
+		const inner = width - 2;
+		const listWidth = Math.min(LIST_MAX_WIDTH, Math.floor(inner * LIST_RATIO));
+		const threadWidth = inner - listWidth - 4;
+		const title = `❀ Agents · ${this.counts()}`;
+		const top = theme.fg(ROLE.FRAME, "╭─ ") + theme.fg(ROLE.TITLE, title) + theme.fg(ROLE.FRAME, ` ${rule(inner - visibleWidth(title) - 3)}╮`);
+		const rows = this.bodyRows();
+		const right = this.threadWindow(rows, threadWidth);
+		const body: string[] = [];
+		for (let row = 0; row < rows; row += 1) {
+			body.push(`${theme.fg(ROLE.FRAME, "│")} ${fit(this.taskLine(row), listWidth)} ${theme.fg(ROLE.FRAME, "│")} ${fit(right[row] ?? "", threadWidth)}${theme.fg(ROLE.FRAME, "│")}`);
+		}
+		const keys = KEYS.map(([key, label]) => `${theme.fg(ROLE.KEY, key)} ${theme.fg(ROLE.KEY_TEXT, label)}`).join("   ");
+		const keysLine = `${theme.fg(ROLE.FRAME, "│")} ${fit(keys, inner - 2)} ${theme.fg(ROLE.FRAME, "│")}`;
+		return [top, ...body, keysLine, theme.fg(ROLE.FRAME, `╰${rule(inner)}╯`)];
+	}
+
+	invalidate(): void {}
+
+	private counts(): string {
+		const active = this.tasks.filter((task) => !isFinished(task.status)).length;
+		return `${active} active · ${this.tasks.length - active} finished`;
+	}
+
+	private bodyRows(): number {
+		return Math.max(MIN_BODY_ROWS, this.deps.rows - CHROME_ROWS);
+	}
+
+	private refreshTasks(): void {
+		const selectedId = this.tasks[this.selected]?.id;
+		this.tasks = this.deps.store.list();
+		const index = this.tasks.findIndex((task) => task.id === selectedId);
+		this.selected = index === -1 ? Math.max(0, Math.min(this.selected, this.tasks.length - 1)) : index;
+		if (index === -1) this.subscribeSelected();
+	}
+
+	private subscribeSelected(): void {
+		this.unsubscribeTask?.();
+		const task = this.selectedTask();
+		this.unsubscribeTask = task ? this.deps.store.subscribe(task.id, () => this.deps.requestRender()) : undefined;
+	}
+
+	private taskLine(row: number): string {
+		if (this.tasks.length === 0) return row === 0 ? this.deps.theme.fg(ROLE.EMPTY, EMPTY_LIST) : "";
+		const task = this.tasks[row];
+		if (!task) return "";
+		const theme = this.deps.theme;
+		const marker = row === this.selected ? theme.fg(ROLE.SELECTED, "▸") : " ";
+		const glyph = theme.fg(GLYPH_ROLE[task.status], GLYPH[task.status]);
+		const name = theme.fg(row === this.selected ? ROLE.NAME : ROLE.NAME_IDLE, task.agent);
+		const time = task.startedAt === null ? "" : theme.fg(ROLE.META, formatElapsed((task.endedAt ?? this.deps.now()) - task.startedAt));
+		return `${marker} ${glyph} ${name}  ${time}`;
+	}
+
+	private threadLines(thread: TaskThread, width: number): string[] {
+		if (this.cacheWidth !== width) {
+			this.cache = new WeakMap();
+			this.cacheWidth = width;
+		}
+		const lines: string[] = [];
+		if (thread.dropped > 0) lines.push(this.deps.theme.fg(ROLE.META, `… ${thread.dropped} earlier items not kept`));
+		for (const item of thread.items) {
+			let rendered = this.cache.get(item);
+			if (!rendered) {
+				rendered = itemLines(item, this.deps.theme, width);
+				this.cache.set(item, rendered);
+			}
+			lines.push(...rendered);
+		}
+		return lines;
+	}
+
+	private threadWindow(rows: number, width: number): string[] {
+		const task = this.selectedTask();
+		if (!task) return [];
+		const theme = this.deps.theme;
+		const header = theme.fg(ROLE.META, truncateToWidth(taskHeader(task, this.deps.now()), width, "…"));
+		const lines = this.threadLines(this.deps.store.thread(task.id), width);
+		if (lines.length === 0) return [header, theme.fg(ROLE.EMPTY, task.error ?? EMPTY_THREAD)];
+		const visible = rows - 1;
+		const maxScroll = Math.max(0, lines.length - visible);
+		this.scroll = this.follow ? maxScroll : Math.min(this.scroll, maxScroll);
+		return [header, ...lines.slice(this.scroll, this.scroll + visible)];
+	}
+
+	private select(index: number): void {
+		const next = Math.max(0, Math.min(this.tasks.length - 1, index));
+		if (next === this.selected) return;
+		this.selected = next;
+		this.scroll = 0;
+		this.follow = true;
+		this.subscribeSelected();
+		this.deps.requestRender();
+	}
+
+	// One page is the thread area: the body minus its header row.
+	private pageRows(): number {
+		return Math.max(1, this.bodyRows() - 1);
+	}
+
+	private scrollBy(delta: number): void {
+		this.follow = false;
+		this.scroll = Math.max(0, this.scroll + delta);
+		this.deps.requestRender();
+	}
+}

--- a/lib/agents-widget.ts
+++ b/lib/agents-widget.ts
@@ -1,0 +1,167 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { isFinished, TASK_STATUS, type TaskRecord, type TaskStatus } from "./agents-protocol.ts";
+import { formatTokens } from "./shell-bar.ts";
+import { CARD_TONE, cardInnerWidth, renderCard, type CardTheme, type CardTone } from "./shell-card.ts";
+
+// Gentle Agents widget: the card above the editor. Reads task records only
+// (status, prompt, counters, timestamps), so drawing it costs nothing per
+// event. One row per task: glyph, agent, task summary, then
+// model · tokens · cost · time right-aligned.
+
+export const AGENTS_GLYPH = "❀";
+
+export interface AgentsWidgetOptions {
+	collapsed: boolean;
+	collapseKey?: string;
+}
+
+interface StatusLook {
+	glyph: string;
+	role: string;
+}
+
+interface Columns {
+	inner: number;
+	name: number;
+	task: number;
+	meta: number;
+	withModel: boolean;
+}
+
+const LOOK: Record<TaskStatus, StatusLook> = {
+	[TASK_STATUS.QUEUED]: { glyph: "○", role: "muted" },
+	[TASK_STATUS.RUNNING]: { glyph: "◐", role: "accent" },
+	[TASK_STATUS.WAITING]: { glyph: "?", role: "warning" },
+	[TASK_STATUS.COMPLETED]: { glyph: "✓", role: "success" },
+	[TASK_STATUS.FAILED]: { glyph: "✗", role: "error" },
+	[TASK_STATUS.CANCELLED]: { glyph: "–", role: "dim" },
+	[TASK_STATUS.TIMED_OUT]: { glyph: "✗", role: "error" },
+};
+const FINISHED_TTL_MS = 60_000;
+const MAX_FINISHED = 3;
+const NAME_MAX = 20;
+const TASK_MIN = 12;
+const GLYPH_GAP = "  ";
+const COLUMN_GAP = "  ";
+const NAME_ROLE = "text";
+const TASK_ROLE = "muted";
+const META_ROLE = "dim";
+const ELLIPSIS = "…";
+
+export function formatElapsed(ms: number): string {
+	const total = Math.max(0, Math.floor(ms / 1000));
+	if (total < 60) return `${total}s`;
+	const minutes = Math.floor(total / 60);
+	if (minutes < 60) return `${minutes}m${String(total % 60).padStart(2, "0")}s`;
+	return `${Math.floor(minutes / 60)}h${String(minutes % 60).padStart(2, "0")}m`;
+}
+
+function clip(text: string, width: number): string {
+	if (visibleWidth(text) <= width) return text;
+	let out = "";
+	for (const char of text) {
+		if (visibleWidth(out + char) > width - 1) break;
+		out += char;
+	}
+	return `${out}${ELLIPSIS}`;
+}
+
+// Every active task plus the few that finished within the last minute, in
+// the order they started, so a batch reads top to bottom like a timeline.
+export function widgetTasks(tasks: readonly TaskRecord[], now: number): TaskRecord[] {
+	const active = tasks.filter((task) => !isFinished(task.status));
+	const finished = tasks
+		.filter((task) => isFinished(task.status) && task.endedAt !== null && now - task.endedAt <= FINISHED_TTL_MS)
+		.sort((a, b) => (b.endedAt ?? 0) - (a.endedAt ?? 0))
+		.slice(0, MAX_FINISHED);
+	return [...active, ...finished].sort((a, b) => (a.startedAt ?? a.createdAt) - (b.startedAt ?? b.createdAt));
+}
+
+function elapsed(task: TaskRecord, now: number): string {
+	return task.startedAt === null ? "" : formatElapsed((task.endedAt ?? now) - task.startedAt);
+}
+
+function modelLabel(task: TaskRecord): string {
+	const id = task.model.includes("/") ? task.model.slice(task.model.lastIndexOf("/") + 1) : task.model;
+	return id === "default" ? "" : id;
+}
+
+function meta(task: TaskRecord, now: number, withModel: boolean): string {
+	if (task.status === TASK_STATUS.QUEUED) return "queued";
+	const parts = [withModel ? modelLabel(task) : "", task.tokens > 0 ? formatTokens(task.tokens) : "", task.cost > 0 ? `$${task.cost.toFixed(2)}` : "", elapsed(task, now)];
+	return parts.filter((part) => part.length > 0).join(" · ");
+}
+
+function taskText(task: TaskRecord): string {
+	if (task.status === TASK_STATUS.WAITING) return task.lastStep;
+	if (task.error) return task.error;
+	return task.label;
+}
+
+// Narrow cards give up the task column first, then the model label.
+function columns(tasks: readonly TaskRecord[], inner: number, now: number): Columns {
+	const name = Math.min(NAME_MAX, Math.max(...tasks.map((task) => visibleWidth(task.agent))));
+	const fixed = 1 + GLYPH_GAP.length + name + COLUMN_GAP.length;
+	const metaWidth = (withModel: boolean) => Math.max(...tasks.map((task) => visibleWidth(meta(task, now, withModel))));
+	const full = metaWidth(true);
+	const task = inner - fixed - full - COLUMN_GAP.length;
+	if (task >= TASK_MIN) return { inner, name, meta: full, task, withModel: true };
+	return { inner, name, meta: metaWidth(false), task: 0, withModel: false };
+}
+
+function row(task: TaskRecord, theme: CardTheme, cols: Columns, now: number): string[] {
+	const look = LOOK[task.status];
+	const name = clip(task.agent, cols.name);
+	const head = `${theme.fg(look.role, look.glyph)}${GLYPH_GAP}${theme.fg(NAME_ROLE, name)}${" ".repeat(cols.name - visibleWidth(name))}`;
+	const tail = theme.fg(META_ROLE, meta(task, now, cols.withModel).padStart(cols.meta));
+	if (cols.task === 0) return [`${head}${" ".repeat(Math.max(COLUMN_GAP.length, cols.inner - visibleWidth(head) - visibleWidth(tail)))}${tail}`];
+	const text = clip(taskText(task), cols.task);
+	return [`${head}${COLUMN_GAP}${theme.fg(TASK_ROLE, text)}${" ".repeat(cols.task - visibleWidth(text))}${COLUMN_GAP}${tail}`];
+}
+
+function counts(tasks: readonly TaskRecord[]): string {
+	const labels: Array<[TaskStatus, string]> = [
+		[TASK_STATUS.RUNNING, "active"],
+		[TASK_STATUS.WAITING, "waiting"],
+		[TASK_STATUS.QUEUED, "queued"],
+		[TASK_STATUS.COMPLETED, "done"],
+		[TASK_STATUS.FAILED, "failed"],
+		[TASK_STATUS.TIMED_OUT, "timed out"],
+		[TASK_STATUS.CANCELLED, "cancelled"],
+	];
+	return labels
+		.map(([status, label]) => [tasks.filter((task) => task.status === status).length, label] as const)
+		.filter(([count]) => count > 0)
+		.map(([count, label]) => `${count} ${label}`)
+		.join(" · ");
+}
+
+function tone(tasks: readonly TaskRecord[]): CardTone {
+	if (tasks.some((task) => task.status === TASK_STATUS.WAITING)) return CARD_TONE.WARNING;
+	if (tasks.some((task) => task.status === TASK_STATUS.FAILED || task.status === TASK_STATUS.TIMED_OUT)) return CARD_TONE.ERROR;
+	return CARD_TONE.INFO;
+}
+
+// The batch clock: from the first start among the shown tasks until now, or
+// until the last one ended when nothing is running.
+function batchElapsed(tasks: readonly TaskRecord[], now: number): string | undefined {
+	const starts = tasks.map((task) => task.startedAt).filter((value): value is number => value !== null);
+	if (starts.length === 0) return undefined;
+	const active = tasks.some((task) => !isFinished(task.status));
+	const end = active ? now : Math.max(...tasks.map((task) => task.endedAt ?? now));
+	return formatElapsed(end - Math.min(...starts));
+}
+
+export function renderAgentsCard(tasks: readonly TaskRecord[], theme: CardTheme, width: number, now: number, options: AgentsWidgetOptions): string[] {
+	const shown = widgetTasks(tasks, now);
+	if (shown.length === 0) return [];
+	const cols = columns(shown, cardInnerWidth(width), now);
+	const listed = options.collapsed ? [shown[0]] : shown;
+	const hint = options.collapsed && options.collapseKey ? `${options.collapseKey} expand` : batchElapsed(shown, now);
+	return renderCard(
+		{ title: "Agents", subtitle: counts(shown), body: listed.flatMap((task) => row(task, theme, cols, now)), tone: tone(shown), glyph: AGENTS_GLYPH },
+		theme,
+		width,
+		{ expanded: true, hint },
+	);
+}

--- a/lib/gentle-ai-renderer.ts
+++ b/lib/gentle-ai-renderer.ts
@@ -62,22 +62,28 @@ export function getGentleAiRenderState(state: unknown): GentleAiRenderState | un
 // The call row: the top rule, with the expand key at its right end once the
 // tool finished, and the command when expanded. pi renders the result
 // component right below it, and that one closes the frame.
+// The call card owns the top rule. While the execution is still running it
+// also closes the frame, because no result row exists yet; once a final
+// result is in, the result card closes it instead.
 export class GentleAiCallCard {
 	private card: Card = { title: CARD_TITLE, body: [], tone: CARD_TONE.WARNING };
 	private theme: CardTheme = passthroughTheme;
 	private detail: string | undefined;
 	private hint: string | undefined;
+	private open = true;
 
 	update(status: LifecycleStatus, operationPath: string, theme: CardTheme, detail?: string, hint?: string): void {
 		this.card = { title: CARD_TITLE, subtitle: `${status} · ${operationPath}`, body: [], tone: STATUS_TONE[status], glyph: CARD_GLYPH };
 		this.theme = theme;
 		this.detail = detail;
 		this.hint = hint;
+		this.open = status === LIFECYCLE_STATUS.RUNNING || status === LIFECYCLE_STATUS.PREPARING;
 	}
 
 	render(width: number): string[] {
 		const lines = [cardTop(this.card, this.theme, width, this.hint)];
 		if (this.detail) lines.push(cardLine(this.theme.fg(DETAIL_ROLE, this.detail), this.card.tone, this.theme, width));
+		if (this.open) lines.push(cardBottom(this.card.tone, this.theme, width));
 		return lines;
 	}
 
@@ -93,12 +99,14 @@ export class GentleAiResultCard {
 	private readonly expanded: boolean;
 	private readonly tone: CardTone;
 	private readonly theme: CardTheme;
+	private readonly partial: boolean;
 
-	constructor(text: string, expanded: boolean, tone: CardTone, theme: CardTheme) {
+	constructor(text: string, expanded: boolean, tone: CardTone, theme: CardTheme, partial = false) {
 		this.text = text;
 		this.expanded = expanded;
 		this.tone = tone;
 		this.theme = theme;
+		this.partial = partial;
 	}
 
 	render(width: number): string[] {
@@ -114,7 +122,8 @@ export class GentleAiResultCard {
 				lines.push(cardLine(this.theme.fg(HIDDEN_ROLE, `${count} ${count === 1 ? "line" : "lines"}`), this.tone, this.theme, width));
 			}
 		}
-		lines.push(cardBottom(this.tone, this.theme, width));
+		// A partial result sits under a running call card, which still closes the frame.
+		if (!this.partial) lines.push(cardBottom(this.tone, this.theme, width));
 		return lines;
 	}
 
@@ -141,9 +150,12 @@ export function renderGentleAiResult(
 		const changed = state.finished !== true || state.failed !== (options.isError === true);
 		state.finished = true;
 		state.failed = options.isError === true;
-		if (changed) context?.invalidate?.();
+		// pi's invalidate re-runs the tool display synchronously; called from
+		// inside this render it would nest a second call+result pair into the
+		// same container. Deferring it keeps one frame per execution.
+		if (changed) queueMicrotask(() => context?.invalidate?.());
 	}
-	return new GentleAiResultCard(text, options.expanded === true, tone, theme);
+	return new GentleAiResultCard(text, options.expanded === true, tone, theme, options.isPartial === true);
 }
 
 export function renderGentleAiLifecycleCall(

--- a/lib/shell-bar.ts
+++ b/lib/shell-bar.ts
@@ -1,6 +1,7 @@
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { GAUGE_CELLS, gaugeTone, paintGauge, renderGauge, type GaugeTone } from "./shell-gauge.ts";
 import { renderUsageBar, type ProviderUsage } from "./shell-usage.ts";
+import { sanitizeTerminalText } from "./terminal-theme.ts";
 
 export { gaugeTone, renderGauge, type GaugeTone };
 
@@ -48,8 +49,10 @@ export const SHELL_BAR_BRAND = "✿ gentle-pi";
 export const SHELL_BAR_SEPARATOR = "⟡";
 export const SHELL_BAR_GAUGE_CELLS = GAUGE_CELLS;
 const RIGHT_PADDING = 2;
+const COMPACT_BRANCH_WIDTH = 15;
 
 export function shellEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (env.GENTLE_PI_AGENTS_CHILD === "1") return false;
 	const value = env.GENTLE_PI_SHELL?.trim().toLowerCase();
 	return !(value === "0" || value === "false" || value === "off");
 }
@@ -67,8 +70,10 @@ export function formatCost(total: number, subscription: boolean): string {
 	return subscription ? `$${amount} sub` : `$${amount}`;
 }
 
+// Extensions may paint their status themselves (pi-mcp-adapter does); the bar
+// owns the palette, so their escapes go and the text takes the status role.
 function sanitizeStatus(text: string): string {
-	return text.replace(/[\r\n\t]/g, " ").replace(/ +/g, " ").trim();
+	return sanitizeTerminalText(text.replace(/[\r\n\t]/g, " ")).replace(/ +/g, " ").trim();
 }
 
 function buildSegments(model: ShellBarModel, theme: ShellBarTheme): string[] {
@@ -87,12 +92,32 @@ function buildSegments(model: ShellBarModel, theme: ShellBarTheme): string[] {
 	return [theme.fg(ROLE.BRAND, SHELL_BAR_BRAND), location, modelSegment, context, cost, ...(usage ? [usage] : []), ...statuses];
 }
 
+// When the line overflows, the location gives way first: the path shrinks to
+// its last segment and a long branch is clipped, so the trailing statuses
+// (MCP servers, extension notices) survive on ordinary terminal widths.
+function compactModel(model: ShellBarModel): ShellBarModel {
+	const cwd = model.cwd.split("/").filter((part) => part.length > 0).pop() ?? model.cwd;
+	const branch = model.branch && visibleWidth(model.branch) > COMPACT_BRANCH_WIDTH ? clipText(model.branch, COMPACT_BRANCH_WIDTH) : model.branch;
+	return { ...model, cwd, branch };
+}
+
+// Plain clip: pi's truncateToWidth wraps the result in resets, which would end
+// up inside a painted segment.
+function clipText(text: string, max: number): string {
+	let clipped = "";
+	for (const char of text) {
+		if (visibleWidth(clipped + char) > max - 1) break;
+		clipped += char;
+	}
+	return `${clipped}…`;
+}
+
 function joinSegments(segments: string[], theme: ShellBarTheme): string {
 	return segments.join(` ${theme.fg(ROLE.SEPARATOR, SHELL_BAR_SEPARATOR)} `);
 }
 
 export function renderShellBar(model: ShellBarModel, theme: ShellBarTheme, width: number): string[] {
-	const segments = buildSegments(model, theme);
+	let segments = buildSegments(model, theme);
 	const right = model.sessionName ? theme.fg(ROLE.SESSION, model.sessionName) : undefined;
 
 	let left = joinSegments(segments, theme);
@@ -101,6 +126,10 @@ export function renderShellBar(model: ShellBarModel, theme: ShellBarTheme, width
 		return [left + padding + right];
 	}
 
+	if (visibleWidth(left) > width) {
+		segments = buildSegments(compactModel(model), theme);
+		left = joinSegments(segments, theme);
+	}
 	while (segments.length > 1 && visibleWidth(left) > width) {
 		segments.pop();
 		left = joinSegments(segments, theme);

--- a/lib/shell-changes-view.ts
+++ b/lib/shell-changes-view.ts
@@ -42,7 +42,7 @@ const EMPTY_DIFF = "no diff for this file";
 const CLEAN_TREE = "working tree is clean";
 const KEYS = [
 	["j/k", "file"],
-	["pgup/pgdn", "scroll"],
+	["ctrl+j/k", "scroll"],
 	["o", "open in editor"],
 	["esc", "close"],
 ] as const;
@@ -115,15 +115,16 @@ export class ChangesView {
 			this.deps.onClose();
 			return;
 		}
-		if (data === "o" || matchesKey(data, Key.enter)) {
-			const file = this.model.files[this.selected];
-			if (file) this.deps.onOpen(file);
-			return;
-		}
+		// ctrl+j arrives as a bare line feed, which pi also reads as enter, so
+		// the scroll keys are checked before the open key; a real Enter is CR.
 		if (data === "j" || matchesKey(data, Key.down)) this.select(this.selected + 1);
 		else if (data === "k" || matchesKey(data, Key.up)) this.select(this.selected - 1);
-		else if (matchesKey(data, Key.pageDown)) this.scrollBy(this.bodyRows());
-		else if (matchesKey(data, Key.pageUp)) this.scrollBy(-this.bodyRows());
+		else if (matchesKey(data, Key.pageDown) || matchesKey(data, Key.ctrl("j"))) this.scrollBy(this.bodyRows());
+		else if (matchesKey(data, Key.pageUp) || matchesKey(data, Key.ctrl("k"))) this.scrollBy(-this.bodyRows());
+		else if (data === "o" || matchesKey(data, Key.enter)) {
+			const file = this.model.files[this.selected];
+			if (file) this.deps.onOpen(file);
+		}
 	}
 
 	render(width: number): string[] {

--- a/lib/shell-todo.ts
+++ b/lib/shell-todo.ts
@@ -86,6 +86,8 @@ const STATUS_ROLE: Record<TodoStatus, string> = { [TODO_STATUS.PENDING]: "text",
 const GLYPH_ROLE: Record<TodoStatus, string> = { [TODO_STATUS.PENDING]: "muted", [TODO_STATUS.IN_PROGRESS]: "accent", [TODO_STATUS.DONE]: "success" };
 const NOTE_ROLE = "muted";
 const STALE_AFTER_TURNS = 2;
+/** Above this many rows the finished tasks fold into one line and the rest is capped. */
+const ROW_CAP = 12;
 
 export function emptyTodo(): TodoState {
 	return { tasks: [], nextId: 1, updatedTurn: null };
@@ -242,6 +244,20 @@ function taskRow(task: TodoTask, theme: TodoTheme): string {
 	return `${theme.fg(GLYPH_ROLE[task.status], STATUS_GLYPH[task.status])} ${theme.fg(STATUS_ROLE[task.status], title)}${note}`;
 }
 
+// Long lists keep the card short: done tasks fold into "✓ N done" and the
+// open ones fill the remaining rows, with a trailing count for the rest.
+function bodyRows(state: TodoState, theme: TodoTheme): string[] {
+	if (state.tasks.length <= ROW_CAP) return state.tasks.map((task) => taskRow(task, theme));
+	const { done } = todoSummary(state);
+	const open = state.tasks.filter((task) => task.status !== TODO_STATUS.DONE);
+	const rows: string[] = [];
+	if (done > 0) rows.push(`${theme.fg(GLYPH_ROLE[TODO_STATUS.DONE], STATUS_GLYPH[TODO_STATUS.DONE])} ${theme.fg(NOTE_ROLE, `${done} done`)}`);
+	const room = ROW_CAP - rows.length - (open.length > ROW_CAP - rows.length ? 1 : 0);
+	for (const task of open.slice(0, room)) rows.push(taskRow(task, theme));
+	if (open.length > room) rows.push(theme.fg(NOTE_ROLE, `… ${open.length - room} more`));
+	return rows;
+}
+
 function collapsedRow(state: TodoState, theme: TodoTheme): string {
 	const active = state.tasks.find((task) => task.status === TODO_STATUS.IN_PROGRESS);
 	if (active) return taskRow(active, theme);
@@ -254,7 +270,7 @@ export function renderTodoCard(state: TodoState, theme: TodoTheme, width: number
 	const { done, total } = todoSummary(state);
 	const stale = options.staleTurns >= STALE_AFTER_TURNS;
 	const hint = stale ? `stale · ${options.staleTurns} turns` : options.collapsed && options.collapseKey ? `${options.collapseKey} expand` : undefined;
-	const body = options.collapsed ? [collapsedRow(state, theme)] : state.tasks.map((task) => taskRow(task, theme));
+	const body = options.collapsed ? [collapsedRow(state, theme)] : bodyRows(state, theme);
 	return renderCard(
 		{ title: "Todos", subtitle: `${done} of ${total}`, body, tone: stale ? CARD_TONE.WARNING : CARD_TONE.INFO, glyph: TODO_GLYPH },
 		theme,

--- a/tests/agents-config.test.ts
+++ b/tests/agents-config.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import {
+	AGENT_MODE,
+	discoverAgents,
+	parseAgentDefinition,
+	parseAgentsConfig,
+	parseFrontmatter,
+	parseModelRef,
+	resolveAgentProfile,
+} from "../lib/agents-config.ts";
+
+// Gentle Agents configuration: markdown agent definitions (the same files
+// gentle-ai installs) and subagents.json, both parsed without touching pi.
+
+const root = mkdtempSync(join(tmpdir(), "gentle-agents-config-"));
+after(() => rmSync(root, { recursive: true, force: true }));
+
+const EXPLORER = `---
+name: gentle-ai-explore
+description: Read-only exploration and mapping.
+model: openai-codex/gpt-5.6-terra
+thinking: high
+tools:
+  - read
+  - grep
+  - codegraph
+---
+
+You are the read-only explorer.
+Map files and return a compressed handoff.
+`;
+
+test("parseFrontmatter reads scalars, inline lists, and block lists, and keeps the body", () => {
+	const { data, body } = parseFrontmatter("---\nname: a\ntools: [read, grep]\nlist:\n  - one\n  - two\nquoted: \"x: y\"\n---\nBody here\n");
+	assert.deepEqual(data, { name: "a", tools: ["read", "grep"], list: ["one", "two"], quoted: "x: y" });
+	assert.equal(body, "Body here");
+	assert.deepEqual(parseFrontmatter("no frontmatter"), { data: {}, body: "no frontmatter" });
+});
+
+test("parseModelRef splits provider/id and accepts a bare id", () => {
+	assert.deepEqual(parseModelRef("openai-codex/gpt-5.6-terra"), { provider: "openai-codex", id: "gpt-5.6-terra" });
+	assert.deepEqual(parseModelRef("sonnet"), { provider: undefined, id: "sonnet" });
+	assert.equal(parseModelRef("   "), undefined);
+});
+
+test("parseAgentDefinition builds a definition from the gentle-ai agent format", () => {
+	const agent = parseAgentDefinition(EXPLORER, "/home/x/.pi/agent/agents/gentle-ai-explore.md", "global");
+	assert.ok(!("error" in agent));
+	assert.equal(agent.name, "gentle-ai-explore");
+	assert.equal(agent.description, "Read-only exploration and mapping.");
+	assert.deepEqual(agent.model, { provider: "openai-codex", id: "gpt-5.6-terra" });
+	assert.equal(agent.thinking, "high");
+	assert.deepEqual(agent.tools, ["read", "grep", "codegraph"]);
+	assert.equal(agent.mode, undefined);
+	assert.equal(agent.scope, "global");
+	assert.match(agent.instructions, /^You are the read-only explorer\./);
+});
+
+test("parseAgentDefinition accepts effort and subagent_mode aliases, csv tools, and names from the file", () => {
+	const agent = parseAgentDefinition("---\ndescription: d\neffort: low\nsubagent_mode: background\ntools: read, bash\n---\nbody", "/p/.pi/agents/worker.md", "project");
+	assert.ok(!("error" in agent));
+	assert.equal(agent.name, "worker");
+	assert.equal(agent.thinking, "low");
+	assert.equal(agent.mode, AGENT_MODE.BACKGROUND);
+	assert.deepEqual(agent.tools, ["read", "bash"]);
+});
+
+test("parseAgentDefinition rejects unknown thinking levels, modes, and empty bodies", () => {
+	assert.match((parseAgentDefinition("---\nname: a\nthinking: extreme\n---\nbody", "/a.md", "global") as { error: string }).error, /thinking "extreme"/);
+	assert.match((parseAgentDefinition("---\nname: a\nsubagent_mode: forever\n---\nbody", "/a.md", "global") as { error: string }).error, /mode "forever"/);
+	assert.match((parseAgentDefinition("---\nname: a\n---\n   \n", "/a.md", "global") as { error: string }).error, /no instructions/);
+});
+
+test("discoverAgents merges the four directories with project over global and subagents over agents", () => {
+	const home = join(root, "home");
+	const cwd = join(root, "project");
+	for (const dir of [".pi/agent/agents", ".pi/agent/subagents"]) mkdirSync(join(home, dir), { recursive: true });
+	for (const dir of [".pi/agents", ".pi/subagents"]) mkdirSync(join(cwd, dir), { recursive: true });
+	writeFileSync(join(home, ".pi/agent/agents/explore.md"), EXPLORER);
+	writeFileSync(join(home, ".pi/agent/agents/shared.md"), "---\ndescription: global agents\n---\nglobal");
+	writeFileSync(join(home, ".pi/agent/subagents/shared.md"), "---\ndescription: global subagents\n---\nglobal sub");
+	writeFileSync(join(cwd, ".pi/agents/shared.md"), "---\ndescription: project agents\n---\nproject");
+	writeFileSync(join(cwd, ".pi/agents/broken.md"), "---\nthinking: nope\n---\nx");
+	writeFileSync(join(cwd, ".pi/agents/notes.txt"), "ignored");
+	const { agents, errors } = discoverAgents({ cwd, home });
+	assert.deepEqual(agents.map((agent) => `${agent.name}:${agent.description}:${agent.scope}`), ["gentle-ai-explore:Read-only exploration and mapping.:global", "shared:project agents:project"]);
+	assert.equal(errors.length, 1);
+	assert.match(errors[0], /broken\.md/);
+	assert.deepEqual(discoverAgents({ cwd: join(root, "empty"), home: join(root, "nohome") }), { agents: [], errors: [] });
+});
+
+test("parseAgentsConfig applies defaults, validates values, and lets the project file win", () => {
+	const config = parseAgentsConfig({ default_model: "openai-codex/gpt-6-astra", default_effort: "medium", max_concurrency: 3, timeout_ms: 1000, model_profiles: { explore: { model: "openai-codex/gpt-5.6-terra", effort: "high" } } }, { max_concurrency: 2, model_profiles: { explore: { effort: "low" }, worker: { model: "anthropic/claude-sonnet-5" } } });
+	assert.deepEqual(config.defaultModel, { provider: "openai-codex", id: "gpt-6-astra" });
+	assert.equal(config.defaultThinking, "medium");
+	assert.equal(config.maxConcurrency, 2);
+	assert.equal(config.timeoutMs, 1000);
+	assert.deepEqual(config.modelProfiles.explore, { model: { provider: "openai-codex", id: "gpt-5.6-terra" }, thinking: "low" });
+	assert.deepEqual(config.modelProfiles.worker, { model: { provider: "anthropic", id: "claude-sonnet-5" }, thinking: undefined });
+	const defaults = parseAgentsConfig(undefined, undefined);
+	assert.equal(defaults.maxConcurrency, 5);
+	assert.equal(defaults.timeoutMs, 20 * 60_000);
+	assert.equal(defaults.stallTimeoutMs, 4 * 60_000);
+	assert.equal(defaults.defaultMode, AGENT_MODE.TASK);
+	assert.equal(defaults.historyMaxTasks, 200);
+	assert.equal(parseAgentsConfig({ max_concurrency: "many", default_effort: "wild", default_mode: "background" }, undefined).maxConcurrency, 5);
+	assert.equal(parseAgentsConfig({ default_mode: "background" }, undefined).defaultMode, AGENT_MODE.BACKGROUND);
+});
+
+test("resolveAgentProfile prefers the profile, then the definition, then the defaults", () => {
+	const config = parseAgentsConfig({ default_model: "openai-codex/gpt-6-astra", default_effort: "medium", model_profiles: { "gentle-ai-explore": { effort: "high" } } }, undefined);
+	const explore = parseAgentDefinition(EXPLORER, "/x/explore.md", "global");
+	assert.ok(!("error" in explore));
+	assert.deepEqual(resolveAgentProfile(explore, config), { model: { provider: "openai-codex", id: "gpt-5.6-terra" }, thinking: "high", source: { model: "definition", thinking: "profile" } });
+	const bare = parseAgentDefinition("---\nname: bare\n---\nbody", "/x/bare.md", "global");
+	assert.ok(!("error" in bare));
+	assert.deepEqual(resolveAgentProfile(bare, config), { model: { provider: "openai-codex", id: "gpt-6-astra" }, thinking: "medium", source: { model: "default", thinking: "default" } });
+	assert.deepEqual(resolveAgentProfile(bare, parseAgentsConfig(undefined, undefined)).source, { model: "unresolved", thinking: "unresolved" });
+});

--- a/tests/agents-fake-child.ts
+++ b/tests/agents-fake-child.ts
@@ -1,0 +1,51 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildLike } from "../lib/agents-runner.ts";
+
+// A fake `pi --mode rpc` child: answers every command with a success
+// response, records what the host wrote, and lets tests emit events.
+
+export interface FakeChild {
+	child: ChildLike;
+	written: Array<Record<string, unknown>>;
+	emit(event: Record<string, unknown>): void;
+	exit(code: number): void;
+	fail(message: string): void;
+	killed: string[];
+}
+
+export function fakeChild(): FakeChild {
+	const emitter = new EventEmitter();
+	const stdin = new PassThrough();
+	const stdout = new PassThrough();
+	const written: Array<Record<string, unknown>> = [];
+	const killed: string[] = [];
+	let buffer = "";
+	stdin.on("data", (chunk: Buffer) => {
+		buffer += chunk.toString();
+		const lines = buffer.split("\n");
+		buffer = lines.pop() ?? "";
+		for (const line of lines) {
+			const command = JSON.parse(line) as Record<string, unknown>;
+			written.push(command);
+			if (command.type === "extension_ui_response") continue;
+			const data = command.type === "get_state" ? { sessionFile: "/sessions/child.jsonl" } : undefined;
+			stdout.write(`${JSON.stringify({ type: "response", id: command.id, command: command.type, success: true, data })}\n`);
+		}
+	});
+	const child: ChildLike = {
+		pid: 42,
+		stdin,
+		stdout,
+		stderr: new PassThrough(),
+		kill: (signal) => {
+			killed.push(String(signal ?? "SIGTERM"));
+			return true;
+		},
+		on: (event, listener) => {
+			emitter.on(event, listener);
+			return child;
+		},
+	};
+	return { child, written, killed, emit: (event) => stdout.write(`${JSON.stringify(event)}\n`), exit: (code) => emitter.emit("exit", code, null), fail: (message) => emitter.emit("error", new Error(message)) };
+}

--- a/tests/agents-history.test.ts
+++ b/tests/agents-history.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import { historyDir, loadHistory, loadStoredTask, pruneHistory, saveTask } from "../lib/agents-history.ts";
+import { applyTaskEvent, emptyThread, TASK_EVENT, TASK_STATUS, TaskStore, type TaskRecord } from "../lib/agents-protocol.ts";
+
+// Gentle Agents history: JSON per task, async, lazy, pruned by count.
+
+const root = mkdtempSync(join(tmpdir(), "gentle-agents-history-"));
+after(() => rmSync(root, { recursive: true, force: true }));
+const dir = join(root, "tasks");
+
+function task(id: string, createdAt: number): TaskRecord {
+	return { id, agent: "explore", mode: "task", prompt: "p", label: "p", cwd: "/r", parentSessionId: "s", status: TASK_STATUS.COMPLETED, createdAt, startedAt: createdAt, endedAt: createdAt + 5, model: "m", thinking: undefined, sessionPath: null, error: null, result: "ok", lastStep: "done", lastActivityAt: createdAt, turns: 1, toolCalls: 0, tokens: 10, cost: 0.01 };
+}
+
+test("historyDir lives under the pi agent home", () => {
+	assert.equal(historyDir("/home/x"), join("/home/x", ".pi", "agent", "gentle-agents", "tasks"));
+});
+
+test("saveTask writes a task with its thread and loadStoredTask reads it back", async () => {
+	const thread = applyTaskEvent(emptyThread(), { type: TASK_EVENT.TEXT, text: "hello" });
+	await saveTask(dir, task("a1", 1000), thread);
+	const stored = await loadStoredTask(dir, "a1");
+	assert.equal(stored?.task.result, "ok");
+	assert.deepEqual(stored?.thread.items, [{ kind: "text", text: "hello" }]);
+	assert.equal(await loadStoredTask(dir, "missing"), undefined);
+	assert.equal(await loadStoredTask(dir, "../etc/passwd"), undefined);
+	assert.deepEqual(readdirSync(dir), ["a1.json"], "no temp file is left behind");
+});
+
+test("loadHistory skips broken files, sorts newest first, and pruneHistory keeps the newest N", async () => {
+	await saveTask(dir, task("b2", 3000), emptyThread());
+	await saveTask(dir, task("c3", 2000), emptyThread());
+	writeFileSync(join(dir, "junk.json"), "{not json");
+	writeFileSync(join(dir, "shape.json"), JSON.stringify({ task: { id: 1 } }));
+	assert.deepEqual((await loadHistory(dir)).map((entry) => entry.task.id), ["b2", "c3", "a1"]);
+	assert.equal(await pruneHistory(dir, 2), 1);
+	assert.deepEqual((await loadHistory(dir)).map((entry) => entry.task.id), ["b2", "c3"]);
+	assert.deepEqual(await loadHistory(join(root, "nowhere")), []);
+});
+
+test("TaskStore.restore adds a stored task without clobbering a live one", () => {
+	const store = new TaskStore();
+	const thread = applyTaskEvent(emptyThread(), { type: TASK_EVENT.NOTE, text: "restored" });
+	assert.equal(store.restore(task("r1", 1000), thread), true);
+	assert.equal(store.thread("r1").items.length, 1);
+	assert.equal(store.restore({ ...task("r1", 1000), result: "other" }, emptyThread()), false);
+	assert.equal(store.get("r1")?.result, "ok");
+});

--- a/tests/agents-protocol.test.ts
+++ b/tests/agents-protocol.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	applyTaskEvent,
+	emptyThread,
+	normalizeRpcEvent,
+	TASK_EVENT,
+	TASK_STATUS,
+	taskLabel,
+	TaskStore,
+	THREAD_ITEM,
+	type TaskRecord,
+} from "../lib/agents-protocol.ts";
+
+// Gentle Agents protocol: the child pi process streams RPC events; the host
+// normalizes them into small typed deltas, applies them to an append-only
+// thread, and notifies only the listeners of the task that changed.
+
+function record(overrides: Partial<TaskRecord> = {}): TaskRecord {
+	return {
+		id: "t1",
+		agent: "gentle-ai-explore",
+		mode: "task",
+		prompt: "Map the repo",
+		label: "map the repo",
+		cwd: "/repo",
+		parentSessionId: "s1",
+		status: TASK_STATUS.QUEUED,
+		createdAt: 1000,
+		startedAt: null,
+		endedAt: null,
+		model: "openai-codex/gpt-5.6-terra",
+		thinking: "high",
+		sessionPath: null,
+		error: null,
+		result: null,
+		lastStep: "queued",
+		lastActivityAt: 1000,
+		turns: 0,
+		toolCalls: 0,
+		tokens: 0,
+		cost: 0,
+		...overrides,
+	};
+}
+
+test("normalizeRpcEvent maps pi RPC events to task deltas and ignores the rest", () => {
+	assert.deepEqual(normalizeRpcEvent({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Hi" } }), [{ type: TASK_EVENT.TEXT, text: "Hi" }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "hmm" } }), [{ type: TASK_EVENT.THINKING, text: "hmm" }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "ls" } }), [{ type: TASK_EVENT.TOOL_START, callId: "c1", name: "bash", args: { command: "ls" } }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "tool_execution_update", toolCallId: "c1", toolName: "bash", partialResult: { content: [{ type: "text", text: "a\nb" }] } }), [{ type: TASK_EVENT.TOOL_UPDATE, callId: "c1", output: "a\nb" }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "tool_execution_end", toolCallId: "c1", toolName: "bash", isError: true, result: { content: [{ type: "text", text: "boom" }] } }), [{ type: TASK_EVENT.TOOL_END, callId: "c1", output: "boom", isError: true }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "turn_end" }), [{ type: TASK_EVENT.TURN_END }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "done." }] }] }), [{ type: TASK_EVENT.AGENT_END, text: "done." }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "message_update", assistantMessageEvent: { type: "error", reason: "error", error: { message: "rate limited" } } }), [{ type: TASK_EVENT.ERROR, message: "rate limited" }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "extension_ui_request", id: "u1", method: "confirm", title: "Delete?" }), [{ type: TASK_EVENT.ASK, request: { id: "u1", method: "confirm", title: "Delete?" } }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "extension_ui_request", id: "u2", method: "setStatus", statusKey: "mcp" }), [], "fire-and-forget UI requests never count as questions");
+	assert.deepEqual(normalizeRpcEvent({ type: "extension_ui_request", id: "u3", method: "notify", message: "hi" }), []);
+	assert.deepEqual(normalizeRpcEvent({ type: "auto_retry_start", attempt: 1, maxAttempts: 3 }), [{ type: TASK_EVENT.NOTE, text: "retrying (1/3)" }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "message_end", message: { role: "assistant", usage: { totalTokens: 9621, cost: { total: 0.0193 } } } }), [{ type: TASK_EVENT.USAGE, tokens: 9621, cost: 0.0193 }]);
+	assert.deepEqual(normalizeRpcEvent({ type: "message_end", message: { role: "user" } }), []);
+	assert.deepEqual(normalizeRpcEvent({ type: "queue_update" }), []);
+	assert.deepEqual(normalizeRpcEvent("garbage"), []);
+});
+
+test("taskLabel prefers an explicit label and otherwise takes the prompt's first sentence", () => {
+	assert.equal(taskLabel("Map the repo. Then report.", "  map  the repo "), "map the repo");
+	assert.equal(taskLabel("Repeat a fresh read-only exploration of lib. Own runtime architecture: extensions, hooks."), "Repeat a fresh read-only exploration of lib");
+	assert.equal(taskLabel("\n\nFirst line here:\nsecond"), "First line here");
+	assert.equal(taskLabel(`${"x".repeat(100)} tail`).length, 72);
+	assert.equal(taskLabel("\x1b[31mred\x1b[0m"), "red");
+});
+
+test("applyTaskEvent appends incrementally: text deltas merge, tool output is replaced, items stay bounded", () => {
+	let thread = emptyThread({ maxItems: 3, maxOutputChars: 9 });
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.TEXT, text: "Hel" });
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.TEXT, text: "lo" });
+	assert.deepEqual(thread.items, [{ kind: THREAD_ITEM.TEXT, text: "Hello" }]);
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.TOOL_START, callId: "c1", name: "bash", args: { command: "ls" } });
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.TOOL_UPDATE, callId: "c1", output: "line one\nline two" });
+	assert.equal(thread.items[1].kind, THREAD_ITEM.TOOL);
+	assert.equal((thread.items[1] as { output: string }).output, "…line two", "tool output keeps the tail");
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.TOOL_END, callId: "c1", output: "ok", isError: false });
+	assert.deepEqual(thread.items[1], { kind: THREAD_ITEM.TOOL, callId: "c1", name: "bash", args: { command: "ls" }, output: "ok", running: false, isError: false });
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.NOTE, text: "retrying (1/3)" });
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.TEXT, text: "After" });
+	assert.equal(thread.items.length, 3);
+	assert.equal(thread.dropped, 1, "the oldest item made room");
+	assert.equal(thread.items[0].kind, THREAD_ITEM.TOOL);
+	assert.equal(thread.version, 7);
+});
+
+test("applyTaskEvent sanitizes text, ignores updates for unknown tools, and records asks as notes", () => {
+	let thread = emptyThread();
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.TEXT, text: "\x1b[31mred\x1b[0m" });
+	assert.deepEqual(thread.items, [{ kind: THREAD_ITEM.TEXT, text: "red" }]);
+	const before = thread;
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.TOOL_UPDATE, callId: "missing", output: "x" });
+	assert.strictEqual(thread, before);
+	thread = applyTaskEvent(thread, { type: TASK_EVENT.ASK, request: { id: "u1", method: "confirm", title: "Delete?" } });
+	assert.deepEqual(thread.items[1], { kind: THREAD_ITEM.NOTE, text: "asked: Delete?" });
+});
+
+test("TaskStore notifies only the listeners of the task that changed and keeps summaries cheap", () => {
+	const store = new TaskStore();
+	store.add(record({ id: "a" }));
+	store.add(record({ id: "b", agent: "worker" }));
+	const seenA: string[] = [];
+	const seenB: string[] = [];
+	const summaries: string[] = [];
+	const offA = store.subscribe("a", (task) => seenA.push(`${task.status}:${task.lastStep}`));
+	store.subscribe("b", (task) => seenB.push(task.status));
+	store.subscribeSummary((summary) => summaries.push(`${summary.running}/${summary.queued}/${summary.finished}`));
+	store.update("a", { status: TASK_STATUS.RUNNING, startedAt: 2000, lastStep: "starting" });
+	store.apply("a", { type: TASK_EVENT.TOOL_START, callId: "c1", name: "bash", args: {} }, 2500);
+	assert.deepEqual(seenA, ["running:starting", "running:bash"]);
+	assert.deepEqual(seenB, []);
+	assert.deepEqual(summaries, ["1/1/0"], "an event inside a task never touches the summary");
+	assert.equal(store.get("a")?.toolCalls, 1);
+	assert.equal(store.get("a")?.lastActivityAt, 2500);
+	assert.equal(store.thread("a").items.length, 1);
+	offA();
+	store.update("a", { status: TASK_STATUS.COMPLETED, endedAt: 3000 });
+	assert.equal(seenA.length, 2, "unsubscribed listener stays quiet");
+	assert.deepEqual(summaries, ["1/1/0", "0/1/1"]);
+	assert.deepEqual(store.list("s1").map((task) => task.id), ["a", "b"], "newest activity first");
+	assert.equal(store.get("missing"), undefined);
+	assert.deepEqual(store.thread("missing"), emptyThread());
+});
+
+test("TaskStore.apply moves the task to waiting on ask, back to running on any later event, and counts turns", () => {
+	const store = new TaskStore();
+	store.add(record({ id: "a", status: TASK_STATUS.RUNNING }));
+	store.apply("a", { type: TASK_EVENT.ASK, request: { id: "u1", method: "input", title: "Name?" } }, 1);
+	assert.equal(store.get("a")?.status, TASK_STATUS.WAITING);
+	assert.equal(store.get("a")?.lastStep, "asked: Name?");
+	store.apply("a", { type: TASK_EVENT.TEXT, text: "thanks" }, 2);
+	assert.equal(store.get("a")?.status, TASK_STATUS.RUNNING);
+	store.apply("a", { type: TASK_EVENT.TURN_END }, 3);
+	store.apply("a", { type: TASK_EVENT.TURN_END }, 4);
+	assert.equal(store.get("a")?.turns, 2);
+	store.apply("a", { type: TASK_EVENT.USAGE, tokens: 100, cost: 0.5 }, 4);
+	store.apply("a", { type: TASK_EVENT.USAGE, tokens: 50, cost: 0.25 }, 4);
+	assert.equal(store.get("a")?.tokens, 150);
+	assert.equal(store.get("a")?.cost, 0.75);
+	store.apply("a", { type: TASK_EVENT.AGENT_END, text: "final answer" }, 5);
+	assert.equal(store.get("a")?.result, "final answer");
+	assert.equal(store.get("a")?.status, TASK_STATUS.RUNNING, "agent_end alone does not finish: the runner decides");
+});

--- a/tests/agents-runner.test.ts
+++ b/tests/agents-runner.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AGENT_MODE, type AgentDefinition } from "../lib/agents-config.ts";
+import { TASK_STATUS, TaskStore } from "../lib/agents-protocol.ts";
+import { AgentRunner, childArguments, JsonLines, piCommand, type RunnerDeps, type TaskRequest } from "../lib/agents-runner.ts";
+import { fakeChild, type FakeChild } from "./agents-fake-child.ts";
+
+// Gentle Agents runner: every subagent is a child `pi --mode rpc` process.
+// The host only parses JSON lines, applies deltas to the store, answers
+// dialogs, and enforces timeouts. These tests drive a fake child.
+
+const explorer: AgentDefinition = { name: "explore", description: "maps", filePath: "/a/explore.md", scope: "global", instructions: "You map things.", model: undefined, thinking: undefined, mode: undefined, tools: ["read", "grep"] };
+
+function request(overrides: Partial<TaskRequest> = {}): TaskRequest {
+	return { agent: explorer, prompt: "Map the repo", label: undefined, context: undefined, mode: AGENT_MODE.TASK, cwd: "/repo", parentSessionId: "s1", model: { provider: "openai-codex", id: "gpt-5.6-terra" }, thinking: "high", sessionDir: "/sessions", resumeSessionPath: undefined, env: {}, ...overrides };
+}
+
+interface Harness {
+	store: TaskStore;
+	runner: AgentRunner;
+	children: FakeChild[];
+	timers: Array<{ fn: () => void; ms: number; cancelled: boolean }>;
+	asks: Array<{ taskId: string; method: string }>;
+}
+
+function harness(options: { maxConcurrency?: number; answer?: Record<string, unknown> } = {}): Harness {
+	const children: FakeChild[] = [];
+	const timers: Harness["timers"] = [];
+	const asks: Harness["asks"] = [];
+	let clock = 1000;
+	const deps: RunnerDeps = {
+		spawn: () => {
+			const fake = fakeChild();
+			children.push(fake);
+			return fake.child;
+		},
+		now: () => (clock += 1),
+		schedule: (fn, ms) => {
+			const timer = { fn, ms, cancelled: false };
+			timers.push(timer);
+			return () => {
+				timer.cancelled = true;
+			};
+		},
+		pi: { command: "pi", args: [] },
+	};
+	const store = new TaskStore();
+	const runner = new AgentRunner(store, { maxConcurrency: options.maxConcurrency ?? 2, timeoutMs: 60_000, stallTimeoutMs: 10_000 }, deps, {
+		askUser: async (taskId, ask) => {
+			asks.push({ taskId, method: ask.method });
+			return options.answer ?? { value: "yes" };
+		},
+	});
+	return { store, runner, children, timers, asks };
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+test("childArguments builds an rpc launch with model, thinking, tools, session dir, and instructions", () => {
+	const args = childArguments(request());
+	assert.deepEqual(args.slice(0, 2), ["--mode", "rpc"]);
+	assert.ok(args.includes("--session-dir") && args[args.indexOf("--session-dir") + 1] === "/sessions");
+	assert.equal(args[args.indexOf("--model") + 1], "openai-codex/gpt-5.6-terra:high");
+	assert.equal(args[args.indexOf("--tools") + 1], "read,grep");
+	assert.equal(args[args.indexOf("--append-system-prompt") + 1], "You map things.");
+	assert.ok(!args.includes("--session"));
+	const resumed = childArguments(request({ resumeSessionPath: "/sessions/old.jsonl", model: undefined, thinking: undefined, agent: { ...explorer, tools: [] } }));
+	assert.equal(resumed[resumed.indexOf("--session") + 1], "/sessions/old.jsonl");
+	assert.ok(!resumed.includes("--model") && !resumed.includes("--tools"));
+});
+
+test("piCommand reuses the running pi entry point and honors the override", () => {
+	assert.deepEqual(piCommand({ execPath: "/bin/node", argv: ["/bin/node", "/x/dist/cli.js"], env: {} }), { command: "/bin/node", args: ["/x/dist/cli.js"] });
+	assert.deepEqual(piCommand({ execPath: "/bin/node", argv: ["/bin/node", "/x/other.js"], env: {} }), { command: "pi", args: [] });
+	assert.deepEqual(piCommand({ execPath: "/bin/node", argv: [], env: { GENTLE_PI_AGENTS_PI: "/opt/pi --flag" } }), { command: "/opt/pi", args: ["--flag"] });
+});
+
+test("JsonLines splits on LF only, tolerates CRLF, and skips lines that are not JSON", () => {
+	const seen: unknown[] = [];
+	const lines = new JsonLines((value) => seen.push(value));
+	lines.push('{"a":1}\r\n{"b":"x y"}\nnot json\n{"c":');
+	lines.push("3}\n");
+	assert.deepEqual(seen, [{ a: 1 }, { b: "x y" }, { c: 3 }]);
+});
+
+test("AgentRunner runs a task end to end: prompt, deltas into the store, completion with the last answer", async () => {
+	const { store, runner, children } = harness();
+	const task = runner.run(request());
+	assert.equal(task.status, TASK_STATUS.QUEUED);
+	await tick();
+	assert.equal(store.get(task.id)?.status, TASK_STATUS.RUNNING);
+	const [child] = children;
+	await tick();
+	assert.deepEqual(children[0].written.map((command) => command.type), ["get_state", "prompt"]);
+	assert.equal(children[0].written[1].message, "Map the repo");
+	child.emit({ type: "tool_execution_start", toolCallId: "c1", toolName: "grep", args: {} });
+	child.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Found it" } });
+	child.emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Found it" }] }] });
+	await tick();
+	const finished = store.get(task.id);
+	assert.equal(finished?.status, TASK_STATUS.COMPLETED);
+	assert.equal(finished?.result, "Found it");
+	assert.equal(finished?.toolCalls, 1);
+	assert.equal(finished?.sessionPath, "/sessions/child.jsonl");
+	assert.equal(finished?.label, "Map the repo");
+	assert.ok(children[0].killed.length > 0, "the child is stopped once the answer is in");
+	assert.equal(store.thread(task.id).items.length, 2);
+	assert.equal((await runner.waitFor(task.id)).status, TASK_STATUS.COMPLETED);
+});
+
+test("AgentRunner queues beyond max concurrency and starts the next task when one finishes", async () => {
+	const { store, runner, children } = harness({ maxConcurrency: 1 });
+	const first = runner.run(request());
+	const second = runner.run(request({ prompt: "Second" }));
+	await tick();
+	assert.equal(children.length, 1);
+	assert.equal(store.get(second.id)?.status, TASK_STATUS.QUEUED);
+	children[0].emit({ type: "agent_end", messages: [] });
+	await tick();
+	await tick();
+	assert.equal(store.get(first.id)?.status, TASK_STATUS.COMPLETED);
+	assert.equal(children.length, 2);
+	assert.equal(store.get(second.id)?.status, TASK_STATUS.RUNNING);
+});
+
+test("AgentRunner answers dialogs through askUser in task mode and cancels them in background mode", async () => {
+	const { store, runner, children, asks } = harness({ answer: { confirmed: true } });
+	const task = runner.run(request());
+	const background = runner.run(request({ mode: AGENT_MODE.BACKGROUND }));
+	await tick();
+	children[0].emit({ type: "extension_ui_request", id: "u1", method: "confirm", title: "Delete?" });
+	children[1].emit({ type: "extension_ui_request", id: "u2", method: "select", title: "Pick", options: ["a"] });
+	children[1].emit({ type: "extension_ui_request", id: "u3", method: "notify", message: "hi" });
+	await tick();
+	await tick();
+	assert.deepEqual(asks, [{ taskId: task.id, method: "confirm" }]);
+	assert.deepEqual(children[0].written.at(-1), { type: "extension_ui_response", id: "u1", confirmed: true });
+	assert.deepEqual(children[1].written.at(-1), { type: "extension_ui_response", id: "u2", cancelled: true });
+	assert.equal(store.get(background.id)?.status, TASK_STATUS.RUNNING);
+	assert.equal(store.get(task.id)?.status, TASK_STATUS.RUNNING, "answered questions do not leave the task waiting");
+});
+
+test("AgentRunner cancels, times out on the watchdog, and fails when the child exits early", async () => {
+	const { store, runner, children, timers } = harness({ maxConcurrency: 3 });
+	const cancelled = runner.run(request());
+	const timedOut = runner.run(request());
+	const crashed = runner.run(request());
+	await tick();
+	runner.cancel(cancelled.id);
+	await tick();
+	assert.equal(store.get(cancelled.id)?.status, TASK_STATUS.CANCELLED);
+	assert.ok(children[0].written.some((command) => command.type === "abort"));
+	const watchdog = timers.find((timer) => timer.ms === 60_000 && !timer.cancelled);
+	assert.ok(watchdog);
+	watchdog.fn();
+	await tick();
+	assert.equal(store.get(timedOut.id)?.status, TASK_STATUS.TIMED_OUT);
+	children[2].exit(1);
+	await tick();
+	assert.equal(store.get(crashed.id)?.status, TASK_STATUS.FAILED);
+	assert.match(store.get(crashed.id)?.error ?? "", /exited with code 1/);
+	assert.ok(runner.steer(cancelled.id, "x") === false, "a finished task cannot be steered");
+});
+
+test("AgentRunner steers a running task and marks a stalled one", async () => {
+	const { store, runner, children, timers } = harness();
+	const task = runner.run(request({ mode: AGENT_MODE.BACKGROUND }));
+	await tick();
+	assert.equal(runner.steer(task.id, "Focus on lib/"), true);
+	await tick();
+	assert.deepEqual(children[0].written.at(-1), { id: children[0].written.at(-1)?.id, type: "steer", message: "Focus on lib/" });
+	const stall = timers.filter((timer) => timer.ms === 10_000 && !timer.cancelled).at(-1);
+	assert.ok(stall);
+	stall.fn();
+	await tick();
+	assert.equal(store.get(task.id)?.status, TASK_STATUS.TIMED_OUT);
+	assert.match(store.get(task.id)?.error ?? "", /stalled/);
+});
+
+test("AgentRunner.cancelAll stops every queued and running task", async () => {
+	const { store, runner, children } = harness({ maxConcurrency: 1 });
+	const running = runner.run(request());
+	const queued = runner.run(request());
+	await tick();
+	assert.equal(runner.cancelAll(), 2);
+	await tick();
+	assert.equal(store.get(running.id)?.status, TASK_STATUS.CANCELLED);
+	assert.equal(store.get(queued.id)?.status, TASK_STATUS.CANCELLED);
+	assert.deepEqual(children[0].killed, ["SIGTERM"]);
+	assert.equal(children.length, 1, "nothing else starts after cancelAll");
+});
+
+test("AgentRunner fails only the task when the child cannot start, and the queue moves on", async () => {
+	const { store, runner, children, timers } = harness({ maxConcurrency: 1 });
+	const broken = runner.run(request());
+	const next = runner.run(request({ prompt: "After" }));
+	await tick();
+	children[0].fail("spawn pi ENOENT");
+	await tick();
+	assert.equal(store.get(broken.id)?.status, TASK_STATUS.FAILED);
+	assert.match(store.get(broken.id)?.error ?? "", /could not start pi: spawn pi ENOENT/);
+	assert.equal((await runner.waitFor(broken.id)).status, TASK_STATUS.FAILED, "waiters settle");
+	await tick();
+	assert.equal(children.length, 2, "the next queued task starts");
+	assert.equal(store.get(next.id)?.status, TASK_STATUS.RUNNING);
+	assert.ok(timers.filter((timer) => timer.ms === 60_000).every((timer, index) => index === 1 || timer.cancelled), "the failed task's watchdog is cancelled");
+});
+
+test("AgentRunner turns a synchronous spawn exception into a failed task", async () => {
+	const store = new TaskStore();
+	const runner = new AgentRunner(store, { maxConcurrency: 1, timeoutMs: 1000, stallTimeoutMs: 1000 }, {
+		spawn: () => {
+			throw new Error("ENOENT: pi not found");
+		},
+		now: () => 1,
+		schedule: () => () => {},
+		pi: { command: "missing-pi", args: [] },
+	}, { askUser: async () => ({ cancelled: true }) });
+	const task = runner.run(request());
+	const finished = await runner.waitFor(task.id);
+	assert.equal(finished.status, TASK_STATUS.FAILED);
+	assert.match(finished.error ?? "", /could not start pi: ENOENT/);
+});

--- a/tests/agents-transcript.test.ts
+++ b/tests/agents-transcript.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sessionToMarkdown } from "../lib/agents-transcript.ts";
+
+// Gentle Agents transcript: session JSONL in, readable markdown out.
+
+const session = [
+	JSON.stringify({ type: "session", version: 3, id: "x" }),
+	JSON.stringify({ type: "model_change", provider: "openai-codex", modelId: "gpt-5.6-terra" }),
+	JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "text", text: "Map lib/." }] } }),
+	JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "thinking", thinking: "secret" }, { type: "toolCall", id: "c1", name: "bash", arguments: { command: "ls  lib" } }] } }),
+	JSON.stringify({ type: "message", message: { role: "toolResult", toolCallId: "c1", toolName: "bash", isError: false, content: [{ type: "text", text: Array.from({ length: 45 }, (_, index) => `f${index}.ts`).join("\n") }] } }),
+	JSON.stringify({ type: "message", message: { role: "toolResult", toolCallId: "c2", toolName: "grep", isError: true, content: [{ type: "text", text: "\x1b[31mno matches\x1b[0m" }] } }),
+	"not json",
+	JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "Three files.\n" }] } }),
+].join("\n");
+
+test("sessionToMarkdown writes user, tool calls with results, and assistant text, dropping thinking and noise", () => {
+	const markdown = sessionToMarkdown(session, { title: "explore · map lib", maxOutputLines: 40 });
+	assert.match(markdown, /^# explore · map lib\n\n## User\n\nMap lib\/\.\n\n### ▸ bash ls lib\n\n<!-- bash -->\n```\n… 5 earlier lines omitted\nf5\.ts\n/);
+	assert.match(markdown, /<!-- grep error -->\n```\nno matches\n```/);
+	assert.match(markdown, /## Assistant\n\nThree files\.\n$/);
+	assert.doesNotMatch(markdown, /secret/);
+	assert.equal(sessionToMarkdown(""), "# Subagent transcript\n");
+});
+
+test("sessionToMarkdown widens the fence when the output itself contains backticks", () => {
+	const line = JSON.stringify({ type: "message", message: { role: "toolResult", toolName: "read", content: [{ type: "text", text: "```ts\nlet a = 1\n```" }] } });
+	assert.match(sessionToMarkdown(line), /````\n```ts\nlet a = 1\n```\n````/);
+});

--- a/tests/agents-view.test.ts
+++ b/tests/agents-view.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { emptyThread, TASK_EVENT, TASK_STATUS, TaskStore, type TaskRecord } from "../lib/agents-protocol.ts";
+import { AgentsView, itemLines, taskHeader } from "../lib/agents-view.ts";
+import { stripAnsi } from "../lib/terminal-theme.ts";
+
+// Gentle Agents overlay: list left, selected thread right, tail-following,
+// and only the selected task subscribed.
+
+const plainTheme = { fg: (_color: string, text: string) => text };
+
+function task(id: string, overrides: Partial<TaskRecord> = {}): TaskRecord {
+	return { id, agent: "explore", mode: "task", prompt: "p", label: "p", cwd: "/r", parentSessionId: "s", status: TASK_STATUS.RUNNING, createdAt: 1000, startedAt: 1000, endedAt: null, model: "gpt-5.6-terra", thinking: undefined, sessionPath: "/sessions/x.jsonl", error: null, result: null, lastStep: "grep", lastActivityAt: 1000, turns: 0, toolCalls: 0, tokens: 34_000, cost: 0.27, ...overrides };
+}
+
+function harness(rows = 8) {
+	const store = new TaskStore();
+	const events: string[] = [];
+	let renders = 0;
+	const view = new AgentsView({
+		theme: plainTheme,
+		rows,
+		store,
+		now: () => 61_000,
+		onCancel: (entry) => events.push(`cancel:${entry.id}`),
+		onOpen: (entry) => events.push(`open:${entry.id}`),
+		onClose: () => events.push("close"),
+		requestRender: () => (renders += 1),
+	});
+	return { store, view, events, renders: () => renders };
+}
+
+test("itemLines renders text, thinking, tools with an output tail, and notes", () => {
+	assert.deepEqual(itemLines({ kind: "text", text: "one two three four" }, plainTheme, 9), ["one two", "three", "four"]);
+	assert.deepEqual(itemLines({ kind: "thinking", text: "deep\nthoughts" }, plainTheme, 20), ["∴ deep"]);
+	const output = Array.from({ length: 10 }, (_, index) => `line ${index}`).join("\n");
+	const tool = itemLines({ kind: "tool", callId: "c", name: "bash", args: { command: "ls  -la" }, output, running: true, isError: false }, plainTheme, 30);
+	assert.equal(tool[0], "▸ bash ls -la");
+	assert.equal(tool.length, 10, "head, eight tail lines, running marker");
+	assert.equal(tool[1], "  line 2");
+	assert.equal(tool[9], "  …");
+	assert.deepEqual(itemLines({ kind: "note", text: "error: boom" }, plainTheme, 30), ["· error: boom"]);
+	assert.equal(taskHeader(task("a"), 61_000), "explore · running · gpt-5.6-terra · 34k · $0.27 · 1m00s");
+});
+
+test("AgentsView renders the frame with the task list and the selected thread's tail, at width", () => {
+	const { store, view } = harness(8);
+	store.add(task("a"));
+	store.add(task("b", { agent: "worker", status: TASK_STATUS.COMPLETED, endedAt: 5000, createdAt: 900, lastActivityAt: 900 }));
+	for (let index = 0; index < 6; index += 1) store.apply("a", { type: TASK_EVENT.TEXT, text: `line ${index}\n` }, 2000);
+	const lines = view.render(90);
+	for (const line of lines) assert.equal(visibleWidth(line), 90, `"${stripAnsi(line)}" is not 90 wide`);
+	const plain = lines.map(stripAnsi);
+	assert.equal(plain.length, 8);
+	assert.match(plain[0], /^╭─ ❀ Agents · 1 active · 1 finished ─+╮$/);
+	assert.match(plain[1], /^│ ▸ ◐ explore  1m00s +│ explore · running · gpt-5\.6-terra · 34k · \$0\.27 · 1m00s +│$/);
+	assert.match(plain[2], /^│   ✓ worker  4s +│ line 3 +│$/, "the thread window follows the tail");
+	assert.match(plain[4], /line 5/);
+	assert.match(plain[6], /j\/k task .* esc close/);
+	assert.match(plain[7], /^╰─+╯$/);
+});
+
+test("AgentsView keys move the selection, scroll, follow, cancel, open, and close", () => {
+	const { store, view, events } = harness(8);
+	store.add(task("a"));
+	store.add(task("b", { createdAt: 900, lastActivityAt: 900, status: TASK_STATUS.COMPLETED, endedAt: 5000 }));
+	assert.equal(view.selectedTask()?.id, "a");
+	view.handleInput("j");
+	assert.equal(view.selectedTask()?.id, "b");
+	view.handleInput("c");
+	assert.deepEqual(events, [], "finished tasks cannot be cancelled");
+	view.handleInput("k");
+	view.handleInput("c");
+	view.handleInput("o");
+	view.handleInput("\x1b");
+	assert.deepEqual(events, ["cancel:a", "open:a", "close"]);
+	for (let index = 0; index < 12; index += 1) store.apply("a", { type: TASK_EVENT.TEXT, text: `l${index}\n` }, 2000);
+	view.handleInput("\x1b[5~");
+	assert.match(stripAnsi(view.render(80)[2]), /│ l0 +│$/, "page up leaves follow mode and shows the top");
+	view.handleInput("\x0a");
+	assert.match(stripAnsi(view.render(80)[2]), /│ l4 +│$/, "ctrl+j scrolls one page down");
+	view.handleInput("\x0b");
+	assert.match(stripAnsi(view.render(80)[2]), /│ l0 +│$/, "ctrl+k scrolls one page up");
+	view.handleInput("f");
+	assert.match(stripAnsi(view.render(80)[2]), /│ l9 +│$/, "f follows the tail again");
+});
+
+test("AgentsView subscribes only to the selected task and survives an empty store", () => {
+	const { store, view, renders } = harness(6);
+	assert.match(stripAnsi(view.render(60)[1]), /no tasks yet/);
+	store.add(task("a"));
+	store.add(task("b", { createdAt: 900, lastActivityAt: 900 }));
+	const before = renders();
+	store.apply("b", { type: TASK_EVENT.TEXT, text: "quiet" }, 2000);
+	assert.equal(renders(), before, "an event on the unselected task renders nothing");
+	store.apply("a", { type: TASK_EVENT.TEXT, text: "loud" }, 2000);
+	assert.equal(renders(), before + 1);
+	view.dispose();
+	store.apply("a", { type: TASK_EVENT.TEXT, text: "after" }, 2000);
+	assert.equal(renders(), before + 1, "disposed views stay quiet");
+});

--- a/tests/agents-widget.test.ts
+++ b/tests/agents-widget.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { TASK_STATUS, type TaskRecord } from "../lib/agents-protocol.ts";
+import { formatElapsed, renderAgentsCard, widgetTasks } from "../lib/agents-widget.ts";
+import { stripAnsi } from "../lib/terminal-theme.ts";
+
+// Gentle Agents widget: the card above the editor that shows what the
+// subagents are doing, drawn from task records only (never from threads).
+// Layout: glyph, agent, task summary (wrapped), then model · tokens · cost · time.
+
+const plainTheme = { fg: (_color: string, text: string) => text };
+
+function task(overrides: Partial<TaskRecord>): TaskRecord {
+	return { id: "t", agent: "sdd-explore", mode: "task", prompt: "map footer data sources", label: "map footer data sources", cwd: "/r", parentSessionId: "s", status: TASK_STATUS.RUNNING, createdAt: 1000, startedAt: 1000, endedAt: null, model: "anthropic/claude-sonnet-5", thinking: undefined, sessionPath: null, error: null, result: null, lastStep: "grep", lastActivityAt: 1000, turns: 0, toolCalls: 0, tokens: 34_000, cost: 0.27, ...overrides };
+}
+
+test("formatElapsed renders seconds, minutes, and hours compactly", () => {
+	assert.equal(formatElapsed(4_000), "4s");
+	assert.equal(formatElapsed(65_000), "1m05s");
+	assert.equal(formatElapsed(3_720_000), "1h02m");
+	assert.equal(formatElapsed(-5), "0s");
+});
+
+test("widgetTasks keeps active tasks in start order and only recently finished ones", () => {
+	const tasks = [
+		task({ id: "old-done", status: TASK_STATUS.COMPLETED, endedAt: 10_000 }),
+		task({ id: "new-done", status: TASK_STATUS.FAILED, endedAt: 95_000 }),
+		task({ id: "queued", status: TASK_STATUS.QUEUED, createdAt: 3000, startedAt: null }),
+		task({ id: "running", createdAt: 2000, startedAt: 2000 }),
+	];
+	assert.deepEqual(widgetTasks(tasks, 100_000).map((entry) => entry.id), ["new-done", "running", "queued"]);
+	assert.deepEqual(widgetTasks([], 100_000), []);
+});
+
+test("renderAgentsCard draws columns for agent, task, and model · tokens · cost · time, with the batch time in the rule", () => {
+	const tasks = [
+		task({ id: "a", status: TASK_STATUS.COMPLETED, startedAt: 1000, endedAt: 26_000 }),
+		task({ id: "b", agent: "sdd-apply", label: "write gentle-shell footer", startedAt: 44_000, tokens: 12_000, cost: 0.09 }),
+	];
+	const lines = renderAgentsCard(tasks, plainTheme, 84, 85_000, { collapsed: false });
+	for (const line of lines) assert.equal(visibleWidth(line), 84, `"${stripAnsi(line)}" is not 84 wide`);
+	const plain = lines.map(stripAnsi);
+	assert.match(plain[0], /^╭─ ❀ Agents · 1 active · 1 done ─+ 1m24s ╮$/);
+	assert.match(plain[1], /^│ ✓  sdd-explore  map footer data sources +claude-sonnet-5 · 34k · \$0\.27 · 25s │$/);
+	assert.match(plain[2], /^│ ◐  sdd-apply    write gentle-shell footer +claude-sonnet-5 · 12k · \$0\.09 · 41s │$/);
+	assert.match(plain[3], /^╰─+╯$/);
+	assert.deepEqual(renderAgentsCard([], plainTheme, 60, 0, { collapsed: false }), []);
+});
+
+test("renderAgentsCard keeps every task on one line, clipping long labels, and drops the task column when the card is narrow", () => {
+	const tasks = [task({ id: "a", label: "write the gentle shell footer and all of its tests before lunch" })];
+	const wide = renderAgentsCard(tasks, plainTheme, 84, 5_000, { collapsed: false }).map(stripAnsi);
+	assert.equal(wide.length, 3);
+	assert.match(wide[1], /^│ ◐  sdd-explore  write the gentle shell foot… +claude-sonnet-5 · 34k · \$0\.27 · 4s │$/);
+	const narrow = renderAgentsCard(tasks, plainTheme, 44, 5_000, { collapsed: false }).map(stripAnsi);
+	assert.equal(narrow.length, 3);
+	assert.match(narrow[1], /^│ ◐  sdd-explore +34k · \$0\.27 · 4s │$/);
+});
+
+test("renderAgentsCard shows questions and failures in place of the task, and collapses to the first row", () => {
+	const tasks = [
+		task({ id: "a", status: TASK_STATUS.WAITING, lastStep: "asked: Delete?", tokens: 0, cost: 0 }),
+		task({ id: "b", status: TASK_STATUS.FAILED, endedAt: 2000, error: "pi exited with code 1", lastStep: "pi exited with code 1" }),
+		task({ id: "c", status: TASK_STATUS.QUEUED, createdAt: 1500, startedAt: null, tokens: 0, cost: 0 }),
+	];
+	const plain = renderAgentsCard(tasks, plainTheme, 80, 3000, { collapsed: false }).map(stripAnsi);
+	assert.match(plain[0], /^╭─ ❀ Agents · 1 waiting · 1 queued · 1 failed ─+ 2s ╮$/);
+	assert.match(plain[1], /^│ \?  sdd-explore  asked: Delete\? +claude-sonnet-5 · 2s │$/);
+	assert.match(plain[2], /^│ ✗  sdd-explore  pi exited with code 1 +claude-sonnet-5 · 34k · \$0\.27 · 1s │$/);
+	assert.match(plain[3], /^│ ○  sdd-explore  map footer data sources +queued │$/);
+	const collapsed = renderAgentsCard(tasks, plainTheme, 80, 3000, { collapsed: true, collapseKey: "ctrl+shift+a" }).map(stripAnsi);
+	assert.equal(collapsed.length, 3);
+	assert.match(collapsed[0], /ctrl\+shift\+a expand ╮$/);
+	assert.match(collapsed[1], /^│ \?  sdd-explore  asked: Delete\?/);
+});

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import gentleAgents, { agentsCollapseKey, agentsEnabled, agentsViewKey, answerThroughUi, completionText, legacySubagentsInstalled, type AgentsDeps } from "../extensions/gentle-agents.ts";
+import { loadHistory } from "../lib/agents-history.ts";
+import { stripAnsi } from "../lib/terminal-theme.ts";
+import { fakeChild, type FakeChild } from "./agents-fake-child.ts";
+
+// Gentle Agents extension: the subagent_* tools drive isolated pi children,
+// the card above the editor follows the store, and dialogs reach the host UI.
+
+type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
+interface Registered {
+	name: string;
+	execute(id: string, params: unknown, signal: undefined, onUpdate: undefined, ctx: ExtensionContext): Promise<{ content: Array<{ text: string }>; details: Record<string, unknown> }>;
+	renderCall(args: unknown, theme: unknown): { render(width: number): string[] };
+}
+
+const plainTheme = { fg: (_color: string, text: string) => text };
+const fakeTui = { requestRender() {} };
+const root = mkdtempSync(join(tmpdir(), "gentle-agents-ext-"));
+after(() => rmSync(root, { recursive: true, force: true }));
+const home = join(root, "home");
+const cwd = join(root, "project");
+mkdirSync(join(home, ".pi", "agent", "agents"), { recursive: true });
+mkdirSync(cwd, { recursive: true });
+writeFileSync(join(home, ".pi", "agent", "agents", "explore.md"), "---\ndescription: maps things\nmodel: openai-codex/gpt-5.6-terra\nthinking: high\ntools: [read, grep]\n---\nYou map things.");
+writeFileSync(join(home, ".pi", "agent", "subagents.json"), JSON.stringify({ max_concurrency: 2, model_profiles: { explore: { effort: "low" } } }));
+
+function fakePi() {
+	const handlers = new Map<string, Handler[]>();
+	const tools = new Map<string, Registered>();
+	const shortcuts = new Map<string, { handler(ctx: ExtensionContext): Promise<void> }>();
+	const commands = new Map<string, { handler(args: string, ctx: ExtensionContext): Promise<void> }>();
+	const sent: Array<{ message: Record<string, unknown>; options: Record<string, unknown> }> = [];
+	const renderers = new Map<string, (message: unknown, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }>();
+	const pi = {
+		sendMessage: (message: Record<string, unknown>, options: Record<string, unknown>) => sent.push({ message, options }),
+		registerMessageRenderer: (type: string, renderer: (message: unknown, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }) => renderers.set(type, renderer),
+		on: (event: string, handler: Handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
+		registerTool: (tool: Registered) => tools.set(tool.name, tool),
+		registerShortcut: (key: string, registration: { handler(ctx: ExtensionContext): Promise<void> }) => shortcuts.set(key, registration),
+		registerCommand: (name: string, registration: { handler(args: string, ctx: ExtensionContext): Promise<void> }) => commands.set(name, registration),
+	} as unknown as ExtensionAPI;
+	const fire = async (event: string, ctx: ExtensionContext, payload: unknown = {}) => {
+		for (const handler of handlers.get(event) ?? []) await handler(payload, ctx);
+	};
+	return { pi, tools, shortcuts, commands, fire, sent, renderers };
+}
+
+function fakeContext() {
+	const widgets = new Map<string, (tui: unknown, theme: unknown) => { render(width: number): string[] }>();
+	const dialogs: string[] = [];
+	const overlays: Array<{ render(width: number): string[]; handleInput(data: string): void }> = [];
+	const ctx = {
+		hasUI: true,
+		sessionManager: { getSessionId: () => "s1", getCwd: () => cwd },
+		ui: {
+			notify: (message: string) => dialogs.push(`notify:${message}`),
+			custom: (factory: (tui: unknown, theme: unknown, keybindings: unknown, done: (value: unknown) => void) => { render(width: number): string[]; handleInput(data: string): void }) =>
+				new Promise((resolve) => {
+					const component = factory({ terminal: { rows: 30 }, requestRender() {} }, plainTheme, {}, resolve);
+					overlays.push(component);
+				}),
+			setWidget(key: string, content: ((tui: unknown, theme: unknown) => { render(width: number): string[] }) | undefined) {
+				if (content === undefined) widgets.delete(key);
+				else widgets.set(key, content);
+			},
+			select: async (title: string, options: string[]) => {
+				dialogs.push(`select:${title}:${options.join("|")}`);
+				return options[0];
+			},
+			confirm: async (title: string) => {
+				dialogs.push(`confirm:${title}`);
+				return true;
+			},
+			input: async (title: string) => {
+				dialogs.push(`input:${title}`);
+				return undefined;
+			},
+			editor: async () => "edited",
+		},
+	} as unknown as ExtensionContext;
+	const widget = () => {
+		const factory = widgets.get("gentle-agents");
+		return factory ? factory(fakeTui, plainTheme).render(72).map(stripAnsi) : undefined;
+	};
+	return { ctx, widget, dialogs, overlays };
+}
+
+function deps(): { deps: Partial<AgentsDeps>; children: FakeChild[]; spawned: string[][] } {
+	const children: FakeChild[] = [];
+	const spawned: string[][] = [];
+	let clock = 1000;
+	return {
+		children,
+		spawned,
+		deps: {
+			spawn: (command, args) => {
+				spawned.push([command, ...args]);
+				const child = fakeChild();
+				children.push(child);
+				return child.child;
+			},
+			now: () => (clock += 500),
+			schedule: () => () => {},
+			pi: { command: "pi", args: [] },
+			home,
+			env: { PATH: "/bin" },
+		},
+	};
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+test("agentsEnabled and agentsCollapseKey read their flags and stay off inside a child", () => {
+	assert.equal(agentsEnabled({}), true);
+	assert.equal(agentsEnabled({ GENTLE_PI_AGENTS: "off" }), false);
+	assert.equal(agentsEnabled({ GENTLE_PI_AGENTS_CHILD: "1" }), false);
+	assert.equal(agentsCollapseKey({}), "ctrl+shift+a");
+	assert.equal(agentsCollapseKey({ GENTLE_PI_AGENTS_KEY: "off" }), undefined);
+	assert.equal(agentsViewKey({}), "alt+a");
+	assert.equal(agentsViewKey({ GENTLE_PI_AGENTS_VIEW_KEY: "off" }), undefined);
+	const off = fakePi();
+	gentleAgents(off.pi, { GENTLE_PI_AGENTS: "0" });
+	assert.equal(off.tools.size, 0);
+});
+
+test("while pi-subagents-j0k3r is still installed the tools stay unregistered and the user is told how to switch", async () => {
+	const legacyHome = join(root, "legacy-home");
+	mkdirSync(join(legacyHome, ".pi", "agent"), { recursive: true });
+	writeFileSync(join(legacyHome, ".pi", "agent", "settings.json"), JSON.stringify({ packages: ["npm:pi-subagents-j0k3r", "../../work/gentle-pi"] }));
+	assert.equal(legacySubagentsInstalled(legacyHome), true);
+	assert.equal(legacySubagentsInstalled(home), false);
+	assert.equal(legacySubagentsInstalled(join(root, "missing")), false);
+	const { pi, tools, fire } = fakePi();
+	gentleAgents(pi, {}, { ...deps().deps, home: legacyHome });
+	assert.equal(tools.size, 0);
+	const notices: string[] = [];
+	const ctx = { hasUI: true, ui: { notify: (message: string, level: string) => notices.push(`${level}:${message}`) } } as unknown as ExtensionContext;
+	await fire("session_start", ctx);
+	assert.match(notices[0] ?? "", /^warning:❀ Gentle Agents is waiting: remove the old package first with "pi remove npm:pi-subagents-j0k3r"/);
+});
+
+test("subagent_list_agents and subagent_run in task mode launch a child with the resolved profile and return its answer", async () => {
+	const { pi, tools, fire } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx, widget } = fakeContext();
+	await fire("session_start", ctx);
+	assert.deepEqual([...tools.keys()].sort(), ["subagent_cancel", "subagent_continue", "subagent_list_agents", "subagent_list_tasks", "subagent_result", "subagent_run", "subagent_send_message", "subagent_status"]);
+	const listed = await tools.get("subagent_list_agents")!.execute("c0", {}, undefined, undefined, ctx);
+	assert.match(listed.content[0].text, /- explore \(global\): maps things/);
+
+	const running = tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Map lib/ and report every module.", label: "map lib modules", context: "Focus on agents-*.ts" }, undefined, undefined, ctx);
+	await tick();
+	const [args] = harness.spawned;
+	assert.equal(args[args.indexOf("--model") + 1], "openai-codex/gpt-5.6-terra:low", "the profile effort overrides the definition");
+	assert.equal(args[args.indexOf("--tools") + 1], "read,grep");
+	await tick();
+	assert.match(String(harness.children[0].written[1].message), /Map lib\/ and report every module\.\n\n## Context\nFocus on agents-\*\.ts/);
+	assert.match(widget()![0], /^╭─ ❀ Agents · 1 active ─+ \d+s ╮$/);
+	assert.match(widget()![1], /^│ ◐  explore  map lib modules +gpt-5\.6-terra · \d+s │$/);
+	harness.children[0].emit({ type: "tool_execution_start", toolCallId: "c", toolName: "grep", args: {} });
+	harness.children[0].emit({ type: "message_end", message: { role: "assistant", usage: { totalTokens: 12_000, cost: { total: 0.09 } } } });
+	await tick();
+	assert.match(widget()![1], /◐  explore  map lib modules +gpt-5\.6-terra · 12k · \$0\.09 · \d+s │$/);
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "lib has three agent files." }] }] });
+	const result = await running;
+	assert.equal(result.content[0].text, "lib has three agent files.");
+	assert.equal((result.details.gentleAgents as { status: string }).status, "completed");
+	assert.match(widget()![1], /✓  explore  map lib modules/);
+	const orphan = tools.get("subagent_run")!.execute("c9", { agent: "explore", task: "Orphan", mode: "background" }, undefined, undefined, ctx);
+	await orphan;
+	await tick();
+	await fire("session_shutdown", ctx);
+	await tick();
+	assert.deepEqual(harness.children[1].killed, ["SIGTERM"], "closing pi stops the running children");
+	assert.match(tools.get("subagent_run")!.renderCall({ agent: "explore" }, plainTheme).render(60).join(""), /❀ agent run · explore/);
+});
+
+test("background runs return at once; status, result, send_message, cancel, and continue follow the task", async () => {
+	const { pi, tools, fire, sent, renderers } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx } = fakeContext();
+	await fire("session_start", ctx);
+	const started = await tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Long job", mode: "background" }, undefined, undefined, ctx);
+	const id = (started.details.gentleAgents as { taskId: string }).taskId;
+	assert.match(started.content[0].text, new RegExp(`background as task ${id}`));
+	await tick();
+	assert.match((await tools.get("subagent_status")!.execute("c2", { task_id: id }, undefined, undefined, ctx)).content[0].text, /running · background/);
+	assert.match((await tools.get("subagent_result")!.execute("c3", { task_id: id }, undefined, undefined, ctx)).content[0].text, /still running/);
+	assert.match((await tools.get("subagent_send_message")!.execute("c4", { task_id: id, message: "Skip tests" }, undefined, undefined, ctx)).content[0].text, /queued/);
+	await tick();
+	assert.equal(harness.children[0].written.at(-1)?.message, "Skip tests");
+	assert.match((await tools.get("subagent_continue")!.execute("c5", { task_id: id, prompt: "more" }, undefined, undefined, ctx)).content[0].text, /cannot be continued yet/);
+	assert.match((await tools.get("subagent_list_tasks")!.execute("c6", {}, undefined, undefined, ctx)).content[0].text, new RegExp(`^${id} · explore · running`));
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "All done." }] }] });
+	await tick();
+	assert.equal((await tools.get("subagent_result")!.execute("c7", { task_id: id }, undefined, undefined, ctx)).content[0].text, "All done.");
+	assert.equal(sent.length, 1, "a background result is delivered to the model once");
+	assert.equal(sent[0].message.customType, "gentle-agents.result");
+	assert.deepEqual(sent[0].options, { deliverAs: "followUp", triggerTurn: true });
+	assert.match(String(sent[0].message.content), new RegExp(`^Subagent explore \\(task ${id}, "Long job"\\) finished\\.\n\nAll done\\.$`));
+	const card = renderers.get("gentle-agents.result")!(sent[0].message, { expanded: true }, plainTheme).render(70).map(stripAnsi);
+	assert.match(card[0], /^╭─ ❀ Agent result · explore ─+ collapse ╮$/);
+	assert.match(card[1], /Subagent explore/);
+	assert.match(card[card.length - 2], /All done\./);
+	const resumed = tools.get("subagent_continue")!.execute("c8", { task_id: id, prompt: "Now summarize", mode: "task" }, undefined, undefined, ctx);
+	await tick();
+	const args = harness.spawned[1];
+	assert.equal(args[args.indexOf("--session") + 1], "/sessions/child.jsonl");
+	await tick();
+	harness.children[1].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Summary." }] }] });
+	assert.equal((await resumed).content[0].text, "Summary.");
+	assert.match((await tools.get("subagent_cancel")!.execute("c9", { task_id: id }, undefined, undefined, ctx)).content[0].text, /not running/);
+	assert.match((await tools.get("subagent_status")!.execute("c10", { task_id: "nope" }, undefined, undefined, ctx)).content[0].text, /Error: no task nope/);
+	assert.match((await tools.get("subagent_run")!.execute("c11", { agent: "ghost", task: "x" }, undefined, undefined, ctx)).content[0].text, /no subagent named "ghost"\. Known: explore/);
+});
+
+test("completionText names the outcome before the answer", () => {
+	const base = { id: "t1", agent: "explore", mode: "background", prompt: "p", label: "map lib", cwd: "/r", parentSessionId: "s", status: "failed" as const, createdAt: 1, startedAt: 1, endedAt: 2, model: "m", thinking: undefined, sessionPath: null, error: "pi exited with code 1", result: null, lastStep: "x", lastActivityAt: 2, turns: 0, toolCalls: 0, tokens: 0, cost: 0 };
+	assert.equal(completionText(base), 'Subagent explore (task t1, "map lib") failed.\n\nSubagent explore failed: pi exited with code 1');
+	assert.equal(completionText({ ...base, status: "timed_out", error: "stalled for 4 min" }), 'Subagent explore (task t1, "map lib") timed out.\n\nSubagent explore timed_out: stalled for 4 min');
+});
+
+test("a task-mode child's dialog reaches the host UI and the answer goes back to the child", async () => {
+	const { pi, tools, fire } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx, dialogs, widget } = fakeContext();
+	await fire("session_start", ctx);
+	const running = tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Ask me" }, undefined, undefined, ctx);
+	await tick();
+	harness.children[0].emit({ type: "extension_ui_request", id: "u1", method: "select", title: "Which file?", options: ["a.ts", "b.ts"] });
+	await tick();
+	await tick();
+	assert.deepEqual(dialogs, ["select:❀ Which file?:a.ts|b.ts"]);
+	assert.deepEqual(harness.children[0].written.at(-1), { type: "extension_ui_response", id: "u1", value: "a.ts" });
+	assert.match(widget()![1], /◐  explore  Ask me/);
+	harness.children[0].emit({ type: "agent_end", messages: [] });
+	await running;
+	assert.deepEqual(await answerThroughUi(ctx.ui, { id: "u2", method: "confirm", title: "Sure?" }, { message: "really" }), { confirmed: true });
+	assert.deepEqual(await answerThroughUi(ctx.ui, { id: "u3", method: "input", title: "Name" }, {}), { cancelled: true });
+	assert.deepEqual(await answerThroughUi(ctx.ui, { id: "u4", method: "editor", title: "Edit" }, {}), { value: "edited" });
+	assert.deepEqual(await answerThroughUi(undefined, { id: "u5", method: "select", title: "x" }, {}), { cancelled: true });
+});
+
+test("finished tasks are written to history, come back through resolveTask, and the overlay lists them", async () => {
+	const { pi, tools, fire, commands, shortcuts } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx, overlays } = fakeContext();
+	await fire("session_start", ctx);
+	const started = await tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Persist me", mode: "background" }, undefined, undefined, ctx);
+	const id = (started.details.gentleAgents as { taskId: string }).taskId;
+	await tick();
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Kept." }] }] });
+	await tick();
+	const tasksDir = join(home, ".pi", "agent", "gentle-agents", "tasks");
+	let stored = await loadHistory(tasksDir);
+	for (let attempt = 0; attempt < 40 && !stored.some((entry) => entry.task.id === id); attempt += 1) {
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		stored = await loadHistory(tasksDir);
+	}
+	assert.ok(stored.some((entry) => entry.task.id === id && entry.task.result === "Kept."), "the finished task is on disk");
+
+	const fresh = fakePi();
+	gentleAgents(fresh.pi, {}, deps().deps);
+	const again = fakeContext();
+	await fresh.fire("session_start", again.ctx);
+	assert.equal((await fresh.tools.get("subagent_result")!.execute("c2", { task_id: id }, undefined, undefined, again.ctx)).content[0].text, "Kept.");
+
+	assert.ok(commands.has("gentle:agents") && shortcuts.has("alt+a"));
+	const opened = commands.get("gentle:agents")!.handler("", ctx);
+	for (let attempt = 0; attempt < 40 && overlays.length === 0; attempt += 1) await new Promise((resolve) => setTimeout(resolve, 25));
+	const overlay = overlays[0];
+	assert.ok(overlay, "the overlay component was created");
+	assert.match(stripAnsi(overlay.render(80)[0]), /^╭─ ❀ Agents · 0 active · \d+ finished/);
+	assert.ok(overlay.render(80).map(stripAnsi).some((line) => /✓ explore/.test(line)), "the finished task is listed");
+	overlay.handleInput("\x1b");
+	await opened;
+});

--- a/tests/gentle-ai-renderer.test.ts
+++ b/tests/gentle-ai-renderer.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderGentleAiResult, GentleAiCallCard } from "../lib/gentle-ai-renderer.ts";
+import { stripAnsi } from "../lib/terminal-theme.ts";
+
+// Rose cards: exactly one component closes the frame in every state. While
+// a call runs, the call card draws the bottom rule (a partial result never
+// does); once the final result is in, the result card closes the frame.
+
+const plainTheme = { fg: (_color: string, text: string) => text };
+
+test("a running call card closes its own frame and a completed one leaves that to the result", () => {
+	const card = new GentleAiCallCard();
+	card.update("running", "review capture · reliability", plainTheme);
+	const running = card.render(60).map(stripAnsi);
+	assert.equal(running.length, 2);
+	assert.match(running[0], /^╭─ 🌹︎ Gentle AI · running · review capture · reliability ─*╮$/);
+	assert.match(running[1], /^╰─+╯$/);
+	card.update("preparing", "review status", plainTheme, "$ gentle-ai review status");
+	assert.match(card.render(60).map(stripAnsi)[2], /^╰─+╯$/);
+	card.update("completed", "review status", plainTheme, undefined, "ctrl+o to expand");
+	const completed = card.render(60).map(stripAnsi);
+	assert.equal(completed.length, 1);
+	assert.match(completed[0], /ctrl\+o to expand ╮$/);
+});
+
+test("a partial result draws no bottom rule and a final one draws exactly one", () => {
+	const partial = renderGentleAiResult({ content: [{ type: "text", text: "half" }] }, { expanded: false, isPartial: true }, plainTheme).render(60).map(stripAnsi);
+	assert.deepEqual(partial.map((line) => line.slice(0, 1)), ["│"], "only the count row, no closing rule");
+	const final = renderGentleAiResult({ content: [{ type: "text", text: "one\ntwo" }] }, { expanded: false }, plainTheme).render(60).map(stripAnsi);
+	assert.equal(final.length, 2);
+	assert.match(final[0], /^│ 2 lines +│$/);
+	assert.match(final[1], /^╰─+╯$/);
+	const empty = renderGentleAiResult({ content: [] }, { expanded: false }, plainTheme).render(60).map(stripAnsi);
+	assert.deepEqual(empty.map((line) => line.slice(0, 1)), ["╰"]);
+});
+
+test("promoting the shared state to finished invalidates after the render returns, never inside it", async () => {
+	const state: Record<string, unknown> = {};
+	let invalidations = 0;
+	const context = { state, invalidate: () => (invalidations += 1) };
+	renderGentleAiResult({ content: [{ type: "text", text: "done" }] }, { expanded: false }, plainTheme, context as never);
+	assert.equal(invalidations, 0, "no reentrant invalidate while rendering");
+	await new Promise((resolve) => queueMicrotask(() => resolve(undefined)));
+	assert.equal(invalidations, 1);
+	renderGentleAiResult({ content: [{ type: "text", text: "done" }] }, { expanded: false }, plainTheme, context as never);
+	await new Promise((resolve) => queueMicrotask(() => resolve(undefined)));
+	assert.equal(invalidations, 1, "an unchanged state does not invalidate again");
+});

--- a/tests/gentle-todo.test.ts
+++ b/tests/gentle-todo.test.ts
@@ -166,3 +166,17 @@ test("session_start replays the list from the branch, rpiv-todo results included
 	await fire("session_start", headless.ctx);
 	assert.equal(headless.widget(), undefined);
 });
+
+test("session_start drops a list that was already finished, so a reload never shows stale done work", async () => {
+	const { pi, fire } = fakePi();
+	gentleTodo(pi, {});
+	const finished = [
+		{ type: "message", message: { role: "user", content: "hi" } },
+		{ type: "message", message: { role: "toolResult", toolName: "todo", isError: false, details: { gentleTodo: { tasks: [{ id: 1, title: "Done A", status: "done" }, { id: 2, title: "Done B", status: "done" }], nextId: 3, updatedTurn: 1 } } } },
+	];
+	const { ctx, widget } = fakeContext(finished);
+	await fire("session_start", ctx);
+	assert.equal(widget(), undefined, "nothing to show after a reload of finished work");
+	const prompt = (await fire("before_agent_start", ctx, { systemPrompt: "base" })) as { systemPrompt: string } | undefined;
+	assert.equal(prompt, undefined, "and nothing is injected into the prompt");
+});

--- a/tests/gentle-todo.test.ts
+++ b/tests/gentle-todo.test.ts
@@ -70,6 +70,7 @@ function fakeContext(branch: unknown[] = [], hasUI = true) {
 test("todoEnabled and todoCollapseKey read their environment flags", () => {
 	assert.equal(todoEnabled({}), true);
 	assert.equal(todoEnabled({ GENTLE_PI_TODO: "0" }), false);
+	assert.equal(todoEnabled({ GENTLE_PI_AGENTS_CHILD: "1" }), false);
 	assert.equal(todoCollapseKey({}), "ctrl+shift+t");
 	assert.equal(todoCollapseKey({ GENTLE_PI_TODO_KEY: "alt+t" }), "alt+t");
 	assert.equal(todoCollapseKey({ GENTLE_PI_TODO_KEY: "off" }), undefined);

--- a/tests/quiet-tool-rendering.test.ts
+++ b/tests/quiet-tool-rendering.test.ts
@@ -1276,7 +1276,9 @@ test("quiet tool rendering respects command and env wrapper order", () => {
 	assertGenericBash(bash, command);
 });
 
-test("quiet tool rendering lets a final result promote a replayed call card to its outcome", () => {
+test("quiet tool rendering lets a final result promote a replayed call card to its outcome", async () => {
+	// The promotion invalidates after the render returns (a microtask), never inside it.
+	const flush = () => new Promise((resolve) => queueMicrotask(() => resolve(undefined)));
 	const { pi, tools } = createPi();
 	withEnv({ GENTLE_PI_QUIET_TOOLS: undefined }, () => quietTools(pi as any));
 	const tool = tools.get("bash");
@@ -1288,6 +1290,8 @@ test("quiet tool rendering lets a final result promote a replayed call card to i
 	const call = tool.renderCall({ command }, statusTheme, replayed);
 	assert.equal(cardTitle(renderToString(call)), "🌹︎ Gentle AI · preparing · review status");
 	renderToString(tool.renderResult(textResult("done"), { expanded: false, isPartial: false }, statusTheme, replayed));
+	assert.equal(invalidations, 0, "never reentrant");
+	await flush();
 	assert.equal(invalidations, 1);
 	const promoted = tool.renderCall({ command }, statusTheme, { ...replayed, lastComponent: call });
 	assert.strictEqual(promoted, call);
@@ -1295,9 +1299,11 @@ test("quiet tool rendering lets a final result promote a replayed call card to i
 	assert.equal(cardTone(renderToString(promoted)), "success");
 
 	renderToString(tool.renderResult(textResult("boom"), { expanded: false, isPartial: false }, statusTheme, { ...replayed, isError: true }));
+	await flush();
 	assert.equal(invalidations, 2);
 	assert.equal(cardTitle(renderToString(tool.renderCall({ command }, statusTheme, { ...replayed, lastComponent: call }))), "🌹︎ Gentle AI · failed · review status");
 	renderToString(tool.renderResult(textResult("boom"), { expanded: false, isPartial: false }, statusTheme, { ...replayed, isError: true }));
+	await flush();
 	assert.equal(invalidations, 2, "an unchanged outcome must not request another render");
 });
 

--- a/tests/shell-bar.test.ts
+++ b/tests/shell-bar.test.ts
@@ -135,6 +135,23 @@ test("renderShellBar appends extension statuses as trailing segments", () => {
 	assert.match(line, /⟡ 🔌 MCP: 3 servers enabled$/);
 });
 
+test("renderShellBar repaints extension statuses in the bar role, discarding colors the extension embedded", () => {
+	const tagged = { fg: (color: string, text: string) => `<${color}>${text}</${color}>`, bold: (text: string) => text };
+	const [line] = renderShellBar(model({ statuses: ["\x1b[38;2;255;0;0mMCP: 3/3 servers\x1b[0m"] }), tagged, 400);
+	assert.match(line, /<muted>MCP: 3\/3 servers<\/muted>$/);
+	assert.doesNotMatch(line, /\x1b\[/);
+});
+
+test("renderShellBar compacts the path and branch before it sacrifices an extension status", () => {
+	const long = model({ branch: "fix/shell-bar-status-ansi", dirty: 2, statuses: ["MCP: 3/3 servers"] });
+	const [full] = renderShellBar(long, plainTheme, 160);
+	assert.match(full, /~\/work\/gentle-pi fix\/shell-bar-status-ansi ±2 .* MCP: 3\/3 servers$/);
+	const [compact] = renderShellBar(long, plainTheme, 118);
+	assert.ok(visibleWidth(compact) <= 118, `line overflowed: ${visibleWidth(compact)}`);
+	assert.match(compact, /⟡ gentle-pi fix\/shell-bar-… ±2 ⟡/);
+	assert.match(compact, /MCP: 3\/3 servers$/);
+});
+
 test("renderShellBar drops the session name, then trailing segments, before truncating", () => {
 	const wide = model({ sessionName: "Release notes", statuses: ["MCP: 3 servers enabled"] });
 	const [atNinety] = renderShellBar(wide, plainTheme, 90);
@@ -145,6 +162,10 @@ test("renderShellBar drops the session name, then trailing segments, before trun
 	const [atFifty] = renderShellBar(wide, plainTheme, 50);
 	assert.ok(visibleWidth(atFifty) <= 50, `line overflowed: ${visibleWidth(atFifty)}`);
 	assert.match(atFifty, /^✿ gentle-pi/);
+});
+
+test("shellEnabled stays off inside a Gentle Agents child", () => {
+	assert.equal(shellEnabled({ GENTLE_PI_AGENTS_CHILD: "1" }), false);
 });
 
 test("shellEnabled honors GENTLE_PI_SHELL=0", () => {

--- a/tests/shell-changes-view.test.ts
+++ b/tests/shell-changes-view.test.ts
@@ -102,6 +102,10 @@ test("ChangesView scrolls the diff pane and shows an empty state for files witho
 	const plain = component.render(80).map(stripAnsi);
 	assert.doesNotMatch(plain[1], /@@/);
 	assert.match(plain[1], /\+line \d+/);
+	component.handleInput("\x0b");
+	assert.match(stripAnsi(component.render(80)[1]), /@@/, "ctrl+k scrolls back to the top");
+	component.handleInput("\x0a");
+	assert.doesNotMatch(stripAnsi(component.render(80)[1]), /@@/, "ctrl+j scrolls a page down");
 
 	const empty = view({ async loadDiff() { return ""; } });
 	await settle();

--- a/tests/shell-todo.test.ts
+++ b/tests/shell-todo.test.ts
@@ -141,6 +141,22 @@ test("renderTodoCard draws the framed list with status glyphs and keeps every li
 	assert.match(plain[4], /^╰─+╯$/);
 });
 
+test("renderTodoCard folds a long list: done tasks become one row and the open ones are capped", () => {
+	const tasks = Array.from({ length: 40 }, (_, index) => ({ title: `Task ${index + 1}`, status: index < 25 ? "done" : index === 25 ? "in_progress" : "pending" }));
+	const state = applyTodo(emptyTodo(), { action: "write", tasks }, 1).state;
+	const plain = renderTodoCard(state, plainTheme, 60, { collapsed: false, staleTurns: 0 }).map(stripAnsi);
+	assert.equal(plain.length, 14, "top rule, twelve rows, bottom rule");
+	assert.match(plain[0], /Todos · 25 of 40/);
+	assert.match(plain[1], /^│ ✓ 25 done +│$/);
+	assert.match(plain[2], /^│ ◐ Task 26 +│$/);
+	assert.match(plain[11], /^│ ○ Task 35 +│$/);
+	assert.match(plain[12], /^│ … 5 more +│$/);
+	const allDone = applyTodo(emptyTodo(), { action: "write", tasks: tasks.map((task) => ({ ...task, status: "done" })) }, 1).state;
+	const folded = renderTodoCard(allDone, plainTheme, 60, { collapsed: false, staleTurns: 0 }).map(stripAnsi);
+	assert.equal(folded.length, 3);
+	assert.match(folded[1], /^│ ✓ 40 done +│$/);
+});
+
 test("renderTodoCard marks a stale list in the top rule and collapses to the task in progress", () => {
 	const stale = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
 	assert.match(stale[0], /^╭─ ❀ Todos · 1 of 3 ─+ stale · 2 turns ╮$/);


### PR DESCRIPTION
Closes #606

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Gentle Agents replaces `pi-subagents-j0k3r`: every subagent is an isolated `pi --mode rpc` child, the host applies small deltas to a bounded per-task thread and notifies only that task's listeners, so long sessions never freeze.
- Same `subagent_*` tool names, agent markdown, and `subagents.json`; with the background policy on, delegations default to background and results come back to the model as `gentle-agents.result` messages drawn as rose cards.
- Gentle Shell card (agent, one-line label, model · tokens · cost · time), overlay (`/gentle:agents`, `alt+a`, `ctrl+j`/`ctrl+k` scroll), on-disk history with retention, markdown transcripts; plus the MCP status fix in the bar, rose cards closing their frame while running, and todo lists that fold and clear on reload.

## Changes

| File | Change |
|------|--------|
| `lib/agents-config.ts` | Agent markdown definitions and `subagents.json` parsing, profile resolution |
| `lib/agents-protocol.ts` | RPC deltas, bounded thread, per-task store, usage accumulation |
| `lib/agents-runner.ts` | Isolated `pi --mode rpc` children, watchdogs, dialogs, steer/cancel, spawn error containment |
| `lib/agents-widget.ts` | The agents card |
| `lib/agents-view.ts`, `lib/agents-history.ts`, `lib/agents-transcript.ts` | Overlay, JSON history with retention, markdown transcripts |
| `extensions/gentle-agents.ts` | Tools, card, command and shortcuts, background result delivery, legacy-package guard |
| `assets/orchestrator-delegation.md` | Background by default with completion messages when the policy is on |
| `lib/shell-bar.ts` | Extension statuses repainted; location compacts before statuses drop |
| `lib/gentle-ai-renderer.ts` | Running call card closes the frame; deferred invalidate (no duplicated result rows) |
| `lib/shell-todo.ts`, `extensions/gentle-todo.ts` | Finished lists dropped on reload; long lists fold |
| `lib/shell-changes-view.ts` | `ctrl+j`/`ctrl+k` scrolling |
| `README.md` | Gentle Agents section, key hints, retired package removed |
| `tests/*` | Unit tests for every module plus a fake rpc child |

## Review budget

Single `size:exception` PR at the maintainer's request; twelve work-unit commits, each with its tests. Native review (RDD) ran on both candidates: the runner gained spawn-error containment from one CRITICAL finding, and both lineages were approved and acknowledged.

## Test Plan

- [x] `pnpm test` (1372 pass, 0 fail)
- [x] Manually tested: five parallel subagents, background delivery, the overlay, transcripts, MCP status in the bar
- [x] Docs updated

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gentle Agents for running isolated subagents in the background or interactively.
  * Added task status tracking, persistence across restarts, cancellation, messaging, result notifications, and transcript viewing.
  * Added an in-app agents card and task overlay with controls and configurable agent/model profiles.

* **Documentation**
  * Updated installation, delegation, background-policy, configuration, and keyboard shortcut guidance.

* **Bug Fixes**
  * Improved shell-bar layout and terminal-text handling.
  * Cleared completed todo lists on reload and capped expanded todo display.
  * Added `ctrl+j`/`ctrl+k` diff scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->