### PR TITLE
chore(github): add a structured feature request form

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,109 @@
+name: Feature Request
+description: Propose a new capability or a behavior change in gentle-pi.
+labels: ["enhancement", "status:needs-review"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem before the solution, so maintainers can evaluate the need
+        and not only the proposed shape.
+        Requests receive `enhancement` and `status:needs-review`; these labels do not imply approval.
+        Only an issue carrying `status:approved` may be implemented in a pull request.
+
+        Keep the entire request public-safe: remove credentials, tokens, private paths,
+        hostnames, and other sensitive data, including from logs and screenshots.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open and closed issues and did not find this request.
+          required: true
+        - label: I reviewed this request and removed credentials, tokens, private paths, hostnames, and other sensitive data.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is difficult, impossible, or error-prone today? Describe the need, not the implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the behavior you expect once this exists, from the point of view of someone using gentle-pi.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: List the observable conditions that would make this request complete. Include the existing behavior that must remain unchanged.
+      placeholder: |
+        - ...
+        - Existing ... remains unchanged.
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals (optional)
+      description: State what this request deliberately excludes, to keep the eventual change reviewable.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Describe workarounds you tried and why they are insufficient.
+    validations:
+      required: false
+
+  - type: input
+    id: gentle_pi_version
+    attributes:
+      label: gentle-pi version (optional)
+      description: Provide the installed package version, or the commit if running from source.
+    validations:
+      required: false
+
+  - type: input
+    id: pi_version
+    attributes:
+      label: Pi version (optional)
+      description: Provide the Pi coding agent version this request applies to.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: Select the platform this request targets, or that it is not platform specific.
+      multiple: false
+      options:
+        - Not platform specific
+        - macOS
+        - Linux
+        - Windows
+        - Windows (WSL)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context (optional)
+      description: Include only useful excerpts. Remove credentials, tokens, private paths, hostnames, and other sensitive data before pasting.
+      render: text
+    validations:
+      required: false


### PR DESCRIPTION
Closes #726

## PR type
- [x] Maintenance/tooling (`type:chore`)

## Summary
- Publish `.github/ISSUE_TEMPLATE/feature_request.yml`, so feature submissions have the entry point the issue-first pull request flow already requires.
- Mirror the structure and tone of `bug_report.yml`: same public-safe warning, same pre-submission checklist shape, same field ordering discipline.
- Require the problem, the proposed behavior, and acceptance criteria; keep non-goals, alternatives, and version fields optional.

## Changes
| File | Change |
| --- | --- |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | New GitHub issue form for feature requests (109 lines) |

## Design notes
- **Labels.** The form applies `enhancement` and `status:needs-review`, symmetric with `bug_report.yml`, which applies `bug` rather than `type:bug`; `type:*` labels identify pull requests. The intro states explicitly that these labels do not imply approval and that only a `status:approved` issue may be implemented.
- **Problem before proposal.** The `Problem` field asks for the need and not the implementation, so a request can be evaluated on the need it describes.
- **Acceptance criteria required.** Approved issues in this repository already carry them, and its placeholder prompts for the existing behavior that must remain unchanged.
- **Non-goals optional but present.** Stating exclusions early keeps the eventual change within the review budget.
- **Version fields optional.** Unlike a bug report, a feature proposal does not depend on a specific version; the operating system dropdown offers `Not platform specific` as its first option.

## Test plan
- [x] Both issue forms parse as valid YAML and match the GitHub issue-form schema; the new form yields 11 blocks with the expected field ids and dropdown options.
- [x] `pnpm test`: 1662 passed, 0 failed, 1 skipped; provider contract check and runtime harness passed.
- [x] `pnpm run check:runtime-modules`: passed (6 modules).
- [x] `node scripts/verify-package-files.mjs`: passed (167 files, 68 byte-pinned contract artifacts).
- [x] Confirmed `.github/` is absent from the `files` array in `package.json`, so the new form is not packed and the published package is unaffected.
- [ ] Not verified: the rendered form in the GitHub new-issue UI, which is only observable once this is merged to the default branch.

## Note for maintainers
This pull request comes from a fork with read access on this repository, so I cannot apply the `type:chore` label myself. Please add it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a structured feature request form with submission guidance.
  - Added required fields for the problem, proposed behavior, and acceptance criteria.
  - Added optional fields for alternatives, non-goals, environment details, and additional context.
  - Added reminders to remove sensitive information before submitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->