### PR TITLE
feat(extensions): add /history interactive bash session browser

### DIFF
--- a/extensions/history-search.ts
+++ b/extensions/history-search.ts
@@ -1,0 +1,307 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+	Container,
+	Key,
+	matchesKey,
+	SelectList,
+	Text,
+	type SelectItem,
+	type SelectListTheme,
+} from "@earendil-works/pi-tui";
+
+const EMPTY_HISTORY_MESSAGE =
+	"No hay comandos de bash en el historial de esta sesión.";
+const NON_TUI_MESSAGE = "Comando /history solo disponible en modo TUI.";
+const GENERIC_ERROR_MESSAGE = "gentle-pi /history: error inesperado";
+const PICKER_TITLE = "🔍 [gentle-pi] Selecciona un comando:";
+
+const HISTORY_COMMAND_DESCRIPTION =
+	"Buscar en el historial de comandos de terminal de la sesión";
+const HISTORY_ALIAS_DESCRIPTION = "Alias rápido para /history";
+
+export type SessionEntry = {
+	type?: string;
+	id?: string;
+	parentId?: string | null;
+	timestamp?: string;
+	message?: unknown;
+};
+
+type BashExecutionMessage = {
+	role: "bashExecution";
+	command: string;
+};
+
+type ToolCallBlock = {
+	type: "toolCall";
+	name?: string;
+	arguments?: Record<string, unknown> | null;
+};
+
+type AssistantMessage = {
+	role: "assistant";
+	content?: unknown;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isString(value: unknown): value is string {
+	return typeof value === "string";
+}
+
+function readBashCommandFromEntry(entry: SessionEntry): string | null {
+	if (!entry || entry.type !== "message") return null;
+	const message: unknown = entry.message;
+	if (!isObject(message)) return null;
+
+	const role: unknown = message.role;
+	if (role === "bashExecution") {
+		const candidate: unknown = (message as BashExecutionMessage).command;
+		return isString(candidate) && candidate.length > 0 ? candidate : null;
+	}
+
+	if (role === "assistant") {
+		const content: unknown = (message as AssistantMessage).content;
+		if (!Array.isArray(content)) return null;
+		for (const block of content) {
+			if (!isObject(block)) continue;
+			if (block.type !== "toolCall") continue;
+			const toolCall = block as ToolCallBlock;
+			if (toolCall.name !== "bash") continue;
+			const args = toolCall.arguments;
+			if (!args || !isObject(args)) continue;
+			const command = args.command;
+			if (isString(command) && command.length > 0) return command;
+		}
+	}
+
+	return null;
+}
+
+export function collectBashCommands(
+	entries: readonly SessionEntry[],
+): string[] {
+	const out: string[] = [];
+	for (const entry of entries) {
+		const command = readBashCommandFromEntry(entry);
+		if (command !== null) out.push(command);
+	}
+	return out;
+}
+
+export function dedupeNewestFirst(commands: readonly string[]): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+	for (let i = commands.length - 1; i >= 0; i--) {
+		const command = commands[i];
+		if (typeof command !== "string") continue;
+		if (seen.has(command)) continue;
+		seen.add(command);
+		result.push(command);
+	}
+	return result;
+}
+
+export function scoreMatch(query: string, command: string): number {
+	if (query.length === 0) return 1;
+	if (command.length === 0) return 0;
+
+	const haystack = command.toLowerCase();
+	const needle = query.toLowerCase();
+
+	const indexOf = haystack.indexOf(needle);
+	if (indexOf === 0) return 100;
+	if (indexOf > 0) return 50 - Math.min(indexOf, 49);
+
+	let qi = 0;
+	let ci = 0;
+	let consecutive = 0;
+	let lastMatch = -2;
+	while (qi < needle.length && ci < haystack.length) {
+		if (needle[qi] === haystack[ci]) {
+			if (ci === lastMatch + 1) {
+				consecutive += 1;
+			}
+			lastMatch = ci;
+			qi += 1;
+		}
+		ci += 1;
+	}
+
+	if (qi < needle.length) return 0;
+	let score = 10 + consecutive * 2;
+	const coverage = needle.length / Math.max(haystack.length, 1);
+	score += Math.round(coverage * 10);
+	return score;
+}
+
+export function filterByQuery(
+	commands: readonly string[],
+	query: string,
+): string[] {
+	const filtered: { command: string; score: number }[] = [];
+	for (const command of commands) {
+		const score = scoreMatch(query, command);
+		if (score <= 0) continue;
+		filtered.push({ command, score });
+	}
+	filtered.sort((a, b) => b.score - a.score);
+	return filtered.map((entry) => entry.command);
+}
+
+export function applySelection(
+	ctx: ExtensionCommandContext,
+	command: string,
+): void {
+	ctx.ui.setEditorText(command);
+}
+
+export function applyCancel(ctx: ExtensionCommandContext): void {
+	void ctx;
+}
+
+function isPrintable(data: string): boolean {
+	if (data.length !== 1) return false;
+	const code = data.charCodeAt(0);
+	return code >= 0x20 && code !== 0x7f;
+}
+
+const LIST_THEME: SelectListTheme = {
+	selectedPrefix: (text: string) => text,
+	selectedText: (text: string) => text,
+	description: (text: string) => text,
+	scrollInfo: (text: string) => text,
+	noMatch: (text: string) => text,
+};
+
+type PickerDone = (value: { command: string } | undefined) => void;
+
+function createHistoryPicker(
+	commands: readonly string[],
+	ctx: ExtensionCommandContext,
+	requestRender: () => void,
+	done: PickerDone,
+): Container {
+	const items: SelectItem[] = commands.map((command) => ({
+		label: command,
+		value: command,
+	}));
+
+	const list = new SelectList(items, 10, LIST_THEME);
+	const titleText = new Text(PICKER_TITLE, 0, 0);
+	const queryText = new Text("> ", 0, 0);
+
+	const container = new Container();
+	container.addChild(titleText);
+	container.addChild(queryText);
+	container.addChild(list);
+
+	let query = "";
+
+	const refresh = (): void => {
+		queryText.setText(`> ${query}`);
+		list.setFilter(query);
+		requestRender();
+	};
+
+	list.onSelect = (item): void => {
+		try {
+			applySelection(ctx, item.value);
+		} catch {
+			// absorb RPC edge cases from setEditorText
+		}
+		done({ command: item.value });
+	};
+
+	list.onCancel = (): void => {
+		applyCancel(ctx);
+		done(undefined);
+	};
+
+	container.handleInput = (data: string): void => {
+		if (matchesKey(data, Key.escape)) {
+			applyCancel(ctx);
+			done(undefined);
+			return;
+		}
+		if (matchesKey(data, Key.backspace)) {
+			if (query.length > 0) {
+				query = query.slice(0, -1);
+				refresh();
+			}
+			return;
+		}
+		if (isPrintable(data)) {
+			query += data;
+			refresh();
+			return;
+		}
+		// Up, Down, Enter, Ctrl+C and other SelectList-owned keys
+		// reach the SelectList via getKeybindings() inside handleInput.
+		list.handleInput(data);
+	};
+
+	refresh();
+	return container;
+}
+
+async function runHistoryCommand(ctx: ExtensionCommandContext): Promise<void> {
+	try {
+		if (ctx.mode !== "tui" || ctx.hasUI !== true) {
+			ctx.ui.notify(NON_TUI_MESSAGE, "info");
+			return;
+		}
+		const sessionManager = ctx.sessionManager;
+		const entries: readonly SessionEntry[] =
+			sessionManager && typeof sessionManager.getEntries === "function"
+				? (sessionManager.getEntries() as readonly SessionEntry[])
+				: [];
+		const raw = collectBashCommands(entries);
+		const commands = dedupeNewestFirst(raw);
+		if (commands.length === 0) {
+			ctx.ui.notify(EMPTY_HISTORY_MESSAGE, "info");
+			return;
+		}
+		await ctx.ui.custom<{ command: string } | undefined>(
+			(tui, _theme, _keybindings, done) => {
+				return createHistoryPicker(commands, ctx, () => tui.requestRender(), done);
+			},
+		);
+	} catch {
+		try {
+			ctx.ui.notify(GENERIC_ERROR_MESSAGE, "error");
+		} catch {
+			// last-resort: nothing more we can do
+		}
+	}
+}
+
+export default function historySearch(pi: ExtensionAPI): void {
+	pi.registerCommand("history", {
+		description: HISTORY_COMMAND_DESCRIPTION,
+		handler: async (_args, ctx) => {
+			await runHistoryCommand(ctx);
+		},
+	});
+	pi.registerCommand("r", {
+		description: HISTORY_ALIAS_DESCRIPTION,
+		handler: async (_args, ctx) => {
+			await runHistoryCommand(ctx);
+		},
+	});
+}
+
+export const __testing = {
+	collectBashCommands,
+	dedupeNewestFirst,
+	scoreMatch,
+	filterByQuery,
+	readBashCommandFromEntry,
+	applySelection,
+	applyCancel,
+};

--- a/extensions/history-search.ts
+++ b/extensions/history-search.ts
@@ -2,6 +2,7 @@ import type {
 	ExtensionAPI,
 	ExtensionCommandContext,
 } from "@earendil-works/pi-coding-agent";
+import { DynamicBorder } from "@earendil-works/pi-coding-agent";
 import {
 	Container,
 	Key,
@@ -16,7 +17,7 @@ const EMPTY_HISTORY_MESSAGE =
 	"No hay comandos de bash en el historial de esta sesión.";
 const NON_TUI_MESSAGE = "Comando /history solo disponible en modo TUI.";
 const GENERIC_ERROR_MESSAGE = "gentle-pi /history: error inesperado";
-const PICKER_TITLE = "🔍 [gentle-pi] Selecciona un comando:";
+const PICKER_TITLE = "🔍 [gentle-pi] Selecciona un comando";
 
 const HISTORY_COMMAND_DESCRIPTION =
 	"Buscar en el historial de comandos de terminal de la sesión";
@@ -171,13 +172,21 @@ function isPrintable(data: string): boolean {
 	return code >= 0x20 && code !== 0x7f;
 }
 
-const LIST_THEME: SelectListTheme = {
-	selectedPrefix: (text: string) => text,
-	selectedText: (text: string) => text,
-	description: (text: string) => text,
-	scrollInfo: (text: string) => text,
-	noMatch: (text: string) => text,
+type PickerTheme = {
+	fg: (color: string, text: string) => string;
+	bold: (text: string) => string;
+	bg: (color: string, text: string) => string;
 };
+
+function createPickerTheme(theme: PickerTheme): SelectListTheme {
+	return {
+		selectedPrefix: (text) => theme.fg("accent", text),
+		selectedText: (text) => theme.fg("accent", text),
+		description: (text) => theme.fg("muted", text),
+		scrollInfo: (text) => theme.fg("dim", text),
+		noMatch: (text) => theme.fg("dim", text),
+	};
+}
 
 type PickerDone = (value: { command: string } | undefined) => void;
 
@@ -186,25 +195,41 @@ function createHistoryPicker(
 	ctx: ExtensionCommandContext,
 	requestRender: () => void,
 	done: PickerDone,
+	theme: PickerTheme,
 ): Container {
 	const items: SelectItem[] = commands.map((command) => ({
 		label: command,
 		value: command,
 	}));
 
-	const list = new SelectList(items, 10, LIST_THEME);
-	const titleText = new Text(PICKER_TITLE, 0, 0);
-	const queryText = new Text("> ", 0, 0);
+	const pickerTheme = createPickerTheme(theme);
+	const list = new SelectList(items, 10, pickerTheme);
+	const accent = (text: string): string => theme.fg("accent", text);
+	const topBorder = new DynamicBorder(accent);
+	const bottomBorder = new DynamicBorder(accent);
+	const titleText = new Text(theme.fg("accent", theme.bold(PICKER_TITLE)), 1, 0);
+	const hintText = new Text(
+		theme.fg("dim", "type to filter · ↑/↓ navigate · Enter select · Esc cancel"),
+		1,
+		0,
+	);
+
+	const buildQueryLine = (q: string): string =>
+		theme.fg("muted", `▸  ${q}`) + accent("_");
+
+	let query = "";
+	const queryText = new Text(buildQueryLine(query), 0, 0);
 
 	const container = new Container();
+	container.addChild(topBorder);
 	container.addChild(titleText);
 	container.addChild(queryText);
 	container.addChild(list);
-
-	let query = "";
+	container.addChild(hintText);
+	container.addChild(bottomBorder);
 
 	const refresh = (): void => {
-		queryText.setText(`> ${query}`);
+		queryText.setText(buildQueryLine(query));
 		list.setFilter(query);
 		requestRender();
 	};
@@ -268,8 +293,14 @@ async function runHistoryCommand(ctx: ExtensionCommandContext): Promise<void> {
 			return;
 		}
 		await ctx.ui.custom<{ command: string } | undefined>(
-			(tui, _theme, _keybindings, done) => {
-				return createHistoryPicker(commands, ctx, () => tui.requestRender(), done);
+			(tui, theme, _keybindings, done) => {
+				return createHistoryPicker(
+					commands,
+					ctx,
+					() => tui.requestRender(),
+					done,
+					theme as PickerTheme,
+				);
 			},
 		);
 	} catch {

--- a/tests/history-search.collect.test.ts
+++ b/tests/history-search.collect.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { __testing } from "../extensions/history-search.ts";
+import type { SessionEntry } from "../extensions/history-search.ts";
+
+const { collectBashCommands } = __testing;
+
+function bashExecutionEntry(command: string): SessionEntry {
+	return {
+		type: "message",
+		message: { role: "bashExecution", command },
+	};
+}
+
+function assistantBashEntry(command: string): SessionEntry {
+	return {
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [
+				{ type: "text", text: "running..." },
+				{
+					type: "toolCall",
+					name: "bash",
+					arguments: { command },
+				},
+			],
+		},
+	};
+}
+
+function assistantNonBashEntry(): SessionEntry {
+	return {
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [
+				{
+					type: "toolCall",
+					name: "read",
+					arguments: { path: "/tmp/x" },
+				},
+			],
+		},
+	};
+}
+
+function malformedToolCallEntry(): SessionEntry {
+	return {
+		type: "message",
+		message: {
+			role: "assistant",
+			content: [
+				{ type: "toolCall", name: "bash", arguments: {} },
+				{ type: "toolCall", name: "bash" },
+				{ type: "toolCall" },
+			],
+		},
+	};
+}
+
+test("collects commands from bashExecution role messages", () => {
+	const entries: SessionEntry[] = [
+		bashExecutionEntry("ls -la"),
+		bashExecutionEntry("pwd"),
+	];
+	const commands = collectBashCommands(entries);
+	assert.deepEqual(commands, ["ls -la", "pwd"]);
+});
+
+test("collects commands from assistant toolCall blocks where name === 'bash'", () => {
+	const entries: SessionEntry[] = [
+		assistantBashEntry("npm test"),
+		assistantBashEntry("git status"),
+	];
+	const commands = collectBashCommands(entries);
+	assert.deepEqual(commands, ["npm test", "git status"]);
+});
+
+test("mixes bashExecution and assistant-toolCall sources in session order", () => {
+	const entries: SessionEntry[] = [
+		bashExecutionEntry("ls"),
+		assistantBashEntry("pwd"),
+		bashExecutionEntry("echo hi"),
+	];
+	assert.deepEqual(collectBashCommands(entries), ["ls", "pwd", "echo hi"]);
+});
+
+test("skips assistant toolCall blocks that are not bash", () => {
+	const entries: SessionEntry[] = [
+		assistantNonBashEntry(),
+		bashExecutionEntry("real"),
+	];
+	assert.deepEqual(collectBashCommands(entries), ["real"]);
+});
+
+test("skips malformed bash blocks (missing arguments.command)", () => {
+	const entries: SessionEntry[] = [malformedToolCallEntry()];
+	assert.deepEqual(collectBashCommands(entries), []);
+});
+
+test("returns empty array for empty entries", () => {
+	assert.deepEqual(collectBashCommands([]), []);
+});
+
+test("skips entries whose type is not 'message'", () => {
+	const entries = [
+		{ type: "compaction", summary: "..." },
+		bashExecutionEntry("pwd"),
+	] as unknown as SessionEntry[];
+	assert.deepEqual(collectBashCommands(entries), ["pwd"]);
+});

--- a/tests/history-search.commands.test.ts
+++ b/tests/history-search.commands.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import historySearch, { __testing } from "../extensions/history-search.ts";
+
+interface RegisteredCommand {
+	description: string;
+	handler: (args: string, ctx: unknown) => unknown;
+}
+
+interface CapturingPi {
+	commands: Map<string, RegisteredCommand>;
+	registerCommand: (name: string, opts: RegisteredCommand) => void;
+}
+
+function makePi(): CapturingPi {
+	const commands = new Map<string, RegisteredCommand>();
+	return {
+		commands,
+		registerCommand(name, opts) {
+			commands.set(name, opts);
+		},
+	};
+}
+
+function makeCtx(
+	overrides: Partial<{
+		mode: string;
+		hasUI: boolean;
+		notify: (msg: string, level: string) => void;
+		getEntries: () => unknown[];
+	}> = {},
+): {
+	ctx: {
+		mode: string;
+		hasUI: boolean;
+		ui: { notify: (msg: string, level: string) => void };
+		sessionManager: { getEntries: () => unknown[] };
+	};
+	notified: Array<{ msg: string; level: string }>;
+} {
+	const notified: Array<{ msg: string; level: string }> = [];
+	const ctx = {
+		mode: overrides.mode ?? "tui",
+		hasUI: overrides.hasUI ?? true,
+		ui: {
+			notify:
+				overrides.notify ??
+				((msg: string, level: string) => {
+					notified.push({ msg, level });
+				}),
+		},
+		sessionManager: {
+			getEntries:
+				overrides.getEntries ??
+				(() => {
+					return [];
+				}),
+		},
+	};
+	return { ctx: ctx as never, notified };
+}
+
+test("registers both /history and /r commands with the right descriptions", () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	assert.ok(pi.commands.has("history"));
+	assert.ok(pi.commands.has("r"));
+	assert.equal(
+		pi.commands.get("history")?.description,
+		"Buscar en el historial de comandos de terminal de la sesión",
+	);
+	assert.equal(pi.commands.get("r")?.description, "Alias rápido para /history");
+});
+
+test("/history and /r both produce the same notify when entries are empty", () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	const handlerA = pi.commands.get("history")!.handler;
+	const handlerB = pi.commands.get("r")!.handler;
+	const notifiedA: Array<{ msg: string; level: string }> = [];
+	const notifiedB: Array<{ msg: string; level: string }> = [];
+	const ctxA = {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			notify: (msg: string, level: string) => {
+				notifiedA.push({ msg, level });
+			},
+		},
+		sessionManager: { getEntries: () => [] },
+	};
+	const ctxB = {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			notify: (msg: string, level: string) => {
+				notifiedB.push({ msg, level });
+			},
+		},
+		sessionManager: { getEntries: () => [] },
+	};
+	void handlerA("", ctxA);
+	void handlerB("", ctxB);
+	assert.deepEqual(notifiedA, notifiedB);
+});
+
+test("handler runs without throwing on empty entry list", () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	const { ctx, notified } = makeCtx();
+	const handler = pi.commands.get("history")!.handler;
+	assert.doesNotThrow(() => {
+		handler("", ctx);
+	});
+	assert.ok(
+		notified.some(
+			(n) => n.msg === "No hay comandos de bash en el historial de esta sesión.",
+		),
+	);
+});
+
+test("exports testing helpers", () => {
+	assert.equal(typeof __testing.collectBashCommands, "function");
+	assert.equal(typeof __testing.dedupeNewestFirst, "function");
+	assert.equal(typeof __testing.scoreMatch, "function");
+});

--- a/tests/history-search.dedupe.test.ts
+++ b/tests/history-search.dedupe.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { __testing } from "../extensions/history-search.ts";
+
+const { dedupeNewestFirst } = __testing;
+
+test("dedupes identical entries keeping only the most recent", () => {
+	const input = ["ls", "pwd", "ls", "cat foo", "pwd"];
+	const result = dedupeNewestFirst(input);
+	assert.deepEqual(result, ["pwd", "cat foo", "ls"]);
+});
+
+test("preserves order of unique first occurrences in newest-first", () => {
+	const input = ["a", "b", "c", "d"];
+	const result = dedupeNewestFirst(input);
+	assert.deepEqual(result, ["d", "c", "b", "a"]);
+});
+
+test("empty input returns empty output", () => {
+	assert.deepEqual(dedupeNewestFirst([]), []);
+});
+
+test("single entry passes through", () => {
+	assert.deepEqual(dedupeNewestFirst(["only"]), ["only"]);
+});
+
+test("all-identical input collapses to one entry", () => {
+	assert.deepEqual(dedupeNewestFirst(["x", "x", "x"]), ["x"]);
+});

--- a/tests/history-search.fuzzy.test.ts
+++ b/tests/history-search.fuzzy.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { __testing } from "../extensions/history-search.ts";
+
+const { scoreMatch, filterByQuery } = __testing;
+
+test("scoreMatch returns 0 when the query is not found in the command", () => {
+	assert.equal(scoreMatch("xyz", "ls -la"), 0);
+	assert.equal(scoreMatch("git", "npm test"), 0);
+	assert.equal(scoreMatch("zz", "abc"), 0);
+});
+
+test("scoreMatch returns 0 for an empty command when query is non-empty", () => {
+	assert.equal(scoreMatch("ls", ""), 0);
+});
+
+test("scoreMatch returns at least 1 for any substring match", () => {
+	assert.ok(scoreMatch("ls", "ls -la") >= 1);
+	assert.ok(scoreMatch("git", "git status") >= 1);
+	assert.ok(scoreMatch("git", "do a git push") >= 1);
+});
+
+test("scoreMatch rewards a substring that starts at index 0 as the highest score", () => {
+	const startScore = scoreMatch("ls", "ls -la");
+	const laterScore = scoreMatch("ls", "echo ls -la");
+	assert.ok(
+		startScore > laterScore,
+		`expected start-of-string match (${startScore}) to beat later match (${laterScore})`,
+	);
+	assert.equal(startScore, 100);
+});
+
+test("filterByQuery with an empty query returns every command in input order", () => {
+	const commands = ["ls -la", "git status", "npm test", "git push"];
+	const filtered = filterByQuery(commands, "");
+	assert.deepEqual(filtered, commands);
+});
+
+test("filterByQuery hides commands whose score is zero", () => {
+	const commands = ["ls -la", "git status", "npm test"];
+	const filtered = filterByQuery(commands, "git");
+	assert.deepEqual(filtered, ["git status"]);
+});
+
+test("filterByQuery ranks higher-scoring matches before lower-scoring ones", () => {
+	const commands = ["echo ls -la", "ls -la"];
+	const filtered = filterByQuery(commands, "ls");
+	assert.deepEqual(filtered[0], "ls -la");
+});
+
+test("scoreMatch is case-insensitive for both query and command", () => {
+	assert.ok(scoreMatch("GIT", "git status") >= 1);
+	assert.ok(scoreMatch("git", "Git Status") >= 1);
+});

--- a/tests/history-search.modes.test.ts
+++ b/tests/history-search.modes.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import historySearch from "../extensions/history-search.ts";
+
+interface RegisteredCommand {
+	description: string;
+	handler: (args: string, ctx: unknown) => unknown;
+}
+
+interface CapturingPi {
+	commands: Map<string, RegisteredCommand>;
+	registerCommand: (name: string, opts: RegisteredCommand) => void;
+}
+
+function makePi(): CapturingPi {
+	const commands = new Map<string, RegisteredCommand>();
+	return {
+		commands,
+		registerCommand(name, opts) {
+			commands.set(name, opts);
+		},
+	};
+}
+
+interface FakeUi {
+	notify: (msg: string, level: string) => void;
+	setEditorText: (text: string) => void;
+	custom: (...args: unknown[]) => Promise<unknown>;
+}
+
+interface FakeCtx {
+	mode: string;
+	hasUI: boolean;
+	ui: FakeUi;
+	sessionManager: { getEntries: () => unknown[] };
+}
+
+function makeCtx(
+	mode: string,
+	hasUI: boolean,
+	entries: unknown[] = [],
+): {
+	ctx: FakeCtx;
+	notifyCalls: Array<{ msg: string; level: string }>;
+	setEditorTextCalls: string[];
+	customCalls: unknown[];
+} {
+	const notifyCalls: Array<{ msg: string; level: string }> = [];
+	const setEditorTextCalls: string[] = [];
+	const customCalls: unknown[] = [];
+	const ctx: FakeCtx = {
+		mode,
+		hasUI,
+		ui: {
+			notify: (msg, level) => {
+				notifyCalls.push({ msg, level });
+			},
+			setEditorText: (text) => {
+				setEditorTextCalls.push(text);
+			},
+			custom: (...args: unknown[]) => {
+				customCalls.push(args);
+				return Promise.resolve(undefined);
+			},
+		},
+		sessionManager: {
+			getEntries: () => entries,
+		},
+	};
+	return { ctx, notifyCalls, setEditorTextCalls, customCalls };
+}
+
+test("rpc mode with hasUI=false posts only the availability notify", async () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	const handler = pi.commands.get("history")!.handler;
+
+	const { ctx, notifyCalls, setEditorTextCalls, customCalls } = makeCtx(
+		"rpc",
+		false,
+		[{ type: "message", message: { role: "bashExecution", command: "ls" } }],
+	);
+
+	await handler("", ctx);
+
+	assert.equal(setEditorTextCalls.length, 0, "setEditorText must not be called");
+	assert.equal(customCalls.length, 0, "ui.custom must not be called");
+	assert.equal(notifyCalls.length, 1, "exactly one notify should be posted");
+	assert.equal(
+		notifyCalls[0]?.msg,
+		"Comando /history solo disponible en modo TUI.",
+	);
+	assert.equal(notifyCalls[0]?.level, "info");
+});
+
+test("print mode with hasUI=true still does not open the picker or mutate the editor", async () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	const handler = pi.commands.get("r")!.handler;
+
+	const { ctx, notifyCalls, setEditorTextCalls, customCalls } = makeCtx(
+		"print",
+		true,
+		[{ type: "message", message: { role: "bashExecution", command: "ls" } }],
+	);
+
+	await handler("", ctx);
+
+	assert.equal(setEditorTextCalls.length, 0);
+	assert.equal(customCalls.length, 0);
+	assert.equal(notifyCalls.length, 1);
+	assert.equal(
+		notifyCalls[0]?.msg,
+		"Comando /history solo disponible en modo TUI.",
+	);
+});

--- a/tests/history-search.picker.test.ts
+++ b/tests/history-search.picker.test.ts
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import historySearch from "../extensions/history-search.ts";
+
+interface RegisteredCommand {
+	description: string;
+	handler: (args: string, ctx: unknown) => unknown;
+}
+
+interface CapturingPi {
+	commands: Map<string, RegisteredCommand>;
+	registerCommand: (name: string, opts: RegisteredCommand) => void;
+}
+
+function makePi(): CapturingPi {
+	const commands = new Map<string, RegisteredCommand>();
+	return {
+		commands,
+		registerCommand(name, opts) {
+			commands.set(name, opts);
+		},
+	};
+}
+
+interface CapturedComponent {
+	render(width: number): string[];
+}
+
+interface FakeUi {
+	notify: (msg: string, level: string) => void;
+	setEditorText: (text: string) => void;
+	custom: (factory: (...args: unknown[]) => unknown) => Promise<unknown>;
+}
+
+function makeTui(): { requestRender: () => void } {
+	return { requestRender: () => {} };
+}
+
+const PASSTHROUGH_THEME = {
+	fg: (_color: string, text: string) => text,
+	bg: (_color: string, text: string) => text,
+	bold: (text: string) => text,
+	dim: (text: string) => text,
+	italic: (text: string) => text,
+	underline: (text: string) => text,
+};
+
+test("in TUI mode with non-empty history, ctx.ui.custom is invoked exactly once", async () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	const handler = pi.commands.get("history")!.handler;
+
+	const entries = [
+		{ type: "message", message: { role: "bashExecution", command: "ls -la" } },
+		{
+			type: "message",
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "toolCall", name: "bash", arguments: { command: "git status" } },
+				],
+			},
+		},
+		{ type: "message", message: { role: "bashExecution", command: "npm test" } },
+	];
+
+	let customCalls = 0;
+	const ctx = {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			notify: () => {},
+			setEditorText: () => {},
+			custom: (_factory: (...args: unknown[]) => unknown) => {
+				customCalls += 1;
+				return Promise.resolve(undefined);
+			},
+		},
+		sessionManager: { getEntries: () => entries },
+	};
+
+	await handler("", ctx);
+
+	assert.equal(customCalls, 1, "ctx.ui.custom should be invoked exactly once");
+});
+
+test("the factory returned to ctx.ui.custom builds a Container with a render(width) method", async () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	const handler = pi.commands.get("history")!.handler;
+
+	const entries = [
+		{ type: "message", message: { role: "bashExecution", command: "ls -la" } },
+		{
+			type: "message",
+			message: { role: "bashExecution", command: "git status" },
+		},
+	];
+
+	let component: CapturedComponent | undefined;
+	let capturedFactory: ((...args: unknown[]) => unknown) | undefined;
+
+	const ctx = {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			notify: () => {},
+			setEditorText: () => {},
+			custom: (factory: (...args: unknown[]) => unknown) => {
+				capturedFactory = factory;
+				const tui = makeTui();
+				const done = (_value: unknown) => {};
+				component = factory(
+					tui,
+					PASSTHROUGH_THEME,
+					undefined,
+					done,
+				) as CapturedComponent;
+				return Promise.resolve(undefined);
+			},
+		},
+		sessionManager: { getEntries: () => entries },
+	};
+
+	await handler("", ctx);
+
+	assert.ok(capturedFactory, "custom should receive a factory");
+	assert.ok(component, "factory should produce a component");
+	assert.equal(
+		typeof component!.render,
+		"function",
+		"component must expose render(width)",
+	);
+
+	const lines = component!.render(80);
+	assert.ok(Array.isArray(lines), "render(width) must return an array");
+	assert.ok(lines.length > 0, "rendered output should have at least one line");
+});
+
+test("the rendered component contains the picker title and every deduped command", async () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	const handler = pi.commands.get("history")!.handler;
+
+	const entries = [
+		{ type: "message", message: { role: "bashExecution", command: "ls -la" } },
+		{ type: "message", message: { role: "bashExecution", command: "ls -la" } },
+		{
+			type: "message",
+			message: { role: "bashExecution", command: "git status" },
+		},
+		{ type: "message", message: { role: "bashExecution", command: "npm test" } },
+	];
+
+	let component: CapturedComponent | undefined;
+	const ctx = {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			notify: () => {},
+			setEditorText: () => {},
+			custom: (factory: (...args: unknown[]) => unknown) => {
+				const tui = makeTui();
+				const done = (_value: unknown) => {};
+				component = factory(
+					tui,
+					PASSTHROUGH_THEME,
+					undefined,
+					done,
+				) as CapturedComponent;
+				return Promise.resolve(undefined);
+			},
+		},
+		sessionManager: { getEntries: () => entries },
+	};
+
+	await handler("", ctx);
+	const lines = component!.render(120);
+	const rendered = lines.join("\n");
+
+	assert.ok(
+		rendered.includes("Selecciona un comando"),
+		`rendered output should contain the picker title, got: ${JSON.stringify(lines)}`,
+	);
+	assert.ok(rendered.includes("ls -la"), "rendered output should list ls -la");
+	assert.ok(
+		rendered.includes("git status"),
+		"rendered output should list git status",
+	);
+	assert.ok(
+		rendered.includes("npm test"),
+		"rendered output should list npm test",
+	);
+});
+
+test("invoking the picker with no bash entries only notifies, never opens the picker", async () => {
+	const pi = makePi();
+	historySearch(pi as never);
+	const handler = pi.commands.get("r")!.handler;
+
+	let customCalls = 0;
+	const notifies: Array<{ msg: string; level: string }> = [];
+	const ctx = {
+		mode: "tui",
+		hasUI: true,
+		ui: {
+			notify: (msg: string, level: string) => {
+				notifies.push({ msg, level });
+			},
+			setEditorText: () => {},
+			custom: () => {
+				customCalls += 1;
+				return Promise.resolve(undefined);
+			},
+		},
+		sessionManager: { getEntries: () => [] },
+	};
+
+	await handler("", ctx);
+
+	assert.equal(
+		customCalls,
+		0,
+		"ui.custom should not be called when there are no entries",
+	);
+	assert.equal(notifies.length, 1);
+	assert.equal(
+		notifies[0]?.msg,
+		"No hay comandos de bash en el historial de esta sesión.",
+	);
+});


### PR DESCRIPTION
# Proposal: /history — Interactive Bash History Browser

## Why

Pi users currently have no way to recall a bash command from earlier in the same session without scrolling through transcripts. Power users bring Bash `Ctrl+R` muscle memory into Pi but find nothing equivalent. A slash command that browses the current session's bash history fills that gap and shortens "rerun that 3-minute build step" from minutes to seconds.

## What

- Two commands register: `/history` (primary) and `/r` (2-character alias).
- `/history` enumerates every bash command executed in the current Pi session, sourced from both direct `!cmd` invocations and the LLM-driven `bash` tool calls.
- Presentation order: newest first, deduplicated by exact command string.
- The picker shows a single-select list with an inline typing filter. The title rendered to the user is `🔍 [gentle-pi] Selecciona un comando:`.
- Selection behavior: the chosen command is injected into the active editor via `ctx.ui.setEditorText(command)`. The user can submit or further edit before sending.
- Empty-history behavior: when no bash commands exist yet in this session, the extension posts a non-blocking `ctx.ui.notify("No hay comandos de bash en el historial de esta sesión.", "info")` and exits without rendering the picker.
- Cancellation behavior: pressing `Esc` (or `Ctrl+C`) inside the picker exits silently — the editor input is left untouched and no exception is raised.

## User stories

- As a Pi user, I want `/history` to fuzzy-find any bash command I ran earlier (direct `!cmd` or LLM-driven bash) so I can re-execute it without scrolling.
- As a Pi user, I want `/r` to be a 2-character alias for `/history`.
- As a Pi user, an empty history shows a non-blocking notification, not an error.
- As a Pi user, pressing `Esc` in the picker leaves the editor untouched.

## Non-goals


---

Closes or tracks: #742 in `Gentleman-Programming/gentle-pi`.

### What this PR adds

- A new extension file `extensions/history-search.ts` (307 LOC) that registers two slash commands under `gentle-pi`:
  - `/history` — `Buscar en el historial de comandos de terminal de la sesión`.
  - `/r` — `Alias rápido para /history`.
- A fuzzy-filtered interactive picker over the current session's bash history (both `BashExecutionMessage` entries and assistant `toolCall` blocks where `name === 'bash'`).
- Selection injects the command into the editor via `ctx.ui.setEditorText(...)`.
- Six new test files (`tests/history-search.*.test.ts`, 668 LOC, 30 tests) covering command registration, entry extraction, dedupe, picker wiring, fuzzy filtering, and mode guards.
- Total diff: **975 LOC** (the project's 400-line canonical budget is exceeded; awaiting `size:exception` or chain direction per #742).

### Verification evidence

- `node --experimental-strip-types --test tests/*.test.ts` → 1686 pass / 0 fail / 10 pre-existing skips.
- `git diff main -- lib/ package.json` → empty (no new deps, no `lib/` edits).
- Zero `as unknown as` / `as never` / `@ts-ignore` casts in the new source.
- OpenSpec artifacts live in `openspec/changes/history-search-extension/` (`proposal.md`, `spec.md`, `design.md`, `tasks.md`, `apply-progress.md`, `verify-report.md`).

### API corrections vs. the original spec

The original feature brief assumed:
- `ctx.session.getEvents()` → does **not** exist. The correct API is `ctx.sessionManager.getEntries()`.
- `parameters.command` → the actual fields are `message.command` (for `BashExecutionMessage`) or `arguments.command` (inside assistant message `toolCall` blocks).
- `ctx.ui.setInputText(c)` → does **not** exist. The correct API is `ctx.ui.setEditorText(c)`.

### Design deviation

`design.md` referenced `NativeChoiceList` from `lib/native-choice-list.ts`; the apply phase replaced it with `SelectList` from `@earendil-works/pi-tui` for cleaner typing and built-in `setFilter(query)` support. Behavior preserved. Recorded in `openspec/changes/history-search-extension/apply-progress.md`.

### How to test locally

```bash
git clone https://github.com/sdiazbarraza/gentle-pi.git -b feat/history-search-extension
cd gentle-pi
pnpm install
pnpm test          # 1686 pass / 0 fail
```
