### PR TITLE
feat(agents): make overlay geometry resize-safe

### DIFF
--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -29,8 +29,7 @@ export const AGENTS_RESULT_TYPE = "gentle-agents.result";
 const COLLAPSE_KEY_DEFAULT = "ctrl+shift+a";
 const VIEW_KEY_DEFAULT = "alt+a";
 const STOP_KEY_DEFAULT = "alt+s";
-const OVERLAY_HEIGHT_RATIO = 0.8;
-const OVERLAY_MIN_ROWS = 12;
+const OVERLAY_VERTICAL_MARGIN = 2;
 const RENDER_COALESCE_MS = 400;
 const CLOCK_TICK_MS = 1000;
 const TOOL_PREFIX = "subagent_";
@@ -343,7 +342,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 				overlayHost = tui;
 				view = new AgentsView({
 					theme,
-					rows: Math.max(OVERLAY_MIN_ROWS, Math.floor(tui.terminal.rows * OVERLAY_HEIGHT_RATIO)),
+					rows: () => Math.max(0, tui.terminal.rows - OVERLAY_VERTICAL_MARGIN),
 					store,
 					sessionId: ctx.sessionManager.getSessionId() ?? "",
 					now: () => deps.now(),

--- a/lib/agents-view-layout.ts
+++ b/lib/agents-view-layout.ts
@@ -1,0 +1,36 @@
+// Shared Agents overlay geometry. Rendering and pointer routing use one bounded
+// measurement so terminal resizes cannot retain stale cells.
+
+export const AGENTS_FALLBACK_WIDTH = 12;
+export const AGENTS_SPLIT_LIST_MIN_WIDTH = 22;
+export const AGENTS_SPLIT_THREAD_MIN_WIDTH = 32;
+const FRAME_WIDTH = 6;
+const LIST_MAX_WIDTH = 34;
+const LIST_RATIO = 0.32;
+const CHROME_ROWS = 3;
+
+export type AgentsViewMode = "panes" | "fallback";
+
+export interface AgentsViewLayout {
+	mode: AgentsViewMode;
+	width: number;
+	height: number;
+	bodyRows: number;
+	footerY: number | undefined;
+	listX: number;
+	listWidth: number;
+	threadX: number;
+	threadWidth: number;
+}
+
+export function measureAgentsViewLayout(width: number, height: number): AgentsViewLayout {
+	const boundedWidth = Math.max(0, Math.floor(width));
+	const boundedHeight = Math.max(0, Math.floor(height));
+	if (boundedWidth < AGENTS_SPLIT_LIST_MIN_WIDTH + AGENTS_SPLIT_THREAD_MIN_WIDTH + FRAME_WIDTH || boundedHeight < CHROME_ROWS) {
+		return { mode: "fallback", width: boundedWidth, height: boundedHeight, bodyRows: 0, footerY: undefined, listX: 0, listWidth: 0, threadX: 0, threadWidth: 0 };
+	}
+	const inner = boundedWidth - 2;
+	const listWidth = Math.min(LIST_MAX_WIDTH, Math.max(AGENTS_SPLIT_LIST_MIN_WIDTH, Math.floor(inner * LIST_RATIO)));
+	const threadWidth = inner - listWidth - 4;
+	return { mode: "panes", width: boundedWidth, height: boundedHeight, bodyRows: boundedHeight - CHROME_ROWS, footerY: boundedHeight - 2, listX: 2, listWidth, threadX: listWidth + 5, threadWidth };
+}

--- a/lib/agents-view.ts
+++ b/lib/agents-view.ts
@@ -1,5 +1,6 @@
 import { Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type TuiMouseEvent, type TuiMouseEventResult } from "@earendil-works/pi-tui";
 import { createNativePointerScope, type NativePointerRegion } from "./native-pointer-region.ts";
+import { measureAgentsViewLayout, type AgentsViewLayout } from "./agents-view-layout.ts";
 import { isFinished, TASK_STATUS, THREAD_ITEM, type TaskRecord, type TaskStore, type TaskThread, type ThreadItem, type ToolItem } from "./agents-protocol.ts";
 import { formatElapsed } from "./agents-widget.ts";
 import { formatTokens } from "./shell-bar.ts";
@@ -24,7 +25,7 @@ export type ViewScope = (typeof VIEW_SCOPE)[keyof typeof VIEW_SCOPE];
 
 export interface AgentsViewDeps {
 	theme: AgentsViewTheme;
-	rows: number;
+	rows: number | (() => number);
 	store: TaskStore;
 	// The active session; without it there is nothing to scope by and the
 	// list shows every task.
@@ -74,10 +75,6 @@ const GLYPH_ROLE: Record<string, string> = {
 	[TASK_STATUS.CANCELLED]: "dim",
 	[TASK_STATUS.TIMED_OUT]: "error",
 };
-const LIST_MAX_WIDTH = 34;
-const LIST_RATIO = 0.32;
-const CHROME_ROWS = 3;
-const MIN_BODY_ROWS = 1;
 export const SESSION_FINISHED_TTL_MS = 15 * 60_000;
 const SCOPE_LABEL: Record<ViewScope, string> = { [VIEW_SCOPE.SESSION]: "this session", [VIEW_SCOPE.ALL]: "all sessions" };
 const SCOPE_KEY: Record<ViewScope, string> = { [VIEW_SCOPE.SESSION]: "all sessions", [VIEW_SCOPE.ALL]: "this session" };
@@ -104,15 +101,7 @@ interface PointerButtonLayout {
 	width: number;
 }
 
-interface PointerLayout {
-	width: number;
-	height: number;
-	listX: number;
-	listWidth: number;
-	threadX: number;
-	threadWidth: number;
-	bodyRows: number;
-	footerY: number;
+interface PointerLayout extends AgentsViewLayout {
 	followButton?: PointerButtonLayout;
 	openButton?: PointerButtonLayout;
 }
@@ -260,6 +249,8 @@ export class AgentsView {
 	handleMouse(event: TuiMouseEvent): TuiMouseEventResult | undefined {
 		const layout = this.pointerLayout;
 		if (!layout || event.width !== layout.width || event.height !== layout.height || event.x < 0 || event.y < 0 || event.x >= layout.width || event.y >= layout.height) return undefined;
+		const live = this.layout(layout.width);
+		if (live.mode !== "panes" || live.height !== layout.height) return undefined;
 		if (event.y >= 1 && event.y < 1 + layout.bodyRows) {
 			const row = event.y - 1;
 			if (event.x >= layout.listX && event.x < layout.listX + layout.listWidth) {
@@ -279,28 +270,33 @@ export class AgentsView {
 	}
 
 	render(width: number): string[] {
+		const layout = this.layout(width);
+		if (layout.width === 0 || layout.height === 0) {
+			this.clearFooterLayout();
+			return [];
+		}
+		if (layout.mode === "fallback") {
+			this.clearFooterLayout();
+			return [fit("Agents", layout.width)];
+		}
 		// Finished rows age out of the session scope while the overlay is open;
 		// the list is otherwise reordered only when a status changes.
 		const now = this.deps.now();
 		if (this.tasks.some((task) => !this.inScope(task, now))) this.refreshTasks();
-		if (this.pointerLayout && this.pointerLayout.width !== width) this.clearFooterLayout();
+		if (this.pointerLayout && (this.pointerLayout.width !== layout.width || this.pointerLayout.height !== layout.height)) this.clearFooterLayout();
 		const theme = this.deps.theme;
-		const inner = width - 2;
-		const listWidth = Math.min(LIST_MAX_WIDTH, Math.floor(inner * LIST_RATIO));
-		const threadWidth = inner - listWidth - 4;
-		const rows = this.bodyRows();
-		const footerY = rows + 1;
-		this.followSelection(rows);
-		this.pointerLayout = { width, height: rows + CHROME_ROWS, listX: 2, listWidth, threadX: listWidth + 5, threadWidth, bodyRows: rows, footerY };
-		this.listRegion.render(listWidth);
-		this.threadRegion.render(threadWidth);
+		const inner = layout.width - 2;
+		this.followSelection(layout.bodyRows);
+		this.pointerLayout = { ...layout };
+		this.listRegion.render(layout.listWidth);
+		this.threadRegion.render(layout.threadWidth);
 		const scope = this.deps.sessionId === undefined ? "" : `${SCOPE_LABEL[this.scope]} · `;
 		const title = `❀ Agents · ${scope}${this.counts()}`;
 		const top = theme.fg(ROLE.FRAME, "╭─ ") + theme.fg(ROLE.TITLE, title) + theme.fg(ROLE.FRAME, ` ${rule(inner - visibleWidth(title) - 3)}╮`);
-		const right = this.threadWindow(rows, threadWidth);
+		const right = this.threadWindow(layout.bodyRows, layout.threadWidth);
 		const body: string[] = [];
-		for (let row = 0; row < rows; row += 1) {
-			body.push(`${theme.fg(ROLE.FRAME, "│")} ${fit(this.taskLine(row), listWidth)} ${theme.fg(ROLE.FRAME, "│")} ${fit(right[row] ?? "", threadWidth)}${theme.fg(ROLE.FRAME, "│")}`);
+		for (let row = 0; row < layout.bodyRows; row += 1) {
+			body.push(`${theme.fg(ROLE.FRAME, "│")} ${fit(this.taskLine(row), layout.listWidth)} ${theme.fg(ROLE.FRAME, "│")} ${fit(right[row] ?? "", layout.threadWidth)}${theme.fg(ROLE.FRAME, "│")}`);
 		}
 		const keys = this.keys().map(([key, label]) => `${theme.fg(ROLE.KEY, key)} ${theme.fg(ROLE.KEY_TEXT, label)}`).join("   ");
 		const footer = this.footer(keys, inner - 2);
@@ -362,8 +358,13 @@ export class AgentsView {
 		this.listScroll = Math.max(0, Math.min(this.listScroll, Math.max(0, this.tasks.length - rows)));
 	}
 
+	private layout(width = this.pointerLayout?.width ?? 80): AgentsViewLayout {
+		const rows = typeof this.deps.rows === "function" ? this.deps.rows() : this.deps.rows;
+		return measureAgentsViewLayout(width, rows);
+	}
+
 	private bodyRows(): number {
-		return Math.max(MIN_BODY_ROWS, this.deps.rows - CHROME_ROWS);
+		return this.layout().bodyRows;
 	}
 
 	private refreshTasks(): void {

--- a/tests/agents-responsive.test.ts
+++ b/tests/agents-responsive.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { measureAgentsViewLayout } from "../lib/agents-view-layout.ts";
+
+const widths = [0, 1, 2, 11, 12, 60, 90];
+
+for (const rows of [0, 1, 2]) {
+	test(`Agents layout safely bounds ${rows}-row terminals`, () => {
+		for (const width of widths) {
+			const layout = measureAgentsViewLayout(width, rows);
+			assert.equal(layout.height, rows);
+			assert.ok(layout.width >= 0 && layout.width <= width);
+			assert.ok(layout.bodyRows >= 0);
+			assert.ok(layout.listWidth >= 0 && layout.threadWidth >= 0);
+		}
+	});
+}
+
+test("Agents layout uses the whole bounded frame only when two panes fit", () => {
+	const fallback = measureAgentsViewLayout(59, 8);
+	assert.equal(fallback.mode, "fallback");
+	const layout = measureAgentsViewLayout(60, 8);
+	assert.equal(layout.mode, "panes");
+	assert.equal(layout.height, 8);
+	assert.equal(layout.bodyRows, 5);
+	assert.equal(layout.footerY, 6);
+	assert.equal(layout.listX, 2);
+	assert.equal(layout.threadX, layout.listX + layout.listWidth + 3);
+	assert.ok(layout.threadX + layout.threadWidth + 1 <= layout.width);
+	assert.equal(visibleWidth("寿司"), 4, "multibyte widths remain terminal-cell widths");
+});

--- a/tests/agents-view.test.ts
+++ b/tests/agents-view.test.ts
@@ -272,3 +272,61 @@ test("AgentsView footer buttons follow, open only a session-backed selection, an
 	assert.equal(empty.handleMouse(mouse(openX, footerY, width, emptyLines.length, "click")), undefined, "Open is disabled with no selected session");
 	empty.dispose();
 });
+
+test("AgentsView reads live rows, preserves manual scroll and selection, and invalidates stale pointer bounds", () => {
+	const store = new TaskStore();
+	let rows = 8;
+	const view = new AgentsView({
+		theme: plainTheme,
+		rows: () => rows,
+		store,
+		sessionId: "s",
+		now: () => 61_000,
+		onCancel() {},
+		onOpen() {},
+		onClose() {},
+		requestRender() {},
+	});
+	for (let index = 0; index < 6; index += 1) store.add(task(`t${index}`, { agent: `agent${index}`, createdAt: 1000 - index, lastActivityAt: 1000 - index }));
+	for (let index = 0; index < 10; index += 1) store.apply("t4", { type: TASK_EVENT.TEXT, text: `line ${index}\n` }, 2000);
+	for (let index = 0; index < 4; index += 1) view.handleInput("j");
+	view.render(80);
+	view.handleInput("\x1b[5~");
+	rows = 6;
+	const resized = view.render(80).map(stripAnsi);
+	assert.equal(resized.length, 6, "the frame uses the live terminal height budget");
+	assert.equal(view.selectedTask()?.id, "t4", "resize never changes the selected task");
+	assert.match(resized[3] ?? "", /▸ ◐ agent4/, "the list scroll clamps while retaining the selected row");
+	assert.doesNotMatch(resized.join("\n"), /line 9/, "manual thread scroll survives resize instead of returning to the tail");
+	assert.equal(view.handleMouse(mouse(4, 2, 80, 8, "click")), undefined, "old-height pointer input is stale after resize");
+	rows = 2;
+	assert.equal(view.render(80).length, 1, "a tiny terminal gets one bounded fallback line, never forced chrome");
+	view.dispose();
+});
+
+test("AgentsView rejects cached-height pointer input before the live resize renders", () => {
+	const store = new TaskStore();
+	let rows = 8;
+	const view = new AgentsView({
+		theme: plainTheme,
+		rows: () => rows,
+		store,
+		now: () => 61_000,
+		onCancel() {},
+		onOpen() {},
+		onClose() {},
+		requestRender() {},
+	});
+	store.add(task("a"));
+	for (let index = 0; index < 12; index += 1) store.apply("a", { type: TASK_EVENT.TEXT, text: `l${index}\n` }, 2000);
+	view.handleInput("\x1b[5~");
+	const oldFrame = view.render(80);
+	assert.match(stripAnsi(oldFrame[2] ?? ""), /l0/, "manual scrolling establishes a stable pre-resize position");
+	rows = 6;
+	assert.equal(view.handleMouse(mouse(50, 2, 80, oldFrame.length, "wheel", 1)), undefined, "old-height wheel input is inert before the resize frame");
+	const resized = view.render(80);
+	assert.match(stripAnsi(resized[2] ?? ""), /l0/, "the stale wheel leaves manual thread scroll unchanged");
+	assert.equal(view.handleMouse(mouse(50, 2, 80, resized.length, "wheel", 1))?.handled, true, "the new-height wheel reaches the rendered thread region");
+	assert.match(stripAnsi(view.render(80)[2] ?? ""), /l1/, "the live wheel scrolls after the new frame");
+	view.dispose();
+});

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -71,7 +71,7 @@ function fakePi() {
 	return { pi, tools, shortcuts, commands, fire, sent, renderers };
 }
 
-function fakeContext(tui: { requestRender(): void } = fakeTui, confirmResult: (title: string, message: string) => Promise<boolean> = async () => true, inputResult: (title: string, placeholder: string | undefined) => Promise<string | undefined> = async () => undefined) {
+function fakeContext(tui: { requestRender(): void } = fakeTui, confirmResult: (title: string, message: string) => Promise<boolean> = async () => true, inputResult: (title: string, placeholder: string | undefined) => Promise<string | undefined> = async () => undefined, overlayTui: { terminal: { rows: number }; requestRender(): void } = { terminal: { rows: 30 }, requestRender() {} }) {
 	const widgets = new Map<string, (tui: unknown, theme: unknown) => { render(width: number): string[] }>();
 	const dialogs: string[] = [];
 	const overlays: Overlay[] = [];
@@ -87,7 +87,7 @@ function fakeContext(tui: { requestRender(): void } = fakeTui, confirmResult: (t
 						customCompletions.push(value);
 						resolve(value);
 					};
-					const component = factory({ terminal: { rows: 30 }, requestRender() {} }, plainTheme, {}, done);
+					const component = factory(overlayTui, plainTheme, {}, done);
 					overlays.push(component);
 				}),
 			setWidget(key: string, content: ((tui: unknown, theme: unknown) => { render(width: number): string[] }) | undefined) {
@@ -738,4 +738,24 @@ test("the card caps its rows to the terminal height and says how many tasks are 
 	assert.equal(card.length, 8, "a 20-row terminal gets five card rows (four tasks and the overflow line) inside the frame, then the spacer");
 	assert.match(card[0], /2 active · 4 queued/);
 	assert.match(card[5], /^│ … 2 more · alt\+a to view +│$/);
+});
+
+test("the production overlay reads terminal rows at render time without a minimum-height override", async () => {
+	const { pi, fire, commands } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	let rows = 10;
+	const overlayTui = { terminal: { get rows() { return rows; } }, requestRender() {} };
+	const { ctx, overlays } = fakeContext(fakeTui, async () => true, async () => undefined, overlayTui);
+	await fire("session_start", ctx);
+	const opened = commands.get("gentle:agents")!.handler("", ctx);
+	for (let attempt = 0; attempt < 40 && overlays.length === 0; attempt += 1) await new Promise((resolve) => setTimeout(resolve, 25));
+	const overlay = overlays[0]!;
+	assert.equal(overlay.render(80).length, 8, "the overlay leaves its two-row host margin");
+	rows = 5;
+	assert.equal(overlay.render(80).length, 3, "a live terminal resize changes the production frame budget");
+	rows = 2;
+	assert.equal(overlay.render(80).length, 0, "the two-row host budget renders nothing rather than forced chrome");
+	overlay.handleInput("\x1b");
+	await opened;
 });


### PR DESCRIPTION
## Linked issue
Closes #709

## PR type
- [x] New feature (`type:feature`)

## Summary
- Measure live overlay rows with a two-row host margin; honor actual 0/1/2-row budgets rather than forcing oversized chrome.
- Re-clamp list/thread scroll on resize without changing selected task or manual follow state; use a bounded fallback below safe pane dimensions.
- Reject stale-height pointer input before every route, then resume after rerender. Preserve scope, Stop, Follow/Open, and native keyboard ownership.

## Approved Close/fallback policy
This PR intentionally supersedes compact Close rendering in constrained viewports. Below 60 columns, or when height cannot support the frame, the bounded fallback has no pointer controls, including Close. Pane-capable dimensions retain the full `[× Close]` control. Escape/q still close the overlay without cancelling tasks.

The operator explicitly approved this integration policy after reviewing the CodeRabbit scope warnings. Compact Close inside fallback and narrow list/detail navigation are not part of this slice. This is a deliberate presentation change, not a claim that earlier compact-button behavior is unchanged.

## Changes
| File | Change |
| --- | --- |
| `lib/agents-view-layout.ts` | Shared bounded geometry helper |
| `lib/agents-view.ts` | Live dimensions, resize clamping, and common pointer guard |
| `extensions/gentle-agents.ts` | Live terminal-row budget |
| `tests/agents-responsive.test.ts` | Tiny-height and pane-boundary coverage |
| `tests/agents-view.test.ts` | Resize preservation and stale-wheel regression |
| `tests/gentle-agents.test.ts` | Production live-row wiring |
| `tests/agents-integration.test.ts` | Combined grouping, Close, semantic scroll, and resize regressions |

## Test plan
- [x] Current head `d1fababd`: independent 12-file Node 24 run, 99 passed with no failures or skips; source/index manifests unchanged.
- [x] Corrective RED/GREEN read back: stale old-height wheel was handled before the fix (12 pass/1 fail); after the fix 13/13 view tests passed. Current-height wheel still scrolls after rerender.
- [x] Whitespace check; actual host width/height behavior inspected.
- [x] GitHub run `34291067186` on the current head: tests, generated runtime modules, package contents, packed installation, and Windows checks passed.
- [ ] Live TUI: not manually validated on this head.

Original missing-module RED was not independently verified; it is separate from the retained, verified corrective RED above.

## Contributor checklist
- [x] Approved issue linked; exactly one type label.
- [x] Conventional commit; no attribution trailers. No scripts or skills changed (shellcheck/skill loading not applicable).

Scope: 7 files, +271/-55, 326 changed lines. Includes the explicitly approved Close/fallback integration adjustment, while preserving already-merged grouping, semantic content, and session/worktree behavior. Excludes narrow list/detail navigation, messaging, and protocol/retention changes. Dependencies/evidence excluded. Receipt-driven development is disabled/unmanaged; no receipt approval is claimed.

CodeRabbit reported no actionable inline findings. This description clarifies the scope behind its Close warnings; the docstring-coverage warning is not claimed as resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The agents overlay now uses available terminal height and resizes dynamically.
  * The agents view switches between split-pane and compact layouts based on terminal width.
  * Very small terminals receive a bounded fallback layout.
  * Scrolling, selection, and pointer interactions remain reliable during resizing.
  * The full Close control is displayed when space allows.

* **Tests**
  * Added coverage for responsive layouts, resizing, terminal cell widths, scrolling, and pointer handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->