### PR TITLE
fix(review): scope consent replay to candidate content and let any session answer a binding

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3657,7 +3657,13 @@ const PENDING_REVIEW_CONSENT_STALE_DISPOSITION_LIMIT = 32;
  */
 export class PendingReviewConsentRegistry {
 	private readonly sessions = new Map<PendingReviewConsentSessionKey, Map<string, PendingReviewConsent>>();
-	private readonly staleDispositions = new Map<PendingReviewConsentSessionKey, Map<string, PendingReviewConsentDisposition>>();
+	// gentle-pi#455: a binding id is globally unique (randomUUID), so its live
+	// owner and its stale disposition are tracked by binding id alone. This
+	// index lets answer-consent resolve and atomically take exactly once a
+	// binding another active Pi session's START created; the per-session map
+	// above stays authoritative for session-scoped listings and shutdown cleanup.
+	private readonly byBinding = new Map<string, PendingReviewConsentSessionKey>();
+	private readonly staleDispositions = new Map<string, PendingReviewConsentDisposition>();
 
 	get(sessionKey: PendingReviewConsentSessionKey): Map<string, PendingReviewConsent> | undefined {
 		return this.sessions.get(sessionKey);
@@ -3672,34 +3678,46 @@ export class PendingReviewConsentRegistry {
 		return pending;
 	}
 
+	// Registers a freshly created pending binding under its owning session and
+	// the cross-session binding index in one step so the two never drift.
+	add(sessionKey: PendingReviewConsentSessionKey, pending: PendingReviewConsent): void {
+		this.ensure(sessionKey).set(pending.id, pending);
+		this.byBinding.set(pending.id, sessionKey);
+	}
+
+	// Resolves a live binding to its owning session regardless of which
+	// session asks, so answer-consent can reach a binding another session's
+	// START created (gentle-pi#455).
+	resolve(bindingId: string): { sessionKey: PendingReviewConsentSessionKey; pending: PendingReviewConsent } | undefined {
+		const sessionKey = this.byBinding.get(bindingId);
+		const pending = sessionKey === undefined ? undefined : this.sessions.get(sessionKey)?.get(bindingId);
+		return pending === undefined ? undefined : { sessionKey, pending };
+	}
+
 	private remove(sessionKey: PendingReviewConsentSessionKey, pending: PendingReviewConsent): boolean {
 		const session = this.sessions.get(sessionKey);
 		if (session?.get(pending.id) !== pending) return false;
 		session.delete(pending.id);
 		if (session.size === 0) this.sessions.delete(sessionKey);
+		if (this.byBinding.get(pending.id) === sessionKey) this.byBinding.delete(pending.id);
 		return true;
 	}
 
-	private rememberDisposition(sessionKey: PendingReviewConsentSessionKey, pending: PendingReviewConsent, disposition: PendingReviewConsentDisposition): void {
-		let stale = this.staleDispositions.get(sessionKey);
-		if (stale === undefined) {
-			stale = new Map<string, PendingReviewConsentDisposition>();
-			this.staleDispositions.set(sessionKey, stale);
-		}
-		stale.delete(pending.id);
-		stale.set(pending.id, disposition);
-		while (stale.size > PENDING_REVIEW_CONSENT_STALE_DISPOSITION_LIMIT) stale.delete(stale.keys().next().value!);
+	private rememberDisposition(pending: PendingReviewConsent, disposition: PendingReviewConsentDisposition): void {
+		this.staleDispositions.delete(pending.id);
+		this.staleDispositions.set(pending.id, disposition);
+		while (this.staleDispositions.size > PENDING_REVIEW_CONSENT_STALE_DISPOSITION_LIMIT) this.staleDispositions.delete(this.staleDispositions.keys().next().value!);
 	}
 
 	consume(sessionKey: PendingReviewConsentSessionKey, pending: PendingReviewConsent): boolean {
 		if (!this.remove(sessionKey, pending)) return false;
-		this.rememberDisposition(sessionKey, pending, PENDING_REVIEW_CONSENT_DISPOSITION.CONSUMED);
+		this.rememberDisposition(pending, PENDING_REVIEW_CONSENT_DISPOSITION.CONSUMED);
 		return true;
 	}
 
 	expire(sessionKey: PendingReviewConsentSessionKey, pending: PendingReviewConsent): boolean {
 		if (!this.remove(sessionKey, pending)) return false;
-		this.rememberDisposition(sessionKey, pending, PENDING_REVIEW_CONSENT_DISPOSITION.EXPIRED);
+		this.rememberDisposition(pending, PENDING_REVIEW_CONSENT_DISPOSITION.EXPIRED);
 		return true;
 	}
 
@@ -3707,14 +3725,14 @@ export class PendingReviewConsentRegistry {
 		this.remove(sessionKey, pending);
 	}
 
-	staleDisposition(sessionKey: PendingReviewConsentSessionKey, binding: string): PendingReviewConsentDisposition | undefined {
-		return this.staleDispositions.get(sessionKey)?.get(binding);
+	staleDisposition(binding: string): PendingReviewConsentDisposition | undefined {
+		return this.staleDispositions.get(binding);
 	}
 
 	take(sessionKey: PendingReviewConsentSessionKey): PendingReviewConsent[] {
 		const session = this.sessions.get(sessionKey);
 		this.sessions.delete(sessionKey);
-		this.staleDispositions.delete(sessionKey);
+		if (session !== undefined) for (const pending of session.values()) if (this.byBinding.get(pending.id) === sessionKey) this.byBinding.delete(pending.id);
 		return session === undefined ? [] : [...session.values()];
 	}
 }
@@ -3840,6 +3858,29 @@ function staleConsentBindingOutcome(operation: ReviewControllerOperation, bindin
 		...nativeStartPreAuthorityRejection(),
 		provider_action: status.action,
 		...(status.action === "start" ? { next_action: "restart-for-fresh-consent" } : mapped.next_action === undefined ? { next_action: status.action } : {}),
+	};
+}
+
+// gentle-pi#455 correction: cross-session resolution looks a binding up by
+// its opaque id alone, so it must independently confirm the answering
+// invocation addresses the same repository its owning START minted it for.
+// This is a typed, non-bearer refusal in the same shape family as the
+// stale-binding outcome -- it never runs the mode gate or native
+// answerConsent, and never consumes the binding, so it stays answerable from
+// the correct repository afterwards.
+function consentBindingRepositoryMismatchOutcome(operation: ReviewControllerOperation, binding: string, mintingRepositoryCwd: string, answeringRepositoryCwd: string): Record<string, unknown> {
+	return {
+		operation,
+		status: "blocked",
+		outcome: "consent-binding-repository-mismatch",
+		consent_binding: binding,
+		diagnostics: {
+			code: "consent-binding-repository-mismatch",
+			message: `consent binding ${binding} was minted for repository ${mintingRepositoryCwd}, not ${answeringRepositoryCwd}. Answer this binding from a session addressing ${mintingRepositoryCwd}; do not resend this binding from a different repository.`,
+		},
+		native_invocation_attempted: false,
+		...nativeStartPreAuthorityRejection(),
+		next_action: "answer-from-minting-repository",
 	};
 }
 
@@ -5358,13 +5399,18 @@ async function executeReviewControllerOperation(
 		if (Object.keys(input).some((key) => key !== "consentBinding" && key !== "answer") || Object.keys(input).length !== 2) throw new Error("Review controller answer-consent input must contain exactly consentBinding and answer");
 		if (typeof input.consentBinding !== "string" || input.consentBinding.length === 0) throw new Error("Review controller answer-consent requires an opaque consentBinding");
 		if (input.answer !== "granted" && input.answer !== "declined") throw new Error("Review controller answer-consent answer must be granted or declined");
-		const pending = pendingReviewConsentRegistry.get(pendingReviewConsentSession)?.get(input.consentBinding);
+		// gentle-pi#455: resolve the binding by its opaque id alone, so a
+		// binding one active Pi session's START created is answerable from any
+		// active session presenting it -- not only the session that created it.
+		const resolved = pendingReviewConsentRegistry.resolve(input.consentBinding);
+		const pending = resolved?.pending;
+		const owningSession = resolved?.sessionKey ?? pendingReviewConsentSession;
 		if (pending === undefined || pending.expiresAt <= reviewConsentNow()) {
 			const disposition = pending === undefined
-				? pendingReviewConsentRegistry.staleDisposition(pendingReviewConsentSession, input.consentBinding)
+				? pendingReviewConsentRegistry.staleDisposition(input.consentBinding)
 				: PENDING_REVIEW_CONSENT_DISPOSITION.EXPIRED;
 			const stale = staleConsentBindingDiagnostics(input.consentBinding, disposition);
-			if (pending !== undefined) expirePendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession);
+			if (pending !== undefined) expirePendingReviewConsent(pending, pendingReviewConsentRegistry, owningSession);
 			if (nativeReviewCli?.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
 			try {
 				const negotiated = await negotiatedStatusForHostTransport(nativeReviewCli, {
@@ -5377,14 +5423,15 @@ async function executeReviewControllerOperation(
 				return nativeStatusFailed(parameters.operation, error);
 			}
 		}
-		if (realpathSync(defaultCwd) !== pending.repositoryCwd) throw new Error("Review controller consent repository binding changed");
+		const answeringRepositoryCwd = realpathSync(defaultCwd);
+		if (answeringRepositoryCwd !== pending.repositoryCwd) return consentBindingRepositoryMismatchOutcome(parameters.operation, input.consentBinding, pending.repositoryCwd, answeringRepositoryCwd);
 		if (reviewConsentDigest(pending.consent) !== pending.consentDigest) throw new Error("Review controller consent envelope binding changed");
 		pending.verifyCandidate();
 		if (nativeReviewCli?.answerConsent === undefined) throw new Error("Native review consent follow-up is unavailable");
-		if (!consumePendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession)) {
+		if (!consumePendingReviewConsent(pending, pendingReviewConsentRegistry, owningSession)) {
 			const stale = staleConsentBindingDiagnostics(
 				input.consentBinding,
-				pendingReviewConsentRegistry.staleDisposition(pendingReviewConsentSession, input.consentBinding),
+				pendingReviewConsentRegistry.staleDisposition(input.consentBinding),
 			);
 			if (nativeReviewCli.targetStatus === undefined) return nativeStatusUnsupported(parameters.operation);
 			try {
@@ -5401,11 +5448,11 @@ async function executeReviewControllerOperation(
 		try {
 			const gated = await resolveReviewModeGate(nativeReviewCli, parameters.operation, defaultCwd, signal);
 			if (gated !== undefined) {
-				cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession);
+				cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, owningSession);
 				return gated;
 			}
 		} catch (error) {
-			cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession);
+			cleanupPendingReviewConsent(pending, pendingReviewConsentRegistry, owningSession);
 			return nativeOperationFailure(parameters.operation, error);
 		}
 		// The one-shot binding is consumed before the first answer-path await. Any
@@ -5525,7 +5572,16 @@ async function executeReviewControllerOperation(
 			} catch (error) {
 				return nativeOperationFailure(parameters.operation, error);
 			}
-			const replayKey = JSON.stringify({ cwd: defaultCwd, lineageId: parameters.lineageId ?? null, input: parameters.input ?? null, inputPath: parameters.inputPath ?? null });
+			// gentle-pi#323: the replay key must fold in the current candidate
+			// content identity. Without it, a second START with identical
+			// {cwd, lineageId, input, inputPath} reuses a still-live (never
+			// lineage-bound) frozen candidate view from within the consent TTL
+			// window even after the live candidate content changed underneath
+			// it, and dead-ends at candidate-target-projection-drift with no
+			// recovery. Folding in currentCandidateTree makes a content change
+			// mint a fresh replay key -- and therefore a fresh candidate view --
+			// instead of reusing the stale one.
+			const replayKey = JSON.stringify({ cwd: defaultCwd, lineageId: parameters.lineageId ?? null, input: parameters.input ?? null, inputPath: parameters.inputPath ?? null, candidateTree: target.projection.currentCandidateTree });
 			// Synchronously drop any binding whose TTL has already elapsed
 			// before reusing its retained candidate view, so a fresh-candidate
 			// retry cannot reuse a view tied to an expired binding and trip
@@ -5595,7 +5651,7 @@ async function executeReviewControllerOperation(
 							consentDigest,
 							expiresAt: reviewConsentNow() + PENDING_REVIEW_CONSENT_TTL_MS,
 						};
-						pendingReviewConsentRegistry.ensure(pendingReviewConsentSession).set(id, pending);
+						pendingReviewConsentRegistry.add(pendingReviewConsentSession, pending);
 						pending.expiry = reviewConsentScheduleTimer(
 							() => expirePendingReviewConsent(pending, pendingReviewConsentRegistry, pendingReviewConsentSession),
 							PENDING_REVIEW_CONSENT_TTL_MS,

--- a/tests/native-review-parity.test.ts
+++ b/tests/native-review-parity.test.ts
@@ -401,7 +401,7 @@ test("public gentle:review-mode handler reports current operations, global-off w
 	assert.deepEqual(unavailableNotices, [{ message: "Gentle AI review mode is not available with the currently negotiated native version.", type: "info" }]);
 });
 
-test("public consent relay is session-bound, one-shot, and candidate-scoped", async (t) => {
+test("public consent relay allows any active session to resolve a live binding, is one-shot, and is candidate-scoped", async (t) => {
 	const cwd = repository(t);
 	const sharedRegistry = new PendingReviewConsentRegistry();
 	const fixture = consentNative(cwd);
@@ -411,14 +411,22 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	const sameSessionResult = await answerConsent(second, cwd, sameSession.consent_binding, "declined", "same-session");
 	assert.equal(sameSessionResult.outcome, "consent-declined-this-candidate");
 
+	// gentle-pi#455: a binding is answerable by whichever active Pi session
+	// presents it, not only the session whose START created it.
 	const blockedA = await beginConsent(first, cwd, "session-a");
 	assert.deepEqual(blockedA.consent, decodeReviewConsentV3(captured("consent-v3.captured.json")).raw);
-	const staleOtherSession = await answerConsent(second, cwd, blockedA.consent_binding, "declined", "session-b");
-	assert.equal(staleOtherSession.operation, "answer-consent");
-	// gentle-pi#516: a binding this session does not hold must never read as
-	// a healthy pre-start STATUS; it names itself and the exit.
-	assertStaleConsentBinding(staleOtherSession, blockedA.consent_binding, "consent-binding-unknown");
-	assert.deepEqual(fixture.answers, ["declined"]);
+	const declinedFromOtherSession = await answerConsent(second, cwd, blockedA.consent_binding, "declined", "session-b");
+	assert.equal(declinedFromOtherSession.operation, "answer-consent");
+	assert.equal(declinedFromOtherSession.outcome, "consent-declined-this-candidate");
+	assert.deepEqual(fixture.answers, ["declined", "declined"]);
+
+	// Cross-session resolution still enforces single use: once answered, no
+	// session -- including the one whose START created it -- may answer it again.
+	const staleAfterCrossSessionAnswer = await answerConsent(first, cwd, blockedA.consent_binding, "declined", "session-a");
+	assert.equal(staleAfterCrossSessionAnswer.operation, "answer-consent");
+	assertStaleConsentBinding(staleAfterCrossSessionAnswer, blockedA.consent_binding, "consent-binding-already-consumed");
+	assert.deepEqual(fixture.answers, ["declined", "declined"]);
+
 	const blockedB = await beginConsent(second, cwd, "session-b");
 	const declined = await answerConsent(second, cwd, blockedB.consent_binding, "declined", "session-b");
 	assert.equal(declined.outcome, "consent-declined-this-candidate");
@@ -426,15 +434,19 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	const staleConsumed = await answerConsent(second, cwd, blockedB.consent_binding, "declined", "session-b");
 	assert.equal(staleConsumed.operation, "answer-consent");
 	assertStaleConsentBinding(staleConsumed, blockedB.consent_binding, "consent-binding-already-consumed");
-	assert.deepEqual(fixture.answers, ["declined", "declined"]);
+	assert.deepEqual(fixture.answers, ["declined", "declined", "declined"]);
 
+	// A binding still pending when its owning session shuts down is discarded
+	// and becomes unreachable to every session -- cross-session resolution
+	// included.
+	const blockedShutdown = await beginConsent(first, cwd, "session-a");
 	const shutdown = first.events.get("session_shutdown");
 	assert.ok(shutdown);
 	await shutdown!({}, context(cwd, "session-a"));
 	await shutdown!({}, context(cwd, "session-a"));
-	const staleShutdown = await answerConsent(first, cwd, blockedA.consent_binding, "declined", "session-a");
+	const staleShutdown = await answerConsent(second, cwd, blockedShutdown.consent_binding, "declined", "session-b");
 	assert.equal(staleShutdown.operation, "answer-consent");
-	assertStaleConsentBinding(staleShutdown, blockedA.consent_binding, "consent-binding-unknown");
+	assertStaleConsentBinding(staleShutdown, blockedShutdown.consent_binding, "consent-binding-unknown");
 
 	writeFileSync(join(cwd, "app.ts"), "export const value = 3;\n");
 	const nextCandidate = await beginConsent(second, cwd, "session-b");
@@ -450,7 +462,7 @@ test("public consent relay is session-bound, one-shot, and candidate-scoped", as
 	const staleModeCleared = await answerConsent(second, cwd, nextCandidate.consent_binding, "declined", "session-b");
 	assert.equal(staleModeCleared.operation, "answer-consent");
 	assertStaleConsentBinding(staleModeCleared, nextCandidate.consent_binding, "consent-binding-unknown");
-	assert.equal(fixture.starts.count, 4);
+	assert.equal(fixture.starts.count, 5);
 });
 
 test("already-consumed local consent bindings reconcile exactly once with the native status transition", async (t) => {

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -490,6 +490,31 @@ test("candidate registry isolates replay, projection, current, and cleanup state
 	registry.cleanupTerminal("same-lineage", "approved", rootA);
 });
 
+// gentle-pi#323: `createOrReuse` reuses whatever view a replay key maps to,
+// with no awareness of live candidate content -- a content-independent key
+// reuses a stale view even after the candidate content it was frozen from
+// has changed. The fix lives at the START call site (extensions/gentle-ai.ts),
+// which now folds the current candidate tree into the replay key; this test
+// documents both the registry's plain-key reuse contract and that folding
+// content identity into the key produces a fresh view once content changes.
+test("candidate registry reuses a replay-keyed view verbatim regardless of live content, so callers must fold content identity into the key", (t) => {
+	const registry = new CandidateViewRegistry();
+	t.after(() => registry.cleanupAll());
+	const contributorRoot = repository(t);
+	const contentIndependentKey = "cwd-and-lineage-only";
+	const first = registry.createOrReuse({ contributorRoot, replayKey: contentIndependentKey });
+	writeFileSync(join(contributorRoot, "tracked.txt"), "candidate two\n");
+	const staleReuse = registry.createOrReuse({ contributorRoot, replayKey: contentIndependentKey });
+	assert.equal(staleReuse.token, first.token, "a content-independent replay key reuses the stale view");
+	const freshForCurrentContent = registry.create({ contributorRoot });
+	assert.notEqual(staleReuse.candidateTree, freshForCurrentContent.candidateTree, "the stale reused view no longer reflects live candidate content");
+	const contentScopedKey = `${contentIndependentKey} ${freshForCurrentContent.candidateTree}`;
+	const rekeyed = registry.createOrReuse({ contributorRoot, replayKey: contentScopedKey });
+	assert.notEqual(rekeyed.token, staleReuse.token, "folding candidate content into the replay key mints a fresh view once content changes");
+	assert.equal(rekeyed.candidateTree, freshForCurrentContent.candidateTree);
+	registry.cleanup(freshForCurrentContent.token);
+});
+
 test("candidate registry rejects a lineage target whose authorized symlink was replaced", (t) => {
 	const root = repository(t);
 	const replacement = repository(t);

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1220,6 +1220,119 @@ test("ordinary START refuses a target projection that no longer matches the froz
 	assert.equal(startCalls, 0);
 });
 
+// gentle-pi#455: a consent binding one active Pi session's START created must
+// be answerable from another active session presenting the same opaque
+// binding id -- consent bindings are not partitioned by which session's
+// START created them, only by the repository and candidate they are scoped to.
+test("answer-consent resolves a valid binding presented by a different active Pi session", async (t) => {
+	const cwd = repository(t);
+	const consent = decodeReviewConsentV3(JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "consent-v3.captured.json"), "utf8")));
+	const registry = new PendingReviewConsentRegistry();
+	const sessionA = Symbol("session-a"), sessionB = Symbol("session-b");
+	let answerCalls = 0;
+	const native = {
+		targetStatus: async () => startStatus(cwd),
+		start: async () => { throw new NativeReviewConsentRequiredError(consent); },
+		answerConsent: async () => {
+			answerCalls += 1;
+			return { kind: "granted", start: { lineageId: "cross-session", state: "reviewing", riskLevel: "low", selectedLenses: [], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: false, riskReasons: [] } };
+		},
+	} as unknown as NativeReviewCli;
+	const started = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native, undefined, undefined, undefined, undefined, registry, sessionA);
+	assert.equal(typeof started.consent_binding, "string", JSON.stringify(started));
+	const answered = await __testing.executeReviewControllerOperation({ operation: "answer-consent", input: JSON.stringify({ consentBinding: started.consent_binding, answer: "granted" }) }, cwd, native, undefined, undefined, undefined, undefined, registry, sessionB);
+	assert.equal(answerCalls, 1, JSON.stringify(answered));
+	assert.equal((answered.result as { lineage_id?: string } | undefined)?.lineage_id, "cross-session", JSON.stringify(answered));
+	assert.notEqual(answered.status, "blocked", JSON.stringify(answered));
+});
+
+// gentle-pi#455: cross-session resolution must still enforce single use --
+// once a binding is answered by any session, no session (including the one
+// whose START created it) may answer it again.
+test("a consumed consent binding cannot be answered a second time from any session", async (t) => {
+	const cwd = repository(t);
+	const consent = decodeReviewConsentV3(JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "consent-v3.captured.json"), "utf8")));
+	const registry = new PendingReviewConsentRegistry();
+	const sessionA = Symbol("session-a"), sessionB = Symbol("session-b");
+	let answerCalls = 0;
+	const native = {
+		targetStatus: async () => startStatus(cwd),
+		start: async () => { throw new NativeReviewConsentRequiredError(consent); },
+		answerConsent: async () => {
+			answerCalls += 1;
+			return { kind: "granted", start: { lineageId: "single-use", state: "reviewing", riskLevel: "low", selectedLenses: [], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: false, riskReasons: [] } };
+		},
+	} as unknown as NativeReviewCli;
+	const started = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native, undefined, undefined, undefined, undefined, registry, sessionA);
+	const binding = started.consent_binding as string;
+	const first = await __testing.executeReviewControllerOperation({ operation: "answer-consent", input: JSON.stringify({ consentBinding: binding, answer: "granted" }) }, cwd, native, undefined, undefined, undefined, undefined, registry, sessionB);
+	assert.equal(answerCalls, 1, JSON.stringify(first));
+	const replay = await __testing.executeReviewControllerOperation({ operation: "answer-consent", input: JSON.stringify({ consentBinding: binding, answer: "granted" }) }, cwd, native, undefined, undefined, undefined, undefined, registry, sessionA);
+	assert.equal(answerCalls, 1, JSON.stringify(replay));
+	assert.equal(replay.status, "blocked", JSON.stringify(replay));
+	assert.equal(replay.outcome, "consent-binding-stale", JSON.stringify(replay));
+	assert.equal((replay.diagnostics as { code?: string } | undefined)?.code, "consent-binding-already-consumed", JSON.stringify(replay));
+});
+
+// gentle-pi#455 correction: cross-session resolution looks a binding up by
+// its opaque id alone, so it must independently refuse an answer presented
+// from a different repository than the one its owning START minted it for,
+// without ever running the mode gate or native answerConsent, and without
+// consuming the binding -- leaving it answerable from the right repository.
+test("answer-consent refuses a binding presented from a different repository than the one its START minted, and leaves it answerable from the right one", async (t) => {
+	const cwdA = repository(t), cwdB = repository(t);
+	const consent = decodeReviewConsentV3(JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "consent-v3.captured.json"), "utf8")));
+	const registry = new PendingReviewConsentRegistry();
+	const sessionA = Symbol("session-a"), sessionB = Symbol("session-b");
+	let answerCalls = 0;
+	const native = {
+		targetStatus: async () => startStatus(cwdA),
+		start: async () => { throw new NativeReviewConsentRequiredError(consent); },
+		answerConsent: async () => {
+			answerCalls += 1;
+			return { kind: "granted", start: { lineageId: "right-repo", state: "reviewing", riskLevel: "low", selectedLenses: [], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: false, riskReasons: [] } };
+		},
+	} as unknown as NativeReviewCli;
+	const started = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwdA, native, undefined, undefined, undefined, undefined, registry, sessionA);
+	const binding = started.consent_binding as string;
+	const wrongRepo = await __testing.executeReviewControllerOperation({ operation: "answer-consent", input: JSON.stringify({ consentBinding: binding, answer: "granted" }) }, cwdB, native, undefined, undefined, undefined, undefined, registry, sessionB);
+	assert.equal(answerCalls, 0, JSON.stringify(wrongRepo));
+	assert.equal(wrongRepo.status, "blocked", JSON.stringify(wrongRepo));
+	assert.equal(wrongRepo.outcome, "consent-binding-repository-mismatch", JSON.stringify(wrongRepo));
+	assert.equal((wrongRepo.diagnostics as { code?: string } | undefined)?.code, "consent-binding-repository-mismatch", JSON.stringify(wrongRepo));
+	assert.equal(wrongRepo.mutation_performed, false, JSON.stringify(wrongRepo));
+	const rightRepo = await __testing.executeReviewControllerOperation({ operation: "answer-consent", input: JSON.stringify({ consentBinding: binding, answer: "granted" }) }, cwdA, native, undefined, undefined, undefined, undefined, registry, sessionA);
+	assert.equal(answerCalls, 1, JSON.stringify(rightRepo));
+	assert.equal((rightRepo.result as { lineage_id?: string } | undefined)?.lineage_id, "right-repo", JSON.stringify(rightRepo));
+});
+
+// gentle-pi#323: within the live consent TTL window, a content-independent
+// replay key let a second ordinary START reuse the first START's still-live
+// (never lineage-bound) frozen candidate view even though the live candidate
+// content changed underneath it, and then dead-ended at
+// candidate-target-projection-drift instead of minting a fresh view and a
+// fresh consent envelope. An intended-untracked selection is retained across
+// both calls so the pre-existing empty-untracked drift-recovery branch does
+// not mask the general content-change gap this covers.
+test("ordinary START mints a fresh candidate view when candidate content changes within the live consent TTL window", async (t) => {
+	const candidateViews = new CandidateViewRegistry();
+	t.after(() => candidateViews.cleanupAll());
+	const cwd = repository(t);
+	writeFileSync(join(cwd, "extra.md"), "kept\n");
+	const consent = decodeReviewConsentV3(JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "consent-v3.captured.json"), "utf8")));
+	const native = {
+		targetStatus: async () => startStatus(cwd, undefined, ["extra.md"]),
+		start: async () => { throw new NativeReviewConsentRequiredError(consent); },
+	} as unknown as NativeReviewCli;
+	const first = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native, undefined, candidateViews);
+	assert.equal(first.outcome, "native-review-consent-required", JSON.stringify(first));
+	writeFileSync(join(cwd, "tracked.txt"), "candidate two\n");
+	const second = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native, undefined, candidateViews);
+	assert.notEqual(second.outcome, "native-operation-failed", JSON.stringify(second));
+	assert.equal(second.outcome, "native-review-consent-required", JSON.stringify(second));
+	assert.notEqual(second.consent_binding, first.consent_binding, JSON.stringify(second));
+});
+
 test("controller-owned dispatch confines single and parallel graph actors to the current candidate view", async (t) => {
 	const cwd = repository(t);
 	const candidateViews = new CandidateViewRegistry();


### PR DESCRIPTION
Closes #323
Closes #455

## Summary
- The consent-window replay key now folds in the current candidate tree, so changed content never reuses a stale frozen view and START no longer dead-ends with `candidate-target-projection-drift` (#323).
- The pending consent registry gains a global by-binding index: any active Pi session on the same repository can answer a binding exactly once; a session on another repository gets a typed `consent-binding-repository-mismatch` outcome and the binding is not consumed (#455, native review correction R1/R3).
- The parity test that had codified the session-bound behaviour now asserts the cross-session semantics.

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | content-scoped replay key; by-binding registry index; repository-mismatch outcome |
| `tests/review-controller-native-routing.test.ts` | replay within TTL, cross-session answer, single use, cross-repository refusal |
| `tests/review-candidate-view.test.ts` | registry contract for the replay key |
| `tests/native-review-parity.test.ts` | cross-session semantics |

## Test plan
- [x] `pnpm test`: 1384 pass, 1 skipped (pre-existing), 0 fail
- [x] `pnpm run check:runtime-modules`: runtime matches sources
- [x] Native review approved and acknowledged (lineage review-d90417b9fb0a29e2, one bounded correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M