### PR TITLE
fix(review): accept status/v6 and later for the intended-untracked selection

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -4632,8 +4632,18 @@ function exactCollectArgument(input: ReviewCollectInputV3, name: string): string
 	return matches.length === 1 ? matches[0]!.value : undefined;
 }
 
+// The intended-untracked collect input arrived with status/v6 and every later
+// status version keeps it; matching one exact version left every workspace
+// with untracked files unable to start a review once gentle-ai answered v7
+// (gentle-pi#610, gentle-ai#4187).
+const INTENDED_UNTRACKED_STATUS_SCHEMA = /^gentle-ai\.review-integration\.status\/v(\d+)$/;
+function statusCarriesIntendedUntrackedSelection(schema: unknown): boolean {
+	const match = typeof schema === "string" ? INTENDED_UNTRACKED_STATUS_SCHEMA.exec(schema) : null;
+	return match !== null && Number(match[1]) >= 6;
+}
+
 function reviewIntendedUntrackedInput(status: ReviewStatusV3): ReviewCollectInputV3 | undefined {
-	if (status.raw.schema !== "gentle-ai.review-integration.status/v6" || status.nextTransition?.kind !== "collect") return undefined;
+	if (!statusCarriesIntendedUntrackedSelection(status.raw.schema) || status.nextTransition?.kind !== "collect") return undefined;
 	const matches = (status.nextTransition.collect?.inputs ?? []).filter((input) => {
 		const value = input.submission?.values[0];
 		return input.name === "intended_untracked_selection" && input.schema === "gentle-ai.review-intended-untracked-selection/v1" && input.captureOperation === "external.select_intended_untracked" && input.submission?.operationToken === "status" && input.submission.values.length === 1 && value?.slot === "intended_untracked_selection" && value.domain === "schema_bound_json";

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -722,7 +722,7 @@ test("ordinary START binds the native workspace candidate and returns the native
 	assert.equal(startCalls, 1);
 });
 
-test("pre-lineage intended-untracked selection revalidates and starts at an explicit workspace root", async (t) => {
+for (const statusSchema of ["gentle-ai.review-integration.status/v6", "gentle-ai.review-integration.status/v7"]) test(`pre-lineage intended-untracked selection revalidates and starts at an explicit workspace root (${statusSchema})`, async (t) => {
 	const cwd = realpathSync(repository(t)), sessionCwd = repository(t), eligible = "selected.md";
 	writeFileSync(join(cwd, eligible), "selected\n");
 	const initialTarget = startStatus(cwd), target = startStatus(cwd, undefined, [eligible]);
@@ -735,7 +735,7 @@ test("pre-lineage intended-untracked selection revalidates and starts at an expl
 		],
 		submission: { operationToken: "status", argumentTokens: ["--contract=gentle-ai.review-integration/v2", "--next-transition=true", "--agent=pi", "--projection=workspace", "--intended-untracked-selection={{value}}"], values: [{ slot: "intended_untracked_selection", domain: "schema_bound_json", schema: "gentle-ai.review-intended-untracked-selection/v1", substitutionLocation: 4 }] },
 	};
-	const initial = { ...initialTarget, nextTransition: { kind: "collect", reasonCode: "intended_untracked_selection_required", collect: { inputs: [selection] } }, raw: { schema: "gentle-ai.review-integration.status/v6" } } as ReviewStatusV3;
+	const initial = { ...initialTarget, nextTransition: { kind: "collect", reasonCode: "intended_untracked_selection_required", collect: { inputs: [selection] } }, raw: { schema: statusSchema } } as ReviewStatusV3;
 	const requests: Array<Record<string, unknown>> = [], starts: Array<Record<string, unknown>> = [], retained = new Map();
 	const native = {
 		reviewMode: async () => ({ operation: "status", scope: "clone", status: { global: "on", cloneLocal: "on", effective: "on", source: "clone_local" } }),


### PR DESCRIPTION
Closes #610

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- `reviewIntendedUntrackedInput` matched `gentle-ai.review-integration.status/v6` exactly; gentle-ai main answers `status/v7`, so the intended-untracked selection binding was never found: every workspace with untracked files could not start a review from Pi, and `inspect` reported `intended_untracked_selection_required` without its binding (gentle-ai#4187 has the same root).
- The selection is now recognized on status/v6 and every later version; the routing test runs for both.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Version floor instead of an exact schema match |
| `tests/review-controller-native-routing.test.ts` | Pre-lineage selection test parametrized over v6 and v7 |

## Test Plan

- [x] `pnpm test` (1376 pass)
- [x] Native review (RDD) approved and acknowledged

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reviews with untracked files now start successfully when using status schema version 6 or newer.
  * Improved compatibility with newer review status versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->