### PR TITLE
fix(agents): clear the finished row of the Agents card on an idle terminal

### DIFF
--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -11,7 +11,7 @@ import { AgentRunner, piCommand, type AskAnswer, type RunnerDeps, type TaskReque
 import { historyDir, loadHistory, loadStoredTask, pruneHistory, saveTask } from "../lib/agents-history.ts";
 import { sessionToMarkdown } from "../lib/agents-transcript.ts";
 import { AgentsView } from "../lib/agents-view.ts";
-import { AGENTS_GLYPH, renderAgentsCard } from "../lib/agents-widget.ts";
+import { AGENTS_GLYPH, renderAgentsCard, widgetExpiryMs } from "../lib/agents-widget.ts";
 import { CARD_TONE, renderCard } from "../lib/shell-card.ts";
 import { openInExternalEditor } from "./gentle-shell.ts";
 
@@ -177,16 +177,26 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		}, RENDER_COALESCE_MS);
 	};
 
-	// The elapsed column ticks once a second, and only while something runs.
+	// The elapsed column ticks once a second while something runs. Once every
+	// task is done, one frame is due when the next finished row leaves the
+	// card, so an idle terminal still sees it clear.
 	const tickClock = () => {
 		cancelClock?.();
 		cancelClock = undefined;
-		if (store.list().some((task) => !isFinished(task.status))) {
+		const tasks = store.list();
+		if (tasks.some((task) => !isFinished(task.status))) {
 			cancelClock = deps.schedule(() => {
 				requestRender();
 				tickClock();
 			}, CLOCK_TICK_MS);
+			return;
 		}
+		const expiry = widgetExpiryMs(tasks, deps.now());
+		if (expiry === undefined) return;
+		cancelClock = deps.schedule(() => {
+			host?.requestRender();
+			tickClock();
+		}, expiry);
 	};
 
 	// A finished task goes to disk once, after its child is gone; the history

--- a/lib/agents-widget.ts
+++ b/lib/agents-widget.ts
@@ -71,10 +71,20 @@ function clip(text: string, width: number): string {
 export function widgetTasks(tasks: readonly TaskRecord[], now: number): TaskRecord[] {
 	const active = tasks.filter((task) => !isFinished(task.status));
 	const finished = tasks
-		.filter((task) => isFinished(task.status) && task.endedAt !== null && now - task.endedAt <= FINISHED_TTL_MS)
+		.filter((task) => isFinished(task.status) && task.endedAt !== null && now - task.endedAt < FINISHED_TTL_MS)
 		.sort((a, b) => (b.endedAt ?? 0) - (a.endedAt ?? 0))
 		.slice(0, MAX_FINISHED);
 	return [...active, ...finished].sort((a, b) => (a.startedAt ?? a.createdAt) - (b.startedAt ?? b.createdAt));
+}
+
+// How long until the next finished row leaves the card, or undefined when no
+// shown row is waiting to expire. The host asks for exactly one frame at that
+// moment instead of ticking while the terminal is idle.
+export function widgetExpiryMs(tasks: readonly TaskRecord[], now: number): number | undefined {
+	const deadlines = widgetTasks(tasks, now)
+		.filter((task) => isFinished(task.status) && task.endedAt !== null)
+		.map((task) => (task.endedAt ?? now) + FINISHED_TTL_MS - now);
+	return deadlines.length === 0 ? undefined : Math.max(1, Math.min(...deadlines));
 }
 
 function elapsed(task: TaskRecord, now: number): string {

--- a/tests/agents-widget.test.ts
+++ b/tests/agents-widget.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { TASK_STATUS, type TaskRecord } from "../lib/agents-protocol.ts";
-import { formatElapsed, renderAgentsCard, widgetTasks } from "../lib/agents-widget.ts";
+import { formatElapsed, renderAgentsCard, widgetExpiryMs, widgetTasks } from "../lib/agents-widget.ts";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 
 // Gentle Agents widget: the card above the editor that shows what the
@@ -31,6 +31,16 @@ test("widgetTasks keeps active tasks in start order and only recently finished o
 	];
 	assert.deepEqual(widgetTasks(tasks, 100_000).map((entry) => entry.id), ["new-done", "running", "queued"]);
 	assert.deepEqual(widgetTasks([], 100_000), []);
+});
+
+test("widgetExpiryMs says how long until the next finished row leaves the card", () => {
+	const running = task({ id: "running", createdAt: 2000, startedAt: 2000 });
+	const done = task({ id: "done", status: TASK_STATUS.COMPLETED, endedAt: 95_000 });
+	const later = task({ id: "later", status: TASK_STATUS.COMPLETED, endedAt: 99_000 });
+	assert.equal(widgetExpiryMs([running, done, later], 100_000), 55_000, "the oldest shown row expires first");
+	assert.equal(widgetExpiryMs([done], 155_000), undefined, "a row past its minute is already gone");
+	assert.equal(widgetExpiryMs([running], 100_000), undefined, "active rows never expire");
+	assert.equal(widgetExpiryMs([], 100_000), undefined);
 });
 
 test("renderAgentsCard draws columns for agent, task, and model · tokens · cost · time, with the batch time in the rule", () => {

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -51,7 +51,7 @@ function fakePi() {
 	return { pi, tools, shortcuts, commands, fire, sent, renderers };
 }
 
-function fakeContext() {
+function fakeContext(tui: { requestRender(): void } = fakeTui) {
 	const widgets = new Map<string, (tui: unknown, theme: unknown) => { render(width: number): string[] }>();
 	const dialogs: string[] = [];
 	const overlays: Array<{ render(width: number): string[]; handleInput(data: string): void }> = [];
@@ -86,7 +86,7 @@ function fakeContext() {
 	} as unknown as ExtensionContext;
 	const widget = () => {
 		const factory = widgets.get("gentle-agents");
-		return factory ? factory(fakeTui, plainTheme).render(72).map(stripAnsi) : undefined;
+		return factory ? factory(tui, plainTheme).render(72).map(stripAnsi) : undefined;
 	};
 	return { ctx, widget, dialogs, overlays };
 }
@@ -220,6 +220,39 @@ test("background runs return at once; status, result, send_message, cancel, and 
 	assert.match((await tools.get("subagent_cancel")!.execute("c9", { task_id: id }, undefined, undefined, ctx)).content[0].text, /not running/);
 	assert.match((await tools.get("subagent_status")!.execute("c10", { task_id: "nope" }, undefined, undefined, ctx)).content[0].text, /Error: no task nope/);
 	assert.match((await tools.get("subagent_run")!.execute("c11", { agent: "ghost", task: "x" }, undefined, undefined, ctx)).content[0].text, /no subagent named "ghost"\. Known: explore/);
+});
+
+test("once the last task is done the card asks for one frame when its finished row expires, so an idle terminal clears it", async () => {
+	const { pi, tools, fire } = fakePi();
+	const harness = deps();
+	let clock = 1000;
+	const timers: Array<{ fn: () => void; ms: number; cancelled: boolean }> = [];
+	harness.deps.now = () => clock;
+	harness.deps.schedule = (fn, ms) => {
+		const timer = { fn, ms, cancelled: false };
+		timers.push(timer);
+		return () => {
+			timer.cancelled = true;
+		};
+	};
+	gentleAgents(pi, {}, harness.deps);
+	let frames = 0;
+	const { ctx, widget } = fakeContext({ requestRender: () => (frames += 1) });
+	await fire("session_start", ctx);
+	await tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Short job", mode: "background" }, undefined, undefined, ctx);
+	await tick();
+	widget();
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Done." }] }] });
+	await tick();
+	assert.match(widget()![1], /✓  explore  Short job/);
+	const expiry = timers.filter((timer) => !timer.cancelled && timer.ms === 60_000);
+	assert.equal(expiry.length, 1, "exactly one timer waits for the finished row to leave the card");
+	clock += 60_000;
+	const before = frames;
+	expiry[0].fn();
+	assert.equal(frames, before + 1, "the expiry asks the terminal for a frame");
+	assert.deepEqual(widget(), [], "the card is gone");
+	assert.equal(timers.filter((timer) => !timer.cancelled && timer.ms === 60_000).length, 0, "nothing is rescheduled once the card is empty");
 });
 
 test("completionText names the outcome before the answer", () => {


### PR DESCRIPTION
Closes #622

## Summary
- The Agents card hid finished rows after 60s, but the extension clock only ran while a task was active, so on an idle terminal the "✓ done" row stayed until an unrelated render.
- `widgetExpiryMs` reports how long until the next shown finished row leaves; once nothing runs, `tickClock` schedules exactly one host frame at that moment and re-evaluates. Nothing is rescheduled once the card is empty.
- The TTL comparison is now strict so the expiry lands exactly on `endedAt + FINISHED_TTL_MS`.

| File | Change |
|------|--------|
| `lib/agents-widget.ts` | `widgetExpiryMs`; strict TTL comparison in `widgetTasks` |
| `extensions/gentle-agents.ts` | `tickClock` schedules the expiry frame when every task is finished |
| `tests/agents-widget.test.ts` | `widgetExpiryMs` picks the oldest shown row, ignores active and already-gone rows |
| `tests/gentle-agents.test.ts` | controllable clock and scheduler; the expiry asks for one frame and empties the card |

## Test plan
- [x] `pnpm test` exit 0; `pnpm run check:runtime-modules` exit 0
- [x] Native review approved and acknowledged (lineage review-9cd80fde8eddffaf, reliability lens, four informational suggestions, no correction)

https://claude.ai/code/session_012xRCga42ASsUfEAEGRP7VA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Finished task rows now disappear from the Agents card precisely when their display period ends.
  * The card now refreshes automatically after the final task completes, ensuring completed rows are cleared even when the terminal remains idle.

* **Tests**
  * Added coverage for task-row expiry timing and automatic cleanup after the final task finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->