### PR TITLE
fix(review): accept collect and execute as v2 status root actions

### DIFF
--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -79,7 +79,10 @@ const RISK_LEVELS = ["low", "medium", "high"] as const;
 const REVIEW_LENSES = ["review-risk", "review-resilience", "review-readability", "review-reliability"] as const;
 const RISK_REASON_CODES = ["configuration_change", "empty_content", "executable_change", "executable_mode", "hot_path", "large_change", "non_executable_only", "process_boundary", "process_scan_limit", "service_token", "shell_source"] as const;
 const RISK_SIGNALS = ["auth", "update", "security", "payments", "permissions", "shell_process"] as const;
-const STATUS_ACTIONS = ["start", "recover", "maintainer_action", "select_lineage", "repair_authority", "stop"] as const;
+// "collect" and "execute" are the v2 envelope's projection of a live
+// transaction whose next_transition is mandatory: the root action names the
+// transition kind instead of reading as a terminal stop.
+const STATUS_ACTIONS = ["start", "recover", "maintainer_action", "select_lineage", "repair_authority", "stop", "collect", "execute"] as const;
 const RECEIPT_STATUSES = ["expected_missing", "present", "publication_pending", "not_applicable"] as const;
 type ReviewReceiptStatus = (typeof RECEIPT_STATUSES)[number];
 export const REVIEW_STATUS_ACTION_DISPOSITION = {

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -80,7 +80,10 @@ const RISK_LEVELS = ["low", "medium", "high"]         ;
 const REVIEW_LENSES = ["review-risk", "review-resilience", "review-readability", "review-reliability"]         ;
 const RISK_REASON_CODES = ["configuration_change", "empty_content", "executable_change", "executable_mode", "hot_path", "large_change", "non_executable_only", "process_boundary", "process_scan_limit", "service_token", "shell_source"]         ;
 const RISK_SIGNALS = ["auth", "update", "security", "payments", "permissions", "shell_process"]         ;
-const STATUS_ACTIONS = ["start", "recover", "maintainer_action", "select_lineage", "repair_authority", "stop"]         ;
+// "collect" and "execute" are the v2 envelope's projection of a live
+// transaction whose next_transition is mandatory: the root action names the
+// transition kind instead of reading as a terminal stop.
+const STATUS_ACTIONS = ["start", "recover", "maintainer_action", "select_lineage", "repair_authority", "stop", "collect", "execute"]         ;
 const RECEIPT_STATUSES = ["expected_missing", "present", "publication_pending", "not_applicable"]         ;
 
 export const REVIEW_STATUS_ACTION_DISPOSITION = {

--- a/tests/review-integration-v2.test.ts
+++ b/tests/review-integration-v2.test.ts
@@ -711,6 +711,11 @@ test("status enforces authority/frozen/receipt conditionals and decodes the requ
 	const decoded = decodeReviewStatusV3(current);
 	assert.equal(decoded.repair.status, "unsupported");
 	assert.equal(decoded.authority?.state, "reviewing");
+	for (const action of ["collect", "execute"]) {
+		const projected = clone(current);
+		projected.action = action;
+		assert.equal(decodeReviewStatusV3(projected).action, action, "a live transaction's root action names its mandated transition kind");
+	}
 
 	const missingAuthority = clone(current);
 	delete missingAuthority.authority;


### PR DESCRIPTION
Closes #611

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Mirror of Gentleman-Programming/gentle-ai#3928: the v2 status envelope's root `action` gains `collect` and `execute` for live transactions with a mandatory `next_transition`.
- The strict decoder in `lib/review-integration-v2.ts` accepts both values; routing keeps following `next_transition` as the contract mandates.

## Changes

| File | Change |
|------|--------|
| `lib/review-integration-v2.ts` | `STATUS_ACTIONS` gains `collect`, `execute` |
| `tests/review-integration-v2.test.ts` | Decodes a live status with each new value |

## Test Plan

- [x] `pnpm test` (1372 pass)
- [x] Native review (RDD) approved and acknowledged

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `collect` and `execute` status actions representing live transaction transitions.
  * These actions now participate in status handling alongside existing transaction actions, with continuation information supplied through the transition details.

* **Tests**
  * Added coverage confirming that live transaction actions correctly identify their required transition type.
  * Verified decoding behavior for both `collect` and `execute` actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->