### PR TITLE
fix(review): accept capture-result collect inputs without changed_path_manifest

### DIFF
--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -1642,8 +1642,11 @@ function decodeCollectInput(value: unknown, label: string, v5: boolean, v6: bool
 	}
 
 	if (captureOperation === "review.capture-result") {
-		if (input.artifact_subject === undefined || input.base_tree === undefined || input.candidate_tree === undefined || input.changed_path_manifest === undefined) {
-			throw new TypeError(`${label} requires artifact_subject, base_tree, candidate_tree, and changed_path_manifest`);
+		// changed_path_manifest is optional here: the artifact subject's
+		// changed_path_manifest_sha256 already binds the frozen manifest, and
+		// gentle-ai stops inlining one copy per lens (gentle-ai#3922).
+		if (input.artifact_subject === undefined || input.base_tree === undefined || input.candidate_tree === undefined) {
+			throw new TypeError(`${label} requires artifact_subject, base_tree, and candidate_tree`);
 		}
 		if (schema !== "https://gentle-ai.dev/schema/review/reviewer/v1") throw new TypeError(`${label}.schema must be https://gentle-ai.dev/schema/review/reviewer/v1`);
 	} else if (input.artifact_subject !== undefined || input.base_tree !== undefined || input.candidate_tree !== undefined || input.changed_path_manifest !== undefined) {

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -1643,8 +1643,11 @@ function decodeCollectInput(value         , label        , v5         , v6      
 	}
 
 	if (captureOperation === "review.capture-result") {
-		if (input.artifact_subject === undefined || input.base_tree === undefined || input.candidate_tree === undefined || input.changed_path_manifest === undefined) {
-			throw new TypeError(`${label} requires artifact_subject, base_tree, candidate_tree, and changed_path_manifest`);
+		// changed_path_manifest is optional here: the artifact subject's
+		// changed_path_manifest_sha256 already binds the frozen manifest, and
+		// gentle-ai stops inlining one copy per lens (gentle-ai#3922).
+		if (input.artifact_subject === undefined || input.base_tree === undefined || input.candidate_tree === undefined) {
+			throw new TypeError(`${label} requires artifact_subject, base_tree, and candidate_tree`);
 		}
 		if (schema !== "https://gentle-ai.dev/schema/review/reviewer/v1") throw new TypeError(`${label}.schema must be https://gentle-ai.dev/schema/review/reviewer/v1`);
 	} else if (input.artifact_subject !== undefined || input.base_tree !== undefined || input.candidate_tree !== undefined || input.changed_path_manifest !== undefined) {

--- a/tests/review-integration-v2.test.ts
+++ b/tests/review-integration-v2.test.ts
@@ -700,6 +700,22 @@ test("v5 targeted-validator collect inputs carry the exact provider-owned valida
 	assert.throws(() => decodeReviewNextTransitionV3(weakenedRequest, { v5: true }), /policy_content/);
 });
 
+test("a capture-result collect input decodes without changed_path_manifest, which the artifact subject digest already binds", () => {
+	const status = fixture<JsonObject>("status.fixture.json");
+	const transition = clone((status.next_transition ?? {}) as JsonObject);
+	const inputs = ((transition.collect as JsonObject | undefined)?.inputs ?? []) as JsonObject[];
+	const captureInput = inputs.find((input) => input.capture_operation === "review.capture-result");
+	assert.ok(captureInput, "the status fixture carries a capture-result collect input");
+	assert.doesNotThrow(() => decodeReviewNextTransitionV3(transition, { v5: true, v6: true }), "with the manifest");
+	delete captureInput.changed_path_manifest;
+	const decoded = decodeReviewNextTransitionV3(transition, { v5: true, v6: true });
+	const decodedInput = decoded.collect?.inputs.find((input) => input.captureOperation === "review.capture-result");
+	assert.ok(decodedInput?.artifactSubject?.changedPathManifestSha256, "the digest on the artifact subject is the binding");
+	assert.equal(decodedInput?.changedPathManifest, undefined);
+	delete captureInput.artifact_subject;
+	assert.throws(() => decodeReviewNextTransitionV3(transition, { v5: true, v6: true }), /requires artifact_subject, base_tree, and candidate_tree/);
+});
+
 test("status enforces authority/frozen/receipt conditionals and decodes the required repair field", () => {
 	const current = devFixture<JsonObject>("status-v5-repository-context.captured.json");
 	delete current.receipt;


### PR DESCRIPTION
Closes #615

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- First half of the fix for gentle-ai#3922 / #543 (STATUS payload scaling with the changed-path manifest per lens): the decoder accepts a `review.capture-result` collect input without `changed_path_manifest`. The artifact subject's `changed_path_manifest_sha256` is the binding.
- Backward compatible: inputs that still carry the manifest decode as before. The gentle-ai side (stop inlining) follows in a separate PR.

## Changes

| File | Change |
|------|--------|
| `lib/review-integration-v2.ts` | Manifest optional on capture-result collect inputs |
| `runtime/review-integration-v2.mjs` | Regenerated |
| `tests/review-integration-v2.test.ts` | Decodes with and without the manifest; still requires the subject and trees |

## Test Plan

- [x] `pnpm test` (1375 pass)
- [x] `node scripts/build-runtime-modules.mjs --check`
- [x] Native review (RDD) approved and acknowledged

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M