### PR TITLE
fix(tui): bound card rendering to narrow terminal widths

### DIFF
--- a/lib/shell-card.ts
+++ b/lib/shell-card.ts
@@ -71,22 +71,46 @@ function soft(theme: CardTheme, _tone: CardTone, text: string): string {
 }
 
 export function cardTop(card: Card, theme: CardTheme, width: number, hint?: string): string {
+	const targetWidth = Math.max(0, Math.floor(width));
+	if (targetWidth === 0) return "";
+	if (targetWidth < 5) {
+		const left = theme.fg(TONE_ROLE[card.tone], "╭");
+		if (targetWidth === 1) return left;
+		return left + soft(theme, card.tone, `${rule(targetWidth - 2)}╮`);
+	}
+
 	const title = titleText(card, theme);
-	const hintWidth = hint ? visibleWidth(hint) + 2 : 0;
-	const fill = rule(width - title.width - 5 - hintWidth);
-	const tail = hint ? ` ${theme.fg(HINT_ROLE, hint)} ` : "";
-	return theme.fg(TONE_ROLE[card.tone], "╭") + soft(theme, card.tone, "─ ") + title.styled + soft(theme, card.tone, ` ${fill}`) + tail + soft(theme, card.tone, "╮");
+	const fullHintWidth = hint ? visibleWidth(hint) + 2 : 0;
+	const shownHint = hint && title.width + 5 + fullHintWidth <= targetWidth ? hint : undefined;
+	const hintWidth = shownHint ? fullHintWidth : 0;
+	const titleWidth = Math.max(0, targetWidth - 5 - hintWidth);
+	const styledTitle = title.width <= titleWidth ? title.styled : truncateToWidth(title.styled, titleWidth, "");
+	const styledTitleWidth = title.width <= titleWidth ? title.width : visibleWidth(styledTitle);
+	const fill = rule(targetWidth - styledTitleWidth - 5 - hintWidth);
+	const tail = shownHint ? ` ${theme.fg(HINT_ROLE, shownHint)} ` : "";
+	return theme.fg(TONE_ROLE[card.tone], "╭") + soft(theme, card.tone, "─ ") + styledTitle + soft(theme, card.tone, ` ${fill}`) + tail + soft(theme, card.tone, "╮");
 }
 
 export function cardLine(text: string, tone: CardTone, theme: CardTheme, width: number): string {
-	const innerWidth = Math.max(1, width - FRAME_COLUMNS);
-	const clipped = truncateToWidth(text, innerWidth, "…");
+	const targetWidth = Math.max(0, Math.floor(width));
+	if (targetWidth === 0) return "";
+	const left = theme.fg(TONE_ROLE[tone], "│");
+	if (targetWidth === 1) return left;
+	if (targetWidth === 2) return left + soft(theme, tone, "│");
+	if (targetWidth === 3) return `${left} ${soft(theme, tone, "│")}`;
+
+	const innerWidth = targetWidth - FRAME_COLUMNS;
+	const clipped = innerWidth === 0 ? "" : truncateToWidth(text, innerWidth, "…");
 	const padding = " ".repeat(Math.max(0, innerWidth - visibleWidth(clipped)));
-	return `${theme.fg(TONE_ROLE[tone], "│")} ${clipped}${padding} ${soft(theme, tone, "│")}`;
+	return `${left} ${clipped}${padding} ${soft(theme, tone, "│")}`;
 }
 
 export function cardBottom(tone: CardTone, theme: CardTheme, width: number): string {
-	return theme.fg(TONE_ROLE[tone], "╰") + soft(theme, tone, `${rule(width - 2)}╯`);
+	const targetWidth = Math.max(0, Math.floor(width));
+	if (targetWidth === 0) return "";
+	const left = theme.fg(TONE_ROLE[tone], "╰");
+	if (targetWidth === 1) return left;
+	return left + soft(theme, tone, `${rule(targetWidth - 2)}╯`);
 }
 
 export function cardInnerWidth(width: number): number {

--- a/tests/gentle-ai-renderer.test.ts
+++ b/tests/gentle-ai-renderer.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Box, visibleWidth } from "@earendil-works/pi-tui";
 import { renderGentleAiResult, GentleAiCallCard } from "../lib/gentle-ai-renderer.ts";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 
@@ -19,9 +20,24 @@ test("a running call card closes its own frame and a completed one leaves that t
 	card.update("preparing", "review status", plainTheme, "$ gentle-ai review status");
 	assert.match(card.render(60).map(stripAnsi)[2], /^╰─+╯$/);
 	card.update("completed", "review status", plainTheme, undefined, "ctrl+o to expand");
-	const completed = card.render(60).map(stripAnsi);
+	const completed = card.render(80).map(stripAnsi);
 	assert.equal(completed.length, 1);
 	assert.match(completed[0], /ctrl\+o to expand ╮$/);
+	assert.equal(visibleWidth(completed[0]), 80);
+});
+
+test("completed review cards fit Pi's default Box at terminal width 57", () => {
+	for (const operationPath of ["review inspect", "review status", "review capture · reliability", "review acknowledge approved"]) {
+		const card = new GentleAiCallCard();
+		card.update("completed", operationPath, plainTheme, undefined, "ctrl+o to expand");
+		const box = new Box(1, 1);
+		box.addChild(card);
+		const lines = box.render(57).map(stripAnsi);
+		for (const line of lines) assert.equal(visibleWidth(line), 57, `${operationPath}: ${JSON.stringify(line)}`);
+		if (operationPath === "review inspect") {
+			assert.equal(lines[1], " ╭─ 🌹︎ Gentle AI · completed · review inspect ─────────╮ ");
+		}
+	}
 });
 
 test("a partial result draws no bottom rule and a final one draws exactly one", () => {

--- a/tests/shell-card.test.ts
+++ b/tests/shell-card.test.ts
@@ -20,6 +20,12 @@ const taggedTheme = {
 	},
 };
 
+const ansiTheme = {
+	fg(_color: string, text: string) {
+		return `\x1b[35m${text}\x1b[0m`;
+	},
+};
+
 function card(overrides: Partial<Card> = {}): Card {
 	return {
 		title: "Gentle AI",
@@ -83,4 +89,30 @@ test("renderCard accepts a custom glyph and an empty body", () => {
 test("renderCard keeps the top rule at width with a two-cell glyph", () => {
 	const lines = renderCard(card({ glyph: "\u{1F339}\uFE0E" }), plainTheme, 60, { expanded: false, hint: "ctrl+o expand" });
 	for (const line of lines) assert.equal(visibleWidth(line), 60, `"${stripAnsi(line)}" is not 60 wide`);
+});
+
+test("renderCard drops the hint before truncating title content", () => {
+	const lines = renderCard(card(), plainTheme, 40, { expanded: false, hint: "ctrl+o expand" }).map(stripAnsi);
+	assert.equal(lines[0], "╭─ ✿ Gentle AI · review preflight ─────╮");
+	assert.ok(!lines[0].includes("ctrl+o"));
+	assert.equal(visibleWidth(lines[0]), 40);
+});
+
+test("renderCard truncates ANSI-styled title content at display width", () => {
+	const lines = renderCard(
+		card({ glyph: "\u{1F339}\uFE0E", title: "Gentle AI review", subtitle: "completed · review acknowledge approved" }),
+		ansiTheme,
+		30,
+		{ expanded: false, hint: "ctrl+o to expand" },
+	);
+	assert.match(stripAnsi(lines[0]), /^╭─ 🌹︎ Gentle AI review.*╮$/);
+	assert.ok(!stripAnsi(lines[0]).includes("ctrl+o"));
+	for (const line of lines) assert.equal(visibleWidth(line), 30, `"${stripAnsi(line)}" is not 30 wide`);
+});
+
+test("renderCard never exceeds extremely narrow supplied widths", () => {
+	for (const width of [0, 1, 2, 3, 4, 5, 8, 16]) {
+		const lines = renderCard(card({ glyph: "\u{1F339}\uFE0E" }), ansiTheme, width, { expanded: true, hint: "ctrl+o to expand" });
+		for (const line of lines) assert.equal(visibleWidth(line), width, `"${stripAnsi(line)}" is not ${width} wide`);
+	}
 });


### PR DESCRIPTION
## Linked issue
Closes #624

## PR type
- [x] Bug fix

## Summary
- Drop decorative hints before ANSI-safe title truncation when card headers exceed available columns.
- Keep card frames and body rows bounded even at very small widths.
- Cover the restored review-card crash in a 57-column terminal with actual Box padding.

## Changes
| File | Change |
|------|--------|
| `lib/shell-card.ts` | Width-safe card rendering and hint-first degradation |
| `tests/shell-card.test.ts` | Narrow widths, ANSI styles, wide glyphs, and frame regression coverage |
| `tests/gentle-ai-renderer.test.ts` | Completed review-card regression at terminal width 57 |

## Test plan
- [x] Focused tests: 13 passed, 0 failed
- [x] Independent verification and git diff --check
- [x] Native RDD review approved and acknowledged
- [ ] Full test suite and runtime-module consistency (running)
- [ ] Live mobile terminal smoke test (maintainer)

## Contributor checklist
- [x] Approved issue linked
- [x] Exactly one type label
- [x] Conventional commit; no Co-Authored-By trailers
- Shellcheck: not applicable (no shell scripts changed)
- Skill testing: not applicable (no skills changed)
- No public API or configuration changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved card rendering at narrow terminal widths.
  - Titles now truncate cleanly, while hints are shown only when space allows.
  - Preserved correct alignment and visible widths for styled text and wide characters.
  - Prevented malformed frame segments when cards have very limited space.

- **Tests**
  - Added coverage for narrow layouts, title truncation, hints, ANSI styling, and completed review cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->