### PR TITLE
fix(review): preserve Windows consent cwd paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,7 @@ jobs:
       - name: Run Windows Git authority probe
         shell: pwsh
         run: pnpm exec node --experimental-strip-types --test tests/review-repository.test.ts
+
+      - name: Run Windows native consent boundary
+        shell: pwsh
+        run: pnpm exec node --experimental-strip-types --test tests/native-review-consent.test.ts

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -1613,14 +1613,20 @@ function splitNativeConsentInvocation(invocation: string): readonly string[] {
 	let quote: "'" | '"' | undefined;
 	let escaping = false;
 	let started = false;
-	for (const character of invocation.trim()) {
+	const source = invocation.trim();
+	for (let index = 0; index < source.length; index += 1) {
+		const character = source[index]!;
 		if (escaping) {
 			current += character;
 			escaping = false;
 			started = true;
 			continue;
 		}
-		if (character === "\\" && quote !== "'") {
+		// Provider invocations are not shell commands. Keep every path backslash
+		// verbatim, including quoted UNC and drive-root paths. Outside quotes,
+		// only a backslash before whitespace joins a space-containing token.
+		const next = source[index + 1];
+		if (character === "\\" && quote === undefined && next !== undefined && /\s/.test(next)) {
 			escaping = true;
 			started = true;
 			continue;
@@ -1711,7 +1717,9 @@ function consentInvocationArguments(request: NativeReviewConsentAnswerRequest): 
 	if (words[0] !== "gentle-ai" || words[1] !== "review" || words[2] !== "start") throw new NativeReviewConsentBindingError("consent-invocation-not-start", "Native consent invocation is not a provider review START");
 	const arguments_ = words.slice(1);
 	if (exactConsentOption(arguments_, "--contract") !== REVIEW_INTEGRATION_CONTRACT) throw new NativeReviewConsentBindingError("consent-invocation-contract-changed", "Native consent invocation contract changed");
-	if (exactConsentOption(arguments_, "--cwd") !== request.cwd) throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
+	const providerCwd = exactConsentOption(arguments_, "--cwd");
+	const requestedCwd = normalizeNativeReviewCwd(request.cwd);
+	if (normalizeNativeReviewCwd(providerCwd) !== requestedCwd) throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
 	const lineageId = optionalConsentLineageOption(arguments_);

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -1614,14 +1614,20 @@ function splitNativeConsentInvocation(invocation        )                    {
 	let quote                       ;
 	let escaping = false;
 	let started = false;
-	for (const character of invocation.trim()) {
+	const source = invocation.trim();
+	for (let index = 0; index < source.length; index += 1) {
+		const character = source[index] ;
 		if (escaping) {
 			current += character;
 			escaping = false;
 			started = true;
 			continue;
 		}
-		if (character === "\\" && quote !== "'") {
+		// Provider invocations are not shell commands. Keep every path backslash
+		// verbatim, including quoted UNC and drive-root paths. Outside quotes,
+		// only a backslash before whitespace joins a space-containing token.
+		const next = source[index + 1];
+		if (character === "\\" && quote === undefined && next !== undefined && /\s/.test(next)) {
 			escaping = true;
 			started = true;
 			continue;
@@ -1712,7 +1718,9 @@ function consentInvocationArguments(request                                  )  
 	if (words[0] !== "gentle-ai" || words[1] !== "review" || words[2] !== "start") throw new NativeReviewConsentBindingError("consent-invocation-not-start", "Native consent invocation is not a provider review START");
 	const arguments_ = words.slice(1);
 	if (exactConsentOption(arguments_, "--contract") !== REVIEW_INTEGRATION_CONTRACT) throw new NativeReviewConsentBindingError("consent-invocation-contract-changed", "Native consent invocation contract changed");
-	if (exactConsentOption(arguments_, "--cwd") !== request.cwd) throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
+	const providerCwd = exactConsentOption(arguments_, "--cwd");
+	const requestedCwd = normalizeNativeReviewCwd(request.cwd);
+	if (normalizeNativeReviewCwd(providerCwd) !== requestedCwd) throw new NativeReviewConsentBindingError("consent-invocation-cwd-changed", "Native consent invocation repository binding changed");
 	if (exactConsentOption(arguments_, "--target") !== request.consent.targetIdentity) throw new NativeReviewConsentBindingError("consent-invocation-target-changed", "Native consent invocation target binding changed");
 	if (exactConsentOption(arguments_, "--projection") !== request.consent.projection) throw new NativeReviewConsentBindingError("consent-invocation-projection-changed", "Native consent invocation projection binding changed");
 	const lineageId = optionalConsentLineageOption(arguments_);

--- a/tests/native-review-consent.test.ts
+++ b/tests/native-review-consent.test.ts
@@ -176,6 +176,97 @@ test("consent follow-up executes the provider-named invocation exactly once and 
 
 // A binding mismatch is decided entirely inside Pi, before the provider is
 // launched, so it must not be reported as a provider failure (issue #247).
+test("consent answer preserves quoted Windows provider cwd tokens and launches the provider exactly once", async () => {
+	const windowsCwd = "C:\\Users\\x\\repo with spaces";
+	const gitBashCwd = "/c/Users/x/repo with spaces";
+	const cwdPairs = process.platform === "win32"
+		? [{ providerCwd: windowsCwd, requestedCwd: gitBashCwd }, { providerCwd: gitBashCwd, requestedCwd: windowsCwd }, { providerCwd: gitBashCwd, requestedCwd: gitBashCwd }, { providerCwd: windowsCwd, requestedCwd: windowsCwd }]
+		: [{ providerCwd: windowsCwd, requestedCwd: windowsCwd }];
+	for (const { providerCwd, requestedCwd } of cwdPairs) {
+		const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+		const lineage = "windows-cwd-lineage";
+		for (const choice of decoded.choices) {
+			choice.invocation = choice.invocation
+				.replace("--cwd /repo", `--cwd "${providerCwd}"`)
+				.replace("review-consent-fixture", lineage);
+		}
+		const started = JSON.parse(JSON.stringify(fixture<Record<string, unknown>>("start.fixture.json")).replaceAll("review-start-fixture", lineage)) as Record<string, unknown>;
+		const expected = [
+			"review", "start", "--contract", "gentle-ai.review-integration/v2", "--cwd", providerCwd,
+			"--target", decoded.targetIdentity, "--projection", "workspace", "--lineage", lineage, "--consent", "granted",
+		];
+		for (const createClient of [client, runtimeClient]) {
+			const queue = queuedAdapter([capabilities(), structuredClone(started)]);
+			const result = await createClient(queue.adapter).answerConsent({ cwd: requestedCwd, consent: decoded, answer: "granted" });
+			assert.equal(result.kind, "started");
+			assert.deepEqual(queue.calls, [expected]);
+		}
+	}
+});
+
+test("consent answer preserves quoted UNC and drive-root cwd tokens", async () => {
+	for (const providerCwd of ["\\\\server\\share", "C:\\"]) {
+		const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+		const lineage = "windows-root-lineage";
+		for (const choice of decoded.choices) {
+			choice.invocation = choice.invocation
+				.replace("--cwd /repo", `--cwd "${providerCwd}"`)
+				.replace("review-consent-fixture", lineage);
+		}
+		const started = JSON.parse(JSON.stringify(fixture<Record<string, unknown>>("start.fixture.json")).replaceAll("review-start-fixture", lineage)) as Record<string, unknown>;
+		const expected = [
+			"review", "start", "--contract", "gentle-ai.review-integration/v2", "--cwd", providerCwd,
+			"--target", decoded.targetIdentity, "--projection", "workspace", "--lineage", lineage, "--consent", "granted",
+		];
+		for (const createClient of [client, runtimeClient]) {
+			const queue = queuedAdapter([capabilities(), structuredClone(started)]);
+			const result = await createClient(queue.adapter).answerConsent({ cwd: providerCwd, consent: decoded, answer: "granted" });
+			assert.equal(result.kind, "started");
+			assert.deepEqual(queue.calls, [expected]);
+		}
+	}
+});
+
+test("unmatched consent invocation quotes reject before provider launch", async () => {
+	for (const quote of ["'", '"']) {
+		const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+		const choice = decoded.choices.find((candidate) => candidate.answer === "granted") as { invocation: string };
+		choice.invocation = `${choice.invocation} ${quote}`;
+		for (const createClient of [client, runtimeClient]) {
+			const queue = queuedAdapter([]);
+			await assert.rejects(
+				() => createClient(queue.adapter).answerConsent({ cwd: "/repo", consent: decoded, answer: "granted" }),
+				(error: unknown) => error instanceof TypeError && error.message === "Native consent invocation has invalid quoting",
+			);
+			assert.deepEqual(queue.calls, []);
+		}
+	}
+});
+
+test("different, duplicate, missing, and malformed consent cwd options reject before provider launch", async () => {
+	const decoded = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
+	const drifted = (replace: (invocation: string) => string): ReviewConsentV2 => {
+		const consent = structuredClone(decoded);
+		const choice = consent.choices.find((candidate) => candidate.answer === "granted") as { invocation: string };
+		choice.invocation = replace(choice.invocation);
+		return consent;
+	};
+	const cases = [
+		{ label: "different", reason: "consent-invocation-cwd-changed", consent: drifted((value) => value.replace("--cwd /repo", "--cwd /another-repo")) },
+		{ label: "duplicate", reason: "consent-invocation-option-invalid", consent: drifted((value) => `${value} --cwd /repo`) },
+		{ label: "missing", reason: "consent-invocation-option-invalid", consent: drifted((value) => value.replace("--cwd /repo ", "")) },
+		{ label: "malformed", reason: "consent-invocation-cwd-changed", consent: drifted((value) => value.replace("--cwd /repo", '--cwd ""')) },
+	] as const;
+	for (const scenario of cases) {
+		const queue = queuedAdapter([]);
+		await assert.rejects(
+			() => client(queue.adapter).answerConsent!({ cwd: "/repo", consent: scenario.consent, answer: "granted" }),
+			(error: unknown) => error instanceof NativeReviewConsentBindingError && error.reason === scenario.reason,
+		);
+		assert.deepEqual(queue.calls, [], `${scenario.label} cwd must not launch the provider`);
+	}
+});
+
 test("a consent invocation binding mismatch is a typed pre-native error that never launches the provider", async () => {
 	const consent = (await import("../lib/review-integration-v2.ts")).decodeReviewConsentV2(fixture<Record<string, unknown>>("consent.fixture.json"));
 	const queue = queuedAdapter([]);


### PR DESCRIPTION
## Summary

- preserve Windows path separators when tokenizing provider-owned consent invocations
- compare equivalent Windows and Git Bash cwd spellings through the existing Win32 normalizer
- keep different, duplicate, missing, empty, and malformed cwd inputs fail-closed before provider launch
- exercise the source and generated-runtime clients in the existing Windows CI job

## Verification

- `pnpm test` — 1,443 passed, 1 skipped
- focused consent/parity/runtime suites — 38 passed
- independent source/runtime boundary matrix — PASS
- `pnpm run check:runtime-modules` — PASS
- `git diff --check` — PASS
- RDD `review-0787e7bacae158b9` — 4/4 lenses approved and acknowledged

Closes #284


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Windows paths in native review consent commands, including quoted paths, UNC paths, and drive-root paths.
  * Made repository directory validation consistent across Windows and Git Bash path formats.
  * Strengthened validation for malformed, incomplete, duplicated, or mismatched directory options, preventing the provider from launching when consent commands are invalid.

* **Tests**
  * Added coverage for valid Windows path formats, unmatched quotes, and invalid consent command scenarios.
  * Extended Windows repository review checks to include native consent testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->