### PR TITLE
test(review): isolate transport refusal from session handshake

### DIFF
--- a/tests/native-review-parity-runtime.test.ts
+++ b/tests/native-review-parity-runtime.test.ts
@@ -140,6 +140,8 @@ test("generated runtime decoder consumes the captured terminal closure directly"
 
 test("registered gentle_review surfaces the package-pinned Pi transport refusal before native START for a safe internal symlink candidate", async (t) => {
 	await reviewEnabledHome(t);
+	const handshakeLessEnvironment = { ...process.env };
+	delete handshakeLessEnvironment.GENTLE_PI_REVIEW_RELAY_CONTRACT;
 	const workspace = await realpath(await mkdtemp(join(tmpdir(), "gentle-pi-v215-symlink-candidate-")));
 	const repository = join(workspace, "repository");
 	t.after(async () => {
@@ -174,14 +176,14 @@ test("registered gentle_review surfaces the package-pinned Pi transport refusal 
 	// refusal happens before native START, regardless of candidate materialization.
 	const native = new NativeReviewCliV216(async (request) => {
 		if (request.arguments[0] === "review" && request.arguments[1] === "start") nativeStartReached = true;
-		const command = await run(binary, request.arguments, request.cwd, true);
+		const command = await run(binary, request.arguments, request.cwd, true, handshakeLessEnvironment);
 		return { ...command, signal: null, timedOut: false, outputLimitExceeded: false };
 	});
 	const tools = new Map<string, RegisteredController>();
 	// The extension declares the relay handshake in the session environment on
-	// load (gentle-pi#550). This runner spawns the pinned binary with the test
-	// process environment and must keep observing the handshake-less refusal,
-	// so the declaration goes to a throwaway environment here.
+	// load (gentle-pi#550). Keep registration isolated in a throwaway environment
+	// and spawn the pinned binary with an explicit handshake-less environment so
+	// ambient valid relay configuration cannot change this fixture's behavior.
 	createGentleAiExtension({ nativeReviewCli: native, candidateViews, processEnv: {} } as Parameters<typeof createGentleAiExtension>[0])({
 		on() {},
 		registerTool(definition: RegisteredController & { name: string }) { tools.set(definition.name, definition); },


### PR DESCRIPTION
## Linked issue
Closes #550

Test-isolation follow-up to the already-closed issue: preserve the intended session handshake while preventing it from leaking into the negative transport fixture.

## PR type
- [x] Bug fix

## Summary
- Copy the sandbox environment and remove the relay handshake only for the refusal fixture native subprocess.
- Keep extension registration isolated; do not change production behavior or the global environment.

## Changes
| File | Change |
|------|--------|
| `tests/native-review-parity-runtime.test.ts` | Explicit handshake-free subprocess environment and explanatory comment |

## Test plan
- [x] RED: valid ambient handshake reproduces the transport-refusal assertion failure
- [x] GREEN: handshake absent and present both pass 2/2, with nativeStartReached false
- [x] pnpm test: 1,399 passed, 1 skipped, 0 failed (1,400 total)
- [x] Runtime module consistency: four modules match
- [x] git diff --check
- [x] Native four-lens RDD review approved and acknowledged

## Contributor checklist
- [x] Approved issue linked (follow-up to #550)
- [x] Exactly one type label
- [x] Conventional commit without Co-Authored-By trailers
- Shellcheck and skill validation: not applicable; no scripts or skills changed
- Production behavior unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of review transport validation by isolating test environments from ambient relay configuration.
  - Ensured handshake-less scenarios consistently exercise the intended refusal behavior, regardless of external environment settings.
  - No user-facing functionality or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->