### PR TITLE
feat(shell): add responsive sidebar and global fullscreen setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Most coding-agent sessions fail for operational reasons, not model reasons:
 | Capability                     | What it does                                                                                                                                  |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | **el Gentleman persona**       | Makes Pi behave like a senior architect and teacher, not a generic chatbot. Spanish responses use Rioplatense voseo by default; neutral mode is saved globally with project overrides. |
-| **Configurable startup intro** | Adds desktop sidebar branding, a compact startup context panel, and independent rose/text visibility controls.                  |
+| **Configurable startup intro** | Adds a rose/text-logo startup intro, compact runtime panel, color presets, and commands to hide or show the decorative parts.                  |
 | **Work routing discipline**    | Small tasks stay inline. Context-heavy exploration can be delegated. Large or risky changes go through SDD/OpenSpec.                          |
 | **SDD/OpenSpec assets**        | Installs phase agents and chains for `init`, `onboard`, `explore`, `proposal`, `spec`, `design`, `tasks`, `apply`, `verify`, `sync`, and `archive`. |
 | **Lazy SDD preflight**         | Resolves SDD mode, artifact store, delivery strategy, and review budget once per session; prompts only when a choice is genuinely unresolved.              |
@@ -167,7 +167,7 @@ pi
 /gentle:models             Assign global model/effort routing to SDD/custom agents.
 /gentle:persona            Switch between gentleman and neutral persona modes.
 /gentle:background-subagents  Show or set the managed background-subagents policy, with its deciding source.
-/gentle:banner             Configure sidebar rose/text visibility and startup context color.
+/gentle:banner             Configure startup rose, text logo, and color preset.
 ```
 
 Typical flow:
@@ -619,7 +619,7 @@ Legacy string entries are still accepted and treated as `model`-only config.
 
 Gentle Shell is the visual layer gentle-pi puts on top of pi. It follows the Gentle themes: one border language, champagne titles, rose for whatever is alive.
 
-In fullscreen at 140 columns or wider, the right sidebar scrolls **branding → Status → Changes → Agents → TODO** together. The compact banner combines bold `GENTLE PI` terminal text with a dot-scaled version of the original intro rose, without cropping. It uses the active theme, not a custom font. Narrow/mobile terminals and regular mode retain bottom widgets without this artwork; the startup header retains context only.
+In fullscreen at 140 columns or wider, the right sidebar scrolls **✿ Gentle-Pi ✿ → Status → Changes → Agents → TODO** together. The one-line heading is horizontally centered within the usable rail width, with pink flowers and normal white text in the Gentleman themes. Colors follow the active theme; no artwork scaling or custom fonts are used. Narrow/mobile terminals and regular mode retain bottom widgets without the sidebar heading. The original rose and text logo remain in the main chat startup intro.
 
 The status bar replaces pi's three-line footer with a single line of segments:
 
@@ -750,10 +750,10 @@ Set `GENTLE_PI_SHELL=0` to keep pi's built-in footer and editor.
 | `/gentle:persona`                | Switches global persona mode, with project override support.        |
 | `/gentle:background-subagents`   | Shows or sets the managed background-subagents policy (`status\|enable\|disable`), naming the source that decided it. |
 | `/gentle:telemetry`              | Shows or changes the local Gentle AI telemetry trigger (`status\|enable\|disable\|preview`).  |
-| `/gentle:banner`                 | Configures sidebar rose/text visibility and startup context color.        |
-| `/gentle:toggle-rose`            | Toggles the desktop sidebar rose.                                           |
-| `/gentle:toggle-text-logo`       | Toggles the desktop sidebar wordmark.                                      |
-| `/gentle:banner-color`           | Selects a startup context color preset.                              |
+| `/gentle:banner`                 | Configures startup banner rose, text logo, and color preset.        |
+| `/gentle:toggle-rose`            | Toggles the startup rose.                                           |
+| `/gentle:toggle-text-logo`       | Toggles the startup text logo.                                      |
+| `/gentle:banner-color`           | Selects a startup banner color preset.                              |
 | `/gentle-sdd-init`               | Initializes or refreshes `openspec/config.yaml` (openspec/both stores only). |
 | `/gentle:install-sdd`         | Repairs missing global SDD runtime assets without overwriting files. |
 | `/gentle:install-sdd --force` | Force-refreshes installed global SDD assets.                         |
@@ -785,7 +785,7 @@ Both files use the strict shape `{"schema":"gentle-pi.background-subagents/v1","
 
 Because the project file outranks the global one, `enable` still writes the global file but reports plainly when a project file keeps the effective policy unchanged. The resolved capability (`ready` or `absent`) reports whether `subagent_run` is actually callable in this session; a policy of `on` with capability `absent` means Gentle Agents is disabled or the retired subagents package is still installed.
 
-Banner settings remain global in `banner.json` under `GENTLE_PI_CONFIG_HOME` (default `~/.pi/gentle-ai`). Existing `showRose` and `showTextLogo` opt-outs remain independent; both default to enabled. Visibility changes apply on the next session or `/reload`. The sidebar follows the active theme; `pink`, `cyan`, `yellow`, and `green` presets affect startup context only.
+Startup banner settings remain global in `banner.json` under `GENTLE_PI_CONFIG_HOME` (default `~/.pi/gentle-ai`). Existing `showRose` and `showTextLogo` opt-outs independently control the main startup artwork; both default to enabled. Changes apply on the next session or `/reload`. Color presets are `pink` (default), `cyan`, `yellow`, and `green`. The static sidebar heading is independent of these preferences and follows the active theme.
 
 Startup flag:
 
@@ -857,7 +857,7 @@ To opt out:
 | `scripts/gentle-ai-installer.mjs` | Installs signed Darwin/Linux archives or exact Go SumDB-verified Windows source builds into the package-local runtime. |
 | `contracts/review-integration/v1/` | Byte-identical provider schemas and conformance fixtures for contract `review-integration/v1`, hash-checked before packaging; retained on disk permanently because `/v2`'s schemas `$ref` into these fragments. |
 | `contracts/review-integration/v2/` | Byte-identical provider schemas and conformance fixtures for contract `review-integration/v2` (immutable `base_tree`/`candidate_tree`, ordered `changed_path_manifest`, no inline candidate diff), hash-checked before packaging. |
-| `extensions/startup-banner.ts` | Shows startup context and configures its color presets plus desktop sidebar branding visibility.     |
+| `extensions/startup-banner.ts` | Shows and configures the startup intro, color presets, and compact runtime panel.     |
 | `extensions/sdd-init.ts`       | Registers `/gentle-sdd-init` for OpenSpec initialization.                                                         |
 | `extensions/skill-registry.ts` | Maintains `.atl/skill-registry.md` from project/user skills and closes file watchers on shutdown.          |
 | `assets/orchestrator.md`       | Parent-session orchestration contract (always-on core).                                                    |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Most coding-agent sessions fail for operational reasons, not model reasons:
 | Capability                     | What it does                                                                                                                                  |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | **el Gentleman persona**       | Makes Pi behave like a senior architect and teacher, not a generic chatbot. Spanish responses use Rioplatense voseo by default; neutral mode is saved globally with project overrides. |
-| **Configurable startup intro** | Adds a rose/text-logo startup intro, compact runtime panel, color presets, and commands to hide or show the decorative parts.                  |
+| **Configurable startup intro** | Adds desktop sidebar branding, a compact startup context panel, and independent rose/text visibility controls.                  |
 | **Work routing discipline**    | Small tasks stay inline. Context-heavy exploration can be delegated. Large or risky changes go through SDD/OpenSpec.                          |
 | **SDD/OpenSpec assets**        | Installs phase agents and chains for `init`, `onboard`, `explore`, `proposal`, `spec`, `design`, `tasks`, `apply`, `verify`, `sync`, and `archive`. |
 | **Lazy SDD preflight**         | Resolves SDD mode, artifact store, delivery strategy, and review budget once per session; prompts only when a choice is genuinely unresolved.              |
@@ -109,13 +109,21 @@ Pointer input is fullscreen-only. Regions preserve a consuming child's native re
 `Text`, activate on press or wheel, synthesize outside leave events, or alter terminal tracking.
 Callers own keyboard policy, theme state, and business actions.
 
-**Migration note:** Do not enable `pi-tool-cards` and `quiet-tools` together: Pi rejects duplicate `bash`, `read`, `edit`, and `write` registrations. Disable or remove the standalone package during migration; gentle-pi does not alter user configuration or delete that repository.
+**Migration note:** Do not enable `pi-tool-cards` and `quiet-tools` together: Pi rejects duplicate `bash`, `read`, `edit`, and `write` registrations. Disable or remove the standalone package during migration; gentle-pi does not change those package registrations or delete that repository. The global fullscreen setting described below is a separate install-time change.
 
 ## Install
 
 ```bash
 pi install npm:gentle-pi@0.14.0
 ```
+
+### Install-time fullscreen
+
+For this release, a successful postinstall in Pi's **global npm-managed** `agent-home/npm/node_modules/gentle-pi` installation persists `"tuiMode": "fullscreen"` in `agent-home/settings.json`, preserving other settings. Agent home resolves through `GENTLE_PI_AGENT_HOME`, then `PI_CODING_AGENT_DIR`, then `~/.pi/agent`. Use `/settings` to switch back to regular; rerunning this recognized postinstall resets it to fullscreen. Existing project overrides still take precedence.
+
+Project-local installs (`pi install -l`), Git/local-path installs, temporary packages, development checkouts, ordinary npm consumers, and pnpm symlink-store packages do **not** receive this change. Updates or installs that do not execute postinstall cannot reassert it; this is not a universal install/update guarantee or a change to historical releases.
+
+Malformed/nonobject JSON, symlink/nonregular settings, unsafe paths, or a busy settings lock fail without replacing settings. The installer coordinates with Pi's cooperative settings lock and uses atomic replacement; it does not guarantee safety against noncooperating writers or malicious concurrent directory replacement. Already-fullscreen settings remain byte-identical. Native installation failure leaves settings untouched; `GENTLE_PI_SKIP_GENTLE_AI_INSTALL=1` skips only native provisioning, not the recognized global fullscreen setting.
 
 ### RDD version policy
 
@@ -159,7 +167,7 @@ pi
 /gentle:models             Assign global model/effort routing to SDD/custom agents.
 /gentle:persona            Switch between gentleman and neutral persona modes.
 /gentle:background-subagents  Show or set the managed background-subagents policy, with its deciding source.
-/gentle:banner             Configure startup rose, text logo, and color preset.
+/gentle:banner             Configure sidebar rose/text visibility and startup context color.
 ```
 
 Typical flow:
@@ -611,6 +619,8 @@ Legacy string entries are still accepted and treated as `model`-only config.
 
 Gentle Shell is the visual layer gentle-pi puts on top of pi. It follows the Gentle themes: one border language, champagne titles, rose for whatever is alive.
 
+In fullscreen at 140 columns or wider, the right sidebar scrolls **branding → Status → Changes → Agents → TODO** together. The compact banner combines bold `GENTLE PI` terminal text with a dot-scaled version of the original intro rose, without cropping. It uses the active theme, not a custom font. Narrow/mobile terminals and regular mode retain bottom widgets without this artwork; the startup header retains context only.
+
 The status bar replaces pi's three-line footer with a single line of segments:
 
 ```text
@@ -740,10 +750,10 @@ Set `GENTLE_PI_SHELL=0` to keep pi's built-in footer and editor.
 | `/gentle:persona`                | Switches global persona mode, with project override support.        |
 | `/gentle:background-subagents`   | Shows or sets the managed background-subagents policy (`status\|enable\|disable`), naming the source that decided it. |
 | `/gentle:telemetry`              | Shows or changes the local Gentle AI telemetry trigger (`status\|enable\|disable\|preview`).  |
-| `/gentle:banner`                 | Configures startup banner rose, text logo, and color preset.        |
-| `/gentle:toggle-rose`            | Toggles the startup rose.                                           |
-| `/gentle:toggle-text-logo`       | Toggles the startup text logo.                                      |
-| `/gentle:banner-color`           | Selects a startup banner color preset.                              |
+| `/gentle:banner`                 | Configures sidebar rose/text visibility and startup context color.        |
+| `/gentle:toggle-rose`            | Toggles the desktop sidebar rose.                                           |
+| `/gentle:toggle-text-logo`       | Toggles the desktop sidebar wordmark.                                      |
+| `/gentle:banner-color`           | Selects a startup context color preset.                              |
 | `/gentle-sdd-init`               | Initializes or refreshes `openspec/config.yaml` (openspec/both stores only). |
 | `/gentle:install-sdd`         | Repairs missing global SDD runtime assets without overwriting files. |
 | `/gentle:install-sdd --force` | Force-refreshes installed global SDD assets.                         |
@@ -775,7 +785,7 @@ Both files use the strict shape `{"schema":"gentle-pi.background-subagents/v1","
 
 Because the project file outranks the global one, `enable` still writes the global file but reports plainly when a project file keeps the effective policy unchanged. The resolved capability (`ready` or `absent`) reports whether `subagent_run` is actually callable in this session; a policy of `on` with capability `absent` means Gentle Agents is disabled or the retired subagents package is still installed.
 
-Startup banner settings are global and default to the current pink rose + text logo. Supported color presets are `pink`, `cyan`, `yellow`, and `green`.
+Banner settings remain global in `banner.json` under `GENTLE_PI_CONFIG_HOME` (default `~/.pi/gentle-ai`). Existing `showRose` and `showTextLogo` opt-outs remain independent; both default to enabled. Visibility changes apply on the next session or `/reload`. The sidebar follows the active theme; `pink`, `cyan`, `yellow`, and `green` presets affect startup context only.
 
 Startup flag:
 
@@ -847,7 +857,7 @@ To opt out:
 | `scripts/gentle-ai-installer.mjs` | Installs signed Darwin/Linux archives or exact Go SumDB-verified Windows source builds into the package-local runtime. |
 | `contracts/review-integration/v1/` | Byte-identical provider schemas and conformance fixtures for contract `review-integration/v1`, hash-checked before packaging; retained on disk permanently because `/v2`'s schemas `$ref` into these fragments. |
 | `contracts/review-integration/v2/` | Byte-identical provider schemas and conformance fixtures for contract `review-integration/v2` (immutable `base_tree`/`candidate_tree`, ordered `changed_path_manifest`, no inline candidate diff), hash-checked before packaging. |
-| `extensions/startup-banner.ts` | Shows and configures the startup intro, color presets, compact runtime panel, and collaboration credit.     |
+| `extensions/startup-banner.ts` | Shows startup context and configures its color presets plus desktop sidebar branding visibility.     |
 | `extensions/sdd-init.ts`       | Registers `/gentle-sdd-init` for OpenSpec initialization.                                                         |
 | `extensions/skill-registry.ts` | Maintains `.atl/skill-registry.md` from project/user skills and closes file watchers on shutdown.          |
 | `assets/orchestrator.md`       | Parent-session orchestration contract (always-on core).                                                    |

--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import { join, resolve } from "node:path";
 import { keyHint, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
+import { sidebarPart } from "../lib/shell-sidebar.ts";
 import { AGENT_MODE, discoverAgents, loadAgentsConfig, resolveAgentProfile, type AgentDefinition, type AgentMode } from "../lib/agents-config.ts";
 import { isFinished, TASK_STATUS, TaskStore, type AskRequest, type TaskRecord } from "../lib/agents-protocol.ts";
 import { AgentRunner, piCommand, type AskAnswer, type RunnerDeps, type TaskRequest } from "../lib/agents-runner.ts";
@@ -412,13 +413,16 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		tickClock();
 		ui?.setWidget(AGENTS_WIDGET_KEY, (tui, theme) => {
 			host = tui;
-			return {
+			return sidebarPart(tui, "agents", {
 				render(width: number) {
 					const lines = renderAgentsCard(visibleTasks(), theme, width, deps.now(), { collapsed, collapseKey, maxRows: widgetRows(tui.terminal?.rows), viewKey });
 					return lines.length === 0 ? [] : [...lines, ""];
 				},
 				invalidate() {},
-			};
+			}, {
+				render: (width) => renderAgentsCard(visibleTasks(), theme, width, deps.now(), { collapsed, collapseKey, viewKey }),
+				invalidate() {},
+			});
 		});
 	};
 

--- a/extensions/gentle-shell.ts
+++ b/extensions/gentle-shell.ts
@@ -15,7 +15,6 @@ import { accountIdFromToken, CODEX_PROVIDER, CODEX_USAGE_URL, parseCodexUsage, p
 import { UsageView } from "../lib/shell-usage-view.ts";
 import { sidebarPart } from "../lib/shell-sidebar.ts";
 import { installSidebar } from "../lib/shell-sidebar-layout.ts";
-import { readSidebarBannerConfig } from "../lib/shell-sidebar-banner.ts";
 
 // Gentle Shell: the visual layer gentle-pi puts on top of pi. It installs the
 // status bar, the petal prompt, the working-tree changes widget and overlay,
@@ -546,13 +545,6 @@ export default function gentleShell(pi: ExtensionAPI, env: NodeJS.ProcessEnv = p
 		if (!ctx.hasUI) return;
 		changes = new WorktreeChangesTracker(deps.gitRunner(ctx.cwd), deps.gitRunner, lineCounter, () => sessionRegistry.roots());
 		const tracker = changes;
-		// Install the editor/footer synchronously. Keep branding hidden until its
-		// saved preferences resolve, so an explicit opt-out never flashes on screen.
-		const banner = { showRose: false, showTextLogo: false };
-		void readSidebarBannerConfig().then((config) => {
-			Object.assign(banner, config);
-			renderHost?.requestRender();
-		});
 		ctx.ui.setFooter((tui, theme, footerData) => {
 			renderHost = tui;
 			const bottom = createShellBarComponent(pi, ctx, tui, theme, footerData, () => tracker.model.files.length, () => usage.get(ctx.model?.provider ?? ""));
@@ -560,7 +552,7 @@ export default function gentleShell(pi: ExtensionAPI, env: NodeJS.ProcessEnv = p
 				render: (width) => renderShellSidebarBar(buildShellBarModel(pi, ctx, footerData, { dirty: tracker.model.files.length, usage: usage.get(ctx.model?.provider ?? "") }), theme, width),
 				invalidate() {},
 			});
-			const uninstall = installSidebar(tui, theme, banner);
+			const uninstall = installSidebar(tui, theme);
 			return { ...part, dispose() { uninstall(); part.dispose(); } };
 		});
 		void refreshUsage(ctx, true);

--- a/extensions/gentle-shell.ts
+++ b/extensions/gentle-shell.ts
@@ -4,7 +4,7 @@ import { execFile, spawnSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import * as os from "node:os";
 import { join } from "node:path";
-import { renderShellBar, shellEnabled, type ShellBarModel, type ShellBarTheme } from "../lib/shell-bar.ts";
+import { renderShellBar, renderShellSidebarBar, shellEnabled, type ShellBarModel, type ShellBarTheme } from "../lib/shell-bar.ts";
 import { CHANGE_STATUS, WorktreeChangesTracker, renderChangesWidget, type ChangedFile, type ChangesModel, type GitRunner, type LineCounter, type WorktreeChanges } from "../lib/shell-changes.ts";
 import { WorktreeChangesView } from "../lib/shell-changes-view.ts";
 import { SessionWorktreeRegistry, SESSION_WORKTREE_CHANGED, resolveSessionWorktree, toolWorktreePath, worktreeGitEnvironment, type WorktreeResolver } from "../lib/session-worktree-registry.ts";
@@ -13,6 +13,9 @@ import { GentleAiDevBinaryOverrideError, resolveGentleAiDevBinaryOverride } from
 import { framePromptLines, panelPainter, PROMPT_HINT, PROMPT_STATE, withPromptHint, type PromptState } from "../lib/shell-prompt.ts";
 import { accountIdFromToken, CODEX_PROVIDER, CODEX_USAGE_URL, parseCodexUsage, parseUsageHeaders, UsageStore, type ProviderUsage } from "../lib/shell-usage.ts";
 import { UsageView } from "../lib/shell-usage-view.ts";
+import { sidebarPart } from "../lib/shell-sidebar.ts";
+import { installSidebar } from "../lib/shell-sidebar-layout.ts";
+import { readSidebarBannerConfig } from "../lib/shell-sidebar-banner.ts";
 
 // Gentle Shell: the visual layer gentle-pi puts on top of pi. It installs the
 // status bar, the petal prompt, the working-tree changes widget and overlay,
@@ -354,9 +357,23 @@ function showChanges(ctx: ExtensionContext, model: ChangesModel): void {
 	}
 	ctx.ui.setWidget(
 		CHANGES_WIDGET_KEY,
-		(_tui, theme) => ({
+		(tui, theme) => sidebarPart(tui, "changes", {
 			render(width: number) {
 				return renderChangesWidget(model, theme, width);
+			},
+			invalidate() {},
+		}, {
+			render(width: number) {
+				const noun = model.files.length === 1 ? "file" : "files";
+				return renderCard({
+					title: "Changes",
+					tone: CARD_TONE.INFO,
+					body: [
+						`${model.files.length} ${noun} · ${theme.fg("success", `+${model.added}`)} ${theme.fg("error", `−${model.deleted}`)}`,
+						"",
+						theme.fg("muted", `/${CHANGES_COMMAND_NAME}`),
+					],
+				}, theme, width, { expanded: true });
 			},
 			invalidate() {},
 		}),
@@ -529,9 +546,22 @@ export default function gentleShell(pi: ExtensionAPI, env: NodeJS.ProcessEnv = p
 		if (!ctx.hasUI) return;
 		changes = new WorktreeChangesTracker(deps.gitRunner(ctx.cwd), deps.gitRunner, lineCounter, () => sessionRegistry.roots());
 		const tracker = changes;
+		// Install the editor/footer synchronously. Keep branding hidden until its
+		// saved preferences resolve, so an explicit opt-out never flashes on screen.
+		const banner = { showRose: false, showTextLogo: false };
+		void readSidebarBannerConfig().then((config) => {
+			Object.assign(banner, config);
+			renderHost?.requestRender();
+		});
 		ctx.ui.setFooter((tui, theme, footerData) => {
 			renderHost = tui;
-			return createShellBarComponent(pi, ctx, tui, theme, footerData, () => tracker.model.files.length, () => usage.get(ctx.model?.provider ?? ""));
+			const bottom = createShellBarComponent(pi, ctx, tui, theme, footerData, () => tracker.model.files.length, () => usage.get(ctx.model?.provider ?? ""));
+			const part = sidebarPart(tui, "footer", bottom, {
+				render: (width) => renderShellSidebarBar(buildShellBarModel(pi, ctx, footerData, { dirty: tracker.model.files.length, usage: usage.get(ctx.model?.provider ?? "") }), theme, width),
+				invalidate() {},
+			});
+			const uninstall = installSidebar(tui, theme, banner);
+			return { ...part, dispose() { uninstall(); part.dispose(); } };
 		});
 		void refreshUsage(ctx, true);
 		installPrompt(ctx, (created) => {

--- a/extensions/gentle-todo.ts
+++ b/extensions/gentle-todo.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
+import { sidebarPart } from "../lib/shell-sidebar.ts";
 import {
 	applyTodo,
 	emptyTodo,
@@ -102,13 +103,16 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 		const snapshot = current;
 		current.ui.setWidget(WIDGET_KEY, (tui, theme) => {
 			snapshot.host = tui;
-			return {
+			return sidebarPart(tui, "todo", {
 				render(width: number) {
 					const lines = renderTodoCard(snapshot.state, theme, width, { collapsed: snapshot.collapsed, staleTurns: staleTurns(snapshot.state, snapshot.turn), collapseKey });
 					return lines.length === 0 ? [] : [...lines, ""];
 				},
 				invalidate() {},
-			};
+			}, {
+				render: (width) => renderTodoCard(snapshot.state, theme, width, { collapsed: snapshot.collapsed, staleTurns: staleTurns(snapshot.state, snapshot.turn), collapseKey, scrollable: true }),
+				invalidate() {},
+			});
 		});
 	};
 

--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -44,26 +44,6 @@ const TEXT_LOGO = [
   "     ▒▒▒▒▒▒",
 ];
 
-const ROSE_LARGE_RAW = [
-  "             ⣠⣾⣷⣶⣦⣤⣤⣄⣠⣄⣀  ⢀⣀⣀",
-  "          ⢀⣴⣿⣿⠿⣋⣭⣭⣯⣭⣍⣭⣿⣟⠛⠛⠿⣿⣷⣄",
-  "      ⢀⣴⣾⡟⢻⣿⡟⠁⣼⣿⠏⣵⢻⣿⣻⣿⣿⢿⡻⣿⣿⣶⡌⢿⣿⣷⣦⣤⡄",
-  "   ⣤⣶⣾⣿⣿⠏ ⠈⢿⣄ ⢹⣏⠠⠟⣾⣿⣿⣿⣿⣿⠷⣏⣼⠟⢡⣿⡟⠋⢻⣿⣿⡄",
-  "   ⠈⣿⣿⣿⣿⡆   ⣽⢧⡘⠈⠳⣦⣍⠛⠛⢦⣉⣴⣛⣫⣭⣴⡟⠋  ⣾⣿⣿⡿",
-  "   ⢀⠹⣿⣿⣿⣷⣤⡄ ⠋ ⠙⢆ ⣠⠴⠟⠛⣛⣛⣛⠟⠋⠁⠺⡇ ⣀⣴⣿⣿⡟⠁",
-  "   ⠈⣀⠈⠛⠷⠿⣿⣿⣷⣤⣀ ⢠⠋   ⠈⠉⠉    ⣠⣴⣥⠾⠛⠉⣰⣿⣷",
-  "          ⠹⣯⣝⠛⠛⠷⢶⣤⣤⣀   ⢀⡠⠖⠋⠉⢉⣀⣀⣴⣾⣿⠿⠟⠃",
-  "             ⠘⠻⢿⣦⣄⡀  ⠉⠛⢦⠠⢊⠤⠴⢒⣛⣛⣩⣽⡿⠟⠁",
-  "        ⠶⢶⣤⣄⡀⠨⠭⠽⠟⣓⢦⣀⠈⢇⡥⠖⠛⠋⠉⠉",
-  "           ⠈⢷ ⠐⠂⢤⣽⣄ ⠰⡎⠙⠳⣄⡀ ⠈⢣⠘⢦⠋",
-  "            ⠈⢳⣀⡒⠉⠉⣉⠙⡲⣽⣄ ⣏⠳⡄ ⠘⡇ ⡾⠁",
-  "              ⠛⠻⢦⣄⣉⡁⣀⣀⣈⣙⣺⣌⡇⢠⢀⡇⡾",
-  "                   ⠈⠉    ⠈⠳⡄⣸⢱⠇",
-  "                           ⡷⠡⡯⢖⠉",
-  "                        ⢀⡴⢪⠔⣉⠔⠋",
-  "                           ⠐⠈",
-];
-
 function rgb(r: number, g: number, b: number, text: string): string {
   return `\x1b[38;2;${r};${g};${b}m${text}\x1b[39m`;
 }
@@ -528,12 +508,14 @@ async function countPackageExtensions(packages: unknown[]): Promise<number> {
 }
 
 export default function (pi: ExtensionAPI) {
+  let disposeHeader = () => {};
+  pi.on("session_shutdown", () => disposeHeader());
   const notifyBannerConfig = (ctx: any, config: BannerConfig) => {
     ctx.ui.notify(
       [
-        `Startup banner: rose=${config.showRose ? "on" : "off"}, text logo=${config.showTextLogo ? "on" : "off"}, color=${config.color}`,
+        `Sidebar branding: rose=${config.showRose ? "on" : "off"}, text logo=${config.showTextLogo ? "on" : "off"}; startup context color=${config.color}`,
         `Config: ${bannerConfigPath()}`,
-        "Changes apply on the next startup banner render.",
+        "Visibility applies on the next session or /reload. Sidebar colors follow your theme.",
       ].join("\n"),
       "info",
     );
@@ -541,10 +523,10 @@ export default function (pi: ExtensionAPI) {
 
   const registerBannerCommand = (name: string) => {
     pi.registerCommand(name, {
-      description: "Configure the Gentle Pi startup banner.",
+      description: "Configure sidebar branding visibility and startup context color.",
       handler: async (_args, ctx) => {
         const config = await readBannerConfig();
-        const selected = await ctx.ui.select("Startup banner", [
+        const selected = await ctx.ui.select("Sidebar branding / startup context", [
           `Rose: ${config.showRose ? "on" : "off"}`,
           `Text logo: ${config.showTextLogo ? "on" : "off"}`,
           `Color: ${config.color}`,
@@ -564,7 +546,7 @@ export default function (pi: ExtensionAPI) {
   };
   const registerToggleCommand = (name: string, key: "showRose" | "showTextLogo") => {
     pi.registerCommand(name, {
-      description: `Toggle startup banner ${key === "showRose" ? "rose" : "text logo"}.`,
+      description: `Toggle sidebar ${key === "showRose" ? "rose" : "text logo"}.`,
       handler: async (_args, ctx) => {
         const config = await readBannerConfig();
         config[key] = !config[key];
@@ -597,6 +579,7 @@ export default function (pi: ExtensionAPI) {
   registerColorCommand("gentle:banner-color");
 
   pi.on("session_start", async (_event, ctx) => {
+    disposeHeader();
     if (!ctx.hasUI) return;
 
     // Si se está ejecutando un comando de CLI como "pi update" o "pi install", no mostramos la intro animada.
@@ -607,16 +590,10 @@ export default function (pi: ExtensionAPI) {
 
     if (currentIntroMode() === "skip") return;
 
-    // Fire-and-forget: el setup geométrico de cada letra corre en background
-    // para que la animación arranque en el primer frame sin bloquear el event loop.
-    void warmupLetterStrokes();
-
-    process.stdout.write("\x1b[2J\x1b[3J\x1b[H");
-
+    // Pi has already started its renderer. Let setHeader schedule the paint;
+    // clearing stdout here would leave its previous-frame cache out of sync.
     const bannerConfig = await readBannerConfig();
     const palette = BANNER_PALETTES[bannerConfig.color];
-    const roseBase = padLines(normalizeAscii(ROSE_LARGE_RAW));
-    const logoBase = padLines(TEXT_LOGO);
 
     let gitBranch = "Not a git repo";
     let mcpServersCount = 0;
@@ -637,7 +614,8 @@ export default function (pi: ExtensionAPI) {
           const b = stdout.trim();
           gitBranch = b ? `On branch ${b}` : "Detached HEAD";
         })
-        .catch(() => {});
+        .catch(() => {})
+        .finally(() => refreshStats());
     }, 100);
 
     setTimeout(() => {
@@ -652,6 +630,7 @@ export default function (pi: ExtensionAPI) {
         } catch {
           mcpServersCount = 0;
         }
+        refreshStats();
       })();
     }, 150);
 
@@ -671,10 +650,12 @@ export default function (pi: ExtensionAPI) {
           extensionsCount = 0;
           packagesCount = 0;
         }
+        refreshStats();
       })();
     }, 200);
 
-    let tick = 0;
+    const tick = 0;
+    let refreshStats = () => {};
     const state = {
       timer: null as NodeJS.Timeout | null,
       mode: currentIntroMode() as IntroMode,
@@ -683,6 +664,7 @@ export default function (pi: ExtensionAPI) {
     };
 
     const cleanup = () => {
+      refreshStats = () => {};
       if (state.timer) {
         clearInterval(state.timer);
         state.timer = null;
@@ -697,28 +679,13 @@ export default function (pi: ExtensionAPI) {
       }
     };
 
+    disposeHeader = cleanup;
     setTimeout(() => {
       ctx.ui.setHeader((tui, theme) => {
         if (state.timer) clearInterval(state.timer);
 
-        const animStart = Date.now();
-        const HARD_TIMEOUT_MS = 5000;
-
-        state.timer = setInterval(() => {
-          tick++;
-          const elapsed = Date.now() - animStart;
-          const finishedAnimation =
-            allStrokesReady() && tick > WRITING_END_TICK + 22;
-          if (finishedAnimation || elapsed > HARD_TIMEOUT_MS) {
-            cleanup();
-            return;
-          }
-          try {
-            tui.requestRender();
-          } catch {
-            cleanup();
-          }
-        }, 25);
+        // Context updates request ordinary Pi renders; there is no artwork timer.
+        refreshStats = () => tui.requestRender();
 
         // Grace period: pi-tui emite resizes transitorios mientras compone su layout inicial.
         const bootStart = Date.now();
@@ -730,11 +697,8 @@ export default function (pi: ExtensionAPI) {
             const next = currentIntroMode();
             if (next === state.mode) return;
             state.mode = next;
-            if (next === "skip") {
-              cleanup();
-              process.stdout.write("\x1b[2J\x1b[3J\x1b[H");
-              return;
-            }
+            // render() returns no lines in skip mode; Pi owns their removal.
+            if (next === "skip") cleanup();
             try {
               tui.requestRender();
             } catch {
@@ -757,105 +721,16 @@ export default function (pi: ExtensionAPI) {
                 : 0;
             const frame = Math.floor(tick / 2);
 
-            const sideBySideMinWidth = roseBase.width + 3 + logoBase.width + 4;
             const wideStatsMinWidth = 122;
-            const horizontal =
-              state.mode === "full" && bannerConfig.showRose && bannerConfig.showTextLogo && width >= sideBySideMinWidth;
             const wideStats = width >= wideStatsMinWidth;
 
             const b = new LayoutBuilder();
             b.addRow();
             b.center(width);
 
-            if (state.mode === "minimal") {
-              if (bannerConfig.showTextLogo) for (let logoI = 0; logoI < logoBase.lines.length; logoI++) {
-                const logoLine = logoBase.lines[logoI];
-                b.addRow();
-                b.lines[b.lines.length - 1].push(
-                  ...buildPenLogoLine(
-                    logoLine,
-                    logoI,
-                    logoBase.lines.length,
-                    tick,
-                  ),
-                );
-                b.center(width);
-              }
-            } else if (horizontal) {
-              const rowCount = Math.max(
-                roseBase.lines.length,
-                logoBase.lines.length,
-              );
-              const roseOffset = Math.max(
-                0,
-                Math.floor((rowCount - roseBase.lines.length) / 2),
-              );
-              const logoOffset = Math.max(
-                0,
-                Math.floor((rowCount - logoBase.lines.length) / 2),
-              );
-
-              for (let i = 0; i < rowCount; i++) {
-                const roseI = i - roseOffset;
-                const logoI = i - logoOffset;
-                const roseLine =
-                  roseI >= 0 && roseI < roseBase.lines.length
-                    ? roseBase.lines[roseI]
-                    : " ".repeat(roseBase.width);
-                const logoLine =
-                  logoI >= 0 && logoI < logoBase.lines.length
-                    ? logoBase.lines[logoI]
-                    : " ".repeat(logoBase.width);
-
-                b.addRow();
-                b.add("rose", roseLine);
-                b.add("none", "   ");
-                if (logoI >= 0 && logoI < logoBase.lines.length) {
-                  b.lines[b.lines.length - 1].push(
-                    ...buildPenLogoLine(
-                      logoLine,
-                      logoI,
-                      logoBase.lines.length,
-                      tick,
-                    ),
-                  );
-                } else {
-                  b.add("none", " ".repeat(logoBase.width));
-                }
-                b.center(width);
-              }
-            } else {
-              const showBanner = bannerConfig.showTextLogo && width >= logoBase.width + 2;
-              const showRose = bannerConfig.showRose && width >= roseBase.width + 2;
-              if (showBanner) {
-                for (let logoI = 0; logoI < logoBase.lines.length; logoI++) {
-                  const logoLine = logoBase.lines[logoI];
-                  b.addRow();
-                  b.lines[b.lines.length - 1].push(
-                    ...buildPenLogoLine(
-                      logoLine,
-                      logoI,
-                      logoBase.lines.length,
-                      tick,
-                    ),
-                  );
-                  b.center(width);
-                }
-                if (showRose) {
-                  b.addRow();
-                  b.center(width);
-                }
-              }
-              if (showRose) {
-                for (const roseLine of roseBase.lines) {
-                  b.addRow();
-                  b.add("rose", roseLine);
-                  b.center(width);
-                }
-              }
-            }
-
-            if (state.mode === "full" || (!bannerConfig.showRose && !bannerConfig.showTextLogo)) {
+            // Branding belongs exclusively to the desktop sidebar. Keep startup
+            // context here regardless of the independent rose/wordmark preferences.
+            {
               b.addRow();
               b.center(width);
 

--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -44,6 +44,26 @@ const TEXT_LOGO = [
   "     ▒▒▒▒▒▒",
 ];
 
+const ROSE_LARGE_RAW = [
+  "             ⣠⣾⣷⣶⣦⣤⣤⣄⣠⣄⣀  ⢀⣀⣀",
+  "          ⢀⣴⣿⣿⠿⣋⣭⣭⣯⣭⣍⣭⣿⣟⠛⠛⠿⣿⣷⣄",
+  "      ⢀⣴⣾⡟⢻⣿⡟⠁⣼⣿⠏⣵⢻⣿⣻⣿⣿⢿⡻⣿⣿⣶⡌⢿⣿⣷⣦⣤⡄",
+  "   ⣤⣶⣾⣿⣿⠏ ⠈⢿⣄ ⢹⣏⠠⠟⣾⣿⣿⣿⣿⣿⠷⣏⣼⠟⢡⣿⡟⠋⢻⣿⣿⡄",
+  "   ⠈⣿⣿⣿⣿⡆   ⣽⢧⡘⠈⠳⣦⣍⠛⠛⢦⣉⣴⣛⣫⣭⣴⡟⠋  ⣾⣿⣿⡿",
+  "   ⢀⠹⣿⣿⣿⣷⣤⡄ ⠋ ⠙⢆ ⣠⠴⠟⠛⣛⣛⣛⠟⠋⠁⠺⡇ ⣀⣴⣿⣿⡟⠁",
+  "   ⠈⣀⠈⠛⠷⠿⣿⣿⣷⣤⣀ ⢠⠋   ⠈⠉⠉    ⣠⣴⣥⠾⠛⠉⣰⣿⣷",
+  "          ⠹⣯⣝⠛⠛⠷⢶⣤⣤⣀   ⢀⡠⠖⠋⠉⢉⣀⣀⣴⣾⣿⠿⠟⠃",
+  "             ⠘⠻⢿⣦⣄⡀  ⠉⠛⢦⠠⢊⠤⠴⢒⣛⣛⣩⣽⡿⠟⠁",
+  "        ⠶⢶⣤⣄⡀⠨⠭⠽⠟⣓⢦⣀⠈⢇⡥⠖⠛⠋⠉⠉",
+  "           ⠈⢷ ⠐⠂⢤⣽⣄ ⠰⡎⠙⠳⣄⡀ ⠈⢣⠘⢦⠋",
+  "            ⠈⢳⣀⡒⠉⠉⣉⠙⡲⣽⣄ ⣏⠳⡄ ⠘⡇ ⡾⠁",
+  "              ⠛⠻⢦⣄⣉⡁⣀⣀⣈⣙⣺⣌⡇⢠⢀⡇⡾",
+  "                   ⠈⠉    ⠈⠳⡄⣸⢱⠇",
+  "                           ⡷⠡⡯⢖⠉",
+  "                        ⢀⡴⢪⠔⣉⠔⠋",
+  "                           ⠐⠈",
+];
+
 function rgb(r: number, g: number, b: number, text: string): string {
   return `\x1b[38;2;${r};${g};${b}m${text}\x1b[39m`;
 }
@@ -513,9 +533,9 @@ export default function (pi: ExtensionAPI) {
   const notifyBannerConfig = (ctx: any, config: BannerConfig) => {
     ctx.ui.notify(
       [
-        `Sidebar branding: rose=${config.showRose ? "on" : "off"}, text logo=${config.showTextLogo ? "on" : "off"}; startup context color=${config.color}`,
+        `Startup banner: rose=${config.showRose ? "on" : "off"}, text logo=${config.showTextLogo ? "on" : "off"}, color=${config.color}`,
         `Config: ${bannerConfigPath()}`,
-        "Visibility applies on the next session or /reload. Sidebar colors follow your theme.",
+        "Changes apply on the next startup banner render.",
       ].join("\n"),
       "info",
     );
@@ -523,10 +543,10 @@ export default function (pi: ExtensionAPI) {
 
   const registerBannerCommand = (name: string) => {
     pi.registerCommand(name, {
-      description: "Configure sidebar branding visibility and startup context color.",
+      description: "Configure the Gentle Pi startup banner.",
       handler: async (_args, ctx) => {
         const config = await readBannerConfig();
-        const selected = await ctx.ui.select("Sidebar branding / startup context", [
+        const selected = await ctx.ui.select("Startup banner", [
           `Rose: ${config.showRose ? "on" : "off"}`,
           `Text logo: ${config.showTextLogo ? "on" : "off"}`,
           `Color: ${config.color}`,
@@ -546,7 +566,7 @@ export default function (pi: ExtensionAPI) {
   };
   const registerToggleCommand = (name: string, key: "showRose" | "showTextLogo") => {
     pi.registerCommand(name, {
-      description: `Toggle sidebar ${key === "showRose" ? "rose" : "text logo"}.`,
+      description: `Toggle startup banner ${key === "showRose" ? "rose" : "text logo"}.`,
       handler: async (_args, ctx) => {
         const config = await readBannerConfig();
         config[key] = !config[key];
@@ -594,6 +614,9 @@ export default function (pi: ExtensionAPI) {
     // clearing stdout here would leave its previous-frame cache out of sync.
     const bannerConfig = await readBannerConfig();
     const palette = BANNER_PALETTES[bannerConfig.color];
+    const roseBase = padLines(normalizeAscii(ROSE_LARGE_RAW));
+    const logoBase = padLines(TEXT_LOGO);
+    void warmupLetterStrokes();
 
     let gitBranch = "Not a git repo";
     let mcpServersCount = 0;
@@ -654,7 +677,7 @@ export default function (pi: ExtensionAPI) {
       })();
     }, 200);
 
-    const tick = 0;
+    let tick = 0;
     let refreshStats = () => {};
     const state = {
       timer: null as NodeJS.Timeout | null,
@@ -684,8 +707,17 @@ export default function (pi: ExtensionAPI) {
       ctx.ui.setHeader((tui, theme) => {
         if (state.timer) clearInterval(state.timer);
 
-        // Context updates request ordinary Pi renders; there is no artwork timer.
         refreshStats = () => tui.requestRender();
+        const animStart = Date.now();
+        state.timer = setInterval(() => {
+          tick++;
+          const finished = allStrokesReady() && tick > WRITING_END_TICK + 22;
+          if (finished || Date.now() - animStart > 5000) {
+            clearInterval(state.timer!);
+            state.timer = null;
+          }
+          try { tui.requestRender(); } catch { cleanup(); }
+        }, 25);
 
         // Grace period: pi-tui emite resizes transitorios mientras compone su layout inicial.
         const bootStart = Date.now();
@@ -697,8 +729,7 @@ export default function (pi: ExtensionAPI) {
             const next = currentIntroMode();
             if (next === state.mode) return;
             state.mode = next;
-            // render() returns no lines in skip mode; Pi owns their removal.
-            if (next === "skip") cleanup();
+            // Pi owns removal in skip mode; keep listening for later expansion.
             try {
               tui.requestRender();
             } catch {
@@ -721,6 +752,9 @@ export default function (pi: ExtensionAPI) {
                 : 0;
             const frame = Math.floor(tick / 2);
 
+            const sideBySideMinWidth = roseBase.width + 3 + logoBase.width + 4;
+            const horizontal =
+              state.mode === "full" && bannerConfig.showRose && bannerConfig.showTextLogo && width >= sideBySideMinWidth;
             const wideStatsMinWidth = 122;
             const wideStats = width >= wideStatsMinWidth;
 
@@ -728,9 +762,65 @@ export default function (pi: ExtensionAPI) {
             b.addRow();
             b.center(width);
 
-            // Branding belongs exclusively to the desktop sidebar. Keep startup
-            // context here regardless of the independent rose/wordmark preferences.
-            {
+            if (state.mode === "minimal") {
+              if (bannerConfig.showTextLogo) for (let logoI = 0; logoI < logoBase.lines.length; logoI++) {
+                const logoLine = logoBase.lines[logoI];
+                b.addRow();
+                b.lines[b.lines.length - 1].push(
+                  ...buildPenLogoLine(logoLine, logoI, logoBase.lines.length, tick),
+                );
+                b.center(width);
+              }
+            } else if (horizontal) {
+              const rowCount = Math.max(roseBase.lines.length, logoBase.lines.length);
+              const roseOffset = Math.max(0, Math.floor((rowCount - roseBase.lines.length) / 2));
+              const logoOffset = Math.max(0, Math.floor((rowCount - logoBase.lines.length) / 2));
+              for (let i = 0; i < rowCount; i++) {
+                const roseI = i - roseOffset;
+                const logoI = i - logoOffset;
+                const roseLine = roseI >= 0 && roseI < roseBase.lines.length
+                  ? roseBase.lines[roseI] : " ".repeat(roseBase.width);
+                const logoLine = logoI >= 0 && logoI < logoBase.lines.length
+                  ? logoBase.lines[logoI] : " ".repeat(logoBase.width);
+                b.addRow();
+                b.add("rose", roseLine);
+                b.add("none", "   ");
+                if (logoI >= 0 && logoI < logoBase.lines.length) {
+                  b.lines[b.lines.length - 1].push(
+                    ...buildPenLogoLine(logoLine, logoI, logoBase.lines.length, tick),
+                  );
+                } else {
+                  b.add("none", " ".repeat(logoBase.width));
+                }
+                b.center(width);
+              }
+            } else {
+              const showBanner = bannerConfig.showTextLogo && width >= logoBase.width + 2;
+              const showRose = bannerConfig.showRose && width >= roseBase.width + 2;
+              if (showBanner) {
+                for (let logoI = 0; logoI < logoBase.lines.length; logoI++) {
+                  const logoLine = logoBase.lines[logoI];
+                  b.addRow();
+                  b.lines[b.lines.length - 1].push(
+                    ...buildPenLogoLine(logoLine, logoI, logoBase.lines.length, tick),
+                  );
+                  b.center(width);
+                }
+                if (showRose) {
+                  b.addRow();
+                  b.center(width);
+                }
+              }
+              if (showRose) {
+                for (const roseLine of roseBase.lines) {
+                  b.addRow();
+                  b.add("rose", roseLine);
+                  b.center(width);
+                }
+              }
+            }
+
+            if (state.mode === "full" || (!bannerConfig.showRose && !bannerConfig.showTextLogo)) {
               b.addRow();
               b.center(width);
 

--- a/lib/shell-bar.ts
+++ b/lib/shell-bar.ts
@@ -1,7 +1,8 @@
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { GAUGE_CELLS, gaugeTone, paintGauge, renderGauge, type GaugeTone } from "./shell-gauge.ts";
 import { renderUsageBar, type ProviderUsage } from "./shell-usage.ts";
 import { sanitizeTerminalText } from "./terminal-theme.ts";
+import { CARD_TONE, cardInnerWidth, renderCard } from "./shell-card.ts";
 
 export { gaugeTone, renderGauge, type GaugeTone };
 
@@ -114,6 +115,51 @@ function clipText(text: string, max: number): string {
 
 function joinSegments(segments: string[], theme: ShellBarTheme): string {
 	return segments.join(` ${theme.fg(ROLE.SEPARATOR, SHELL_BAR_SEPARATOR)} `);
+}
+
+// Sidebar groups use structured fields, never positional compact-bar segments
+// or inferred meanings from opaque extension status strings.
+export function renderShellSidebarBar(model: ShellBarModel, theme: ShellBarTheme, width: number): string[] {
+	const value = (text: string) => theme.fg(ROLE.VALUE, theme.bold(text));
+	const label = (text: string) => theme.fg(ROLE.LABEL, text);
+	const dirty = model.dirty ? theme.fg(ROLE.DIRTY, `±${model.dirty}`) : "";
+	const branch = model.branch ? `${label("Branch")} ${value(model.branch)}` : "";
+	const percent = model.contextPercent === null ? "?%" : `${Math.round(model.contextPercent)}%`;
+	const capacity = label(`${formatTokens(model.contextWindow)} tokens`);
+	const usage = model.usage ? renderUsageBar(model.usage, theme) : undefined;
+	const groups: Array<{ title: string; lines: string[] }> = [
+		{
+			title: "Project",
+			lines: [
+				value(model.cwd),
+				...((branch || dirty) ? [[branch, dirty].filter(Boolean).join(" ")] : []),
+				...(model.sessionName ? [`${label("Session")} ${value(model.sessionName)}`] : []),
+			],
+		},
+		{
+			title: "Model",
+			lines: [value(model.modelId), ...(model.effort ? [`${label("Effort")} ${theme.fg(ROLE.EFFORT, model.effort)}`] : [])],
+		},
+		{
+			title: "Context",
+			lines: [`${paintGauge(model.contextPercent, theme)} ${value(percent)}  ${capacity}`],
+		},
+		{
+			title: "Usage",
+			lines: [`${label("Cost")} ${value(formatCost(model.costTotal, model.subscription))}`, ...(usage ? [usage] : [])],
+		},
+		...(model.statuses.length ? [{ title: "Integrations", lines: model.statuses.map((status) => theme.fg(ROLE.STATUS, sanitizeStatus(status))) }] : []),
+	];
+	// Pre-wrap values before indenting so Unicode/ANSI continuation lines keep
+	// the same inset without consuming the card's right border.
+	const innerWidth = cardInnerWidth(width);
+	const inset = Math.min(1, innerWidth - 1);
+	const body = groups.flatMap((group, index) => [
+		...(index ? [""] : []),
+		label(group.title),
+		...group.lines.flatMap((line) => wrapTextWithAnsi(line, innerWidth - inset).map((part) => " ".repeat(inset) + part)),
+	]);
+	return renderCard({ title: "Status", body, tone: CARD_TONE.INFO }, theme, width, { expanded: true });
 }
 
 export function renderShellBar(model: ShellBarModel, theme: ShellBarTheme, width: number): string[] {

--- a/lib/shell-sidebar-banner.ts
+++ b/lib/shell-sidebar-banner.ts
@@ -1,68 +1,11 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { readFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type { ShellBarTheme } from "./shell-bar.ts";
 
-export interface SidebarBannerConfig { showRose: boolean; showTextLogo: boolean }
-const DEFAULT = { showRose: true, showTextLogo: true };
-export async function readSidebarBannerConfig(read = () => readFile(join(process.env.GENTLE_PI_CONFIG_HOME ?? join(homedir(), ".pi", "gentle-ai"), "banner.json"), "utf8")): Promise<SidebarBannerConfig> {
-	try {
-		const config = JSON.parse(await read());
-		return {
-			showRose: typeof config?.showRose === "boolean" ? config.showRose : true,
-			showTextLogo: typeof config?.showTextLogo === "boolean" ? config.showTextLogo : true,
-		};
-	} catch { return { ...DEFAULT }; }
-}
-
-// The original startup rose, scaled as Braille dots rather than cropped cells.
-const ROSE = [
-	"             ⣠⣾⣷⣶⣦⣤⣤⣄⣠⣄⣀  ⢀⣀⣀",
-	"          ⢀⣴⣿⣿⠿⣋⣭⣭⣯⣭⣍⣭⣿⣟⠛⠛⠿⣿⣷⣄",
-	"      ⢀⣴⣾⡟⢻⣿⡟⠁⣼⣿⠏⣵⢻⣿⣻⣿⣿⢿⡻⣿⣿⣶⡌⢿⣿⣷⣦⣤⡄",
-	"   ⣤⣶⣾⣿⣿⠏ ⠈⢿⣄ ⢹⣏⠠⠟⣾⣿⣿⣿⣿⣿⠷⣏⣼⠟⢡⣿⡟⠋⢻⣿⣿⡄",
-	"   ⠈⣿⣿⣿⣿⡆   ⣽⢧⡘⠈⠳⣦⣍⠛⠛⢦⣉⣴⣛⣫⣭⣴⡟⠋  ⣾⣿⣿⡿",
-	"   ⢀⠹⣿⣿⣿⣷⣤⡄ ⠋ ⠙⢆ ⣠⠴⠟⠛⣛⣛⣛⠟⠋⠁⠺⡇ ⣀⣴⣿⣿⡟⠁",
-	"   ⠈⣀⠈⠛⠷⠿⣿⣿⣷⣤⣀ ⢠⠋   ⠈⠉⠉    ⣠⣴⣥⠾⠛⠉⣰⣿⣷",
-	"          ⠹⣯⣝⠛⠛⠷⢶⣤⣤⣀   ⢀⡠⠖⠋⠉⢉⣀⣀⣴⣾⣿⠿⠟⠃",
-	"             ⠘⠻⢿⣦⣄⡀  ⠉⠛⢦⠠⢊⠤⠴⢒⣛⣛⣩⣽⡿⠟⠁",
-	"        ⠶⢶⣤⣄⡀⠨⠭⠽⠟⣓⢦⣀⠈⢇⡥⠖⠛⠋⠉⠉",
-	"           ⠈⢷ ⠐⠂⢤⣽⣄ ⠰⡎⠙⠳⣄⡀ ⠈⢣⠘⢦⠋",
-	"            ⠈⢳⣀⡒⠉⠉⣉⠙⡲⣽⣄ ⣏⠳⡄ ⠘⡇ ⡾⠁",
-	"              ⠛⠻⢦⣄⣉⡁⣀⣀⣈⣙⣺⣌⡇⢠⢀⡇⡾",
-	"                   ⠈⠉    ⠈⠳⡄⣸⢱⠇",
-	"                           ⡷⠡⡯⢖⠉",
-	"                        ⢀⡴⢪⠔⣉⠔⠋",
-	"                           ⠐⠈",
-];
-const DOTS = [[1, 8], [2, 16], [4, 32], [64, 128]];
-const compactRose = (() => {
-	const cells = Array.from({ length: 9 }, () => Array<number>(24).fill(0));
-	ROSE.forEach((line, row) => [...line].forEach((char, col) => {
-		const bits = char.codePointAt(0)! - 0x2800;
-		if (bits < 0 || bits > 255) return;
-		DOTS.forEach((dots, y) => dots.forEach((bit, x) => {
-			if (!(bits & bit)) return;
-			const dx = Math.floor((col * 2 + x) / 2);
-			const dy = Math.floor((row * 4 + y) / 2);
-			cells[Math.floor(dy / 4)][Math.floor(dx / 2)] |= DOTS[dy % 4][dx % 2];
-		}));
-	}));
-	return cells.map((row) => row.map((bits) => bits ? String.fromCodePoint(0x2800 + bits) : " ").join("").trimEnd());
-})();
-
-export function renderSidebarBanner(theme: ShellBarTheme, width: number, config: SidebarBannerConfig = DEFAULT): string[] {
-	// Hide an element whole when it cannot fit; never truncate its identity.
-	const rose = config.showRose && width >= 24 ? compactRose : [];
-	const logo = config.showTextLogo && width >= 9 ? "GENTLE PI" : "";
-	if (!rose.length) return logo ? [theme.fg("text", theme.bold(logo))] : [];
-	const sideBySide = !!logo && width >= 36;
-	const lines = rose.map((line, index) => {
-		const painted = theme.fg("accent", line);
-		return sideBySide && index === 3
-			? painted + " ".repeat(27 - visibleWidth(line)) + theme.fg("text", theme.bold(logo))
-			: painted;
-	});
-	return !sideBySide && logo ? [...lines, theme.fg("text", theme.bold(logo))] : lines;
+export function renderSidebarBanner(theme: ShellBarTheme, width: number): string[] {
+	const label = "✿ Gentle-Pi ✿";
+	const space = width - visibleWidth(label);
+	if (space < 0) return [];
+	// Gentleman's accent is pink; card titles use a separate champagne role.
+	const title = theme.fg("accent", "✿") + " " + theme.fg("text", "Gentle-Pi") + " " + theme.fg("accent", "✿");
+	return [" ".repeat(Math.floor(space / 2)) + title + " ".repeat(Math.ceil(space / 2))];
 }

--- a/lib/shell-sidebar-banner.ts
+++ b/lib/shell-sidebar-banner.ts
@@ -1,0 +1,68 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ShellBarTheme } from "./shell-bar.ts";
+
+export interface SidebarBannerConfig { showRose: boolean; showTextLogo: boolean }
+const DEFAULT = { showRose: true, showTextLogo: true };
+export async function readSidebarBannerConfig(read = () => readFile(join(process.env.GENTLE_PI_CONFIG_HOME ?? join(homedir(), ".pi", "gentle-ai"), "banner.json"), "utf8")): Promise<SidebarBannerConfig> {
+	try {
+		const config = JSON.parse(await read());
+		return {
+			showRose: typeof config?.showRose === "boolean" ? config.showRose : true,
+			showTextLogo: typeof config?.showTextLogo === "boolean" ? config.showTextLogo : true,
+		};
+	} catch { return { ...DEFAULT }; }
+}
+
+// The original startup rose, scaled as Braille dots rather than cropped cells.
+const ROSE = [
+	"             ⣠⣾⣷⣶⣦⣤⣤⣄⣠⣄⣀  ⢀⣀⣀",
+	"          ⢀⣴⣿⣿⠿⣋⣭⣭⣯⣭⣍⣭⣿⣟⠛⠛⠿⣿⣷⣄",
+	"      ⢀⣴⣾⡟⢻⣿⡟⠁⣼⣿⠏⣵⢻⣿⣻⣿⣿⢿⡻⣿⣿⣶⡌⢿⣿⣷⣦⣤⡄",
+	"   ⣤⣶⣾⣿⣿⠏ ⠈⢿⣄ ⢹⣏⠠⠟⣾⣿⣿⣿⣿⣿⠷⣏⣼⠟⢡⣿⡟⠋⢻⣿⣿⡄",
+	"   ⠈⣿⣿⣿⣿⡆   ⣽⢧⡘⠈⠳⣦⣍⠛⠛⢦⣉⣴⣛⣫⣭⣴⡟⠋  ⣾⣿⣿⡿",
+	"   ⢀⠹⣿⣿⣿⣷⣤⡄ ⠋ ⠙⢆ ⣠⠴⠟⠛⣛⣛⣛⠟⠋⠁⠺⡇ ⣀⣴⣿⣿⡟⠁",
+	"   ⠈⣀⠈⠛⠷⠿⣿⣿⣷⣤⣀ ⢠⠋   ⠈⠉⠉    ⣠⣴⣥⠾⠛⠉⣰⣿⣷",
+	"          ⠹⣯⣝⠛⠛⠷⢶⣤⣤⣀   ⢀⡠⠖⠋⠉⢉⣀⣀⣴⣾⣿⠿⠟⠃",
+	"             ⠘⠻⢿⣦⣄⡀  ⠉⠛⢦⠠⢊⠤⠴⢒⣛⣛⣩⣽⡿⠟⠁",
+	"        ⠶⢶⣤⣄⡀⠨⠭⠽⠟⣓⢦⣀⠈⢇⡥⠖⠛⠋⠉⠉",
+	"           ⠈⢷ ⠐⠂⢤⣽⣄ ⠰⡎⠙⠳⣄⡀ ⠈⢣⠘⢦⠋",
+	"            ⠈⢳⣀⡒⠉⠉⣉⠙⡲⣽⣄ ⣏⠳⡄ ⠘⡇ ⡾⠁",
+	"              ⠛⠻⢦⣄⣉⡁⣀⣀⣈⣙⣺⣌⡇⢠⢀⡇⡾",
+	"                   ⠈⠉    ⠈⠳⡄⣸⢱⠇",
+	"                           ⡷⠡⡯⢖⠉",
+	"                        ⢀⡴⢪⠔⣉⠔⠋",
+	"                           ⠐⠈",
+];
+const DOTS = [[1, 8], [2, 16], [4, 32], [64, 128]];
+const compactRose = (() => {
+	const cells = Array.from({ length: 9 }, () => Array<number>(24).fill(0));
+	ROSE.forEach((line, row) => [...line].forEach((char, col) => {
+		const bits = char.codePointAt(0)! - 0x2800;
+		if (bits < 0 || bits > 255) return;
+		DOTS.forEach((dots, y) => dots.forEach((bit, x) => {
+			if (!(bits & bit)) return;
+			const dx = Math.floor((col * 2 + x) / 2);
+			const dy = Math.floor((row * 4 + y) / 2);
+			cells[Math.floor(dy / 4)][Math.floor(dx / 2)] |= DOTS[dy % 4][dx % 2];
+		}));
+	}));
+	return cells.map((row) => row.map((bits) => bits ? String.fromCodePoint(0x2800 + bits) : " ").join("").trimEnd());
+})();
+
+export function renderSidebarBanner(theme: ShellBarTheme, width: number, config: SidebarBannerConfig = DEFAULT): string[] {
+	// Hide an element whole when it cannot fit; never truncate its identity.
+	const rose = config.showRose && width >= 24 ? compactRose : [];
+	const logo = config.showTextLogo && width >= 9 ? "GENTLE PI" : "";
+	if (!rose.length) return logo ? [theme.fg("text", theme.bold(logo))] : [];
+	const sideBySide = !!logo && width >= 36;
+	const lines = rose.map((line, index) => {
+		const painted = theme.fg("accent", line);
+		return sideBySide && index === 3
+			? painted + " ".repeat(27 - visibleWidth(line)) + theme.fg("text", theme.bold(logo))
+			: painted;
+	});
+	return !sideBySide && logo ? [...lines, theme.fg("text", theme.bold(logo))] : lines;
+}

--- a/lib/shell-sidebar-layout.ts
+++ b/lib/shell-sidebar-layout.ts
@@ -1,0 +1,119 @@
+import { ScrollView, visibleWidth, type Component, type TUI } from "@earendil-works/pi-tui";
+import { sidebarState } from "./shell-sidebar.ts";
+import type { ShellBarTheme } from "./shell-bar.ts";
+import { renderSidebarBanner, type SidebarBannerConfig } from "./shell-sidebar-banner.ts";
+
+export const SIDEBAR_BREAKPOINT = 140;
+const RAIL_WIDTH = 50;
+const RAIL_PADDING = 1;
+const GAP = 3;
+// Experimental Pi 0.85.1 internals. Only the fullscreen layout tree is adapted;
+// regular mode keeps native scrollback and the original bottom components.
+const NODE = Symbol.for("@earendil-works/pi-tui/layout-node");
+type LayoutNode = { type: string; entries?: unknown[]; gap?: number; align?: string };
+type LayoutRoot = Component & { [NODE]?: () => LayoutNode };
+type Host = TUI & { mode?: string; layoutRoot?: LayoutRoot };
+
+export function installSidebar(tui: TUI, theme: ShellBarTheme, banner: SidebarBannerConfig = { showRose: false, showTextLogo: false }): () => void {
+	if (!tui.terminal) return () => {};
+	const host = tui as Host;
+	const state = sidebarState(tui);
+	const cleanups: Array<() => void> = [];
+	const roots = new Set<LayoutRoot>();
+	let stopped = false;
+	let failed = false;
+	let railLines: string[] = [];
+	state.active = false;
+	state.ownsHost = () => !stopped && host.mode === "fullscreen" && !!host.layoutRoot && roots.has(host.layoutRoot);
+	const rail: Component = {
+		render: () => railLines,
+		invalidate() { for (const part of state.parts.values()) part.invalidate(); },
+	};
+	const scroll = new ScrollView(rail, {
+		follow: "none",
+		primary: false,
+		overscroll: "contain",
+		scrollbar: "always",
+		scrollbarTrackStyle: (text) => theme.fg("border", text),
+		scrollbarThumbStyle: (text) => theme.fg("accent", text),
+	});
+	const nativeMouse = scroll.handleMouse.bind(scroll);
+	scroll.handleMouse = (event) => {
+		if (event.type !== "wheel") return nativeMouse(event);
+		// Consume even at the boundary or over blank rail space: Pi 0.85.1
+		// can send unconsumed delta to the primary transcript despite containment.
+		scroll.scrollBy(event.wheelDelta ?? 0);
+		return {
+			handled: true,
+			render: true,
+			target: { component: scroll, originX: event.screenX - event.x, originY: event.screenY - event.y, width: event.width, height: event.height },
+		};
+	};
+	const prepare = (width: number): boolean => {
+		state.active = false;
+		if (stopped || failed || host.mode !== "fullscreen" || width < SIDEBAR_BREAKPOINT) return false;
+		try {
+			const contentWidth = scroll.getContentWidth(RAIL_WIDTH);
+			const sections = ["footer", "changes", "agents", "todo"].map((key) => {
+				const lines = [...(state.parts.get(key)?.render(contentWidth - RAIL_PADDING * 2) ?? [])];
+				while (lines.length && lines[lines.length - 1]?.trim() === "") lines.pop();
+				return lines;
+			}).filter((lines) => lines.length > 0);
+			const branding = renderSidebarBanner(theme, contentWidth - RAIL_PADDING * 2, banner);
+			if (sections.length && branding.length) sections.unshift(branding);
+			railLines = sections.flatMap((lines, index) => [
+				...(index === 0 ? [] : [""]),
+				...lines.map((line) => " ".repeat(RAIL_PADDING) + line + " ".repeat(RAIL_PADDING)),
+			]);
+			// Height is owned by the native ScrollView, never by the transcript.
+			if (!railLines.length || railLines.some((line) => visibleWidth(line) > contentWidth)) return false;
+			state.active = true;
+			return true;
+		} catch {
+			failed = true;
+			return false;
+		}
+	};
+	const attach = () => {
+		if (stopped || failed) return;
+		if (host.mode !== "fullscreen") { state.active = false; return; }
+		try {
+			const root = host.layoutRoot;
+			if (!root || typeof root[NODE] !== "function") { state.active = false; return; }
+			if (roots.has(root)) return;
+			const original = root[NODE]!;
+			const descriptor = Object.getOwnPropertyDescriptor(root, NODE);
+			const left = { render: (width: number) => root.render(width), invalidate() {}, [NODE]: () => original.call(root) };
+			const replacement = () => prepare(tui.terminal.columns)
+				? { type: "hstack", gap: GAP, align: "stretch", entries: [
+					{ component: left, basis: 0, grow: 1, shrink: 1, minSize: 1 },
+					{ component: scroll, basis: RAIL_WIDTH, grow: 0, shrink: 0, minSize: RAIL_WIDTH },
+				] }
+				: original.call(root);
+			root[NODE] = replacement;
+			roots.add(root);
+			tui.requestRender();
+			cleanups.push(() => {
+				if (root[NODE] !== replacement) return;
+				if (descriptor) Object.defineProperty(root, NODE, descriptor);
+				else Reflect.deleteProperty(root, NODE);
+			});
+		} catch {
+			failed = true;
+			state.active = false;
+		}
+	};
+	attach();
+	// Pi replaces renderers without a session event. Rebind only that transition;
+	// resize and scroll remain owned by Pi's native layout/render loop.
+	const timer = setInterval(attach, 100);
+	timer.unref();
+	return () => {
+		stopped = true;
+		state.active = false;
+		clearInterval(timer);
+		scroll.hideTransientScrollbar();
+		for (const cleanup of cleanups.reverse()) cleanup();
+		tui.requestRender();
+	};
+}

--- a/lib/shell-sidebar-layout.ts
+++ b/lib/shell-sidebar-layout.ts
@@ -1,7 +1,7 @@
 import { ScrollView, visibleWidth, type Component, type TUI } from "@earendil-works/pi-tui";
 import { sidebarState } from "./shell-sidebar.ts";
 import type { ShellBarTheme } from "./shell-bar.ts";
-import { renderSidebarBanner, type SidebarBannerConfig } from "./shell-sidebar-banner.ts";
+import { renderSidebarBanner } from "./shell-sidebar-banner.ts";
 
 export const SIDEBAR_BREAKPOINT = 140;
 const RAIL_WIDTH = 50;
@@ -14,7 +14,7 @@ type LayoutNode = { type: string; entries?: unknown[]; gap?: number; align?: str
 type LayoutRoot = Component & { [NODE]?: () => LayoutNode };
 type Host = TUI & { mode?: string; layoutRoot?: LayoutRoot };
 
-export function installSidebar(tui: TUI, theme: ShellBarTheme, banner: SidebarBannerConfig = { showRose: false, showTextLogo: false }): () => void {
+export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 	if (!tui.terminal) return () => {};
 	const host = tui as Host;
 	const state = sidebarState(tui);
@@ -59,7 +59,7 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme, banner: SidebarBa
 				while (lines.length && lines[lines.length - 1]?.trim() === "") lines.pop();
 				return lines;
 			}).filter((lines) => lines.length > 0);
-			const branding = renderSidebarBanner(theme, contentWidth - RAIL_PADDING * 2, banner);
+			const branding = renderSidebarBanner(theme, contentWidth - RAIL_PADDING * 2);
 			if (sections.length && branding.length) sections.unshift(branding);
 			railLines = sections.flatMap((lines, index) => [
 				...(index === 0 ? [] : [""]),

--- a/lib/shell-sidebar.ts
+++ b/lib/shell-sidebar.ts
@@ -1,0 +1,30 @@
+import type { Component, TUI } from "@earendil-works/pi-tui";
+
+// Store on the terminal, not a module singleton: extension loaders may isolate
+// modules, while Pi keeps this terminal across regular/fullscreen transitions.
+const STATE = Symbol.for("gentle-pi.experimental-sidebar.state");
+export interface SidebarState {
+	active: boolean;
+	ownsHost?: () => boolean;
+	parts: Map<string, Component>;
+}
+export function sidebarState(tui: TUI): SidebarState {
+	const terminal = tui.terminal as unknown as Record<symbol, SidebarState>;
+	return terminal[STATE] ??= { active: false, parts: new Map() };
+}
+
+/** Keep the original bottom component mounted, suppressing only its paint. */
+export function sidebarPart<T extends Component & { dispose?(): void }>(tui: TUI, key: string, bottom: T, rail: Component = bottom): T {
+	// Minimal extension hosts cannot share terminal-owned layout state.
+	if (!tui.terminal) return bottom;
+	const state = sidebarState(tui);
+	state.parts.set(key, rail);
+	return {
+		...bottom,
+		render: (width: number) => state.active && state.ownsHost?.() ? [] : bottom.render(width),
+		dispose() {
+			if (state.parts.get(key) === rail) state.parts.delete(key);
+			bottom.dispose?.();
+		},
+	};
+}

--- a/lib/shell-todo.ts
+++ b/lib/shell-todo.ts
@@ -71,6 +71,8 @@ export interface TodoTheme extends CardTheme {
 }
 
 export interface TodoRenderOptions {
+	/** A scrollable host supplies the height bound instead of folding tasks. */
+	scrollable?: boolean;
 	collapsed: boolean;
 	staleTurns: number;
 	collapseKey?: string;
@@ -270,7 +272,7 @@ export function renderTodoCard(state: TodoState, theme: TodoTheme, width: number
 	const { done, total } = todoSummary(state);
 	const stale = options.staleTurns >= STALE_AFTER_TURNS;
 	const hint = stale ? `stale · ${options.staleTurns} turns` : options.collapsed && options.collapseKey ? `${options.collapseKey} expand` : undefined;
-	const body = options.collapsed ? [collapsedRow(state, theme)] : bodyRows(state, theme);
+	const body = options.collapsed ? [collapsedRow(state, theme)] : options.scrollable ? state.tasks.map((task) => taskRow(task, theme)) : bodyRows(state, theme);
 	return renderCard(
 		{ title: "Todos", subtitle: `${done} of ${total}`, body, tone: stale ? CARD_TONE.WARNING : CARD_TONE.INFO, glyph: TODO_GLYPH },
 		theme,

--- a/scripts/install-gentle-ai.mjs
+++ b/scripts/install-gentle-ai.mjs
@@ -4,6 +4,7 @@
 // v2.1.11 while writing v2.2.0 to disk, which is the one moment an operator
 // most needs the number to be true.
 import { INSTALLER_VERSION, installGentleAi } from "./gentle-ai-installer.mjs";
+import { installTuiModeSetting } from "./install-tui-mode-setting.mjs";
 
 if (process.env.GENTLE_PI_SKIP_GENTLE_AI_INSTALL === "1") {
 	console.warn("GENTLE_PI_SKIP_GENTLE_AI_INSTALL=1: skipped package-local Gentle AI installation; native review operations will fail with package-local-binary-missing until gentle-pi is reinstalled.");
@@ -13,6 +14,17 @@ if (process.env.GENTLE_PI_SKIP_GENTLE_AI_INSTALL === "1") {
 		console.log(`Gentle AI v${INSTALLER_VERSION} ${result.installed ? "installed" : "integrity-verified"} at ${result.binaryPath}`);
 	} catch (error) {
 		console.error(`gentle-pi could not install its package-local Gentle AI v${INSTALLER_VERSION} binary: ${error instanceof Error ? error.message : String(error)}`);
+		process.exitCode = 1;
+	}
+}
+
+// A native failure never changes settings; the explicit native-only skip does.
+if (!process.exitCode) {
+	try {
+		const result = await installTuiModeSetting();
+		if (result.changed) console.log("gentle-pi enabled fullscreen in global Pi settings; /settings can switch back to regular.");
+	} catch (error) {
+		console.error(`gentle-pi could not enable fullscreen: ${error instanceof Error ? error.message : String(error)}`);
 		process.exitCode = 1;
 	}
 }

--- a/scripts/install-tui-mode-setting.mjs
+++ b/scripts/install-tui-mode-setting.mjs
@@ -1,0 +1,104 @@
+import { closeSync, constants, fchmodSync, fsyncSync, fstatSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, renameSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
+
+function inspect(path) {
+	try { return lstatSync(path); }
+	catch (error) { if (error.code === "ENOENT") return undefined; throw error; }
+}
+
+function sameFile(left, right) {
+	return left && right && left.dev === right.dev && left.ino === right.ino;
+}
+
+function assertDirectories(home, packageRoot) {
+	for (const path of [home, join(home, "npm"), join(home, "npm", "node_modules"), packageRoot]) {
+		const stat = inspect(path);
+		if (!stat?.isDirectory() || stat.isSymbolicLink() || realpathSync(path) !== path) {
+			throw new Error(`Unsafe fullscreen settings installation path: ${path}`);
+		}
+	}
+}
+
+function readSettings(path) {
+	const before = inspect(path);
+	if (!before) return { stat: undefined, text: undefined, value: {} };
+	if (!before.isFile() || before.isSymbolicLink()) throw new Error("settings.json must be a regular, non-symlink file");
+	const fd = openSync(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+	try {
+		if (!sameFile(before, fstatSync(fd))) throw new Error("settings.json changed while opening");
+		const text = readFileSync(fd, "utf8");
+		const value = JSON.parse(text.replace(/^\uFEFF/, ""));
+		if (value === null || typeof value !== "object" || Array.isArray(value)) throw new Error("settings.json must contain a JSON object");
+		return { stat: before, text, value };
+	} finally { closeSync(fd); }
+}
+
+// Pi uses proper-lockfile with realpath:false: its cooperative lock is the
+// settings.json.lock directory. Do not steal stale locks. Keep the synchronous
+// critical section below shorter than proper-lockfile's default stale window.
+async function acquireLock(path) {
+	for (let attempt = 0; attempt < 10; attempt++) {
+		try {
+			mkdirSync(path, { mode: 0o700 });
+			return inspect(path);
+		} catch (error) {
+			if (error.code !== "EEXIST") throw error;
+			if (attempt === 9) throw new Error("Fullscreen settings lock is busy; retry installation when other settings writers finish");
+			await delay(20);
+		}
+	}
+}
+
+/** Only a physically owned global Pi npm install may mutate Pi settings.
+ * Atomic rename protects readers from partial JSON, not arbitrary writers or
+ * malicious same-user ancestor swaps. No lifecycle cwd or store symlink grants ownership.
+ */
+export async function installTuiModeSetting(options = {}) {
+	const env = options.env ?? process.env;
+	const requestedHome = resolve(env.GENTLE_PI_AGENT_HOME || env.PI_CODING_AGENT_DIR || join(options.home ?? homedir(), ".pi", "agent"));
+	const packageRoot = resolve(options.packageRoot ?? dirname(dirname(fileURLToPath(import.meta.url))));
+	let home;
+	try { home = realpathSync(requestedHome); }
+	catch (error) { if (error.code === "ENOENT") return { changed: false, recognized: false }; throw error; }
+	const expected = join(home, "npm", "node_modules", "gentle-pi");
+	// Canonical agent-home aliases (including macOS /var) are supported.
+	// pnpm's physical store and npm link targets are not owned global installs.
+	if (realpathSync(packageRoot) !== expected) return { changed: false, recognized: false };
+	assertDirectories(home, expected);
+	const settingsPath = join(home, "settings.json");
+	const lockPath = `${settingsPath}.lock`;
+	const lock = await acquireLock(lockPath);
+	const started = Date.now();
+	let staging;
+	try {
+		assertDirectories(home, expected);
+		const original = readSettings(settingsPath);
+		if (original.value.tuiMode === "fullscreen") return { changed: false, recognized: true };
+		staging = join(home, `.settings-fullscreen-${randomUUID()}.tmp`);
+		const fd = openSync(staging, "wx", original.stat ? original.stat.mode & 0o777 : 0o600);
+		try {
+			if (original.stat) fchmodSync(fd, original.stat.mode & 0o777);
+			writeFileSync(fd, `${JSON.stringify({ ...original.value, tuiMode: "fullscreen" }, null, 2)}\n`, "utf8");
+			fsyncSync(fd);
+		} finally { closeSync(fd); }
+		assertDirectories(home, expected);
+		const latest = readSettings(settingsPath);
+		if (latest.text !== original.text || (original.stat ? !sameFile(original.stat, latest.stat) : latest.stat !== undefined)) {
+			throw new Error("settings.json changed concurrently; retry installation");
+		}
+		if (!sameFile(lock, inspect(lockPath)) || Date.now() - started >= 5000) throw new Error("Fullscreen settings lock ownership expired; retry installation");
+		renameSync(staging, settingsPath);
+		staging = undefined;
+		return { changed: true, recognized: true };
+	} finally {
+		// Only clean our own artifacts while the original parent remains canonical.
+		if (realpathSync(home) === home) {
+			if (staging) unlinkSync(staging);
+			if (sameFile(lock, inspect(lockPath))) rmdirSync(lockPath);
+		}
+	}
+}

--- a/scripts/test-packed-runner.mjs
+++ b/scripts/test-packed-runner.mjs
@@ -12,6 +12,10 @@ const root = fileURLToPath(new URL("..", import.meta.url));
 const temporary = mkdtempSync(join(tmpdir(), "gentle-pi-packed-runner-"));
 const packDirectory = join(temporary, "pack");
 const installDirectory = join(temporary, "install");
+// Every child inherits only disposable Pi homes, never the operator's settings.
+const agentHome = join(temporary, "agent");
+const piAgentHome = join(temporary, "pi-agent");
+const isolatedEnv = { ...process.env, GENTLE_PI_AGENT_HOME: agentHome, PI_CODING_AGENT_DIR: piAgentHome };
 
 function windowsNpmInvocation() {
 	const candidates = [];
@@ -32,12 +36,16 @@ function windowsNpmInvocation() {
 
 function runNpm(arguments_, options) {
 	const invocation = process.platform === "win32" ? windowsNpmInvocation() : { file: "npm", prefix: [] };
-	return execFileSync(invocation.file, [...invocation.prefix, ...arguments_], options);
+	return execFileSync(invocation.file, [...invocation.prefix, ...arguments_], { ...options, env: isolatedEnv });
 }
 
 try {
 	mkdirSync(packDirectory);
 	mkdirSync(installDirectory);
+	mkdirSync(agentHome);
+	mkdirSync(piAgentHome);
+	const originalSettings = '{ "tuiMode": "regular", "theme": "packed-fixture" }\n';
+	writeFileSync(join(agentHome, "settings.json"), originalSettings);
 	const packed = JSON.parse(runNpm(["pack", "--ignore-scripts", "--json", "--pack-destination", packDirectory], {
 		cwd: root,
 		encoding: "utf8",
@@ -50,7 +58,13 @@ try {
 		cwd: installDirectory,
 		stdio: "inherit",
 	});
+	// This is an ordinary npm consumer, not Pi's managed global npm directory.
+	assert.equal(readFileSync(join(agentHome, "settings.json"), "utf8"), originalSettings);
+	assert.deepEqual(readdirSync(agentHome), ["settings.json"]);
+	assert.deepEqual(readdirSync(piAgentHome), []);
+	assert.equal(existsSync(join(installDirectory, ".pi", "settings.json")), false);
 	const packageRoot = join(installDirectory, "node_modules", "gentle-pi");
+	assert.ok(existsSync(join(packageRoot, "scripts", "install-tui-mode-setting.mjs")));
 	const { nativeReviewAbandonAuthorization } = await import(pathToFileURL(join(packageRoot, "runtime", "native-review-cli.mjs")).href);
 	const abandonAuthorization = nativeReviewAbandonAuthorization({
 		lineage: "review-abc",
@@ -77,7 +91,7 @@ try {
 	const versions = readdirSync(join(packageRoot, ".gentle-ai"), { withFileTypes: true }).filter((entry) => entry.isDirectory() && /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.]*)?$/.test(entry.name));
 	if (versions.length !== 1) throw new Error("packed install did not contain exactly one package-local Gentle AI version");
 	const executable = join(packageRoot, ".gentle-ai", versions[0].name, process.platform === "win32" ? "gentle-ai.exe" : "gentle-ai");
-	const capabilities = JSON.parse(execFileSync(executable, ["review", "capabilities", "--contract", "gentle-ai.review-integration/v2"], { cwd: installDirectory, encoding: "utf8" }));
+	const capabilities = JSON.parse(execFileSync(executable, ["review", "capabilities", "--contract", "gentle-ai.review-integration/v2"], { cwd: installDirectory, encoding: "utf8", env: isolatedEnv }));
 	// Decode with the PACKED consumer's own decoder rather than comparing the
 	// schema string against a list hand-copied into this script. The copy was a
 	// second, silent pin: it accepted only `capabilities/v2`, so the moment the

--- a/tests/install-tui-mode-setting.test.ts
+++ b/tests/install-tui-mode-setting.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { chmodSync, copyFileSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+const helperUrl = new URL("../scripts/install-tui-mode-setting.mjs", import.meta.url);
+const { installTuiModeSetting } = await import(helperUrl.href);
+
+function fixture(t: { after(fn: () => void): void }) {
+	const root = mkdtempSync(join(tmpdir(), "gentle-tui-test-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const home = join(root, "agent");
+	const packageRoot = join(home, "npm", "node_modules", "gentle-pi");
+	mkdirSync(packageRoot, { recursive: true });
+	const settings = join(home, "settings.json");
+	const env = { GENTLE_PI_AGENT_HOME: home, PI_CODING_AGENT_DIR: join(root, "other-agent") };
+	return { root, home, packageRoot, settings, env, options: { packageRoot, env, home: root } };
+}
+
+function link(target: string, path: string, directory = false) {
+	symlinkSync(target, path, directory ? "junction" : "file");
+}
+
+test("recognized global installation persists fullscreen and preserves other settings", async () => {
+	const root = mkdtempSync(join(tmpdir(), "gentle-tui-test-"));
+	try {
+		const home = join(root, "agent");
+		const packageRoot = join(home, "npm", "node_modules", "gentle-pi");
+		mkdirSync(packageRoot, { recursive: true });
+		writeFileSync(join(home, "settings.json"), JSON.stringify({ tuiMode: "regular", theme: "rose", nested: { enabled: false } }));
+		const { installTuiModeSetting } = await import(helperUrl.href);
+		await installTuiModeSetting({ packageRoot, env: { GENTLE_PI_AGENT_HOME: home, PI_CODING_AGENT_DIR: join(root, "unused") }, home: root });
+		assert.deepEqual(JSON.parse(readFileSync(join(home, "settings.json"), "utf8")), { tuiMode: "fullscreen", theme: "rose", nested: { enabled: false } });
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+for (const initial of [undefined, '{ "tuiMode": "regular", "packages": ["npm:example"] }']) {
+	test(`creates or resets fullscreen: ${initial ?? "missing"}`, async (t) => {
+		const f = fixture(t);
+		if (initial) writeFileSync(f.settings, initial);
+		assert.equal((await installTuiModeSetting(f.options)).changed, true);
+		assert.equal(JSON.parse(readFileSync(f.settings, "utf8")).tuiMode, "fullscreen");
+		writeFileSync(f.settings, '{ "tuiMode": "regular", "theme": "custom" }');
+		await installTuiModeSetting(f.options);
+		assert.equal(JSON.parse(readFileSync(f.settings, "utf8")).theme, "custom");
+		assert.equal(JSON.parse(readFileSync(f.settings, "utf8")).tuiMode, "fullscreen");
+	});
+}
+
+test("already fullscreen preserves bytes and inode", async (t) => {
+	const f = fixture(t);
+	const text = '\uFEFF{ "tuiMode" : "fullscreen", "other": [1, null] }\n';
+	writeFileSync(f.settings, text);
+	const before = lstatSync(f.settings);
+	assert.equal((await installTuiModeSetting(f.options)).changed, false);
+	assert.equal(readFileSync(f.settings, "utf8"), text);
+	assert.equal(lstatSync(f.settings).ino, before.ino);
+	assert.deepEqual(readdirSync(f.home).sort(), ["npm", "settings.json"]);
+});
+
+for (const name of ["GENTLE_PI_AGENT_HOME", "PI_CODING_AGENT_DIR", "default"]) {
+	test(`agent-home precedence: ${name}`, async (t) => {
+		const f = fixture(t);
+		const home = name === "default" ? join(f.root, ".pi", "agent") : f.home;
+		const packageRoot = join(home, "npm", "node_modules", "gentle-pi");
+		mkdirSync(packageRoot, { recursive: true });
+		const env = name === "default" ? {} : name === "PI_CODING_AGENT_DIR" ? { PI_CODING_AGENT_DIR: home } : f.env;
+		await installTuiModeSetting({ packageRoot, env, home: f.root });
+		assert.equal(JSON.parse(readFileSync(join(home, "settings.json"), "utf8")).tuiMode, "fullscreen");
+		assert.equal(existsSync(join(f.env.PI_CODING_AGENT_DIR, "settings.json")), false);
+	});
+}
+
+for (const relative of ["project/.pi/npm/node_modules/gentle-pi", "consumer/node_modules/gentle-pi", "checkout", "agent/git/github.com/gentle-pi", "temporary/npm/node_modules/gentle-pi", "store/.pnpm/gentle-pi/node_modules/gentle-pi"]) {
+	test(`unowned install is untouched: ${relative}`, async (t) => {
+		const f = fixture(t);
+		const packageRoot = join(f.root, relative);
+		mkdirSync(packageRoot, { recursive: true });
+		writeFileSync(f.settings, '{"tuiMode":"regular"}');
+		assert.deepEqual(await installTuiModeSetting({ ...f.options, packageRoot }), { changed: false, recognized: false });
+		assert.equal(readFileSync(f.settings, "utf8"), '{"tuiMode":"regular"}');
+		assert.equal(existsSync(join(f.root, "project", ".pi", "settings.json")), false);
+	});
+}
+
+test("missing configured agent home is a no-op", async (t) => {
+	const f = fixture(t);
+	assert.equal((await installTuiModeSetting({ ...f.options, env: { GENTLE_PI_AGENT_HOME: join(f.root, "absent") } })).recognized, false);
+});
+
+test("global package symlink into a store is not ownership", async (t) => {
+	const f = fixture(t);
+	const home = join(f.root, "linked-agent");
+	mkdirSync(join(home, "npm", "node_modules"), { recursive: true });
+	const packageRoot = join(home, "npm", "node_modules", "gentle-pi");
+	link(f.packageRoot, packageRoot, true);
+	assert.equal((await installTuiModeSetting({ packageRoot, env: { GENTLE_PI_AGENT_HOME: home }, home: f.root })).recognized, false);
+	assert.equal(existsSync(join(home, "settings.json")), false);
+});
+
+test("canonical agent-home alias is supported", async (t) => {
+	const f = fixture(t);
+	const alias = join(f.root, "alias");
+	link(f.home, alias, true);
+	await installTuiModeSetting({ ...f.options, env: { GENTLE_PI_AGENT_HOME: alias } });
+	assert.equal(JSON.parse(readFileSync(f.settings, "utf8")).tuiMode, "fullscreen");
+});
+
+for (const text of ["{broken", "[]", "null", "false", "42", '"string"', ""]) {
+	test(`invalid settings remain unchanged: ${text}`, async (t) => {
+		const f = fixture(t);
+		writeFileSync(f.settings, text);
+		await assert.rejects(installTuiModeSetting(f.options));
+		assert.equal(readFileSync(f.settings, "utf8"), text);
+		assert.deepEqual(readdirSync(f.home).sort(), ["npm", "settings.json"]);
+	});
+}
+
+for (const kind of ["directory", "symlink", "dangling"]) {
+	test(`rejects nonregular settings: ${kind}`, async (t) => {
+		const f = fixture(t);
+		const target = join(f.root, "target.json");
+		if (kind === "directory") mkdirSync(f.settings);
+		else {
+			if (kind === "symlink") writeFileSync(target, "{}");
+			link(target, f.settings);
+		}
+		await assert.rejects(installTuiModeSetting(f.options), /regular/);
+		assert.equal(kind === "directory" ? lstatSync(f.settings).isDirectory() : lstatSync(f.settings).isSymbolicLink(), true);
+		if (kind === "symlink") assert.equal(readFileSync(target, "utf8"), "{}");
+		assert.equal(existsSync(`${f.settings}.lock`), false);
+	});
+}
+
+test("preserves existing permissions and creates private new settings", { skip: process.platform === "win32" }, async (t) => {
+	const f = fixture(t);
+	await installTuiModeSetting(f.options);
+	assert.equal(lstatSync(f.settings).mode & 0o777, 0o600);
+	writeFileSync(f.settings, "{}");
+	chmodSync(f.settings, 0o640);
+	await installTuiModeSetting(f.options);
+	assert.equal(lstatSync(f.settings).mode & 0o777, 0o640);
+});
+
+test("cooperative concurrent installers serialize without artifacts", async (t) => {
+	const f = fixture(t);
+	const results = await Promise.all(Array.from({ length: 6 }, () => installTuiModeSetting(f.options)));
+	assert.equal(results.filter((result) => result.changed).length, 1);
+	assert.deepEqual(readdirSync(f.home).sort(), ["npm", "settings.json"]);
+});
+
+test("Pi proper-lockfile contention is bounded and never steals the lock", async (t) => {
+	const f = fixture(t);
+	writeFileSync(f.settings, '{"theme":"kept"}');
+	const piRequire = createRequire(import.meta.resolve("@earendil-works/pi-coding-agent"));
+	const lockfile = piRequire("proper-lockfile");
+	const release = lockfile.lockSync(f.settings, { realpath: false });
+	try {
+		await assert.rejects(installTuiModeSetting(f.options), /lock is busy/);
+		assert.equal(readFileSync(f.settings, "utf8"), '{"theme":"kept"}');
+		assert.equal(existsSync(`${f.settings}.lock`), true);
+	} finally { release(); }
+	await installTuiModeSetting(f.options);
+	assert.equal(JSON.parse(readFileSync(f.settings, "utf8")).theme, "kept");
+});
+
+test("Pi's later packages-only save retains persisted fullscreen", async (t) => {
+	const f = fixture(t);
+	writeFileSync(f.settings, '{"tuiMode":"regular"}');
+	const { SettingsManager } = await import("@earendil-works/pi-coding-agent");
+	const manager = SettingsManager.create(f.root, f.home);
+	await installTuiModeSetting(f.options);
+	manager.setPackages(["npm:gentle-pi"]);
+	await manager.flush();
+	assert.deepEqual(manager.drainErrors(), []);
+	assert.deepEqual(JSON.parse(readFileSync(f.settings, "utf8")), { tuiMode: "fullscreen", packages: ["npm:gentle-pi"] });
+	manager.setTuiMode("regular");
+	await manager.flush();
+	assert.equal(JSON.parse(readFileSync(f.settings, "utf8")).tuiMode, "regular");
+});
+
+test("symlinked npm ancestor cannot grant settings ownership", async (t) => {
+	const f = fixture(t);
+	const home = join(f.root, "unsafe-agent");
+	mkdirSync(home);
+	link(join(f.home, "npm"), join(home, "npm"), true);
+	const result = await installTuiModeSetting({ packageRoot: join(home, "npm", "node_modules", "gentle-pi"), env: { GENTLE_PI_AGENT_HOME: home }, home: f.root });
+	assert.equal(result.recognized, false);
+	assert.equal(existsSync(join(home, "settings.json")), false);
+	assert.equal(existsSync(f.settings), false);
+});
+
+test("waiting installer rereads another cooperative writer's settings", async (t) => {
+	const f = fixture(t);
+	writeFileSync(f.settings, "{}");
+	const piRequire = createRequire(import.meta.resolve("@earendil-works/pi-coding-agent"));
+	const release = piRequire("proper-lockfile").lockSync(f.settings, { realpath: false });
+	const installing = installTuiModeSetting(f.options);
+	writeFileSync(f.settings, '{"theme":"concurrent"}');
+	release();
+	await installing;
+	assert.deepEqual(JSON.parse(readFileSync(f.settings, "utf8")), { theme: "concurrent", tuiMode: "fullscreen" });
+});
+
+for (const fault of ["write", "rename", "concurrent-change"]) {
+	test(`atomic update preserves original or concurrent settings on ${fault}`, (t) => {
+		const f = fixture(t);
+		const original = '{"theme":"original"}';
+		writeFileSync(f.settings, original);
+		// Isolate built-in fault injection in a child; no production test hooks.
+		const code = `
+			import fs from 'node:fs';
+			import { syncBuiltinESMExports } from 'node:module';
+			const originalWrite = fs.writeFileSync;
+			const originalSync = fs.fsyncSync;
+			const fault = ${JSON.stringify(fault)};
+			if (fault === 'write') fs.writeFileSync = () => { throw new Error('injected write failure'); };
+			if (fault === 'rename') fs.renameSync = () => { throw new Error('injected rename failure'); };
+			if (fault === 'concurrent-change') fs.fsyncSync = (fd) => {
+				originalSync(fd);
+				originalWrite(${JSON.stringify(f.settings)}, '{"theme":"concurrent"}');
+			};
+			syncBuiltinESMExports();
+			const { installTuiModeSetting } = await import(${JSON.stringify(helperUrl.href)});
+			try { await installTuiModeSetting(${JSON.stringify(f.options)}); process.exitCode = 2; }
+			catch (error) { console.error(error.message); process.exitCode = 1; }
+		`;
+		const result = spawnSync(process.execPath, ["--input-type=module", "--eval", code], { encoding: "utf8", env: { ...process.env, ...f.env } });
+		assert.equal(result.status, 1, result.stderr);
+		assert.match(result.stderr, fault === "concurrent-change" ? /changed concurrently/ : /injected/);
+		assert.equal(readFileSync(f.settings, "utf8"), fault === "concurrent-change" ? '{"theme":"concurrent"}' : original);
+		assert.deepEqual(readdirSync(f.home).sort(), ["npm", "settings.json"]);
+	});
+}
+
+for (const route of ["skip", "success", "failure"]) {
+	test(`postinstall lifecycle: ${route}`, (t) => {
+		const f = fixture(t);
+		const scripts = join(f.packageRoot, "scripts");
+		mkdirSync(scripts);
+		copyFileSync(helperUrl, join(scripts, "install-tui-mode-setting.mjs"));
+		copyFileSync(new URL("../scripts/install-gentle-ai.mjs", import.meta.url), join(scripts, "install-gentle-ai.mjs"));
+		writeFileSync(join(scripts, "gentle-ai-installer.mjs"), `export const INSTALLER_VERSION = "test"; export async function installGentleAi() { ${route === "failure" ? 'throw new Error("native failed")' : 'return { installed: true, binaryPath: "fixture" }'}; }`);
+		const result = spawnSync(process.execPath, [join(scripts, "install-gentle-ai.mjs")], {
+			encoding: "utf8", env: { ...process.env, ...f.env, GENTLE_PI_SKIP_GENTLE_AI_INSTALL: route === "skip" ? "1" : "0" },
+		});
+		assert.equal(result.status, route === "failure" ? 1 : 0, result.stderr);
+		assert.equal(existsSync(f.settings), route !== "failure");
+		if (route !== "failure") assert.equal(JSON.parse(readFileSync(f.settings, "utf8")).tuiMode, "fullscreen");
+	});
+}
+

--- a/tests/shell-sidebar-banner.test.ts
+++ b/tests/shell-sidebar-banner.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { readSidebarBannerConfig, renderSidebarBanner } from "../lib/shell-sidebar-banner.ts";
+
+const plain = { fg: (_role: string, text: string) => text, bold: (text: string) => text };
+test("compact rose and wordmark fit rail widths without cropping", () => {
+	for (const width of [0, 1, 8, 20, 30, 46, 80]) {
+		const lines = renderSidebarBanner(plain, width, { showRose: true, showTextLogo: true });
+		assert.ok(lines.every((line) => visibleWidth(line) <= width));
+		if (width >= 30) {
+			assert.match(lines.join("\n"), /GENTLE PI/);
+			assert.match(lines.join("\n"), /[\u2800-\u28ff]/);
+			assert.ok(lines.length <= 10);
+		}
+	}
+});
+
+test("rose and wordmark opt-outs remain independent and leave no empty artwork", () => {
+	for (const showRose of [false, true]) for (const showTextLogo of [false, true]) {
+		const text = renderSidebarBanner(plain, 46, { showRose, showTextLogo }).join("\n");
+		assert.equal(text.includes("GENTLE PI"), showTextLogo);
+		assert.equal(/[\u2800-\u28ff]/.test(text), showRose);
+		if (!showRose && !showTextLogo) assert.equal(text, "");
+	}
+});
+
+test("banner paints fresh semantic accent and text roles on each render", () => {
+	let palette = "dark";
+	const theme = { ...plain, fg: (role: string, text: string) => `<${palette}:${role}>${text}` };
+	assert.match(renderSidebarBanner(theme, 46).join("\n"), /dark:accent/);
+	palette = "light";
+	const text = renderSidebarBanner(theme, 46).join("\n");
+	assert.match(text, /light:accent/);
+	assert.match(text, /light:text/);
+	assert.doesNotMatch(text, /dark:/);
+});
+
+test("saved visibility wins; missing and malformed configuration use defaults", async () => {
+	assert.deepEqual(await readSidebarBannerConfig(async () => '{"showRose":false,"showTextLogo":true,"color":"cyan"}'), { showRose: false, showTextLogo: true });
+	for (const raw of ["{}", "null", "[]", "invalid"]) {
+		assert.deepEqual(await readSidebarBannerConfig(async () => raw), { showRose: true, showTextLogo: true });
+	}
+	assert.deepEqual(await readSidebarBannerConfig(async () => { throw new Error("missing"); }), { showRose: true, showTextLogo: true });
+});

--- a/tests/shell-sidebar-banner.test.ts
+++ b/tests/shell-sidebar-banner.test.ts
@@ -1,45 +1,23 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { readSidebarBannerConfig, renderSidebarBanner } from "../lib/shell-sidebar-banner.ts";
+import { renderSidebarBanner } from "../lib/shell-sidebar-banner.ts";
 
 const plain = { fg: (_role: string, text: string) => text, bold: (text: string) => text };
-test("compact rose and wordmark fit rail widths without cropping", () => {
-	for (const width of [0, 1, 8, 20, 30, 46, 80]) {
-		const lines = renderSidebarBanner(plain, width, { showRose: true, showTextLogo: true });
-		assert.ok(lines.every((line) => visibleWidth(line) <= width));
-		if (width >= 30) {
-			assert.match(lines.join("\n"), /GENTLE PI/);
-			assert.match(lines.join("\n"), /[\u2800-\u28ff]/);
-			assert.ok(lines.length <= 10);
-		}
+test("sidebar heading is only the centered literal product label", () => {
+	const label = "✿ Gentle-Pi ✿";
+	for (const width of [0, 1, 8, 11, 20, 21, 30, 45, 46, 80]) {
+		const lines = renderSidebarBanner(plain, width);
+		const space = width - visibleWidth(label);
+		assert.deepEqual(lines, space >= 0 ? [" ".repeat(Math.floor(space / 2)) + label + " ".repeat(Math.ceil(space / 2))] : []);
+		assert.ok(lines.every((line) => visibleWidth(line) === width));
 	}
 });
 
-test("rose and wordmark opt-outs remain independent and leave no empty artwork", () => {
-	for (const showRose of [false, true]) for (const showTextLogo of [false, true]) {
-		const text = renderSidebarBanner(plain, 46, { showRose, showTextLogo }).join("\n");
-		assert.equal(text.includes("GENTLE PI"), showTextLogo);
-		assert.equal(/[\u2800-\u28ff]/.test(text), showRose);
-		if (!showRose && !showTextLogo) assert.equal(text, "");
-	}
-});
-
-test("banner paints fresh semantic accent and text roles on each render", () => {
+test("heading uses the current theme on every render", () => {
 	let palette = "dark";
 	const theme = { ...plain, fg: (role: string, text: string) => `<${palette}:${role}>${text}` };
-	assert.match(renderSidebarBanner(theme, 46).join("\n"), /dark:accent/);
+	assert.equal(renderSidebarBanner(theme, 46)[0].trim(), "<dark:accent>✿ <dark:text>Gentle-Pi <dark:accent>✿");
 	palette = "light";
-	const text = renderSidebarBanner(theme, 46).join("\n");
-	assert.match(text, /light:accent/);
-	assert.match(text, /light:text/);
-	assert.doesNotMatch(text, /dark:/);
-});
-
-test("saved visibility wins; missing and malformed configuration use defaults", async () => {
-	assert.deepEqual(await readSidebarBannerConfig(async () => '{"showRose":false,"showTextLogo":true,"color":"cyan"}'), { showRose: false, showTextLogo: true });
-	for (const raw of ["{}", "null", "[]", "invalid"]) {
-		assert.deepEqual(await readSidebarBannerConfig(async () => raw), { showRose: true, showTextLogo: true });
-	}
-	assert.deepEqual(await readSidebarBannerConfig(async () => { throw new Error("missing"); }), { showRose: true, showTextLogo: true });
+	assert.equal(renderSidebarBanner(theme, 46)[0].trim(), "<light:accent>✿ <light:text>Gentle-Pi <light:accent>✿");
 });

--- a/tests/shell-sidebar-layout.test.ts
+++ b/tests/shell-sidebar-layout.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ScrollView, type TUI } from "@earendil-works/pi-tui";
+import { ScrollView, visibleWidth, type TUI } from "@earendil-works/pi-tui";
 import { installSidebar } from "../lib/shell-sidebar-layout.ts";
 import { sidebarPart, sidebarState } from "../lib/shell-sidebar.ts";
 import { renderShellSidebarBar } from "../lib/shell-bar.ts";
@@ -57,7 +57,7 @@ test("installation on a missing-terminal host is a harmless no-op", () => {
 test("only fullscreen at 140 columns activates; shrinking restores bottom paint", (t) => {
 	for (const [mode, width, active] of [["regular", 140, false], ["fullscreen", 139, false], ["fullscreen", 140, true]] as const) {
 		const f = fixture(mode, width);
-		t.after(installSidebar(f.tui, theme, { showRose: true, showTextLogo: true }));
+		t.after(installSidebar(f.tui, theme));
 		assert.equal(f.root[NODE]().type, active ? "hstack" : "vstack");
 		assert.deepEqual(f.bottom.render(80), active ? [] : ["Status"]);
 		f.host.terminal.columns = 139;
@@ -72,19 +72,24 @@ test("rail orders Status, changes, agents, TODO independent of registration orde
 		sidebarPart(f.tui, key, { render: () => [key, ""], invalidate() {} });
 	}
 	t.after(installSidebar(f.tui, theme));
-	assert.deepEqual(rail(f).render(50).map((line) => line.trim()), ["Status", "", "changes", "", "agents", "", "todo"]);
+	assert.deepEqual(rail(f).render(50).map((line) => line.trim()), ["✿ Gentle-Pi ✿", "", "Status", "", "changes", "", "agents", "", "todo"]);
 });
 
 test("branding belongs to scroll content before Status, never transcript or narrow bottom", (t) => {
 	const f = fixture();
-	t.after(installSidebar(f.tui, theme, { showRose: true, showTextLogo: true }));
+	t.after(installSidebar(f.tui, theme));
 	const scroll = rail(f);
 	const lines = scroll.render(50);
-	const brandIndex = lines.findIndex((line) => line.includes("GENTLE PI"));
+	const brandIndex = lines.findIndex((line) => line.includes("✿ Gentle-Pi ✿"));
 	assert.ok(brandIndex >= 0 && brandIndex < lines.findIndex((line) => line.includes("Status")));
-	assert.match(lines.join("\n"), /[\u2800-\u28ff]/);
+	assert.doesNotMatch(lines.join("\n"), /[\u2800-\u28ff]/);
+	const heading = lines[brandIndex];
+	const usableWidth = scroll.getContentWidth(50) - 2;
+	const spare = usableWidth - visibleWidth("✿ Gentle-Pi ✿");
+	const scrollbarWidth = 50 - scroll.getContentWidth(50);
+	assert.equal(heading, " ".repeat(1 + Math.floor(spare / 2)) + "✿ Gentle-Pi ✿" + " ".repeat(1 + Math.ceil(spare / 2) + scrollbarWidth));
 	assert.deepEqual(f.root.render(), ["transcript"]);
-	scroll.updateLayout(lines.length, 3, () => {});
+	scroll.updateLayout(lines.length, 2, () => {});
 	scroll.scrollBy(9);
 	assert.ok(scroll.scrollTop > 0);
 	f.host.terminal.columns = 80;

--- a/tests/shell-sidebar-layout.test.ts
+++ b/tests/shell-sidebar-layout.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ScrollView, type TUI } from "@earendil-works/pi-tui";
+import { installSidebar } from "../lib/shell-sidebar-layout.ts";
+import { sidebarPart, sidebarState } from "../lib/shell-sidebar.ts";
+import { renderShellSidebarBar } from "../lib/shell-bar.ts";
+import { renderTodoCard, type TodoState } from "../lib/shell-todo.ts";
+
+const NODE = Symbol.for("@earendil-works/pi-tui/layout-node");
+const theme = { fg: (_color: string, text: string) => text, bold: (text: string) => text };
+function fixture(mode = "fullscreen", columns = 140) {
+	const original = () => ({ type: "vstack", entries: [] });
+	const root = { render: () => ["transcript"], invalidate() {}, [NODE]: original };
+	let renders = 0;
+	const host = { mode, terminal: { columns }, layoutRoot: root, requestRender() { renders++; } };
+	const tui = host as unknown as TUI;
+	const bottom = sidebarPart(tui, "footer", { render: (_width: number) => ["Status"], invalidate() {} });
+	return { host, tui, root, original, bottom, renders: () => renders };
+}
+function rail(f: ReturnType<typeof fixture>): ScrollView {
+	const node = f.root[NODE]() as unknown as { type: string; entries: { component: ScrollView }[] };
+	assert.equal(node.type, "hstack");
+	return node.entries[1].component;
+}
+
+test("grouped Status preserves structured fields and opaque integration text", () => {
+	const lines = renderShellSidebarBar({
+		cwd: "/project", branch: "main", dirty: 2, sessionName: "session",
+		modelId: "model", effort: "high", contextPercent: 45, contextWindow: 1000,
+		costTotal: 1, subscription: false, statuses: ["opaque integration"],
+	}, theme, 46);
+	const text = lines.join("\n");
+	let previous = -1;
+	for (const heading of ["Status", "Project", "Model", "Context", "Usage", "Integrations"]) {
+		const index = text.indexOf(heading);
+		assert.ok(index > previous, heading);
+		previous = index;
+	}
+	assert.match(text, /opaque integration/);
+	assert.match(text, /Branch.*main/);
+});
+
+test("scrollable TODO keeps every task while bottom and collapsed cards stay bounded", () => {
+	const state: TodoState = { tasks: Array.from({ length: 20 }, (_, i) => ({ id: i + 1, title: `Task-${i + 1}!`, status: "pending" })), nextId: 21, updatedTurn: 0 };
+	const todoTheme = { ...theme, strikethrough: (text: string) => text };
+	const render = (scrollable: boolean, collapsed = false) => renderTodoCard(state, todoTheme, 46, { scrollable, collapsed, staleTurns: 0 }).join("\n");
+	for (const task of state.tasks) assert.ok(render(true).includes(task.title));
+	assert.ok(!render(false).includes("Task-20!"));
+	assert.ok(!render(true, true).includes("Task-20!"));
+});
+
+test("installation on a missing-terminal host is a harmless no-op", () => {
+	const dispose = installSidebar({} as TUI, theme);
+	assert.doesNotThrow(dispose);
+});
+
+test("only fullscreen at 140 columns activates; shrinking restores bottom paint", (t) => {
+	for (const [mode, width, active] of [["regular", 140, false], ["fullscreen", 139, false], ["fullscreen", 140, true]] as const) {
+		const f = fixture(mode, width);
+		t.after(installSidebar(f.tui, theme, { showRose: true, showTextLogo: true }));
+		assert.equal(f.root[NODE]().type, active ? "hstack" : "vstack");
+		assert.deepEqual(f.bottom.render(80), active ? [] : ["Status"]);
+		f.host.terminal.columns = 139;
+		assert.equal(f.root[NODE]().type, "vstack");
+		assert.deepEqual(f.bottom.render(80), ["Status"]);
+	}
+});
+
+test("rail orders Status, changes, agents, TODO independent of registration order", (t) => {
+	const f = fixture();
+	for (const key of ["todo", "agents", "changes"]) {
+		sidebarPart(f.tui, key, { render: () => [key, ""], invalidate() {} });
+	}
+	t.after(installSidebar(f.tui, theme));
+	assert.deepEqual(rail(f).render(50).map((line) => line.trim()), ["Status", "", "changes", "", "agents", "", "todo"]);
+});
+
+test("branding belongs to scroll content before Status, never transcript or narrow bottom", (t) => {
+	const f = fixture();
+	t.after(installSidebar(f.tui, theme, { showRose: true, showTextLogo: true }));
+	const scroll = rail(f);
+	const lines = scroll.render(50);
+	const brandIndex = lines.findIndex((line) => line.includes("GENTLE PI"));
+	assert.ok(brandIndex >= 0 && brandIndex < lines.findIndex((line) => line.includes("Status")));
+	assert.match(lines.join("\n"), /[\u2800-\u28ff]/);
+	assert.deepEqual(f.root.render(), ["transcript"]);
+	scroll.updateLayout(lines.length, 3, () => {});
+	scroll.scrollBy(9);
+	assert.ok(scroll.scrollTop > 0);
+	f.host.terminal.columns = 80;
+	assert.equal(f.root[NODE]().type, "vstack");
+	assert.deepEqual(f.bottom.render(80), ["Status"]);
+});
+
+test("wheel scrolls the rail and is consumed at both boundaries and blank space", (t) => {
+	const f = fixture();
+	t.after(installSidebar(f.tui, theme));
+	const scroll = rail(f);
+	scroll.updateLayout(20, 5, () => {});
+	for (const [delta, expected] of [[-1, 0], [3, 3], [100, 15], [1, 15], [-100, 0]]) {
+		const result = scroll.handleMouse({ type: "wheel", wheelDelta: delta, x: 3, y: 4, screenX: 93, screenY: 6, width: 50, height: 5 } as Parameters<typeof scroll.handleMouse>[0]);
+		assert.equal(result?.handled, true);
+		assert.equal(scroll.scrollTop, expected);
+		assert.equal(result?.target?.component, scroll);
+	}
+	scroll.updateLayout(1, 5, () => {});
+	assert.equal(scroll.handleMouse({ type: "wheel", wheelDelta: 1 } as Parameters<typeof scroll.handleMouse>[0])?.handled, true);
+	assert.equal(scroll.scrollTop, 0);
+});
+
+test("cleanup restores the native layout and bottom paint without disposing widgets", () => {
+	const f = fixture();
+	const dispose = installSidebar(f.tui, theme);
+	rail(f);
+	dispose();
+	assert.equal(f.root[NODE], f.original);
+	assert.deepEqual(f.bottom.render(80), ["Status"]);
+	assert.equal(sidebarState(f.tui).parts.size, 1);
+	assert.ok(f.renders() >= 2);
+});
+
+test("unsupported roots, empty rails and overflowing parts leave native layout intact", (t) => {
+	for (const lines of [[], ["x".repeat(100)]]) {
+		const f = fixture();
+		sidebarPart(f.tui, "footer", { render: () => lines, invalidate() {} });
+		t.after(installSidebar(f.tui, theme));
+		assert.equal(f.root[NODE]().type, "vstack");
+		assert.equal(sidebarState(f.tui).active, false);
+	}
+	const f = fixture();
+	Reflect.deleteProperty(f.root, NODE);
+	t.after(installSidebar(f.tui, theme));
+	assert.deepEqual(f.bottom.render(80), ["Status"]);
+});

--- a/tests/shell-sidebar.test.ts
+++ b/tests/shell-sidebar.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TUI } from "@earendil-works/pi-tui";
+import { sidebarPart, sidebarState } from "../lib/shell-sidebar.ts";
+
+const host = (terminal?: object) => ({ terminal }) as TUI;
+const component = () => ({ render: (_width = 80) => ["bottom"], invalidate() {} });
+
+test("unsupported hosts retain the original bottom widget and disposal", () => {
+	for (const tui of [host(), host(null as unknown as object)]) {
+		let disposed = 0;
+		const bottom = { ...component(), dispose() { disposed++; } };
+		const part = sidebarPart(tui, "todo", bottom);
+		assert.equal(part, bottom);
+		assert.deepEqual(part.render(), ["bottom"]);
+		part.dispose();
+		assert.equal(disposed, 1);
+	}
+});
+
+test("terminal state survives host replacement without leaking across terminals", () => {
+	const terminal = {};
+	assert.equal(sidebarState(host(terminal)), sidebarState(host(terminal)));
+	assert.notEqual(sidebarState(host(terminal)), sidebarState(host({})));
+});
+
+test("bottom paint is suppressed only while the sidebar owns the host", () => {
+	const tui = host({});
+	const state = sidebarState(tui);
+	const part = sidebarPart(tui, "todo", component());
+	state.active = true;
+	assert.deepEqual(part.render(80), ["bottom"]);
+	state.ownsHost = () => true;
+	assert.deepEqual(part.render(80), []);
+	state.active = false;
+	assert.deepEqual(part.render(80), ["bottom"]);
+});
+
+test("disposing an old part preserves its replacement and releases its bottom", () => {
+	const tui = host({});
+	let disposed = 0;
+	const first = sidebarPart(tui, "todo", { ...component(), dispose() { disposed++; } });
+	const replacement = component();
+	const second = sidebarPart(tui, "todo", replacement);
+	first.dispose?.();
+	assert.equal(disposed, 1);
+	assert.equal(sidebarState(tui).parts.get("todo"), replacement);
+	(second as typeof second & { dispose?(): void }).dispose?.();
+	assert.equal(sidebarState(tui).parts.size, 0);
+});

--- a/tests/startup-banner.test.ts
+++ b/tests/startup-banner.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { syncBuiltinESMExports } from "node:module";
+import fs from "node:fs/promises";
+import startup from "../extensions/startup-banner.ts";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { stripAnsi } from "../lib/terminal-theme.ts";
+
+// Drive the actual header factory, without executing background git/home reads.
+test("startup retains context but emits no artwork, terminal clears or animation", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+	t.mock.method(fs, "readFile", async () => '{"showRose":true,"showTextLogo":true}');
+	syncBuiltinESMExports();
+	t.after(() => { t.mock.restoreAll(); syncBuiltinESMExports(); });
+	const argv = process.argv;
+	process.argv = ["node"];
+	t.after(() => { process.argv = argv; });
+	for (const [key, value] of [["rows", 40], ["columns", 160]] as const) {
+		const descriptor = Object.getOwnPropertyDescriptor(process.stdout, key);
+		Object.defineProperty(process.stdout, key, { configurable: true, value });
+		t.after(() => descriptor ? Object.defineProperty(process.stdout, key, descriptor) : Reflect.deleteProperty(process.stdout, key));
+	}
+	let start: Function;
+	let header: { render(width: number): string[]; invalidate(): void };
+	let renders = 0;
+	const writes: string[] = [];
+	startup({ on: (name: string, fn: Function) => { if (name === "session_start") start = fn; }, registerCommand() {}, getCommands: () => [], getAllTools: () => [] } as unknown as ExtensionAPI);
+	const write = t.mock.method(process.stdout, "write", (text: string) => { writes.push(String(text)); return true; });
+	await start!({}, { hasUI: true, cwd: "/fixture", ui: { setHeader: (factory: Function) => {
+		header = factory({ requestRender: () => { renders++; } }, { fg: (_role: string, text: string) => text });
+	} } });
+	t.mock.timers.tick(50);
+	write.mock.restore();
+	try {
+		for (const width of [40, 80, 160]) {
+			const text = stripAnsi(header!.render(width).join("\n"));
+			assert.match(text, /GIT:/);
+			assert.match(text, /PATH:/);
+			assert.doesNotMatch(text, /[\u2800-\u28ff]|[▒▄▀█]|GENTLE PI/);
+		}
+		t.mock.timers.tick(25);
+		assert.equal(renders, 0, "no periodic artwork repaint");
+		assert.deepEqual(writes, [], "Pi owns stdout and cursor state");
+	} finally { header!.invalidate(); }
+});

--- a/tests/startup-banner.test.ts
+++ b/tests/startup-banner.test.ts
@@ -4,42 +4,68 @@ import { syncBuiltinESMExports } from "node:module";
 import fs from "node:fs/promises";
 import startup from "../extensions/startup-banner.ts";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 
-// Drive the actual header factory, without executing background git/home reads.
-test("startup retains context but emits no artwork, terminal clears or animation", async (t) => {
-	t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
-	t.mock.method(fs, "readFile", async () => '{"showRose":true,"showTextLogo":true}');
-	syncBuiltinESMExports();
-	t.after(() => { t.mock.restoreAll(); syncBuiltinESMExports(); });
-	const argv = process.argv;
-	process.argv = ["node"];
-	t.after(() => { process.argv = argv; });
-	for (const [key, value] of [["rows", 40], ["columns", 160]] as const) {
-		const descriptor = Object.getOwnPropertyDescriptor(process.stdout, key);
-		Object.defineProperty(process.stdout, key, { configurable: true, value });
-		t.after(() => descriptor ? Object.defineProperty(process.stdout, key, descriptor) : Reflect.deleteProperty(process.stdout, key));
-	}
-	let start: Function;
-	let header: { render(width: number): string[]; invalidate(): void };
-	let renders = 0;
-	const writes: string[] = [];
-	startup({ on: (name: string, fn: Function) => { if (name === "session_start") start = fn; }, registerCommand() {}, getCommands: () => [], getAllTools: () => [] } as unknown as ExtensionAPI);
-	const write = t.mock.method(process.stdout, "write", (text: string) => { writes.push(String(text)); return true; });
-	await start!({}, { hasUI: true, cwd: "/fixture", ui: { setHeader: (factory: Function) => {
-		header = factory({ requestRender: () => { renders++; } }, { fg: (_role: string, text: string) => text });
-	} } });
-	t.mock.timers.tick(50);
-	write.mock.restore();
-	try {
-		for (const width of [40, 80, 160]) {
-			const text = stripAnsi(header!.render(width).join("\n"));
-			assert.match(text, /GIT:/);
-			assert.match(text, /PATH:/);
-			assert.doesNotMatch(text, /[\u2800-\u28ff]|[▒▄▀█]|GENTLE PI/);
+// Drive the real header factory; background git/home reads never run.
+for (const showRose of [false, true]) for (const showTextLogo of [false, true]) {
+	test(`startup art respects rose=${showRose}, logo=${showTextLogo} and cyan palette`, async (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+		t.mock.method(fs, "readFile", async () => JSON.stringify({ showRose, showTextLogo, color: "cyan" }));
+		syncBuiltinESMExports();
+		t.after(() => { t.mock.restoreAll(); syncBuiltinESMExports(); });
+		const argv = process.argv;
+		process.argv = ["node"];
+		t.after(() => { process.argv = argv; });
+		for (const [key, value] of [["rows", 40], ["columns", 160]] as const) {
+			const descriptor = Object.getOwnPropertyDescriptor(process.stdout, key);
+			Object.defineProperty(process.stdout, key, { configurable: true, writable: true, value });
+			t.after(() => descriptor ? Object.defineProperty(process.stdout, key, descriptor) : Reflect.deleteProperty(process.stdout, key));
 		}
-		t.mock.timers.tick(25);
-		assert.equal(renders, 0, "no periodic artwork repaint");
-		assert.deepEqual(writes, [], "Pi owns stdout and cursor state");
-	} finally { header!.invalidate(); }
-});
+		let start: Function;
+		let shutdown: Function;
+		let header: { render(width: number): string[]; invalidate(): void };
+		const writes: string[] = [];
+		startup({ on: (name: string, fn: Function) => {
+			if (name === "session_start") start = fn;
+			if (name === "session_shutdown") shutdown = fn;
+		}, registerCommand() {}, getCommands: () => [], getAllTools: () => [] } as unknown as ExtensionAPI);
+		const write = t.mock.method(process.stdout, "write", (text: string) => { writes.push(String(text)); return true; });
+		await start!({}, { hasUI: true, cwd: "/fixture", ui: { setHeader: (factory: Function) => {
+			header = factory({ requestRender() {} }, { fg: (_role: string, text: string) => text });
+		} } });
+		t.mock.timers.tick(50);
+		try {
+			for (const width of [40, 80, 160]) {
+				const lines = header!.render(width);
+				assert.ok(lines.every((line) => visibleWidth(line) <= width));
+				const text = stripAnsi(lines.join("\n"));
+				assert.match(text, /GIT:/);
+				assert.match(text, /PATH:/);
+				if (width === 160) {
+					assert.equal(/[\u2800-\u28ff]/.test(text), showRose);
+					assert.equal(/[▒▄▀█]/.test(text), showTextLogo);
+				}
+				assert.match(lines.join("\n"), /\x1b\[38;2;85;170;205m/, "startup labels use the saved cyan palette");
+			}
+			// Cancel pending context reads before advancing the resize clock.
+			t.mock.timers.reset();
+			t.mock.timers.enable({ apis: ["setTimeout", "Date"], now: Date.now() + 1000 });
+			process.stdout.rows = 10;
+			process.stdout.emit("resize");
+			t.mock.timers.tick(150);
+			assert.deepEqual(header!.render(80), []);
+			process.stdout.rows = 25;
+			process.stdout.columns = 80;
+			process.stdout.emit("resize");
+			t.mock.timers.tick(150);
+			const minimal = stripAnsi(header!.render(80).join("\n"));
+			assert.doesNotMatch(minimal, /[\u2800-\u28ff]/);
+			assert.equal(/[▒▄▀█]/.test(minimal), showTextLogo);
+			assert.deepEqual(writes, [], "Pi owns stdout during startup and resize");
+		} finally {
+			shutdown!();
+			write.mock.restore();
+		}
+	});
+}


### PR DESCRIPTION
## Linked Issue
Closes #738

## PR Type
- [x] New feature (`type:feature`)

## Summary
- Add a scrollable right sidebar in fullscreen terminals at least 140 columns wide. Keep regular and narrow layouts below the editor.
- Group Status and Changes before Agents and TODO, with a centered `✿ Gentle-Pi ✿` heading: themed pink flowers and normal white text. Preserve the original startup artwork and remove external screen clears that hid the editor.
- Persist fullscreen during recognized global Pi-managed npm installs, preserving other settings with cooperative locking and atomic replacement. Other installation scopes remain untouched.

## Changes
| File | Change |
|------|--------|
| `lib/shell-sidebar.ts` | Terminal-shared widget ownership and unsupported-host fallback. |
| `lib/shell-sidebar-layout.ts` | Fullscreen layout integration, responsive width and independent wheel containment. |
| `lib/shell-sidebar-banner.ts` | Centered, theme-aware one-line heading. |
| `lib/shell-bar.ts` | Grouped Status card preserving extension statuses. |
| `lib/shell-todo.ts` | Unfolded tasks inside a scrollable host. |
| `extensions/gentle-shell.ts` | Sidebar lifecycle and changes/status integration with session worktrees. |
| `extensions/gentle-agents.ts` | Agents sidebar registration and scrollable rows. |
| `extensions/gentle-todo.ts` | TODO sidebar registration. |
| `extensions/startup-banner.ts` | Preserve intro preferences; let Pi own screen clearing. |
| `scripts/install-tui-mode-setting.mjs` | Confined global settings update. |
| `scripts/install-gentle-ai.mjs` | Apply setting only after native success or explicit native skip. |
| `scripts/test-packed-runner.mjs` | Isolate agent homes and protect ordinary consumers from settings changes. |
| `tests/install-tui-mode-setting.test.ts` | Install ownership, settings preservation, lifecycle and failure safety. |
| `tests/shell-sidebar.test.ts` | Shared state, fallback, replacement and disposal. |
| `tests/shell-sidebar-layout.test.ts` | Activation, order, scrolling and fallback. |
| `tests/shell-sidebar-banner.test.ts` | Exact heading, centering and theme roles. |
| `tests/startup-banner.test.ts` | Original artwork preferences and stdout safety. |
| `README.md` | Layout, installation scope and override behavior. |

## Test Plan
- [x] Focused shell/sidebar/startup suite: 45 passed.
- [x] `pnpm test`: 1,722 passed, 1 Windows-specific platform skip, zero failures; provider contract and runtime harness completed.
- [x] `pnpm run check:runtime-modules`: 6 modules match.
- [x] `node scripts/verify-package-files.mjs`: 167 files and 68 pinned artifacts verified.
- [x] `pnpm run test:packed-package`: isolated packed installation passed with gentle-pi 2.5.0 and Gentle AI 2.7.0.
- [x] User manually confirmed the final visual design and restored editor visibility.
- [x] Native RDD: four lenses approved this exact candidate; acknowledgement completed. One informational, non-blocking advisory remains at `tests/shell-sidebar-layout.test.ts:11-18` (R3-001); no correction was required.
- [x] Independent verifier confirmed clean HEAD `9599a943a6baca1a9b155ca51f04d0c202fe02c1`.

## Scope and review budget
18 files, 963 additions + 80 deletions = 1,043 authored changed lines. The maintainer explicitly approved one combined candidate up to 1,250 lines rather than splitting sidebar/installer behavior and their regression coverage. This retains the installation safety tests and the final UI/lifecycle checks instead of trimming tests to fit a budget. The feature intake form was already delivered independently in #733. Applying the protected `size:exception` label is a separate maintainer-authorized workflow action.

## Compatibility and rollback
The sidebar depends on experimental Pi 0.85.1 fullscreen layout internals. Real-terminal portability beyond the manual macOS run is not claimed. Global settings persistence recognizes only the managed npm package location; local-project, Git, temporary, ordinary npm consumers and pnpm store-linked packages are excluded. A later postinstall run can reset regular to fullscreen; users can change it back in `/settings`. Atomic replacement does not protect against noncooperating settings writers. Reverting this PR removes the behavior but deliberately does not rewrite existing user settings.

## Contributor Checklist
- [x] Linked approved issue #738.
- [x] Exactly one PR type label: `type:feature`.
- [x] Shellcheck not applicable: no shell scripts changed; modified installer files are JavaScript.
- [x] No agent skill files changed.
- [x] User-facing behavior and exclusions documented.
- [x] Conventional commits; no Co-Authored-By trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a responsive fullscreen sidebar for status, changes, agents, tasks, and branding on wide terminals.
  - Added scrollable task lists and a structured status card with project, model, context, usage, and integration details.
  - Installations can enable fullscreen mode globally for recognized setups.

- **Bug Fixes**
  - Improved startup banner cleanup, resizing, session transitions, and asynchronous updates.
  - Preserved existing settings and improved safety when updating fullscreen preferences.

- **Documentation**
  - Expanded installation and banner documentation, including migration warnings and fullscreen behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->