### PR TITLE
fix(review): declare the relay handshake in the session environment

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1,3 +1,4 @@
+import { declareReviewRelayHandshake } from "../lib/review-relay-contract.ts";
 import { execFileSync } from "node:child_process";
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import {
@@ -5824,6 +5825,10 @@ export interface GentleAiRuntimeDependencies {
 	// sleep and without relying on the queued cleanup macrotask firing.
 	now?: () => number;
 	scheduleTimer?: (callback: () => void, delayMs: number) => { unref: () => void };
+	// The environment the session's child processes inherit; tests inject a
+	// plain object so the handshake declaration is observable without
+	// touching the test runner's own process.env.
+	processEnv?: NodeJS.ProcessEnv;
 }
 
 export function createGentleAiExtension(dependencies: GentleAiRuntimeDependencies = {}): (pi: ExtensionAPI) => void {
@@ -5839,6 +5844,7 @@ function createGentleAiExtensionForTesting(
 	const reviewConsentScheduleTimer = dependencies.scheduleTimer ?? ((callback, delayMs) => setTimeout(callback, delayMs));
 	const pendingReviewConsentRegistry = dependencies.pendingReviewConsentRegistry ?? processPendingReviewConsentRegistry;
 	return function gentleAi(pi: ExtensionAPI): void {
+	declareReviewRelayHandshake(dependencies.processEnv ?? process.env);
 	const pendingReviewConsentFallbackKey = Symbol("pending-review-consent-fallback");
 	const candidateViews = dependencies.candidateViews === undefined ? new CandidateViewRegistry() : dependencies.candidateViews;
 	const herdrLifecycle = createHerdrConfirmationLifecycle(pi.events);

--- a/lib/review-relay-contract.ts
+++ b/lib/review-relay-contract.ts
@@ -14,3 +14,14 @@
 
 export const GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV = "GENTLE_PI_REVIEW_RELAY_CONTRACT";
 export const GENTLE_PI_REVIEW_RELAY_CONTRACT = "gentle-pi.review-relay/v1";
+
+// The host is this extension: every process the session starts (pi's shell
+// tools, Gentle Agents children) runs under it, so the handshake belongs in
+// the session environment too, not only in the extension's own invocations.
+// Without it the first `gentle-ai review status --agent pi` typed in the
+// session shell fails closed (gentle-pi#550). Returns whether anything changed.
+export function declareReviewRelayHandshake(env: NodeJS.ProcessEnv): boolean {
+	if (env[GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV] === GENTLE_PI_REVIEW_RELAY_CONTRACT) return false;
+	env[GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV] = GENTLE_PI_REVIEW_RELAY_CONTRACT;
+	return true;
+}

--- a/runtime/review-relay-contract.mjs
+++ b/runtime/review-relay-contract.mjs
@@ -15,3 +15,14 @@
 
 export const GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV = "GENTLE_PI_REVIEW_RELAY_CONTRACT";
 export const GENTLE_PI_REVIEW_RELAY_CONTRACT = "gentle-pi.review-relay/v1";
+
+// The host is this extension: every process the session starts (pi's shell
+// tools, Gentle Agents children) runs under it, so the handshake belongs in
+// the session environment too, not only in the extension's own invocations.
+// Without it the first `gentle-ai review status --agent pi` typed in the
+// session shell fails closed (gentle-pi#550). Returns whether anything changed.
+export function declareReviewRelayHandshake(env                   )          {
+	if (env[GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV] === GENTLE_PI_REVIEW_RELAY_CONTRACT) return false;
+	env[GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV] = GENTLE_PI_REVIEW_RELAY_CONTRACT;
+	return true;
+}

--- a/tests/native-review-parity-runtime.test.ts
+++ b/tests/native-review-parity-runtime.test.ts
@@ -178,7 +178,11 @@ test("registered gentle_review surfaces the package-pinned Pi transport refusal 
 		return { ...command, signal: null, timedOut: false, outputLimitExceeded: false };
 	});
 	const tools = new Map<string, RegisteredController>();
-	createGentleAiExtension({ nativeReviewCli: native, candidateViews } as Parameters<typeof createGentleAiExtension>[0])({
+	// The extension declares the relay handshake in the session environment on
+	// load (gentle-pi#550). This runner spawns the pinned binary with the test
+	// process environment and must keep observing the handshake-less refusal,
+	// so the declaration goes to a throwaway environment here.
+	createGentleAiExtension({ nativeReviewCli: native, candidateViews, processEnv: {} } as Parameters<typeof createGentleAiExtension>[0])({
 		on() {},
 		registerTool(definition: RegisteredController & { name: string }) { tools.set(definition.name, definition); },
 		registerCommand() {},

--- a/tests/review-relay-contract.test.ts
+++ b/tests/review-relay-contract.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import { declareReviewRelayHandshake, GENTLE_PI_REVIEW_RELAY_CONTRACT, GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV } from "../lib/review-relay-contract.ts";
+
+// gentle-pi#550: the session shell must inherit the relay handshake, so a
+// `gentle-ai review ... --agent pi` typed in a shell tool is eligible without
+// the operator reading package source for the value.
+
+test("declareReviewRelayHandshake exports the exact contract and reports whether it changed anything", () => {
+	const env: NodeJS.ProcessEnv = {};
+	assert.equal(declareReviewRelayHandshake(env), true);
+	assert.equal(env[GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV], GENTLE_PI_REVIEW_RELAY_CONTRACT);
+	assert.equal(declareReviewRelayHandshake(env), false, "already declared");
+	const stale: NodeJS.ProcessEnv = { [GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV]: "gentle-pi.review-relay/v0" };
+	assert.equal(declareReviewRelayHandshake(stale), true, "a wrong value is replaced: this extension is the host");
+	assert.equal(stale[GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV], GENTLE_PI_REVIEW_RELAY_CONTRACT);
+});
+
+test("loading the extension declares the handshake in the session environment", () => {
+	const processEnv: NodeJS.ProcessEnv = { PATH: "/bin" };
+	createGentleAiExtension({ nativeReviewCli: null, processEnv })({ on() {}, registerTool() {}, registerCommand() {} } as unknown as ExtensionAPI);
+	assert.equal(processEnv[GENTLE_PI_REVIEW_RELAY_CONTRACT_ENV], GENTLE_PI_REVIEW_RELAY_CONTRACT);
+	assert.equal(processEnv.PATH, "/bin");
+});


### PR DESCRIPTION
Closes #550

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- The extension now declares `GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1` in the session environment on load, so pi's shell tools and Gentle Agents children inherit it and a `gentle-ai review … --agent pi` typed in the session shell is eligible.
- The other half (a self-describing refusal cause) landed in gentle-ai#4206.

## Changes

| File | Change |
|------|--------|
| `lib/review-relay-contract.ts` | `declareReviewRelayHandshake(env)` |
| `extensions/gentle-ai.ts` | Declare on load; `processEnv` test seam |
| `runtime/review-relay-contract.mjs` | Regenerated |
| `tests/review-relay-contract.test.ts` | Declaration and extension-load coverage |
| `tests/native-review-parity-runtime.test.ts` | Throwaway environment so the pinned binary still observes the handshake-less refusal |

## Test Plan

- [x] `pnpm test` (1374 pass)
- [x] `node scripts/build-runtime-modules.mjs --check`
- [x] Native review (RDD) approved and acknowledged

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M