### PR TITLE
fix(review): replace a lineage's finalize view without leaking or losing it

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3108,6 +3108,15 @@ async function resolveReviewModeGate(
 	}
 }
 
+// gentle-pi#185: a native CLI without negotiated STATUS support (no
+// `targetStatus`, or a version-incompatible provider) hits this boundary
+// before any candidate-view restoration is attempted, so it can never
+// reproduce the #176 empty-registry failure — but the boundary's own
+// `next_action` was a machine token with nothing a human or an agent could
+// run. `remediation_command` names the exact upstream command that
+// re-establishes negotiated STATUS for this session's Pi host identity.
+const NATIVE_STATUS_UNSUPPORTED_REMEDIATION_COMMAND = "gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --agent pi --next-transition";
+
 function nativeStatusUnsupported(operation: ReviewControllerOperation): Record<string, unknown> {
 	return {
 		operation,
@@ -3116,6 +3125,7 @@ function nativeStatusUnsupported(operation: ReviewControllerOperation): Record<s
 		...(operation === REVIEW_CONTROLLER_OPERATION.START ? nativeStartPreAuthorityRejection() : { mutation_performed: false }),
 		inventory_complete: false,
 		next_action: "require-upstream-read-only-native-status-inventory",
+		remediation_command: NATIVE_STATUS_UNSUPPORTED_REMEDIATION_COMMAND,
 		evidence: {
 			native_contract: "gentle-ai/2.1.4",
 			general_status: "unsupported",

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -1322,21 +1322,18 @@ export class CandidateViewRegistry {
 	 * correction.
 	 */
 	rebindForFinalizeFromNative(lineageId: string, contributorRoot: string, descriptor: NativeCandidateProjectionDescriptor): CandidateView {
-		const root = this.canonicalRoot(contributorRoot);
-		const key = this.lineageKey(root, lineageId);
-		const staleToken = this.lineages.get(key);
-		const stale = staleToken === undefined ? undefined : this.records.get(staleToken);
-		this.projections.delete(key);
-		if (stale !== undefined) {
-			this.remove(stale);
-			this.forget(stale);
-		}
-		return this.restoreForFinalizeFromNative(lineageId, root, descriptor);
+		return this.restoreForFinalizeFromNative(lineageId, contributorRoot, descriptor);
 	}
 
+	/**
+	 * Restores a lineage's FINALIZE binding (gentle-pi #185): the stale entry
+	 * is only detached, not destroyed, so a failed restore can undo it.
+	 */
 	restoreForFinalizeFromNative(lineageId: string, contributorRoot: string, descriptor: NativeCandidateProjectionDescriptor): CandidateView {
 		const root = this.canonicalRoot(contributorRoot);
 		const key = this.lineageKey(root, lineageId);
+		const staleToken = this.lineages.get(key), staleProjection = this.projections.get(key);
+		this.lineages.delete(key); this.projections.delete(key);
 		let projectionRestored = false;
 		let record: CandidateViewRecord | undefined;
 		try {
@@ -1354,6 +1351,8 @@ export class CandidateViewRegistry {
 			if (!matchesProjection(record)) throw new CandidateViewError("live candidate does not match the native frozen projection");
 			this.records.set(record.token, record);
 			this.bindRecord(record.token, lineageId, []);
+			const stale = staleToken === undefined ? undefined : this.records.get(staleToken);
+			if (stale !== undefined) { this.remove(stale); this.forget(stale); }
 			return this.expose(record);
 		} catch (error) {
 			if (projectionRestored) this.projections.delete(key);
@@ -1361,6 +1360,8 @@ export class CandidateViewRegistry {
 				this.forget(record);
 				this.remove(record);
 			}
+			if (staleToken !== undefined) this.lineages.set(key, staleToken);
+			if (staleProjection !== undefined) this.projections.set(key, staleProjection);
 			throw error;
 		}
 	}

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -18,6 +18,7 @@ import {
 	digestChangedPathManifest,
 	injectReviewCandidateView,
 	readCandidateContextManifestPage,
+	type NativeCandidateProjectionDescriptor,
 } from "../lib/review-candidate-view.ts";
 
 function git(cwd: string, ...arguments_: string[]): string {
@@ -1994,4 +1995,77 @@ test("candidate view cleans up a partially registered unborn fallback worktree w
 	const parent = join(realpathSync(git(contributorRoot, "rev-parse", "--path-format=absolute", "--git-common-dir")), "gentle-ai", "candidate-views");
 	const leftover = existsSync(parent) ? readdirSync(parent).filter((entry) => lstatSync(join(parent, entry)).isDirectory()) : [];
 	assert.deepEqual(leftover, [], "no candidate directory remains after a partial unborn fallback failure");
+});
+
+function stagedFinalizeDescriptor(cwd: string, path: string, content: string): NativeCandidateProjectionDescriptor {
+	writeFileSync(join(cwd, path), content);
+	git(cwd, "add", path);
+	const baseTree = git(cwd, "rev-parse", "HEAD^{tree}");
+	const currentCandidateTree = git(cwd, "write-tree");
+	return { baseTree, currentCandidateTree, paths: [path], intendedUntracked: [], projection: "staged" };
+}
+
+function candidateViewWorktreeCount(cwd: string): number {
+	return git(cwd, "worktree", "list").split("\n").filter((line) => line.includes("candidate-views")).length;
+}
+
+test("gentle-pi#185: a forecast-restored FINALIZE worktree does not leak across the next restore for the same lineage", (t) => {
+	// gentle-pi#185: `restoreForFinalizeFromNative` materializes a real Git
+	// worktree to restore a lineage's FINALIZE binding from the native frozen
+	// projection. A forecast-only FINALIZE after a process restart uses this
+	// exact path, but its outcome is non-terminal, so `cleanupTerminal` (which
+	// only fires for "approved"/"escalated") never runs for it. Before the fix,
+	// `restoreForFinalizeFromNative` never cleared the stale binding it had
+	// just created, so restoring the same lineage's FINALIZE binding again
+	// (the lineage's later approved FINALIZE, or another restart-time
+	// forecast) threw "native frozen projection is invalid or already
+	// restored" from `restoreProjectionFromNative` — leaving the first
+	// worktree registered forever and breaking the very finalize that should
+	// have succeeded.
+	const cwd = repository(t);
+	const registry = new CandidateViewRegistry();
+	const lineageId = "forecast-lineage-185";
+	const descriptor = stagedFinalizeDescriptor(cwd, "tracked.txt", "forecast change\n");
+
+	assert.equal(candidateViewWorktreeCount(cwd), 0, "no candidate worktree exists before any restore");
+
+	// Reproduces the leak symptom: a forecast-only FINALIZE restore
+	// materializes a worktree that is still registered with Git once the
+	// (non-terminal) forecast finalize returns.
+	registry.restoreForFinalizeFromNative(lineageId, cwd, descriptor);
+	assert.equal(candidateViewWorktreeCount(cwd), 1, "the forecast restore leaves its worktree registered with Git after it returns");
+
+	// A later restore for the same lineage (its approved FINALIZE, or another
+	// restart-time forecast) must clean up the stale worktree and replace it
+	// deterministically instead of throwing or leaking a parallel sibling.
+	assert.doesNotThrow(
+		() => registry.restoreForFinalizeFromNative(lineageId, cwd, descriptor),
+		"restoring the same lineage's FINALIZE binding again must not fail on the stale binding it left behind",
+	);
+	assert.equal(candidateViewWorktreeCount(cwd), 1, "the second restore must replace the first worktree, never accumulate a parallel sibling");
+
+	// The subsequent approved FINALIZE's terminal cleanup must still work for
+	// the worktree that is actually registered after the restore.
+	registry.cleanupTerminal(lineageId, "approved", cwd);
+	assert.equal(candidateViewWorktreeCount(cwd), 0, "approved cleanup removes the restored worktree, leaving no candidate worktree registered");
+});
+
+test("gentle-pi#185 review correction: a restore whose materialization fails leaves the previous binding intact", (t) => {
+	const cwd = repository(t);
+	const lineageId = "forecast-lineage-185-rollback";
+	const descriptor = stagedFinalizeDescriptor(cwd, "tracked.txt", "forecast change\n");
+	let worktreeAdds = 0;
+	const executor: CandidateGitExecutor = (file, args, options) => {
+		if (args[0] === "worktree" && args[1] === "add" && ++worktreeAdds === 2) throw Object.assign(new Error("simulated worktree add failure"), { status: 128 });
+		return execFileSync(file, args, options);
+	};
+	const registry = new CandidateViewRegistry(executor);
+	const first = registry.restoreForFinalizeFromNative(lineageId, cwd, descriptor);
+	assert.equal(candidateViewWorktreeCount(cwd), 1);
+	let failure: unknown;
+	try { registry.restoreForFinalizeFromNative(lineageId, cwd, descriptor); } catch (error) { failure = error; }
+	assert.equal((failure as CandidateViewError)?.reason, "candidate-view-git-failure", "a failed materialization must propagate, not silently succeed");
+	assert.equal(candidateViewWorktreeCount(cwd), 1, "the previously registered worktree must survive the failed restore");
+	assert.equal(registry.resolveForFinalize(lineageId, cwd).token, first.token, "the lineage must still resolve to its original worktree");
+	registry.cleanupTerminal(lineageId, "approved", cwd);
 });

--- a/tests/review-controller.test.ts
+++ b/tests/review-controller.test.ts
@@ -363,12 +363,37 @@ test("general STATUS returns the typed native-status-unsupported boundary withou
 		mutation_performed: false,
 		inventory_complete: false,
 		next_action: "require-upstream-read-only-native-status-inventory",
+		remediation_command: "gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --agent pi --next-transition",
 		evidence: {
 			native_contract: "gentle-ai/2.1.4",
 			general_status: "unsupported",
 			claimant_inventory: "unsupported",
 		},
 	});
+});
+
+test("gentle-pi#185: general STATUS on a non-negotiated native CLI names the exact status command to run", async (t) => {
+	// The legacy `correctionForecast` restoration guard this issue originally
+	// reported (extensions/gentle-ai.ts, then around line 5329) was scoped to
+	// `targetStatus !== undefined` and skipped restoring a candidate view when
+	// the native CLI lacked negotiated STATUS support, reproducing the #176
+	// empty-registry failure. That entire manual FINALIZE lifecycle (and the
+	// `correctionForecast` guard with it) has since been replaced by the
+	// STATUS/capture-driven flow: every operation now checks negotiated STATUS
+	// support up front, so no candidate-view restoration is ever attempted on
+	// a non-negotiated CLI. This test proves the current equivalent boundary
+	// (`nativeStatusUnsupported`) fails closed with an actionable envelope
+	// instead of a bare machine token, so a non-negotiated CLI can never
+	// surface as a silent empty-registry failure.
+	const fixture = createRepository(t);
+	const { controller } = registerRuntime();
+	const result = await controllerCall(controller, extensionContext(fixture.repository), { operation: "status" });
+	assert.equal(result.status, "blocked");
+	assert.equal(result.outcome, "native-status-unsupported");
+	assert.equal(
+		result.remediation_command,
+		"gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --agent pi --next-transition",
+	);
 });
 
 test("failed START gives exact mode and serialization guidance and creates no lineage", async (t) => {


### PR DESCRIPTION
Closes #185

## Summary
- A forecast-only FINALIZE restore followed by a later restore for the same lineage no longer leaks the first worktree or throws `already restored`: the registry detaches the stale binding, materializes the replacement, and only then removes the old worktree. If materialization fails, the previous binding is restored untouched, so the lineage never lands in the empty-registry state.
- On a native CLI without negotiated STATUS, the blocked envelope names the exact `gentle-ai review status … --next-transition` command to run.

## Changes
| File | Change |
|------|--------|
| `lib/review-candidate-view.ts` | Materialize-then-swap restore with rollback on failure |
| `extensions/gentle-ai.ts` | `remediation_command` on the native-status-unsupported boundary |
| `tests/review-candidate-view.test.ts` | Leak regression, failed-materialization keeps the old binding |
| `tests/review-controller.test.ts` | Non-negotiated CLI names the status command |

## Test plan
- [x] `node scripts/build-runtime-modules.mjs --write` (no generated drift)
- [x] `pnpm test` (1395 pass, 1 skipped)
- [x] Native review: correction (57/59 lines) validated and approved (lineage review-1473b28b129a53c1), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M