### PR TITLE
feat(shell): make sidebar rail resizable

### DIFF
--- a/lib/shell-sidebar-layout.ts
+++ b/lib/shell-sidebar-layout.ts
@@ -1,12 +1,13 @@
-import { ScrollView, visibleWidth, type Component, type TUI } from "@earendil-works/pi-tui";
+import { ScrollView, visibleWidth, type Component, type TUI, type TuiMouseEvent } from "@earendil-works/pi-tui";
 import { sidebarState } from "./shell-sidebar.ts";
 import type { ShellBarTheme } from "./shell-bar.ts";
 import { renderSidebarBanner } from "./shell-sidebar-banner.ts";
 
 export const SIDEBAR_BREAKPOINT = 140;
-const RAIL_WIDTH = 50;
+export const SIDEBAR_MIN_WIDTH = 32;
+const SIDEBAR_MAX_WIDTH = 80;
+const TRANSCRIPT_MIN_WIDTH = 60;
 const RAIL_PADDING = 1;
-const GAP = 3;
 // Experimental Pi 0.85.1 internals. Only the fullscreen layout tree is adapted;
 // regular mode keeps native scrollback and the original bottom components.
 const NODE = Symbol.for("@earendil-works/pi-tui/layout-node");
@@ -49,11 +50,35 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 			target: { component: scroll, originX: event.screenX - event.x, originY: event.screenY - event.y, width: event.width, height: event.height },
 		};
 	};
+	let dragX: number | undefined;
+	const maximumWidth = () => Math.min(SIDEBAR_MAX_WIDTH, tui.terminal.columns - TRANSCRIPT_MIN_WIDTH);
+	const handle: Component = {
+		render: () => Array.from({ length: tui.terminal.rows ?? 1 }, () => theme.fg("border", "│")),
+		invalidate() {},
+		handleMouse(event: TuiMouseEvent) {
+			if (event.button !== "left") return undefined;
+			if (event.type === "press") {
+				dragX = event.screenX;
+				return { handled: true as const, capture: true };
+			}
+			if (event.type === "release") {
+				dragX = undefined;
+				return { handled: true as const };
+			}
+			if ((event.type !== "drag" && event.type !== "move") || dragX === undefined) return undefined;
+			const delta = dragX - event.screenX;
+			dragX = event.screenX;
+			state.width = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maximumWidth(), state.width + delta));
+			tui.requestRender();
+			return { handled: true as const, render: true };
+		},
+	};
 	const prepare = (width: number): boolean => {
 		state.active = false;
 		if (stopped || failed || host.mode !== "fullscreen" || width < SIDEBAR_BREAKPOINT) return false;
 		try {
-			const contentWidth = scroll.getContentWidth(RAIL_WIDTH);
+			state.width = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maximumWidth(), state.width));
+			const contentWidth = scroll.getContentWidth(state.width);
 			const sections = ["footer", "changes", "agents", "todo"].map((key) => {
 				const lines = [...(state.parts.get(key)?.render(contentWidth - RAIL_PADDING * 2) ?? [])];
 				while (lines.length && lines[lines.length - 1]?.trim() === "") lines.pop();
@@ -85,9 +110,10 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 			const descriptor = Object.getOwnPropertyDescriptor(root, NODE);
 			const left = { render: (width: number) => root.render(width), invalidate() {}, [NODE]: () => original.call(root) };
 			const replacement = () => prepare(tui.terminal.columns)
-				? { type: "hstack", gap: GAP, align: "stretch", entries: [
+				? { type: "hstack", gap: 0, align: "stretch", entries: [
 					{ component: left, basis: 0, grow: 1, shrink: 1, minSize: 1 },
-					{ component: scroll, basis: RAIL_WIDTH, grow: 0, shrink: 0, minSize: RAIL_WIDTH },
+					{ component: handle, basis: 1, grow: 0, shrink: 0, minSize: 1 },
+					{ component: scroll, basis: state.width, grow: 0, shrink: 0, minSize: state.width },
 				] }
 				: original.call(root);
 			root[NODE] = replacement;

--- a/lib/shell-sidebar.ts
+++ b/lib/shell-sidebar.ts
@@ -5,12 +5,16 @@ import type { Component, TUI } from "@earendil-works/pi-tui";
 const STATE = Symbol.for("gentle-pi.experimental-sidebar.state");
 export interface SidebarState {
 	active: boolean;
+	width: number;
 	ownsHost?: () => boolean;
 	parts: Map<string, Component>;
 }
 export function sidebarState(tui: TUI): SidebarState {
 	const terminal = tui.terminal as unknown as Record<symbol, SidebarState>;
-	return terminal[STATE] ??= { active: false, parts: new Map() };
+	const state = terminal[STATE] ??= { active: false, width: 50, parts: new Map() };
+	// Migrate terminal-owned state created by an older extension instance.
+	if (!Number.isFinite(state.width)) state.width = 50;
+	return state;
 }
 
 /** Keep the original bottom component mounted, suppressing only its paint. */

--- a/tests/shell-sidebar-layout.test.ts
+++ b/tests/shell-sidebar-layout.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ScrollView, visibleWidth, type TUI } from "@earendil-works/pi-tui";
+import { ScrollView, visibleWidth, type Component, type TUI, type TuiMouseEvent } from "@earendil-works/pi-tui";
 import { installSidebar } from "../lib/shell-sidebar-layout.ts";
 import { sidebarPart, sidebarState } from "../lib/shell-sidebar.ts";
 import { renderShellSidebarBar } from "../lib/shell-bar.ts";
@@ -12,7 +12,7 @@ function fixture(mode = "fullscreen", columns = 140) {
 	const original = () => ({ type: "vstack", entries: [] });
 	const root = { render: () => ["transcript"], invalidate() {}, [NODE]: original };
 	let renders = 0;
-	const host = { mode, terminal: { columns }, layoutRoot: root, requestRender() { renders++; } };
+	const host = { mode, terminal: { columns, rows: 24 }, layoutRoot: root, requestRender() { renders++; } };
 	const tui = host as unknown as TUI;
 	const bottom = sidebarPart(tui, "footer", { render: (_width: number) => ["Status"], invalidate() {} });
 	return { host, tui, root, original, bottom, renders: () => renders };
@@ -20,7 +20,10 @@ function fixture(mode = "fullscreen", columns = 140) {
 function rail(f: ReturnType<typeof fixture>): ScrollView {
 	const node = f.root[NODE]() as unknown as { type: string; entries: { component: ScrollView }[] };
 	assert.equal(node.type, "hstack");
-	return node.entries[1].component;
+	return node.entries[2].component;
+}
+function layout(f: ReturnType<typeof fixture>) {
+	return f.root[NODE]() as unknown as { type: string; gap: number; entries: { component: Component; basis: number; minSize: number }[] };
 }
 
 test("grouped Status preserves structured fields and opaque integration text", () => {
@@ -111,6 +114,28 @@ test("wheel scrolls the rail and is consumed at both boundaries and blank space"
 	scroll.updateLayout(1, 5, () => {});
 	assert.equal(scroll.handleMouse({ type: "wheel", wheelDelta: 1 } as Parameters<typeof scroll.handleMouse>[0])?.handled, true);
 	assert.equal(scroll.scrollTop, 0);
+});
+
+test("dragging the handle resizes the rail within its bounds", (t) => {
+	const f = fixture("fullscreen", 160);
+	t.after(installSidebar(f.tui, theme));
+	let node = layout(f);
+	assert.equal(node.gap, 0);
+	assert.deepEqual(node.entries[1].component.render(1), Array(24).fill("│"));
+	const handle = node.entries[1].component;
+	const event = (type: TuiMouseEvent["type"], screenX: number) => ({ type, button: "left", screenX, screenY: 0, x: 0, y: 0, width: 1, height: 10 }) as TuiMouseEvent;
+	assert.equal(handle.handleMouse?.(event("press", 100))?.capture, true);
+	handle.handleMouse?.(event("drag", 90));
+	node = layout(f);
+	assert.equal(sidebarState(f.tui).width, 60);
+	assert.equal(node.entries[2].basis, 60);
+	assert.equal(node.entries[2].minSize, 60);
+	handle.handleMouse?.(event("drag", 0));
+	assert.equal(sidebarState(f.tui).width, 80);
+	handle.handleMouse?.(event("drag", 200));
+	assert.equal(sidebarState(f.tui).width, 32);
+	handle.handleMouse?.(event("release", 200));
+	assert.ok(f.renders() >= 4);
 });
 
 test("cleanup restores the native layout and bottom paint without disposing widgets", () => {

--- a/tests/shell-sidebar.test.ts
+++ b/tests/shell-sidebar.test.ts
@@ -21,7 +21,16 @@ test("unsupported hosts retain the original bottom widget and disposal", () => {
 test("terminal state survives host replacement without leaking across terminals", () => {
 	const terminal = {};
 	assert.equal(sidebarState(host(terminal)), sidebarState(host(terminal)));
+	assert.equal(sidebarState(host(terminal)).width, 50);
 	assert.notEqual(sidebarState(host(terminal)), sidebarState(host({})));
+});
+
+test("terminal state created before sidebar resizing gains the default width in place", () => {
+	const terminal = {} as Record<symbol, unknown>;
+	const legacy = { active: true, parts: new Map() };
+	terminal[Symbol.for("gentle-pi.experimental-sidebar.state")] = legacy;
+	assert.equal(sidebarState(host(terminal)), legacy);
+	assert.equal(sidebarState(host(terminal)).width, 50);
 });
 
 test("bottom paint is suppressed only while the sidebar owns the host", () => {


### PR DESCRIPTION
Closes #767

## Summary

- Persist the fullscreen sidebar width in terminal-owned state.
- Add a captured one-column drag handle with dynamic 32–80 column bounds.
- Preserve narrow-mode fallback, rail scrolling, overflow checks, and centered branding.

## Changes

| File | Change |
|------|--------|
| `lib/shell-sidebar.ts` | Add persisted width state and migrate legacy terminal state. |
| `lib/shell-sidebar-layout.ts` | Add the drag handle and use dynamic rail sizing. |
| `tests/shell-sidebar.test.ts` | Cover default width and legacy-state migration. |
| `tests/shell-sidebar-layout.test.ts` | Cover drag capture, resizing, layout, and clamping. |

## Test plan

- [x] `node --experimental-strip-types --test tests/shell-sidebar.test.ts tests/shell-sidebar-layout.test.ts tests/shell-sidebar-banner.test.ts` — 17 tests passed.
- [x] `git diff --check`
- [x] Confirmed regular mode and terminal widths below 140 retain the existing native layout through focused tests.

## Contributor checklist

- [x] Linked approved issue #767.
- [x] Uses Conventional Commit format.
- [x] Includes tests with the behavior change.
- [x] Contains no unrelated files or co-author trailers.
- [x] No shell scripts changed; shellcheck is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a draggable divider for resizing the sidebar.
  - Sidebar width now adjusts dynamically while respecting minimum, maximum, and available transcript space.
  - Updated the layout to eliminate unnecessary spacing between the transcript, resize control, and sidebar.
  - Sidebar width is preserved during use and defaults to a standard size when no previous setting is available.

- **Bug Fixes**
  - Improved sidebar scrolling behavior while interacting with the updated layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->