### PR TITLE
chore(github): add a structured bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug Report
+description: Report a reproducible problem with gentle-pi.
+labels: ["bug", "status:needs-review"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share enough detail for maintainers to understand and triage the problem.
+        Reports receive `bug` and `status:needs-review`; these labels do not imply approval.
+        Maintainers may ask for clarification or identify an existing duplicate.
+
+        Keep the entire report public-safe: remove credentials, tokens, private paths,
+        hostnames, and other sensitive data, including from logs and screenshots.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues and did not find a report of this problem.
+          required: true
+        - label: I reviewed this report and removed credentials, tokens, private paths, hostnames, and other sensitive data.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What went wrong, and how does it affect your use of gentle-pi?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include minimal steps and relevant setup. Synthetic fixtures are welcome; live SSH or infrastructure access is not required.
+      placeholder: Describe the setup, the action, and how to observe the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected and actual behavior
+      description: Describe both what you expected and what actually happened.
+      placeholder: |
+        Expected:
+        Actual:
+    validations:
+      required: true
+
+  - type: input
+    id: gentle_pi_version
+    attributes:
+      label: gentle-pi version
+      description: Provide the installed package version, or the commit if running from source.
+    validations:
+      required: true
+
+  - type: input
+    id: pi_version
+    attributes:
+      label: Pi version
+      description: Provide the Pi coding agent version used when the problem occurred.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      multiple: false
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Windows (WSL)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output (optional)
+      description: Include only useful excerpts. Remove credentials, tokens, private paths, hostnames, and other sensitive data before pasting.
+      render: text
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add an English GitHub bug Issue Form with reproducible steps, expected/actual behavior, package/Pi versions and OS.
- Require duplicate-search and sanitization affirmations; accept synthetic reproduction and keep logs optional.
- Apply only existing `bug` and `status:needs-review` labels. No automatic approval, new CI gate or runtime change.

## Issue linkage exception
The maintainer explicitly authorized this single prerequisite PR without an associated issue: the repository and organization lacked an Issue Form, and the issue-creation workflow requires one. This exception applies only to `.github/ISSUE_TEMPLATE/bug_report.yml`; it does not authorize unrelated issue-free deliveries.

Context: Gentleman-Programming/gentle-ai#4324. This PR does not contain its Pi security implementation and does not close that tracker.

## Verification
- YAML parsed with the existing `yaml` parser; unique IDs, supported controls, required fields, exact labels/options and privacy wording validated.
- Staged whitespace check passed; 91 added lines, one file.
- Native consolidated review approved and acknowledged: `review-1eb160340d42e0eb`.
- GitHub-hosted form rendering not yet tested; CI pending.

## AI assistance
Material assistance used: Pi delegated writer, independent native review and parent readback. Scope: form drafting, validation and submission preparation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a structured bug report template with checklists, reproduction details, expected and actual behavior, version information, operating system details, and optional logs.
  - Includes guidance to remove sensitive information before submitting reports.
  - Automatically applies relevant issue labels for easier triage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->