### PR TITLE
fix(review): reclaim only proven orphan candidate views

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -6098,7 +6098,7 @@ async function executeReviewControllerOperation(
 							cleanupCandidate: () => {
 								if (candidateCleaned) return;
 								candidateCleaned = true;
-								consentCandidateView.cleanup();
+								try { consentCandidateView.cleanup(); } catch { /* Failed ownership proof preserves the view; consent expiry/teardown still completes. */ }
 							},
 							...(retainedUntrackedSelection === undefined ? {} : { untrackedSelection: retainedUntrackedSelection }),
 							consent: error.consent,
@@ -6419,6 +6419,8 @@ function createGentleAiExtensionForTesting(
 	};
 
 	pi.on("session_shutdown", (event, context) => {
+		// Pi tears down this registry on reload as well as session replacement/quit.
+		try { candidateViews?.cleanupAll(); } catch { /* Preserve failed owned views for later recovery. */ }
 		const reason = (event as { reason?: unknown }).reason;
 		if (reason !== "reload") {
 			if (childStandingReviewPermissionLease !== undefined) childStandingReviewPermissionLease.closeIfCurrent();
@@ -6679,6 +6681,7 @@ function createGentleAiExtensionForTesting(
 	}
 
 	pi.on("session_start", async (event, ctx) => {
+		try { candidateViews?.sweepOrphans(ctx.cwd); } catch { /* Ownership sweeping must not block startup. */ }
 		const reason = (event as { reason?: unknown }).reason;
 		if (reason !== "reload") revokeCurrentReviewSessionPermission(ctx);
 		await refreshReviewSessionPermissionStatus(ctx);

--- a/lib/review-candidate-view-owner.ts
+++ b/lib/review-candidate-view-owner.ts
@@ -1,0 +1,177 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { closeSync, fsyncSync, lstatSync, openSync, readFileSync, readdirSync, readlinkSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { conservativeOwnerDeathProofV1 } from "./review-lock.ts";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const BOOT_UUID = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
+export interface CandidateViewOwner {
+	version: 1;
+	uuid: string;
+	token: string;
+	pid: number;
+	host: string | null;
+	root: string;
+	commonDir: string;
+}
+type Git = (args: readonly string[]) => string;
+
+// A hostname or a repository-local nonce cannot prove that a PID is local.
+// Bind to the kernel boot and, on Linux, its PID namespace. Unsupported or
+// unavailable provenance disables reclamation (including across reboots).
+function localHost(): string | null {
+	try {
+		if (process.platform === "darwin") {
+			const boot = execFileSync("/usr/sbin/sysctl", ["-n", "kern.bootsessionuuid"], { encoding: "utf8", timeout: 1000, maxBuffer: 4096, stdio: ["ignore", "pipe", "pipe"] }).trim();
+			if (BOOT_UUID.test(boot)) return `darwin:${boot.toLowerCase()}`;
+		}
+		if (process.platform === "linux") {
+			const boot = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+			const namespace = readlinkSync("/proc/self/ns/pid");
+			if (BOOT_UUID.test(boot) && /^pid:\[\d+\]$/.test(namespace)) return `linux:${boot}:${namespace}`;
+		}
+	} catch { /* No remote/PID-only fallback. */ }
+	return null;
+}
+
+function directory(path: string, privateMode = false): string {
+	const stat = lstatSync(path);
+	if (!stat.isDirectory() || stat.isSymbolicLink() || realpathSync(path) !== path ||
+		(privateMode && (stat.uid !== process.getuid?.() || (stat.mode & 0o077) !== 0))) throw new Error("Unsafe candidate owner directory");
+	return `${stat.dev}:${stat.ino}`;
+}
+
+export function assertCandidateOwnerParent(commonDir: string): string {
+	directory(commonDir);
+	directory(join(commonDir, "gentle-ai"));
+	const parent = join(commonDir, "gentle-ai", "candidate-views");
+	directory(parent, true);
+	return parent;
+}
+
+function regular(path: string, privateMode = false): string {
+	const stat = lstatSync(path);
+	if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || realpathSync(path) !== path || stat.size > 16384 ||
+		(privateMode && (stat.uid !== process.getuid?.() || (stat.mode & 0o777) !== 0o600))) throw new Error("Unsafe candidate owner file");
+	return `${stat.dev}:${stat.ino}`;
+}
+
+function syncDirectory(path: string): void {
+	const fd = openSync(path, "r");
+	try { fsyncSync(fd); } finally { closeSync(fd); }
+}
+
+function exclusiveFile(path: string, content: string): void {
+	const fd = openSync(path, "wx", 0o600);
+	try { writeFileSync(fd, content); fsyncSync(fd); } finally { closeSync(fd); }
+	syncDirectory(dirname(path));
+}
+
+function markerPath(root: string): string { return `${root}.owner.json`; }
+
+export function createCandidateOwner(commonDir: string, root: string): CandidateViewOwner {
+	const parent = assertCandidateOwnerParent(commonDir);
+	const uuid = basename(root);
+	if (!UUID.test(uuid) || root !== join(parent, uuid) || lstatSync(root, { throwIfNoEntry: false })) throw new Error("Unsafe candidate owner root");
+	const owner: CandidateViewOwner = { version: 1, uuid, token: randomUUID(), pid: process.pid, host: localHost(), root, commonDir };
+	// Any write/fsync failure aborts creation BEFORE Git can register the view.
+	// An incomplete marker is retained, never guessed into ownership.
+	exclusiveFile(markerPath(root), JSON.stringify(owner));
+	syncDirectory(dirname(parent));
+	syncDirectory(commonDir);
+	return Object.freeze(owner);
+}
+
+function readOwner(commonDir: string, root: string): CandidateViewOwner {
+	const parent = assertCandidateOwnerParent(commonDir);
+	if (!UUID.test(basename(root)) || root !== join(parent, basename(root))) throw new Error("Candidate owner escaped parent");
+	regular(markerPath(root), true);
+	const owner = JSON.parse(readFileSync(markerPath(root), "utf8")) as CandidateViewOwner;
+	if (!owner || Object.keys(owner).sort().join(",") !== "commonDir,host,pid,root,token,uuid,version" || owner.version !== 1 ||
+		owner.uuid !== basename(root) || !UUID.test(owner.token) || !Number.isSafeInteger(owner.pid) || owner.pid <= 0 ||
+		owner.root !== root || owner.commonDir !== commonDir || !(owner.host === null || typeof owner.host === "string")) throw new Error("Malformed candidate owner");
+	return owner;
+}
+
+function dead(owner: CandidateViewOwner): boolean {
+	return owner.host !== null && owner.host === localHost() && conservativeOwnerDeathProofV1({
+		pid: owner.pid, token: owner.token, owner_hash: "", repository_id: owner.commonDir, authority_id: owner.uuid,
+	});
+}
+
+function registration(root: string, commonDir: string, git: Git): string {
+	const rows = git(["worktree", "list", "--porcelain", "-z"]).split("\0\0");
+	const matching = rows.filter((row) => row.split("\0")[0] === `worktree ${root}`);
+	if (matching.length !== 1 || matching[0]!.split("\0").some((field) => /^(locked|prunable)( |$)/.test(field))) throw new Error("Candidate registration is ambiguous");
+	const gitFile = join(root, ".git");
+	regular(gitFile);
+	const pointer = readFileSync(gitFile, "utf8");
+	if (!pointer.startsWith("gitdir: ") || !pointer.endsWith("\n")) throw new Error("Unsafe candidate Git pointer");
+	const admin = pointer.slice(8, -1);
+	if (dirname(admin) !== join(commonDir, "worktrees")) throw new Error("Candidate admin escaped common directory");
+	directory(join(commonDir, "worktrees"));
+	directory(admin);
+	regular(join(admin, "gitdir"));
+	regular(join(admin, "commondir"));
+	if (readFileSync(join(admin, "gitdir"), "utf8") !== `${gitFile}\n` ||
+		resolve(admin, readFileSync(join(admin, "commondir"), "utf8").trim()) !== commonDir) throw new Error("Candidate Git backlinks changed");
+	return matching[0]! + pointer;
+}
+
+export function removeCandidateOwner(owner: CandidateViewOwner, git: Git, makeWritable: (root: string) => void, orphan = false): void {
+	const { root, commonDir } = owner;
+	const parent = assertCandidateOwnerParent(commonDir);
+	const expected = JSON.stringify(owner);
+	const parentIdentity = directory(parent, true);
+	const markerIdentity = regular(markerPath(root), true);
+	const checkOwner = (): void => {
+		if (directory(parent, true) !== parentIdentity || regular(markerPath(root), true) !== markerIdentity ||
+			JSON.stringify(readOwner(commonDir, root)) !== expected || (orphan ? !dead(owner) : owner.pid !== process.pid)) throw new Error("Candidate ownership changed");
+	};
+	checkOwner();
+	const lock = `${root}.reaper-lock`;
+	const token = randomUUID();
+	exclusiveFile(lock, token); // EEXIST is final; unknown/stale locks are never stolen.
+	const lockIdentity = regular(lock, true);
+	const checkLock = (): void => {
+		if (regular(lock, true) !== lockIdentity || readFileSync(lock, "utf8") !== token) throw new Error("Candidate reaper lock changed");
+	};
+	try {
+		checkOwner();
+		const identity = [directory(parent, true), directory(root), regular(markerPath(root), true)];
+		const registered = registration(root, commonDir, git);
+		checkOwner();
+		checkLock();
+		makeWritable(root);
+		// Git and chmod are race boundaries: repeat path, owner, lock, and exact
+		// registration proofs immediately before asking Git to remove this root.
+		if (registration(root, commonDir, git) !== registered ||
+			JSON.stringify([directory(parent, true), directory(root), regular(markerPath(root), true)]) !== JSON.stringify(identity)) throw new Error("Candidate cleanup identity changed");
+		checkOwner();
+		checkLock();
+		git(["worktree", "remove", "--force", root]);
+		// Git failure or incomplete removal must never trigger recursive rm.
+		if (lstatSync(root, { throwIfNoEntry: false }) || git(["worktree", "list", "--porcelain", "-z"]).split("\0").includes(`worktree ${root}`)) throw new Error("Candidate removal is incomplete");
+		checkOwner();
+		checkLock();
+		unlinkSync(markerPath(root));
+		syncDirectory(parent);
+	} finally {
+		// Only release this exact lock, even when the deletion itself failed.
+		try { assertCandidateOwnerParent(commonDir); checkLock(); unlinkSync(lock); syncDirectory(parent); } catch {}
+	}
+}
+
+export function sweepCandidateOwners(commonDir: string, git: Git, makeWritable: (root: string) => void): void {
+	try {
+		const parent = assertCandidateOwnerParent(commonDir);
+		for (const name of readdirSync(parent)) {
+			if (!name.endsWith(".owner.json")) continue;
+			try {
+				const owner = readOwner(commonDir, join(parent, name.slice(0, -11)));
+				if (dead(owner)) removeCandidateOwner(owner, git, makeWritable, true);
+			} catch { /* Unknown, legacy, unsafe, unregistered, and contended entries survive. */ }
+		}
+	} catch { /* Startup/materialization sweeps are best-effort; never create a store. */ }
+}

--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -5,6 +5,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { gunzipSync, gzipSync } from "node:zlib";
+import { assertCandidateOwnerParent, createCandidateOwner, removeCandidateOwner, sweepCandidateOwners, type CandidateViewOwner } from "./review-candidate-view-owner.ts";
 
 const REVIEW_LENS = ["review-risk", "review-resilience", "review-readability", "review-reliability"] as const;
 export type ReviewLens = (typeof REVIEW_LENS)[number];
@@ -99,6 +100,7 @@ interface CandidateViewScope {
 }
 
 interface CandidateViewRecord {
+	owner: CandidateViewOwner;
 	token: string;
 	root: string;
 	parent: string;
@@ -628,11 +630,15 @@ function makeWritableForCleanup(path: string): void {
 }
 
 function candidateViewParent(commonDir: string): string {
-	const parent = join(commonDir, "gentle-ai", "candidate-views");
+	const control = join(commonDir, "gentle-ai");
+	mkdirSync(control, { recursive: true, mode: 0o700 });
+	const controlStat = lstatSync(control);
+	if (!controlStat.isDirectory() || controlStat.isSymbolicLink() || realpathSync(control) !== control) throw new CandidateViewError("candidate view ancestor is unsafe");
+	const parent = join(control, "candidate-views");
 	mkdirSync(parent, { recursive: true, mode: 0o700 });
 	const stat = lstatSync(parent);
 	if (!stat.isDirectory() || stat.isSymbolicLink()) throw new CandidateViewError("candidate view parent is unsafe");
-	return realpathSync(parent);
+	return assertCandidateOwnerParent(commonDir);
 }
 
 export interface ResolvedCandidateBase {
@@ -852,6 +858,7 @@ function materializeCandidateView(request: CreateCandidateViewRequest, executor:
 		? resolveCandidateBase(contributorRoot, "HEAD", process.env, executor)
 		: base;
 	const parent = candidateViewParent(canonicalCommonDir);
+	sweepCandidateOwners(canonicalCommonDir, (args) => git(canonicalCommonDir, args, process.env, executor), makeWritableForCleanup);
 	const index = mkdtempSync(join(tmpdir(), "gentle-ai-candidate-index-"));
 	const indexPath = join(index, "index");
 	const environment = { ...process.env, GIT_INDEX_FILE: indexPath };
@@ -875,6 +882,7 @@ function materializeCandidateView(request: CreateCandidateViewRequest, executor:
 		}
 		const candidateTree = git(contributorRoot, ["write-tree"], environment, executor);
 		const root = join(parent, randomUUID());
+		const owner = createCandidateOwner(canonicalCommonDir, root);
 		// The worktree is created under the same try/catch cleanup boundary as
 		// the read-tree materialization that follows. addUnbornWorktree's
 		// fallback path can register a worktree with `worktree add` and then
@@ -895,9 +903,9 @@ function materializeCandidateView(request: CreateCandidateViewRequest, executor:
 			const scope = deriveChangedScope(contributorRoot, base.tree, candidateTree, [...tree.entries, ...tree.gitlinks], executor);
 			for (const gitlink of tree.gitlinks) if (lstatSync(join(root, gitlink.path), { throwIfNoEntry: false })) throw new CandidateViewError("candidate view materialized a metadata-only gitlink");
 			makeReadonly(root, entries);
-			return { token: basename(root), root: realpathSync(root), parent, contributorRoot, commonDir: canonicalCommonDir, baseCommit, baseTree: base.tree, candidateTree, committedOnly, intendedUntracked, entries, gitlinks: tree.gitlinks, scope, gitExecutor: executor };
+			return { owner, token: basename(root), root: realpathSync(root), parent, contributorRoot, commonDir: canonicalCommonDir, baseCommit, baseTree: base.tree, candidateTree, committedOnly, intendedUntracked, entries, gitlinks: tree.gitlinks, scope, gitExecutor: executor };
 		} catch (error) {
-			try { git(contributorRoot, ["worktree", "remove", "--force", root], process.env, executor); } catch { rmSync(root, { recursive: true, force: true }); }
+			try { removeCandidateOwner(owner, (args) => git(canonicalCommonDir, args, process.env, executor), makeWritableForCleanup); } catch { /* Preserve the marker and any partial worktree for conservative recovery. */ }
 			throw error;
 		}
 	} finally {
@@ -1050,8 +1058,18 @@ export class CandidateViewRegistry {
 		return this.createOrReuse(request);
 	}
 
+	sweepOrphans(contributorRoot: string): void {
+		try {
+			const cwd = realpathSync(contributorRoot);
+			const common = realpathSync(resolve(cwd, git(cwd, ["rev-parse", "--git-common-dir"], process.env, this.gitExecutor)));
+			sweepCandidateOwners(common, (args) => git(common, args, process.env, this.gitExecutor), makeWritableForCleanup);
+		} catch { /* Non-repositories and unavailable ownership are preserved. */ }
+	}
+
 	cleanupAll(): void {
-		for (const token of [...this.records.keys()]) this.cleanup(token);
+		for (const token of [...this.records.keys()]) {
+			try { this.cleanup(token); } catch { /* Continue other owned views; failed records remain retryable. */ }
+		}
 	}
 
 	createOrReuse(request: CreateCandidateViewRequest): CandidateView {
@@ -1546,10 +1564,7 @@ export class CandidateViewRegistry {
 
 	private remove(record: CandidateViewRecord): void {
 		if (!isWithin(record.parent, record.root)) throw new CandidateViewError("candidate view cleanup escaped its owned parent");
-		try { makeWritableForCleanup(record.root); } catch {}
-		try { git(record.contributorRoot, ["worktree", "remove", "--force", record.root], process.env, record.gitExecutor); } catch {}
-		// Git removes worktree metadata; physical removal remains this owner's duty.
-		rmSync(record.root, { recursive: true, force: true });
+		removeCandidateOwner(record.owner, (args) => git(record.commonDir, args, process.env, record.gitExecutor), makeWritableForCleanup);
 	}
 
 	private forget(record: CandidateViewRecord): void {

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -27,13 +27,243 @@ function git(cwd: string, ...arguments_: string[]): string {
 
 function repository(t: test.TestContext): string {
 	const cwd = mkdtempSync(join(tmpdir(), "gentle-pi-candidate-view-"));
-	t.after(() => rmSync(cwd, { recursive: true, force: true }));
+	t.after(() => {
+		execFileSync("chmod", ["-R", "u+rwx", cwd]);
+		rmSync(cwd, { recursive: true, force: true });
+	});
 	git(cwd, "init", "-b", "main");
 	writeFileSync(join(cwd, "tracked.txt"), "base\n");
 	git(cwd, "add", "tracked.txt");
 	git(cwd, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "base");
 	return cwd;
 }
+
+function ownerMarker(root: string): string { return `${root}.owner.json`; }
+
+function orphanFixture(t: test.TestContext) {
+	const cwd = repository(t);
+	const registry = new CandidateViewRegistry();
+	const view = registry.create({ contributorRoot: cwd });
+	const marker = ownerMarker(view.root);
+	const owner = JSON.parse(readFileSync(marker, "utf8"));
+	owner.pid = 2147483000;
+	writeFileSync(marker, JSON.stringify(owner));
+	return { cwd, registry, view, marker, owner };
+}
+
+function mockOwnerProbe(t: test.TestContext, code?: string): void {
+	t.mock.method(process, "kill", () => {
+		if (code) throw Object.assign(new Error("fixture probe"), { code });
+		return true;
+	});
+}
+
+test("candidate ownership is private and durable before worktree add; ordinary cleanup removes its marker", (t) => {
+	const cwd = repository(t);
+	let observed = false;
+	let syncs = 0;
+	const fsync = fs.fsyncSync;
+	t.mock.method(fs, "fsyncSync", (fd: number) => { syncs++; fsync(fd); });
+	syncBuiltinESMExports();
+	t.after(() => { t.mock.restoreAll(); syncBuiltinESMExports(); });
+	const registry = new CandidateViewRegistry((file, args, options) => {
+		if (args[0] === "worktree" && args[1] === "add") {
+			const root = args[args.length - 2]!;
+			const marker = ownerMarker(root);
+			const owner = JSON.parse(readFileSync(marker, "utf8"));
+			assert.equal(owner.root, root);
+			assert.equal(owner.pid, process.pid);
+			assert.match(owner.token, /^[0-9a-f-]{36}$/);
+			assert.equal(lstatSync(marker).mode & 0o777, 0o600);
+			assert.equal(existsSync(root), false);
+			assert.ok(syncs >= 4, "marker and every newly created ancestor must be durable before add");
+			observed = true;
+		}
+		return execFileSync(file, args, options);
+	});
+	const view = registry.create({ contributorRoot: cwd });
+	assert.equal(observed, true);
+	view.cleanup();
+	assert.equal(existsSync(view.root), false);
+	assert.equal(existsSync(ownerMarker(view.root)), false);
+});
+
+test("marked registered definitively dead candidate is reclaimed before another materialization", (t) => {
+	const { cwd, view, marker } = orphanFixture(t);
+	mockOwnerProbe(t, "ESRCH");
+	const next = new CandidateViewRegistry().create({ contributorRoot: cwd });
+	assert.equal(existsSync(view.root), false);
+	assert.equal(existsSync(marker), false);
+	assert.ok(!git(cwd, "worktree", "list", "--porcelain").includes(view.root));
+	next.cleanup();
+});
+
+for (const scenario of ["self", "live", "EPERM", "unknown", "malformed", "foreign-host", "unknown-host", "invalid-pid", "extra-key", "legacy", "unregistered", "root-symlink", "marker-symlink", "parent-symlink", "escape", "unknown-lock", "public-marker", "locked", "backlink", "admin-symlink", "missing-root"] as const) {
+	test(`orphan sweep preserves ${scenario} ownership`, (t) => {
+		const { cwd, view, marker, owner } = orphanFixture(t);
+		mockOwnerProbe(t, scenario === "live" ? undefined : scenario === "EPERM" ? "EPERM" : scenario === "unknown" ? "EIO" : "ESRCH");
+		if (scenario === "self") owner.pid = process.pid;
+		if (scenario === "foreign-host") owner.host = "another-host";
+		if (scenario === "unknown-host") owner.host = null;
+		if (scenario === "invalid-pid") owner.pid = -1;
+		if (scenario === "extra-key") owner.extra = true;
+		if (scenario === "escape") owner.root = cwd;
+		writeFileSync(marker, scenario === "malformed" ? "{" : JSON.stringify(owner));
+		if (scenario === "legacy") rmSync(marker);
+		if (scenario === "public-marker") chmodSync(marker, 0o644);
+		if (scenario === "locked") git(cwd, "worktree", "lock", view.root);
+		if (scenario === "backlink" || scenario === "admin-symlink") {
+			const admin = readFileSync(join(view.root, ".git"), "utf8").slice(8).trim();
+			if (scenario === "backlink") writeFileSync(join(admin, "gitdir"), `${cwd}/.git\n`);
+			else { renameSync(admin, `${admin}.saved`); symlinkSync(`${admin}.saved`, admin); }
+		}
+		if (scenario === "missing-root") renameSync(view.root, `${view.root}.saved`);
+		if (scenario === "unknown-lock") writeFileSync(`${view.root}.reaper-lock`, "unknown");
+		if (scenario === "unregistered") {
+			execFileSync("chmod", ["-R", "u+rwx", view.root]);
+			git(cwd, "worktree", "remove", "--force", view.root);
+			mkdirSync(view.root);
+			writeFileSync(join(view.root, "preserve.txt"), "unregistered");
+		}
+		if (scenario === "root-symlink") { renameSync(view.root, `${view.root}.saved`); symlinkSync(`${view.root}.saved`, view.root); }
+		if (scenario === "marker-symlink") { renameSync(marker, `${marker}.saved`); symlinkSync(`${marker}.saved`, marker); }
+		if (scenario === "parent-symlink") {
+			const parent = join(view.root, "..");
+			renameSync(parent, `${parent}.saved`);
+			symlinkSync(`${parent}.saved`, parent);
+		}
+		new CandidateViewRegistry().sweepOrphans(cwd);
+		assert.equal(existsSync(view.root), scenario !== "missing-root");
+		assert.equal(existsSync(marker), scenario !== "legacy");
+		assert.equal(readFileSync(join(cwd, "tracked.txt"), "utf8"), "base\n");
+	});
+}
+
+test("reaper lock excludes concurrent sweeps and rechecks marker identity before removal", (t) => {
+	const { cwd, view, marker, owner } = orphanFixture(t);
+	mockOwnerProbe(t, "ESRCH");
+	let lists = 0;
+	const racing = new CandidateViewRegistry((file, args, options) => {
+		if (args.includes("list")) {
+			lists++;
+			new CandidateViewRegistry().sweepOrphans(cwd);
+			if (lists === 2) writeFileSync(marker, JSON.stringify({ ...owner, token: "00000000-0000-4000-8000-000000000000" }));
+		}
+		return execFileSync(file, args, options);
+	});
+	racing.sweepOrphans(cwd);
+	assert.ok(lists >= 2);
+	assert.equal(existsSync(view.root), true);
+	assert.equal(existsSync(`${view.root}.reaper-lock`), false);
+});
+
+test("failed Git removal preserves owned candidate and marker without recursive fallback", (t) => {
+	const cwd = repository(t);
+	const registry = new CandidateViewRegistry((file, args, options) => {
+		if (args.includes("remove")) throw new Error("fixture removal failure");
+		return execFileSync(file, args, options);
+	});
+	const view = registry.create({ contributorRoot: cwd });
+	assert.throws(() => view.cleanup());
+	assert.equal(existsSync(view.root), true);
+	assert.equal(existsSync(ownerMarker(view.root)), true);
+});
+
+test("failed creation retains a recoverable marker when Git removal also fails", (t) => {
+	const cwd = repository(t);
+	let root = "";
+	const registry = new CandidateViewRegistry((file, args, options) => {
+		if (args[0] === "worktree" && args[1] === "add") root = args[args.length - 2]!;
+		if (args.includes("remove") || (args[0] === "read-tree" && options.cwd === root)) throw new Error("fixture failure");
+		return execFileSync(file, args, options);
+	});
+	assert.throws(() => registry.create({ contributorRoot: cwd }));
+	assert.equal(existsSync(root), true);
+	const owner = JSON.parse(readFileSync(ownerMarker(root), "utf8"));
+	writeFileSync(ownerMarker(root), JSON.stringify({ ...owner, pid: 2147483000 }));
+	mockOwnerProbe(t, "ESRCH");
+	new CandidateViewRegistry().sweepOrphans(cwd);
+	assert.equal(existsSync(root), false);
+});
+
+test("materialization rejects a symlinked owner ancestor without creating an external store", (t) => {
+	const cwd = repository(t);
+	const outside = join(cwd, "outside");
+	mkdirSync(outside);
+	symlinkSync(outside, join(cwd, ".git", "gentle-ai"));
+	assert.throws(() => new CandidateViewRegistry().create({ contributorRoot: cwd }));
+	assert.equal(existsSync(join(outside, "candidate-views")), false);
+});
+
+test("owner fsync failure prevents worktree registration", (t) => {
+	const cwd = repository(t);
+	let adds = 0;
+	t.mock.method(fs, "fsyncSync", () => { throw new Error("fixture fsync failure"); });
+	syncBuiltinESMExports();
+	t.after(() => { t.mock.restoreAll(); syncBuiltinESMExports(); });
+	const registry = new CandidateViewRegistry((file, args, options) => {
+		if (args[0] === "worktree" && args[1] === "add") adds++;
+		return execFileSync(file, args, options);
+	});
+	assert.throws(() => registry.create({ contributorRoot: cwd }), /fsync/);
+	assert.equal(adds, 0);
+});
+
+test("ordinary cleanup preserves mismatched owner and cleanupAll continues other records", (t) => {
+	const cwd = repository(t);
+	const registry = new CandidateViewRegistry();
+	const first = registry.create({ contributorRoot: cwd });
+	const second = registry.create({ contributorRoot: cwd });
+	const marker = ownerMarker(first.root);
+	const bytes = readFileSync(marker, "utf8");
+	writeFileSync(marker, JSON.stringify({ ...JSON.parse(bytes), token: "00000000-0000-4000-8000-000000000000" }));
+	registry.cleanupAll();
+	assert.equal(existsSync(first.root), true);
+	assert.equal(existsSync(marker), true);
+	assert.equal(existsSync(second.root), false);
+	writeFileSync(marker, bytes);
+	registry.cleanupAll();
+	assert.equal(existsSync(first.root), false);
+});
+
+for (const race of ["root", "registration", "lock"] as const) {
+	test(`orphan reaper preserves a ${race} replacement at the Git race boundary`, (t) => {
+		const { cwd, view, marker } = orphanFixture(t);
+		mockOwnerProbe(t, "ESRCH");
+		let lists = 0;
+		const registry = new CandidateViewRegistry((file, args, options) => {
+			const result = execFileSync(file, args, options);
+			if (args.includes("list") && ++lists === 2) {
+				if (race === "root") { renameSync(view.root, `${view.root}.saved`); mkdirSync(view.root); }
+				if (race === "registration") return String(result).replace(`worktree ${view.root}`, `worktree ${view.root}.other`);
+				if (race === "lock") writeFileSync(`${view.root}.reaper-lock`, "replacement");
+			}
+			return result;
+		});
+		registry.sweepOrphans(cwd);
+		assert.equal(existsSync(view.root), true);
+		assert.equal(existsSync(marker), true);
+		if (race === "lock") assert.equal(readFileSync(`${view.root}.reaper-lock`, "utf8"), "replacement");
+	});
+}
+
+test("ordinary cleanup never unlinks a replaced sidecar after Git removal", (t) => {
+	const cwd = repository(t);
+	let marker = "";
+	const registry = new CandidateViewRegistry((file, args, options) => {
+		const result = execFileSync(file, args, options);
+		if (args[0] === "worktree" && args[1] === "remove") {
+			const bytes = readFileSync(marker);
+			renameSync(marker, `${marker}.saved`);
+			writeFileSync(marker, bytes, { mode: 0o600 });
+		}
+		return result;
+	});
+	const view = registry.create({ contributorRoot: cwd });
+	marker = ownerMarker(view.root);
+	assert.throws(() => view.cleanup(), /ownership changed/i);
+	assert.equal(existsSync(marker), true);
+});
 
 function compactCandidateContextManifest(task: string): { encoded: string; sha256: string } {
 	const match = /Frozen changed scope manifest \(gzip\+base64url\): `([A-Za-z0-9_-]+)`\.\nFrozen changed scope manifest SHA-256: `([0-9a-f]{64})`\./.exec(task);
@@ -661,14 +891,15 @@ test("candidate view cleanup is confined and idempotent", (t) => {
 	assert.equal(lstatSync(view.root, { throwIfNoEntry: false }), undefined);
 });
 
-test("candidate cleanup removes a readonly root when Git reports success without deleting it", (t) => {
+test("candidate cleanup preserves a root when Git reports success without deleting it", (t) => {
 	const registry = new CandidateViewRegistry((file, arguments_, options) =>
 		arguments_[0] === "worktree" && arguments_[1] === "remove" ? "" : execFileSync(file, arguments_, options));
 	const view = registry.create({ contributorRoot: repository(t) });
 	assert.equal(lstatSync(view.root).mode & 0o222, 0);
-	view.cleanup();
-	view.cleanup();
-	assert.equal(lstatSync(view.root, { throwIfNoEntry: false }), undefined);
+	assert.throws(() => view.cleanup(), /incomplete/);
+	assert.throws(() => view.cleanup(), /incomplete/);
+	assert.equal(existsSync(view.root), true);
+	assert.equal(existsSync(ownerMarker(view.root)), true);
 });
 
 test("corrected views stay within frozen scope and replace projections only when promoted", (t) => {

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os, { tmpdir } from "node:os";
+import { syncBuiltinESMExports } from "node:module";
+import { dirname, join, resolve, sep } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { __testing, createGentleAiExtension, PendingReviewConsentRegistry } from "../extensions/gentle-ai.ts";
@@ -735,6 +738,94 @@ function repository(t: test.TestContext): string {
 	return cwd;
 }
 
+test("candidate lifecycle sweeps startup and cleans every shutdown including reload", async (t) => {
+	const cwd = repository(t);
+	for (const key of ["HOME", "GENTLE_PI_AGENT_HOME", "PI_CODING_AGENT_DIR", "GENTLE_PI_CONFIG_HOME", "GENTLE_PI_GENTLE_AI_DEV_BINARY"]) {
+		const previous = process.env[key];
+		process.env[key] = key === "GENTLE_PI_GENTLE_AI_DEV_BINARY" ? "" : join(cwd, key);
+		if (process.env[key]) mkdirSync(process.env[key]!, { recursive: true });
+		t.after(() => { if (previous === undefined) delete process.env[key]; else process.env[key] = previous; });
+	}
+	t.mock.method(os, "homedir", () => join(cwd, "HOME"));
+	const homeAgent = join(cwd, "HOME", ".agents", "isolation-probe.md");
+	mkdirSync(dirname(homeAgent), { recursive: true });
+	writeFileSync(homeAgent, "---\nname: isolation-probe\ndescription: Fixture\n---\n");
+	writeFileSync(join(cwd, "GENTLE_PI_CONFIG_HOME", "models.json"), JSON.stringify({ "isolation-probe": { model: "fixture/model" } }));
+	t.diagnostic(`startup routing: cwd=${cwd}; HOME, GENTLE_PI_AGENT_HOME, PI_CODING_AGENT_DIR, GENTLE_PI_CONFIG_HOME are same-named children; dev-binary override disabled`);
+	const calls: string[] = [];
+	const destinations: string[] = [];
+	const violations: string[] = [];
+	const discovery: string[] = [];
+	const assets = resolve("assets");
+	const inside = (root: string, path: string) => path === root || path.startsWith(`${root}${sep}`);
+	const originalExists = fs.existsSync;
+	const originalRealpath = fs.realpathSync;
+	// Install guards BEFORE startup, including RED: a swallowed startup error
+	// must never hide an attempted external write or read real-home contents.
+	for (const [module, names] of [
+		[fs, ["existsSync", "lstatSync", "readdirSync", "readFileSync", "mkdirSync", "writeFileSync", "rmSync"]],
+		[fsp, ["access", "readdir", "readFile", "mkdir", "writeFile"]],
+	] as const) {
+		for (const name of names) {
+			const original = (module as any)[name];
+			t.mock.method(module as any, name, (value: string, ...args: unknown[]) => {
+				const path = resolve(value);
+				const writes = /^(mkdir|writeFile|rm)/.test(name);
+				const allowed = inside(cwd, path) || (!writes && inside(assets, path));
+				if (!allowed && name === "existsSync") return false;
+				if (!allowed && ["access", "readdir"].includes(name)) return Promise.reject(Object.assign(new Error("fixture discovery boundary"), { code: "ENOENT" }));
+				if (!allowed) { violations.push(`${name}:${path}`); throw new Error("fixture filesystem boundary"); }
+				if (writes) {
+					let ancestor = path;
+					while (!originalExists(ancestor)) ancestor = dirname(ancestor);
+					assert.ok(inside(cwd, originalRealpath(ancestor)), "write ancestor escaped fixture");
+					destinations.push(path);
+				}
+				if (name.startsWith("readdir")) discovery.push(path);
+				return original(value, ...args);
+			});
+		}
+	}
+	syncBuiltinESMExports();
+	// Prove the guard refuses an escape without performing the attempted write.
+	const escape = join(cwd, "..", "startup-isolation-escape");
+	assert.throws(() => fs.writeFileSync(escape, "blocked"), /fixture filesystem boundary/);
+	assert.deepEqual(violations, [`writeFileSync:${escape}`]);
+	violations.length = 0;
+	const hooks = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
+	const registry = new CandidateViewRegistry();
+	t.mock.method(registry, "sweepOrphans", (root: string) => { assert.equal(root, cwd); calls.push("sweep"); });
+	t.mock.method(registry, "cleanupAll", () => { calls.push("cleanup"); });
+	createGentleAiExtension({ nativeReviewCli: null, candidateViews: registry, processEnv: {} })({
+		on(name: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) {
+			hooks.set(name, [...(hooks.get(name) ?? []), handler]);
+		},
+		registerTool() {}, registerCommand() {},
+	} as unknown as ExtensionAPI);
+	try {
+		assert.equal(hooks.get("session_start")?.length, 1);
+		await hooks.get("session_start")![0]!({ reason: "startup" }, reviewContext(cwd));
+		assert.deepEqual(violations, []);
+		assert.ok(destinations.length > 0, "startup must actually write fixture assets");
+		assert.ok(discovery.includes(join(cwd, "HOME", ".agents")), "home agent discovery must use the fixture");
+		assert.equal(existsSync(join(cwd, "GENTLE_PI_AGENT_HOME", "gentle-ai", "managed-assets.json")), true);
+		assert.match(readFileSync(homeAgent, "utf8"), /model: fixture\/model/);
+		assert.ok(destinations.includes(homeAgent), "the discovered fixture agent must actually receive routing");
+		assert.ok(destinations.includes(join(cwd, "GENTLE_PI_AGENT_HOME", "subagents.json")));
+		t.diagnostic(`confined startup: ${destinations.length} filesystem mutations; fixture home-agent routing and managed-assets manifest verified; external violations=0`);
+		assert.deepEqual(calls, ["sweep"]);
+	} finally {
+		// Restore only mocks before fixture teardown; never clean external paths.
+		t.mock.restoreAll();
+		syncBuiltinESMExports();
+	}
+	t.mock.method(registry, "cleanupAll", () => { calls.push("cleanup"); });
+	for (const reason of ["quit", "reload", "new", "resume", "fork"]) {
+		for (const hook of hooks.get("session_shutdown")!) await hook({ reason }, reviewContext(cwd));
+	}
+	assert.deepEqual(calls, ["sweep", ...Array(5).fill("cleanup")]);
+});
+
 interface RegisteredControllerTool {
 	execute: (toolCallId: string, params: unknown, signal: AbortSignal | undefined, onUpdate: undefined, ctx: ExtensionContext) => Promise<{ details?: unknown }>;
 }
@@ -873,6 +964,22 @@ test("ordinary START relays native consent without authoring or advancing it", a
 	assert.equal(result.outcome, "native-review-consent-required");
 	assert.equal(typeof result.consent_binding, "string");
 	assert.equal(result.mutation_outcome, "none");
+});
+
+test("shutdown preserves failed consent candidates without interrupting session teardown", async (t) => {
+	const cwd = repository(t);
+	const consent = decodeReviewConsentV3(JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "consent-v3.captured.json"), "utf8")));
+	const native = {
+		targetStatus: async () => startStatus(cwd),
+		start: async () => { throw new NativeReviewConsentRequiredError(consent); },
+	} as unknown as NativeReviewCli;
+	const registry = new CandidateViewRegistry();
+	const runtime = reviewRuntime(native, registry);
+	const ctx = reviewContext(cwd);
+	const result = await runtime.controller.execute("pending", { operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, undefined, undefined, ctx);
+	assert.equal((result.details as { outcome: string }).outcome, "native-review-consent-required");
+	t.mock.method(registry, "cleanup", () => { throw new Error("fixture unsafe ownership"); });
+	assert.doesNotThrow(() => runtime.sessionShutdown({ reason: "reload" }, ctx));
 });
 
 test("ordinary START obeys the review-mode kill switch before target STATUS", async () => {


### PR DESCRIPTION
## Linked issue

Closes #343

## Summary

- Persist private candidate ownership before worktree creation; reclaim only marked, registered views with matching host/boot provenance and a definitive dead-process proof.
- Guard reclamation with exclusive token locks and repeated owner/path/registration checks. Preserve legacy, unregistered, live and ambiguous entries.
- Sweep on startup/before materialization and clean up on shutdown/reload; remove recursive deletion fallbacks and keep failed cleanup retryable.

## Validation

- Direct Node full suite in isolated HOME/Pi/TMP/XDG environment: 1592 passed, 1 skipped, 0 failed.
- Candidate-view tests: 116/116; native routing tests: 51/51.
- Provider-contract check and runtime harness passed; parent repeated provider-contract check.
- Runtime-module parity passed; these package-shipped TypeScript modules have no generated runtime counterpart.
- Complete before/after candidate manifests identical. Lifecycle fixture recorded 38 confined mutations and zero external violations.
- Remote CI, including Windows, pending before merge.

## Native review

`review-4b5925bc12d1bd80`: all four lenses admitted, approved and acknowledged. Informational `R4-lock-retry` at owner module line 134 is separate later work; no correction opened.

## Scope and safety

567 actual changed lines in five files, within the maintainer-authorized 600-line exception. No blanket prune, no migration/deletion of unmarked legacy views, no production-store sweep performed as validation. Rollback boundary is these five files.

## Test-environment incident disclosure

An early pnpm validation auto-installed dependencies and a local binary. An initial lifecycle RED invoked startup before home isolation; attribution of possible historical home-asset writes remains unknown because no before-image was captured. No blind cleanup/restoration was performed. The maintainer explicitly authorized continuation with strengthened isolation. Subsequent lifecycle tests guard external access; final full verification used direct Node with isolated homes and no pnpm/install/postinstall. A contaminated wrapper attempt with forbidden Git environment overrides failed; its evidence was retained and the corrected environment passed without source changes.

## AI assistance

Material assistance: Pi delegated writer, tests, and delivery preparation. Native RDD supplied independent review. Conventional commit without co-author trailers. No public release or change to native review authority contracts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup reliability for candidate views, including when individual cleanup operations or Git actions fail.
  - Preserved candidate views when cleanup cannot be completed safely.
  - Added safeguards against unsafe or incomplete cleanup scenarios.

- **Maintenance**
  - Candidate views left behind after an interrupted session are now detected and cleaned up automatically.
  - Session shutdown now attempts to clean up all candidate views without being blocked by one failure.
  - Startup cleanup runs without preventing the session from launching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->