### PR TITLE
fix(review): rebind retried START candidate views and preserve native inspect causes

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3166,6 +3166,23 @@ function nativeStatusFailed(operation: ReviewControllerOperation, error: unknown
 			next_action: "require-complete-native-authority-inventory",
 		};
 	}
+	// gentle-pi#599: a negotiated STATUS/inspect request the native provider
+	// rejects with a decoded failure/v2 envelope (for example a preflight
+	// `invalid_request` refusal for a nested foreign Git repository) used to
+	// fall through to the generic outcome below, discarding the envelope's own
+	// cause, code, retry_safe, and next_action -- the one piece of information
+	// that makes the refusal actionable (pass the intended nested repo as
+	// workspaceRoot). `nativeOperationFailure` already renders this exact
+	// failure-envelope shape faithfully for every mutating operation; reuse it
+	// here instead of masking the refusal as opaque authority-inventory
+	// corruption.
+	if (error instanceof NativeReviewIntegrationError) {
+		return {
+			...nativeOperationFailure(operation, error),
+			outcome: "native-status-unavailable",
+			inventory_complete: false,
+		};
+	}
 	return {
 		operation,
 		status: "blocked",

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -339,6 +339,26 @@ function gitlinkMapsEqual(left: Readonly<Record<string, string>>, right: Readonl
 	return entries.length === Object.keys(right).length && entries.every(([path, objectId]) => right[path] === objectId);
 }
 
+// Two materialized candidate views describe the exact same reviewable content
+// when their base, candidate tree, commit-state, and changed scope all match.
+// This is what makes a retried native START's freshly-materialized duplicate
+// view safely discardable in favor of an already-bound one (gentle-pi
+// candidate-view rebind defect, ga#4085 / ga#4050): the comparison never
+// trusts a caller-supplied claim, only Git-derived identity already computed
+// by materializeCandidateView for both records.
+function candidateRecordsShareIdentity(left: CandidateViewRecord, right: CandidateViewRecord): boolean {
+	return left.contributorRoot === right.contributorRoot &&
+		left.baseCommit === right.baseCommit &&
+		left.baseTree === right.baseTree &&
+		left.candidateTree === right.candidateTree &&
+		left.committedOnly === right.committedOnly &&
+		JSON.stringify(left.intendedUntracked ?? null) === JSON.stringify(right.intendedUntracked ?? null) &&
+		JSON.stringify(left.scope.paths) === JSON.stringify(right.scope.paths) &&
+		JSON.stringify(left.scope.modes) === JSON.stringify(right.scope.modes) &&
+		gitlinkMapsEqual(left.scope.gitlinks, right.scope.gitlinks) &&
+		JSON.stringify(left.scope.deletedPaths) === JSON.stringify(right.scope.deletedPaths);
+}
+
 function decodeCanonicalPath(value: Buffer): string {
 	const path = value.toString("utf8");
 	if (!Buffer.from(path, "utf8").equals(value) || !isSafeCandidatePath(path)) {
@@ -1030,6 +1050,32 @@ export class CandidateViewRegistry {
 
 	bindCurrent(request: BindCandidateViewRequest): void {
 		const selectedLenses = this.validateSelectedLenses(request.selectedLenses);
+		const candidate = this.records.get(request.token);
+		const key = candidate === undefined ? undefined : this.lineageKey(candidate.contributorRoot, request.lineageId);
+		const existingToken = key === undefined ? undefined : this.lineages.get(key);
+		// A retried native START for a lineage this controller already bound
+		// (native reports it "resumed") re-materializes a fresh, content-
+		// identical candidate view under a new token before it reaches here.
+		// Rebinding that duplicate to the same lineage key used to fail closed
+		// with "candidate view lineage binding is missing or ambiguous" even
+		// though nothing is actually ambiguous: it is the exact same reviewable
+		// content, re-verified from Git. Discard the redundant duplicate and
+		// keep the already-bound view current instead of failing the retry
+		// (gentle-pi candidate-view rebind defect, ga#4085 / ga#4050).
+		if (candidate !== undefined && existingToken !== undefined && existingToken !== request.token) {
+			const existing = this.records.get(existingToken);
+			let existingSafe = false;
+			if (existing !== undefined && existing.lineageId === request.lineageId) {
+				try { assertRecordSafe(existing); existingSafe = true; } catch { existingSafe = false; }
+			}
+			if (existing !== undefined && existingSafe && candidateRecordsShareIdentity(existing, candidate)) {
+				existing.selectedLenses = selectedLenses;
+				this.remove(candidate);
+				this.forget(candidate);
+				this.current.set(existing.contributorRoot, { lineageId: request.lineageId, token: existingToken });
+				return;
+			}
+		}
 		const record = this.bindRecord(request.token, request.lineageId, selectedLenses);
 		this.current.set(record.contributorRoot, { lineageId: request.lineageId, token: request.token });
 	}

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -490,6 +490,51 @@ test("candidate registry isolates replay, projection, current, and cleanup state
 	registry.cleanupTerminal("same-lineage", "approved", rootA);
 });
 
+// ga#4085 / ga#4050: after a valid `granted` consent, a retried native START
+// for a lineage this controller already bound (native reports it "resumed")
+// re-materializes a fresh, content-identical candidate view under a new
+// token -- for example after a transport hiccup between START and the
+// follow-up STATUS call. Rebinding that duplicate to the same lineage used to
+// fail closed with "candidate view lineage binding is missing or ambiguous"
+// even though nothing was actually ambiguous. It must reuse the already-bound
+// view instead of failing the retry.
+test("candidate registry rebinds a retried native START for an already-bound lineage instead of failing closed", (t) => {
+	const contributorRoot = repository(t);
+	writeFileSync(join(contributorRoot, "tracked.txt"), "candidate\n");
+	const registry = new CandidateViewRegistry();
+	t.after(() => registry.cleanupAll());
+	const first = registry.create({ contributorRoot });
+	registry.bindCurrent({ token: first.token, lineageId: "retry-lineage", selectedLenses: ["review-risk"] });
+	assert.equal(registry.hasCurrentBinding(contributorRoot), true);
+
+	const retry = registry.create({ contributorRoot });
+	assert.notEqual(retry.token, first.token, "the retry must materialize a distinct physical worktree/token");
+	assert.doesNotThrow(() => registry.bindCurrent({ token: retry.token, lineageId: "retry-lineage", selectedLenses: ["review-risk"] }));
+
+	// The already-bound view stays current; the redundant duplicate is discarded.
+	assert.equal(registry.resolveForLens("retry-lineage", "review-risk", contributorRoot).root, first.root);
+	assert.equal(registry.resolveCurrentForLens("review-risk", contributorRoot).root, first.root);
+	assert.equal(existsSync(retry.root), false, "the redundant duplicate candidate view must be cleaned up");
+	registry.cleanupTerminal("retry-lineage", "approved", contributorRoot);
+});
+
+test("candidate registry still fails closed rebinding the same lineage to genuinely different content", (t) => {
+	const contributorRoot = repository(t);
+	const registry = new CandidateViewRegistry();
+	t.after(() => registry.cleanupAll());
+	const first = registry.create({ contributorRoot });
+	registry.bindCurrent({ token: first.token, lineageId: "conflict-lineage", selectedLenses: ["review-risk"] });
+	writeFileSync(join(contributorRoot, "tracked.txt"), "different content\n");
+	const conflicting = registry.create({ contributorRoot });
+	assert.notEqual(conflicting.candidateTree, first.candidateTree);
+	assert.throws(
+		() => registry.bindCurrent({ token: conflicting.token, lineageId: "conflict-lineage", selectedLenses: ["review-risk"] }),
+		CandidateViewError,
+	);
+	registry.cleanup(conflicting.token);
+	registry.cleanupTerminal("conflict-lineage", "approved", contributorRoot);
+});
+
 // gentle-pi#323: `createOrReuse` reuses whatever view a replay key maps to,
 // with no awareness of live candidate content -- a content-independent key
 // reuses a stale view even after the candidate content it was frozen from

--- a/tests/review-controller-workspace-root.test.ts
+++ b/tests/review-controller-workspace-root.test.ts
@@ -6,9 +6,9 @@ import { join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { __testing, createGentleAiExtension } from "../extensions/gentle-ai.ts";
-import type { NativeReviewCli } from "../lib/native-review-cli.ts";
+import { NativeReviewIntegrationError, type NativeReviewCli } from "../lib/native-review-cli.ts";
 import { CandidateViewRegistry } from "../lib/review-candidate-view.ts";
-import type { AuthorityRepairAssessmentV1, ReviewStatusV3 } from "../lib/review-integration-v2.ts";
+import { decodeReviewFailureV2, type AuthorityRepairAssessmentV1, type ReviewStatusV3 } from "../lib/review-integration-v2.ts";
 
 interface RegisteredTool {
 	execute: (
@@ -238,6 +238,49 @@ test("INSPECT and STATUS operate on the explicit workspace root while the sessio
 	await controller.execute("status-b", { operation: "status", lineageId: "native-lineage", workspaceRoot: worktree }, undefined, undefined, context(sessionCwd));
 	await controller.execute("inspect-default", { operation: "inspect" }, undefined, undefined, context(sessionCwd));
 	assert.deepEqual(observedCwds, [realpathSync(worktree), realpathSync(worktree), sessionCwd]);
+});
+
+// gentle-pi#599: inspect without an explicit workspaceRoot against a parent
+// repository that wraps an untracked nested Git repository fails at the
+// native preflight with a decoded, actionable `invalid_request` envelope. The
+// facade used to discard that envelope's cause, code, retry_safe, and
+// next_action in favor of a generic `native-status-unavailable` outcome
+// indistinguishable from authority corruption. It must preserve the native
+// envelope instead.
+test("inspect without workspaceRoot preserves the native invalid_request cause for a nested foreign Git repository", async (t) => {
+	const sessionCwd = repository(t);
+	const { controller } = runtime(fakeNative({
+		targetStatus: async () => {
+			throw new NativeReviewIntegrationError(decodeReviewFailureV2({
+				schema: "gentle-ai.review-integration.failure/v2",
+				contract: "gentle-ai.review-integration/v2",
+				operation: "review.status",
+				phase: "preflight",
+				code: "invalid_request",
+				message: "The negotiated review request is invalid.",
+				mutation_outcome: "not_started",
+				authority_applicability: "not_evaluated",
+				retry_safe: true,
+				replayability: "not_replayable",
+				required_inputs: [],
+				next_action: "correct_request",
+				cause: "untracked directory \"engram\" holds another Git repository that is not a linked worktree of this one, so it cannot enter the review candidate: add it to .gitignore, move it outside this repository, or register it as a linked worktree",
+			}));
+		},
+	}));
+	const result = await controller.execute("inspect-nested-foreign-repo", { operation: "inspect" }, undefined, undefined, context(sessionCwd));
+	const details = result.details as {
+		status?: string;
+		outcome?: string;
+		next_action?: string;
+		native_failure?: { code?: string; cause?: string; retry_safe?: boolean };
+	};
+	assert.equal(details.status, "blocked");
+	assert.equal(details.outcome, "native-status-unavailable");
+	assert.equal(details.native_failure?.code, "invalid_request");
+	assert.equal(details.native_failure?.retry_safe, true);
+	assert.match(details.native_failure?.cause ?? "", /engram/);
+	assert.equal(details.next_action, "correct_request");
 });
 
 test("START freezes the candidate from the explicit workspace root and returns the actor binding envelope", async (t) => {


### PR DESCRIPTION
Closes #599
Closes Gentleman-Programming/gentle-ai#4085
Closes Gentleman-Programming/gentle-ai#4050
Closes Gentleman-Programming/gentle-ai#2646

## Summary
- A retried native START for an already-bound lineage (native reports `resumed`) no longer fails with `candidate view lineage binding is missing or ambiguous` after a valid consent: the registry reuses the bound view when lineage, contributor root, and Git-verified content match, and still fails closed on different content.
- `inspect` without `workspaceRoot` now preserves the native `invalid_request` cause (code, retry_safe, next_action) for nested foreign Git repositories instead of a generic `native-status-unavailable` envelope.

## Changes
| File | Change |
|------|--------|
| `lib/review-candidate-view.ts` | `bindCurrent` rebinds a content-identical retried START |
| `extensions/gentle-ai.ts` | `nativeStatusFailed` renders `NativeReviewIntegrationError` through `nativeOperationFailure` |
| `tests/review-candidate-view.test.ts` | Rebind and fail-closed regression tests |
| `tests/review-controller-workspace-root.test.ts` | Nested foreign repo cause preservation |

## Test plan
- [x] `node scripts/build-runtime-modules.mjs --write` (no generated drift)
- [x] `pnpm test` (1392 pass, 1 skipped)
- [x] Native review approved (lineage review-66fcd9cb3b27071a), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved detailed native status failure information, including the underlying cause, error code, retry guidance, and recommended next action.
  * Improved reliability when retrying an operation that produces an identical candidate view, avoiding unnecessary failures and duplicate results.
  * Continued to fail safely when a retry produces different candidate content.
  * Improved error reporting for inspections involving nested Git repositories without an explicitly selected workspace root.

* **Tests**
  * Added coverage for retry handling and native preflight failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->