### PR TITLE
fix(review): accept executable candidate modes on Windows

### DIFF
--- a/lib/review-candidate-view.ts
+++ b/lib/review-candidate-view.ts
@@ -340,6 +340,11 @@ function isMaterializedCandidateMode(mode: string): boolean {
 	return mode === "100644" || mode === "100755" || mode === "120000";
 }
 
+export function hasExpectedExecutableBits(filesystemMode: number, gitMode: string, platform: NodeJS.Platform = process.platform): boolean {
+	return gitMode === "100755" && platform === "win32"
+		|| (filesystemMode & 0o111) === (gitMode === "100755" ? 0o111 : 0);
+}
+
 function isCanonicalObjectId(objectId: string): boolean { return /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(objectId); }
 function gitlinkMapsEqual(left: Readonly<Record<string, string>>, right: Readonly<Record<string, string>>): boolean {
 	const entries = Object.entries(left);
@@ -913,7 +918,7 @@ function materializeCandidateView(request: CreateCandidateViewRequest, executor:
 	}
 }
 
-function assertRecordSafe(record: CandidateViewRecord): void {
+function assertRecordSafe(record: CandidateViewRecord, platform: NodeJS.Platform = process.platform): void {
 	try {
 		const contributor = lstatSync(record.contributorRoot);
 		if (!contributor.isDirectory() || contributor.isSymbolicLink() || realpathSync(record.contributorRoot) !== record.contributorRoot) {
@@ -953,7 +958,7 @@ function assertRecordSafe(record: CandidateViewRecord): void {
 		if (!item) throw new CandidateViewError("candidate view entry is missing or moved");
 		if (entry.mode === "120000") {
 			if (!item.isSymbolicLink()) throw new CandidateViewError("candidate view symlink is unsafe or changed");
-		} else if (!item.isFile() || item.isSymbolicLink() || (item.mode & 0o222) !== 0 || ((item.mode & 0o111) !== (entry.mode === "100755" ? 0o111 : 0))) {
+		} else if (!item.isFile() || item.isSymbolicLink() || (item.mode & 0o222) !== 0 || !hasExpectedExecutableBits(item.mode, entry.mode, platform)) {
 			throw new CandidateViewError("candidate view entry is unsafe, writable, or has a changed mode");
 		}
 		const actualHash = entryContentHash(root, entry);
@@ -964,8 +969,10 @@ function assertRecordSafe(record: CandidateViewRecord): void {
 export class CandidateViewRegistry {
 	private readonly records = new Map<string, CandidateViewRecord>();
 	private readonly gitExecutor: CandidateGitExecutor;
-	constructor(gitExecutor: CandidateGitExecutor = defaultCandidateGitExecutor) {
+	private readonly platform: NodeJS.Platform;
+	constructor(gitExecutor: CandidateGitExecutor = defaultCandidateGitExecutor, platform: NodeJS.Platform = process.platform) {
 		this.gitExecutor = gitExecutor;
+		this.platform = platform;
 	}
 	// Lifecycle state is scoped to the canonical target worktree as well as the
 	// provider lineage. Lineage text is repository-local and may legitimately be
@@ -1051,7 +1058,7 @@ export class CandidateViewRegistry {
 		const key = this.lineageKey(contributorRoot, lineageId);
 		const token = this.lineages.get(key);
 		const record = token === undefined ? undefined : this.records.get(token);
-		if (record !== undefined) assertRecordSafe(record);
+		if (record !== undefined) assertRecordSafe(record, this.platform);
 	}
 
 	create(request: CreateCandidateViewRequest): CandidateView {
@@ -1078,7 +1085,7 @@ export class CandidateViewRegistry {
 		const scopedReplayKey = normalizedRequest.replayKey === undefined ? undefined : this.replayKey(contributorRoot, normalizedRequest.replayKey);
 		const token = scopedReplayKey === undefined ? undefined : this.replays.get(scopedReplayKey);
 		const existing = token === undefined ? undefined : this.records.get(token);
-		if (existing) { assertRecordSafe(existing); return this.expose(existing); }
+		if (existing) { assertRecordSafe(existing, this.platform); return this.expose(existing); }
 		const record = materializeCandidateView(normalizedRequest, this.gitExecutor);
 		this.records.set(record.token, record);
 		if (scopedReplayKey !== undefined) this.replays.set(scopedReplayKey, record.token);
@@ -1107,7 +1114,7 @@ export class CandidateViewRegistry {
 			const existing = this.records.get(existingToken);
 			let existingSafe = false;
 			if (existing !== undefined && existing.lineageId === request.lineageId) {
-				try { assertRecordSafe(existing); existingSafe = true; } catch { existingSafe = false; }
+				try { assertRecordSafe(existing, this.platform); existingSafe = true; } catch { existingSafe = false; }
 			}
 			if (existing !== undefined && existingSafe && candidateRecordsShareIdentity(existing, candidate)) {
 				existing.selectedLenses = selectedLenses;
@@ -1130,7 +1137,7 @@ export class CandidateViewRegistry {
 		const record = this.records.get(request.token);
 		if (!record || record.lineageId !== undefined) throw new CandidateViewError("native reviewing candidate view is missing or already bound", "authoritative-current-match-missing");
 		if (this.current.has(record.contributorRoot)) throw new CandidateViewError("candidate view already has a current lineage binding", "current-binding-already-established");
-		assertRecordSafe(record);
+		assertRecordSafe(record, this.platform);
 		this.assertCurrentBindingMatchesLiveCandidate(record);
 		this.bindCurrent(request);
 	}
@@ -1172,7 +1179,7 @@ export class CandidateViewRegistry {
 		const existing = existingToken === undefined ? undefined : this.records.get(existingToken);
 		if (existing) {
 			if (existing.lineageId !== undefined) throw new CandidateViewError("corrected candidate replay is no longer pending");
-			assertRecordSafe(existing);
+			assertRecordSafe(existing, this.platform);
 			return this.expose(existing);
 		}
 		const record = materializeCandidateView({ contributorRoot: root, baseRef: projection.baseCommit, committedOnly: projection.committedOnly, ...(projection.intendedUntracked === undefined ? {} : { intendedUntracked: projection.intendedUntracked }) }, this.gitExecutor);
@@ -1202,8 +1209,8 @@ export class CandidateViewRegistry {
 		if (currentBinding !== undefined && currentBinding.lineageId !== lineageId) {
 			throw new CandidateViewError("corrected candidate replacement conflicts with the current lineage binding");
 		}
-		assertRecordSafe(replacement);
-		if (current) assertRecordSafe(current);
+		assertRecordSafe(replacement, this.platform);
+		if (current) assertRecordSafe(current, this.platform);
 		if (
 			replacement.contributorRoot !== projection.contributorRoot ||
 			replacement.baseCommit !== projection.baseCommit ||
@@ -1264,7 +1271,7 @@ export class CandidateViewRegistry {
 		const record = this.records.get(token);
 		const key = record === undefined ? undefined : this.lineageKey(record.contributorRoot, lineageId);
 		if (!record || record.lineageId !== undefined || !key || this.lineages.has(key)) throw new CandidateViewError("candidate view lineage binding is missing or ambiguous");
-		assertRecordSafe(record);
+		assertRecordSafe(record, this.platform);
 		record.lineageId = lineageId;
 		record.selectedLenses = selectedLenses;
 		this.lineages.set(key, record.token);
@@ -1463,7 +1470,7 @@ export class CandidateViewRegistry {
 		const token = this.lineages.get(key);
 		const record = token === undefined ? undefined : this.records.get(token);
 		if (!record || record.lineageId !== lineageId || !record.selectedLenses?.includes(lens as ReviewLens)) throw new CandidateViewError("candidate view context is missing, ambiguous, stale, or lens-unselected");
-		assertRecordSafe(record);
+		assertRecordSafe(record, this.platform);
 		return this.expose(record);
 	}
 
@@ -1514,7 +1521,7 @@ export class CandidateViewRegistry {
 		const current = this.currentBinding(contributorRoot);
 		const record = this.records.get(current.token);
 		if (!record || record.lineageId !== current.lineageId || this.lineages.get(this.lineageKey(current.root, current.lineageId)) !== current.token) throw new CandidateViewError("review subagent dispatch current lineage binding is stale or ambiguous", "current-binding-stale");
-		assertRecordSafe(record);
+		assertRecordSafe(record, this.platform);
 		this.assertCurrentBindingMatchesLiveCandidate(record);
 		if (!lenses.every((lens) => record.selectedLenses?.includes(lens as ReviewLens))) throw new CandidateViewError("candidate view context is missing, ambiguous, stale, or lens-unselected", "current-binding-lens-unselected");
 		return lenses.map(() => this.expose(record));
@@ -1543,7 +1550,7 @@ export class CandidateViewRegistry {
 		const token = this.lineages.get(key);
 		const record = token === undefined ? undefined : this.records.get(token);
 		if (!record || record.lineageId !== lineageId) throw new CandidateViewError("candidate view context is missing or ambiguous for FINALIZE");
-		assertRecordSafe(record);
+		assertRecordSafe(record, this.platform);
 		return this.expose(record);
 	}
 
@@ -1596,7 +1603,7 @@ export class CandidateViewRegistry {
 			modes: record.scope.modes,
 			gitlinks: record.scope.gitlinks,
 			deletedPaths: record.scope.deletedPaths,
-			verify: () => assertRecordSafe(record),
+			verify: () => assertRecordSafe(record, this.platform),
 			cleanup: () => this.cleanup(record.token),
 		};
 	}

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -1071,6 +1071,7 @@ test("candidate registry forwards explicit Windows mode validation to view verif
 	writeFileSync(join(contributorRoot, "unchanged-executable.sh"), "#!/bin/sh\necho base\n");
 	git(contributorRoot, "add", "unchanged-executable.sh");
 	git(contributorRoot, "update-index", "--chmod=+x", "unchanged-executable.sh");
+	chmodSync(join(contributorRoot, "unchanged-executable.sh"), 0o755);
 	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "executable base");
 	writeFileSync(join(contributorRoot, "tracked.txt"), "changed\n");
 	const view = new CandidateViewRegistry(undefined, "win32").createOrReuse({ contributorRoot, baseRef: "HEAD" });

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -1073,7 +1073,7 @@ test("candidate registry forwards explicit Windows mode validation to view verif
 	git(contributorRoot, "update-index", "--chmod=+x", "unchanged-executable.sh");
 	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "executable base");
 	writeFileSync(join(contributorRoot, "tracked.txt"), "changed\n");
-	const view = new CandidateViewRegistry(undefined, "win32").createOrReuse({ contributorRoot });
+	const view = new CandidateViewRegistry(undefined, "win32").createOrReuse({ contributorRoot, baseRef: "HEAD" });
 	try {
 		assert.deepEqual(view.paths, ["tracked.txt"]);
 		chmodSync(view.root, 0o755); chmodSync(join(view.root, "unchanged-executable.sh"), 0o444); chmodSync(view.root, 0o555);

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -11,6 +11,7 @@ import { gzipSync } from "node:zlib";
 import {
 	CandidateViewRegistry,
 	CandidateViewError,
+	hasExpectedExecutableBits,
 	type CandidateGitExecutor,
 	createCandidateView,
 	decodeCandidateContextManifest,
@@ -1055,6 +1056,13 @@ test("candidate view verifies unchanged tree entries even when they are absent f
 	} finally {
 		view.cleanup();
 	}
+});
+
+test("candidate executable-mode validation accepts a readonly Git executable on Windows and rejects it on POSIX", () => {
+	assert.equal(hasExpectedExecutableBits(0o444, "100755", "win32"), true);
+	assert.equal(hasExpectedExecutableBits(0o444, "100755", "linux"), false);
+	assert.equal(hasExpectedExecutableBits(0o555, "100755", "linux"), true);
+	assert.equal(hasExpectedExecutableBits(0o555, "100644", "win32"), false);
 });
 
 test("candidate view compacts an oversized non-ASCII scope losslessly and deterministically", (t) => {

--- a/tests/review-candidate-view.test.ts
+++ b/tests/review-candidate-view.test.ts
@@ -1065,6 +1065,24 @@ test("candidate executable-mode validation accepts a readonly Git executable on 
 	assert.equal(hasExpectedExecutableBits(0o555, "100644", "win32"), false);
 });
 
+test("candidate registry forwards explicit Windows mode validation to view verification", (t) => {
+	if (process.platform === "win32") return t.skip("requires POSIX candidate-owner directory permissions unavailable on Windows");
+	const contributorRoot = repository(t);
+	writeFileSync(join(contributorRoot, "unchanged-executable.sh"), "#!/bin/sh\necho base\n");
+	git(contributorRoot, "add", "unchanged-executable.sh");
+	git(contributorRoot, "update-index", "--chmod=+x", "unchanged-executable.sh");
+	git(contributorRoot, "-c", "user.name=Candidate Test", "-c", "user.email=candidate@example.invalid", "commit", "-m", "executable base");
+	writeFileSync(join(contributorRoot, "tracked.txt"), "changed\n");
+	const view = new CandidateViewRegistry(undefined, "win32").createOrReuse({ contributorRoot });
+	try {
+		assert.deepEqual(view.paths, ["tracked.txt"]);
+		chmodSync(view.root, 0o755); chmodSync(join(view.root, "unchanged-executable.sh"), 0o444); chmodSync(view.root, 0o555);
+		assert.doesNotThrow(() => view.verify());
+	} finally {
+		view.cleanup();
+	}
+});
+
 test("candidate view compacts an oversized non-ASCII scope losslessly and deterministically", (t) => {
 	const contributorRoot = repository(t);
 	writeFileSync(join(contributorRoot, "deleted.txt"), "delete me\n");


### PR DESCRIPTION
Closes #673

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Accept read-only Git `100755` candidate entries on Windows without requiring POSIX executable bits from the filesystem.
- Preserve strict executable-mode validation on POSIX and all existing candidate safety checks.
- Add deterministic Windows/POSIX regression coverage against the production predicate.

## Changes

| File | Change |
|------|--------|
| `lib/review-candidate-view.ts` | Make executable-bit validation platform-aware and propagate the platform through candidate verification. |
| `tests/review-candidate-view.test.ts` | Cover Windows acceptance and POSIX rejection for read-only Git executables. |

## Test Plan

- [x] Focused executable-mode regression: 1 passed, 0 skipped.
- [x] `git diff --check`.
- [x] Receipt-driven review approved across all required lenses.

The full candidate-view test file is not passing evidence on Windows because pre-existing fixtures assume POSIX `chmod`, private directory modes, and Git filemode behavior. Ordinary CI retains ownership of the broader suite.

## Contributor Checklist

- [x] Linked approved issue #673.
- [x] Added exactly one `type:*` label.
- [x] Shellcheck completed where applicable (no shell scripts changed).
- [x] Skills tested where applicable (no skill files changed).
- [x] Docs updated where applicable (internal validation correction; no user-facing docs required).
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of executable file permissions on Windows.
  * Windows now correctly accepts Git executable entries regardless of filesystem executable-bit differences.
  * Other platforms retain their existing executable-permission validation behavior.
  * Candidate verification now consistently applies the appropriate platform-specific permission checks, reducing incorrect validation failures across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->