### PR TITLE
fix(review): decode current authority inventory entries

### DIFF
--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -498,8 +498,13 @@ export const NATIVE_REVIEW_AUTHORITY_ENTRY_VERSION = {
 } as const;
 export type NativeReviewAuthorityEntryVersion = (typeof NATIVE_REVIEW_AUTHORITY_ENTRY_VERSION)[keyof typeof NATIVE_REVIEW_AUTHORITY_ENTRY_VERSION];
 
-export const NATIVE_REVIEW_AUTHORITY_ENTRY_STATUS = NATIVE_REVIEW_AUTHORITY_STATUS;
-export type NativeReviewAuthorityEntryStatus = NativeReviewAuthorityStatus;
+export const NATIVE_REVIEW_AUTHORITY_ENTRY_STATUS = {
+	...NATIVE_REVIEW_AUTHORITY_STATUS,
+	INCOMPLETE_STORE_ENTRY: "incomplete-store-entry",
+	HISTORICAL_PRE_RECEIPT: "historical-pre-receipt",
+	INVALIDATED: "invalidated",
+} as const;
+export type NativeReviewAuthorityEntryStatus = (typeof NATIVE_REVIEW_AUTHORITY_ENTRY_STATUS)[keyof typeof NATIVE_REVIEW_AUTHORITY_ENTRY_STATUS];
 
 export const NATIVE_REVIEW_LOCK_STATUS = {
 	OWNED: "owned",
@@ -541,6 +546,10 @@ export interface NativeReviewRecovery {
 	recoveredAt: string;
 	maintainerAuthorization?: string;
 }
+export interface NativeReviewDiscardedWorkSummary {
+	capturedLensResults: readonly string[];
+	findingsPresent: boolean;
+}
 export interface NativeReviewAuthorityEntry {
 	version: NativeReviewAuthorityEntryVersion;
 	lineageId?: string;
@@ -551,6 +560,7 @@ export interface NativeReviewAuthorityEntry {
 	snapshotIdentity?: string;
 	chainIdentity?: string;
 	recovery?: NativeReviewRecovery;
+	discardedWork?: NativeReviewDiscardedWorkSummary;
 	problems: readonly string[];
 }
 export interface NativeReviewAuthorityLock {
@@ -1046,8 +1056,15 @@ function decodeNativeReviewRecovery(value: unknown): NativeReviewRecovery {
 		...(recovery.maintainer_authorization === undefined ? {} : { maintainerAuthorization: requiredString(recovery.maintainer_authorization) }),
 	};
 }
+function decodeNativeReviewDiscardedWorkSummary(value: unknown): NativeReviewDiscardedWorkSummary {
+	const discardedWork = exactObject(value, ["captured_lens_results", "findings_present"]);
+	return {
+		capturedLensResults: stringArray(discardedWork.captured_lens_results),
+		findingsPresent: booleanValue(discardedWork.findings_present),
+	};
+}
 function decodeNativeReviewStatusEntry(value: unknown): NativeReviewAuthorityEntry {
-	const entry = exactObject(value, ["version", "path", "status", "problems"], ["lineage_id", "state", "revision", "snapshot_identity", "chain_identity", "recovery"]);
+	const entry = exactObject(value, ["version", "path", "status", "problems"], ["lineage_id", "state", "revision", "snapshot_identity", "chain_identity", "recovery", "discarded_work"]);
 	return {
 		version: enumString(entry.version, Object.values(NATIVE_REVIEW_AUTHORITY_ENTRY_VERSION)) as NativeReviewAuthorityEntryVersion,
 		...(entry.lineage_id === undefined ? {} : { lineageId: requiredString(entry.lineage_id) }),
@@ -1058,6 +1075,7 @@ function decodeNativeReviewStatusEntry(value: unknown): NativeReviewAuthorityEnt
 		...(entry.snapshot_identity === undefined ? {} : { snapshotIdentity: sha256Identity(entry.snapshot_identity) }),
 		...(entry.chain_identity === undefined ? {} : { chainIdentity: requiredString(entry.chain_identity) }),
 		...(entry.recovery === undefined ? {} : { recovery: decodeNativeReviewRecovery(entry.recovery) }),
+		...(entry.discarded_work === undefined ? {} : { discardedWork: decodeNativeReviewDiscardedWorkSummary(entry.discarded_work) }),
 		problems: stringArray(entry.problems),
 	};
 }

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -499,7 +499,12 @@ export const NATIVE_REVIEW_AUTHORITY_ENTRY_VERSION = {
 }         ;
 
 
-export const NATIVE_REVIEW_AUTHORITY_ENTRY_STATUS = NATIVE_REVIEW_AUTHORITY_STATUS;
+export const NATIVE_REVIEW_AUTHORITY_ENTRY_STATUS = {
+	...NATIVE_REVIEW_AUTHORITY_STATUS,
+	INCOMPLETE_STORE_ENTRY: "incomplete-store-entry",
+	HISTORICAL_PRE_RECEIPT: "historical-pre-receipt",
+	INVALIDATED: "invalidated",
+}         ;
 
 
 export const NATIVE_REVIEW_LOCK_STATUS = {
@@ -531,6 +536,11 @@ export const NATIVE_REVIEW_RECOVERY_DISPOSITION = {
 	INVALIDATED: "invalidated",
 	ESCALATED: "escalated",
 }         ;
+
+
+
+
+
 
 
 
@@ -1047,8 +1057,15 @@ function decodeNativeReviewRecovery(value         )                       {
 		...(recovery.maintainer_authorization === undefined ? {} : { maintainerAuthorization: requiredString(recovery.maintainer_authorization) }),
 	};
 }
+function decodeNativeReviewDiscardedWorkSummary(value         )                                   {
+	const discardedWork = exactObject(value, ["captured_lens_results", "findings_present"]);
+	return {
+		capturedLensResults: stringArray(discardedWork.captured_lens_results),
+		findingsPresent: booleanValue(discardedWork.findings_present),
+	};
+}
 function decodeNativeReviewStatusEntry(value         )                             {
-	const entry = exactObject(value, ["version", "path", "status", "problems"], ["lineage_id", "state", "revision", "snapshot_identity", "chain_identity", "recovery"]);
+	const entry = exactObject(value, ["version", "path", "status", "problems"], ["lineage_id", "state", "revision", "snapshot_identity", "chain_identity", "recovery", "discarded_work"]);
 	return {
 		version: enumString(entry.version, Object.values(NATIVE_REVIEW_AUTHORITY_ENTRY_VERSION))                                     ,
 		...(entry.lineage_id === undefined ? {} : { lineageId: requiredString(entry.lineage_id) }),
@@ -1059,6 +1076,7 @@ function decodeNativeReviewStatusEntry(value         )                          
 		...(entry.snapshot_identity === undefined ? {} : { snapshotIdentity: sha256Identity(entry.snapshot_identity) }),
 		...(entry.chain_identity === undefined ? {} : { chainIdentity: requiredString(entry.chain_identity) }),
 		...(entry.recovery === undefined ? {} : { recovery: decodeNativeReviewRecovery(entry.recovery) }),
+		...(entry.discarded_work === undefined ? {} : { discardedWork: decodeNativeReviewDiscardedWorkSummary(entry.discarded_work) }),
 		problems: stringArray(entry.problems),
 	};
 }

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -609,6 +609,46 @@ test("current native process boundary preserves caps, timeout classes, and sanit
 	);
 });
 
+test("authority inventory accepts compact discarded work and historical entry statuses", async () => {
+	const repository = process.cwd();
+	const discardedWork = { captured_lens_results: [], findings_present: false };
+	const statuses = ["incomplete-store-entry", "historical-pre-receipt", "invalidated"] as const;
+	const body = {
+		schema: "gentle-ai.review-authority-status/v1",
+		operation: "review/status",
+		repository,
+		complete: true,
+		authoritative: true,
+		status: "active",
+		entries: statuses.map((status) => ({
+			version: "compact-v2",
+			lineage_id: `review-${status}`,
+			path: `${repository}/.git/gentle-ai/${status}`,
+			status,
+			discarded_work: discardedWork,
+			problems: [],
+		})),
+		locks: [],
+		diagnostics: [],
+	};
+	const decoded = await client(queuedAdapter([{ stdout: JSON.stringify(body) }]).adapter).reviewStatus({ cwd: repository });
+	assert.deepEqual(decoded.entries.map((entry) => ({ status: entry.status, discardedWork: entry.discardedWork })), statuses.map((status) => ({
+		status,
+		discardedWork: { capturedLensResults: [], findingsPresent: false },
+	})));
+
+	for (const entry of [
+		{ ...body.entries[0], discarded_work: { captured_lens_results: "not-an-array", findings_present: false } },
+		{ ...body.entries[0], discarded_work: { ...discardedWork, unexpected: true } },
+		{ ...body.entries[0], status: "future-status" },
+	]) {
+		await assert.rejects(
+			() => client(queuedAdapter([{ stdout: JSON.stringify({ ...body, entries: [entry] }) }]).adapter).reviewStatus({ cwd: repository }),
+			(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE,
+		);
+	}
+});
+
 test("current review STATUS retains compact snapshot and released-lock wire fields", async (t) => {
 	const repository = process.cwd();
 	const snapshotIdentity = `sha256:${"d".repeat(64)}`;


### PR DESCRIPTION
Closes #631

## Type

- [x] Bug fix

## Summary

- Decode the current provider's typed `discarded_work` summary on compact authority entries.
- Accept the three provider-defined entry-only historical states without widening global authority status routing.
- Preserve fail-closed rejection for malformed summaries, unknown fields, and unknown future statuses.

## Changes

| File | Change |
|------|--------|
| `lib/native-review-cli.ts` | Add typed discarded-work decoding and provider-compatible entry statuses. |
| `runtime/native-review-cli.mjs` | Regenerate the runtime mirror from TypeScript. |
| `tests/native-review-cli.test.ts` | Cover valid compact entries and malformed/unknown fail-closed cases. |

## Test plan

- [x] RED reproduced `schema-incompatible` for valid `discarded_work` and `invalidated`
- [x] Focused decoder suite — 35 passed, 0 failed
- [x] Decoder + acknowledgement routing suites — 84 passed, 0 failed
- [x] `pnpm test` — 1,436 passed, 0 failed, 1 skipped
- [x] `pnpm run check:runtime-modules`
- [x] `git diff --check`
- [x] Provider Go schema independently matched (`CompactDiscardedWorkSummary`)
- [x] Native RDD high-tier review — 4/4 lenses, approved and acknowledged (`review-9779ae0f486fa4cd`)
- [x] Shellcheck N/A — no shell files changed

## Contributor checklist

- [x] Linked approved issue #631
- [x] Exactly one `type:*` label
- [x] Conventional commit
- [x] Tests included with behavior
- [x] Runtime mirror regenerated, not edited independently
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional review entry statuses: incomplete store entry, historical pre-receipt, and invalidated.
  * Review entries can now include discarded-work details, including captured lens results and whether findings were present.

* **Bug Fixes**
  * Added validation to reject malformed discarded-work data and unknown review entry statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->