### PR TITLE
fix(review): materialize committed symlinks from exact blob bytes on Windows

### DIFF
--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -1,6 +1,6 @@
 import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, realpathSync, rmSync, utimesSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, realpathSync, rmSync, symlinkSync, utimesSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -586,7 +586,14 @@ function entryContentHash(root: string, entry: CandidateTreeEntry): string {
 	if (entry.mode === "120000") {
 		if (!item.isSymbolicLink()) throw new CandidateViewError("candidate view symlink does not match its frozen tree");
 		const target = readlinkSync(path, "buffer");
-		const bytes = Buffer.isBuffer(target) ? target : Buffer.from(target);
+		// libuv reports Windows symlink targets with backslash separators even
+		// when the link was materialized from a forward-slash blob target, so raw
+		// readlink bytes can never equal the frozen blob on win32. Normalize win32
+		// separators back to POSIX form before the safety checks and the content
+		// hash; every other platform stays byte-exact.
+		const bytes = process.platform === "win32"
+			? Buffer.from(target.toString("utf8").replace(/\\/g, "/"), "utf8")
+			: Buffer.isBuffer(target) ? target : Buffer.from(target);
 		assertSafeSymlinkTarget(root, entry.path, bytes);
 		return createHash("sha256").update(bytes).digest("hex");
 	}
@@ -746,6 +753,27 @@ export function resolveCanonicalCandidateBase(contributorRoot: string, baseRef: 
 	return resolveCandidateBase(realpathSync(contributorRoot), baseRef, process.env, defaultCandidateGitExecutor);
 }
 
+function materializeSymlinkEntries(root: string, entries: readonly CandidateTreeEntry[], executor: CandidateGitExecutor): void {
+	if (entries.length === 0) return;
+	for (const entry of entries) {
+		const target = candidateGit(root, ["cat-file", "blob", entry.objectId], process.env, "buffer", executor) as Buffer;
+		// The frozen blob bytes are the authoritative symlink target: validate
+		// them lexically before creating anything, so committed targets that are
+		// genuinely unsafe (backslashes, escapes, metadata) are rejected on every
+		// platform identically, independent of how the host readlink renders
+		// separators.
+		assertSafeSymlinkTarget(root, entry.path, target);
+		const path = join(root, entry.path);
+		mkdirSync(dirname(path), { recursive: true });
+		rmSync(path, { force: true });
+		try {
+			symlinkSync(target.toString("utf8"), path);
+		} catch {
+			throw new CandidateViewError("candidate view symlink could not be materialized; the host requires symlink privilege for committed symlinks", "symlink-materialization-failed");
+		}
+	}
+}
+
 function checkoutMaterializedEntries(root: string, entries: readonly CandidateTreeEntry[], executor: CandidateGitExecutor): void {
 	let batch: string[] = [];
 	let bytes = 0;
@@ -755,11 +783,22 @@ function checkoutMaterializedEntries(root: string, entries: readonly CandidateTr
 		batch = []; bytes = 0;
 	};
 	for (const entry of entries) {
+		// Committed symlinks (mode 120000) are excluded from checkout-index and
+		// materialized directly from their blob bytes. Git for Windows cannot
+		// round-trip symlink targets: with core.symlinks=false it writes the
+		// target as a plain file, and even with core.symlinks=true it rewrites
+		// forward slashes to backslashes, so the frozen-tree verification in
+		// entryContentHash (which compares readlinkSync bytes with the blob)
+		// fails with "candidate view symlink does not match its frozen tree" or
+		// an unsafe-target rejection. Node symlinkSync preserves the blob bytes
+		// verbatim on every platform.
+		if (entry.mode === "120000") continue;
 		const size = Buffer.byteLength(entry.path, "utf8") + 1;
 		if (batch.length > 0 && bytes + size > 16_384) flush();
 		batch.push(entry.path); bytes += size;
 	}
 	flush();
+	materializeSymlinkEntries(root, entries.filter((entry) => entry.mode === "120000"), executor);
 }
 
 // Creates an unborn worktree (symbolic HEAD pointing at a branch with no

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -1015,6 +1015,33 @@ test("candidate view detects symlink target-byte tampering after materialization
 	}
 });
 
+test("candidate view materializes committed symlinks from their exact blob targets on every platform", (t) => {
+	const contributorRoot = repository(t);
+	// A committed forward-slash relative target, the canonical POSIX form and
+	// the form Git for Windows cannot round-trip through checkout-index (plain
+	// file with core.symlinks=false, backslash target even with core.symlinks=true).
+	mkdirSync(join(contributorRoot, "target-dir"), { recursive: true });
+	writeFileSync(join(contributorRoot, "target-dir", "file.txt"), "content\n");
+	mkdirSync(join(contributorRoot, "nested"));
+	try {
+		symlinkSync("../target-dir/file.txt", join(contributorRoot, "nested", "committed-link"));
+	} catch {
+		t.skip("platform does not support symlinks");
+		return;
+	}
+	git(contributorRoot, "add", "-A");
+	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "symlink");
+	const registry = new CandidateViewRegistry();
+	const view = registry.create({ contributorRoot });
+	try {
+		const frozenLink = join(view.root, "nested", "committed-link");
+		assert.equal(lstatSync(frozenLink).isSymbolicLink(), true);
+		view.verify();
+	} finally {
+		view.cleanup();
+	}
+});
+
 test("candidate view retains a valid dangling symlink through bind and finalize resolution", (t) => {
 	const contributorRoot = repository(t);
 	try {


### PR DESCRIPTION
Closes #670

## Summary
- Candidate view creation failed on Windows for repositories with committed symlinks (mode `120000`): `checkout-index` under `core.symlinks=false` writes the target as a plain file, Git for Windows rewrites forward-slash targets to backslashes even with `core.symlinks=true`, and libuv `readlinkSync` always reports backslash separators on win32 — so the frozen-tree byte comparison could never pass.
- Committed symlinks are now excluded from the `checkout-index` batch and materialized directly from their blob bytes via `fs.symlinkSync`, with the blob target validated lexically by `assertSafeSymlinkTarget` first (frozen bytes are authoritative; unsafe targets rejected identically on every platform).
- `entryContentHash` normalizes win32 readlink separators back to POSIX form before the safety checks and content hash; every other platform stays byte-exact.

## Verification
| File | Change |
|------|--------|
| `lib/review-candidate-view.ts` | `materializeSymlinkEntries` (new), `checkoutMaterializedEntries` delegates mode `120000`, `entryContentHash` win32 normalization |
| `tests/review-candidate-view.test.ts` | regression test: committed-symlink materialization (fails on `main`, passes with the fix) |

- [x] Regression test RED on `main` (`candidate view symlink does not match its frozen tree`), GREEN with the fix.
- [x] `tests/review-candidate-view.test.ts` on Windows: 69 → 72 passing; tests 38/39 flip fail → pass; 0 regressions.
- [x] End-to-end repro: candidate view for a repository with two committed symlinks (eduvic-mastra) now materializes and reviews.
- [x] Linux-neutral: materialization via `symlinkSync` is equivalent to `checkout-index` with `core.symlinks=true`; unsafe-target rejection preserved via blob-lexical validation.

The remaining Windows-only test failures are the pre-existing `core.autocrlf` contamination tracked as a follow-up in #670.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved candidate view handling for committed symbolic links, including on Windows.
  * Preserved symbolic link targets accurately and validated link paths before materialization.
  * Added clearer error handling when symbolic links cannot be created.

* **Tests**
  * Added coverage verifying committed symbolic links are materialized correctly across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->