### PR TITLE
fix(review): accept the frozen manifest digest in status.frozen

### DIFF
--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -388,6 +388,8 @@ export interface ReviewStatusFrozenV1 {
 	tier: RiskLevel;
 	originalChangedLines: number;
 	correctionBudget: number;
+	/** Digest of the frozen changed-path manifest; binds manifest-less capture inputs (gentle-ai#3922). */
+	changedPathManifestSha256?: string;
 }
 
 export interface ReviewStatusReconciliationV1 {
@@ -1823,11 +1825,12 @@ export function decodeReviewStatusV3(value: unknown): ReviewStatusV3 {
 
 	let frozen: ReviewStatusFrozenV1 | undefined;
 	if (body.frozen !== undefined) {
-		const source = exactRecord(body.frozen, "status.frozen", ["tier", "original_changed_lines", "correction_budget"]);
+		const source = exactRecord(body.frozen, "status.frozen", ["tier", "original_changed_lines", "correction_budget"], ["changed_path_manifest_sha256"]);
 		frozen = {
 			tier: enumeration(source.tier, RISK_LEVELS, "status.frozen.tier"),
 			originalChangedLines: integer(source.original_changed_lines, "status.frozen.original_changed_lines"),
 			correctionBudget: integer(source.correction_budget, "status.frozen.correction_budget", 0, 200),
+			...(source.changed_path_manifest_sha256 === undefined ? {} : { changedPathManifestSha256: sha256(source.changed_path_manifest_sha256, "status.frozen.changed_path_manifest_sha256") }),
 		};
 	}
 	if (authority?.version === REVIEW_AUTHORITY_VERSION.COMPACT_V2 && frozen === undefined) throw new TypeError("compact-v2 status requires frozen metadata");

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -410,6 +410,8 @@ const REPOSITORY_CONTEXT_OUTCOMES = ["applied", "pending", "blocked_conflict", "
 
 
 
+
+
 // Provider-owned completing form for a host-mediated capture slot
 // (gentle-pi#311 P4). The provider issues the exact operation and argument
 // tokens that submit the captured bytes; the host substitutes only the
@@ -1824,11 +1826,12 @@ export function decodeReviewStatusV3(value         )                 {
 
 	let frozen                                  ;
 	if (body.frozen !== undefined) {
-		const source = exactRecord(body.frozen, "status.frozen", ["tier", "original_changed_lines", "correction_budget"]);
+		const source = exactRecord(body.frozen, "status.frozen", ["tier", "original_changed_lines", "correction_budget"], ["changed_path_manifest_sha256"]);
 		frozen = {
 			tier: enumeration(source.tier, RISK_LEVELS, "status.frozen.tier"),
 			originalChangedLines: integer(source.original_changed_lines, "status.frozen.original_changed_lines"),
 			correctionBudget: integer(source.correction_budget, "status.frozen.correction_budget", 0, 200),
+			...(source.changed_path_manifest_sha256 === undefined ? {} : { changedPathManifestSha256: sha256(source.changed_path_manifest_sha256, "status.frozen.changed_path_manifest_sha256") }),
 		};
 	}
 	if (authority?.version === REVIEW_AUTHORITY_VERSION.COMPACT_V2 && frozen === undefined) throw new TypeError("compact-v2 status requires frozen metadata");

--- a/tests/review-integration-v2.test.ts
+++ b/tests/review-integration-v2.test.ts
@@ -700,6 +700,24 @@ test("v5 targeted-validator collect inputs carry the exact provider-owned valida
 	assert.throws(() => decodeReviewNextTransitionV3(weakenedRequest, { v5: true }), /policy_content/);
 });
 
+test("status.frozen carries the optional frozen manifest digest", () => {
+	const current = devFixture<JsonObject>("status-v5-repository-context.captured.json");
+	delete current.receipt;
+	if (current.action === "finalize") {
+		current.action = "stop";
+		delete current.next_transition;
+		delete current.forecast;
+	}
+	assert.equal(typeof (current.frozen as JsonObject | undefined)?.tier, "string", "the captured status carries frozen");
+	const digest = `sha256:${"ab".repeat(32)}`;
+	(current.frozen as JsonObject).changed_path_manifest_sha256 = digest;
+	assert.equal(decodeReviewStatusV3(current).frozen?.changedPathManifestSha256, digest);
+	(current.frozen as JsonObject).changed_path_manifest_sha256 = "not-a-digest";
+	assert.throws(() => decodeReviewStatusV3(current), /changed_path_manifest_sha256/);
+	delete (current.frozen as JsonObject).changed_path_manifest_sha256;
+	assert.equal(decodeReviewStatusV3(current).frozen?.changedPathManifestSha256, undefined);
+});
+
 test("a capture-result collect input decodes without changed_path_manifest, which the artifact subject digest already binds", () => {
 	const status = fixture<JsonObject>("status.fixture.json");
 	const transition = clone((status.next_transition ?? {}) as JsonObject);


### PR DESCRIPTION
Closes #620

## Summary
- `status.frozen` may now carry `changed_path_manifest_sha256`, the digest gentle-ai publishes so manifest-less capture inputs stay bound to the frozen candidate (gentle-ai#3922).
- The decoder validates it as a sha256 digest and exposes it as `changedPathManifestSha256`; envelopes without it decode exactly as before.
- Must land before the gentle-ai side so a newer core never trips the exact-record check.

| File | Change |
|------|--------|
| `lib/review-integration-v2.ts` | optional key on `ReviewStatusFrozenV1` and in the `status.frozen` decoder |
| `runtime/review-integration-v2.mjs` | regenerated mirror |
| `tests/review-integration-v2.test.ts` | decodes the digest, refuses a malformed one, tolerates its absence |

## Test plan
- [x] `pnpm test`: 1377 pass, 0 fail
- [x] Native review approved and acknowledged (lineage review-75ab23a4052f304f, four lenses, no correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M