### PR TITLE
fix(review): use Git-compatible null config paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,27 @@ jobs:
 
       - name: Verify packed installation
         run: pnpm run test:packed-package
+
+  review-repository-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Windows Git authority probe
+        shell: pwsh
+        run: pnpm exec node --experimental-strip-types --test tests/review-repository.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          GENTLE_PI_SKIP_GENTLE_AI_INSTALL: "1"
 
       - name: Run Windows Git authority probe
         shell: pwsh

--- a/lib/review-repository.ts
+++ b/lib/review-repository.ts
@@ -55,8 +55,8 @@ export function reviewGitEnvironment(): NodeJS.ProcessEnv {
 	const environment: NodeJS.ProcessEnv = {};
 	for (const [key, value] of Object.entries(process.env)) if (!key.startsWith("GIT_")) environment[key] = value;
 	environment.GIT_CONFIG_NOSYSTEM = "1";
-	environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
-	environment.GIT_CONFIG_SYSTEM = process.platform === "win32" ? "NUL" : "/dev/null";
+	environment.GIT_CONFIG_GLOBAL = "/dev/null";
+	environment.GIT_CONFIG_SYSTEM = "/dev/null";
 	environment.GIT_OPTIONAL_LOCKS = "0";
 	environment.LC_ALL = "C";
 	environment.LANG = "C";

--- a/tests/review-repository.test.ts
+++ b/tests/review-repository.test.ts
@@ -4,7 +4,7 @@ import { cpSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
-import { resolveRepositoryAuthorityV1, setReviewRepositoryIdentityRetryHookForTesting } from "../lib/review-repository.ts";
+import { resolveRepositoryAuthorityV1, reviewGitEnvironment, setReviewRepositoryIdentityRetryHookForTesting } from "../lib/review-repository.ts";
 import { REVIEW_MODE, ReviewTransactionStore, createReviewState, setReviewMutationLockPlatformForTesting } from "../lib/review-transaction.ts";
 import { REVIEW_LENS, REVIEW_ROUTE } from "../lib/review-triggers.ts";
 import { qualifiedReviewLockPlatform, testSnapshot } from "./review-test-fixtures.ts";
@@ -48,6 +48,33 @@ function addOrphanRoot(root: string, branch: string, file: string): void {
 	git(root, "commit", "-m", `orphan root on ${branch}`);
 	git(root, "checkout", "main");
 }
+
+test("review Git environment uses a Git-compatible null config path on Windows", () => {
+	const environment = reviewGitEnvironment();
+	assert.equal(environment.GIT_CONFIG_GLOBAL, "/dev/null");
+	assert.equal(environment.GIT_CONFIG_SYSTEM, "/dev/null");
+});
+
+test("review Git environment runs a real Git authority probe", (t) => {
+	const root = repository(t);
+	const commonDirectory = execFileSync("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+		cwd: root,
+		encoding: "utf8",
+		env: reviewGitEnvironment(),
+	}).trim();
+	assert.equal(resolve(commonDirectory), resolve(git(root, "rev-parse", "--path-format=absolute", "--git-common-dir")));
+});
+
+test("review Git environment rejects inherited unsafe Git overrides", () => {
+	const prior = process.env.GIT_DIR;
+	try {
+		process.env.GIT_DIR = "/unsafe";
+		assert.throws(() => reviewGitEnvironment(), /REVIEW_GIT_ENV_UNSAFE/);
+	} finally {
+		if (prior === undefined) delete process.env.GIT_DIR;
+		else process.env.GIT_DIR = prior;
+	}
+});
 
 test("a Windows drive-letter Git common directory resolves repository authority", { skip: process.platform !== "win32" }, (t) => {
 	const root = repository(t);


### PR DESCRIPTION
Closes #203

## Type

- [x] Bug fix

## Summary

- Use Git-for-Windows-compatible `/dev/null` paths for sanitized global and system Git configuration.
- Preserve strict rejection of inherited Git routing/configuration overrides.
- Add a focused `windows-latest` authority-probe job so the platform boundary is exercised by real Git.

## Changes

| File | Change |
|------|--------|
| `lib/review-repository.ts` | Replace incompatible Windows `NUL` config paths with `/dev/null`. |
| `tests/review-repository.test.ts` | Cover sanitized paths, a real Git common-directory probe, and inherited override rejection. |
| `.github/workflows/ci.yml` | Run the focused repository-authority suite on Windows. |

## Test plan

- [x] RED: Windows-path regression failed with `'NUL' !== '/dev/null'`
- [x] Focused repository suite — 10 passed, 0 failed, 1 Windows-only skip locally
- [x] Full Node suite — 1,440 passed, 0 failed, 1 skipped
- [x] `pnpm test`
- [x] `pnpm run check:runtime-modules`
- [x] `git diff --check`
- [x] Native RDD high-tier review — 4/4 lenses, approved and acknowledged (`review-135587c17ed330bc`)
- [ ] GitHub `windows-latest` real Git authority probe
- [x] Shellcheck N/A — no shell files changed

## Contributor checklist

- [x] Linked approved issue #203
- [x] Exactly one `type:*` label
- [x] Conventional commit
- [x] Tests and platform CI included with behavior
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git environment handling across platforms for more consistent repository checks.
  - Added safeguards that reject unsafe inherited Git directory settings.

- **Tests**
  - Expanded coverage for Git environment validation, including real repository checks and unsafe configuration scenarios.

- **Chores**
  - Added automated Windows CI coverage to verify repository review behavior on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->