### PR TITLE
fix(orchestrator): restore proactive SDD suggestion and explicit route declaration

### DIFF
--- a/assets/orchestrator-delegation.md
+++ b/assets/orchestrator-delegation.md
@@ -190,9 +190,9 @@ Do not make every task SDD. Do make non-trivial tasks multi-agent at the narrowe
 
 #### 3. SDD (optional)
 
-SDD is never selected by size, file count, or risk alone. Suggest it organically when durable proposal/spec/design/tasks would materially reduce substantial ambiguity (unclear requirements or acceptance criteria, architectural or product decisions, cross-cutting behavior changes), and let the user decide.
+SDD is never auto-selected without user confirmation, but you MUST proactively suggest it when a task involves multi-module features, schema/API contract changes, or architectural decisions where durable proposal/spec/design/tasks would materially reduce ambiguity and protect implementation quality. Present the choice clearly: explain what makes the change substantial and ask whether to run SDD (`/sdd-new`) or proceed with delegated direct execution.
 
-Select SDD only when the user explicitly asks to use SDD, invokes `/gentle-sdd-new`, `/gentle-sdd-ff`, or `/gentle-sdd-continue`, or accepts an SDD proposal. Once selected, do not jump directly to implementation. Calibrate context, create artifacts, and ask for approval at the appropriate gates.
+Select SDD only when the user explicitly asks to use SDD, invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue`, or accepts an SDD proposal. Once selected, do not jump directly to implementation. Calibrate context, create artifacts, and ask for approval at the appropriate gates.
 
 ## Pi Delegation Bindings
 

--- a/assets/orchestrator.md
+++ b/assets/orchestrator.md
@@ -37,11 +37,11 @@ Delegation is not optional once complexity appears. If a task crosses the trigge
 
 ## Work Routing Ladder
 
-Route work through the smallest harness that is safe. Three tiers:
+Route work through the smallest safe harness; state the routing choice directly (inline, worker, or SDD). Three tiers:
 
-1. **Inline Direct** — small, mechanical, parent has context (typo, one-file edit, read-only check of 1-3 known files, bash for state). No SDD ceremony; stop when it is no longer small.
+1. **Inline Direct** — small, mechanical, parent has context (typo, 1-file edit, 1-3 file read check, bash state). No ceremony.
 2. **Simple Delegation** — generic non-SDD exploration → `gentle-ai-explore`; bounded implementation → `gentle-ai-worker`; command-running generic non-SDD verification → `gentle-ai-verify`. Try its package role; if missing/unusable, use native `Agent` under the same read-only mapping/verification constraints and report fallback. SDD roles stay inside SDD.
-3. **SDD (optional)** — selected only by an explicit request (`/gentle-sdd-new`/`/gentle-sdd-ff`/`/gentle-sdd-continue` or a direct ask) or an accepted proposal; size, file count, or risk alone never selects SDD. Suggest it organically when durable proposal/spec/design/tasks would materially reduce substantial ambiguity. Once selected, do not jump to implementation; create artifacts and gate for approval.
+3. **SDD (optional)** — proactively suggest SDD for multi-module scope, contract/schema changes, or architectural decisions where durable artifacts reduce ambiguity; ask first. Selected only by explicit request (`/sdd-new`/`/sdd-ff`/`/sdd-continue` or direct ask) or accepted proposal; size/risk alone never auto-selects SDD. Once selected, create artifacts and gate for approval instead of jumping to code.
 
 ## Delegation Rules
 
@@ -89,7 +89,7 @@ This package injects the mirrored provider-bundle review execution contract into
 
 ## Safety
 
-- For a strictly closed single-select envelope (e.g. `gentle-ai.review-integration.consent/v3`), use `ask_user_choice` when the interactive TUI offers it, passing each label/description with the envelope-owned answer token as `value`, then run the exact provider-owned invocation for the selected answer; otherwise emit the complete envelope as plain chat and stop.
+- For closed single-select envelopes (`consent/v3`), use `ask_user_choice` when available (label/description with answer token as `value`) and run the exact invocation; otherwise emit the full envelope as plain chat and stop.
 - Never commit unless the user explicitly asks.
 - Ask before destructive git operations, publishing, or irreversible file changes.
 - Keep writes single-threaded unless isolated worktrees are explicitly approved.


### PR DESCRIPTION
### Summary of Changes

- **Proactive SDD suggestions (Organic Trigger)**: Updated `assets/orchestrator.md` (Tier 3) and `assets/orchestrator-delegation.md` (`#### 3. SDD (optional)`) so the orchestrator actively suggests SDD when tasks involve multi-module scope, schema/API contract changes, or architectural decisions where durable artifacts reduce ambiguity, asking the user before jumping into code.
- **Explicit routing declaration**: Instructed the orchestrator to declare its routing choice directly in its initial reply (inline direct, delegated worker, or SDD proposal).
- **Prompt budget**: Kept always-on prompt size at 7,792 bytes (under the canonical 8,192 B limit).
- **Test suite**: All 145/145 tests pass.

### Environment & Reproduction Context
- **OS**: CachyOS Linux (Arch-based, Kernel 7.1.8-1-cachyos, x86_64)
- **Node.js**: v24.18.1
- **Pi Version**: 0.85.1
- **Package Version**: gentle-pi v2.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated workflow guidance so SDD is proactively suggested for multi-module features, schema or API contract changes, and architectural decisions.
  - SDD now requires user confirmation before execution, with a clear choice between running SDD and proceeding directly.
  - Renamed SDD commands to `/sdd-new`, `/sdd-ff`, and `/sdd-continue`.
  - Clarified routing and consent requirements for supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->