### PR TITLE
feat(shell): show Git status and line counts in changes lists

### DIFF
--- a/lib/shell-changes-view.ts
+++ b/lib/shell-changes-view.ts
@@ -29,7 +29,6 @@ const ROLE = {
 	PATH_IDLE: "muted",
 	ADDED: "success",
 	REMOVED: "error",
-	NEW: "success",
 	HUNK: "customMessageLabel",
 	KEY: "accent",
 	KEY_TEXT: "dim",
@@ -66,11 +65,20 @@ export function colorDiff(text: string, theme: ChangesViewTheme): string[] {
 	return lines;
 }
 
+const FILE_STATUS = {
+	[CHANGE_STATUS.MODIFIED]: "M",
+	[CHANGE_STATUS.ADDED]: "A",
+	[CHANGE_STATUS.DELETED]: "D",
+	[CHANGE_STATUS.RENAMED]: "R",
+	[CHANGE_STATUS.UNTRACKED]: "??",
+} as const;
+
 function fileCounts(file: ChangedFile, theme: ChangesViewTheme): string {
-	if (file.status === CHANGE_STATUS.UNTRACKED || file.status === CHANGE_STATUS.ADDED) {
-		return `${theme.fg(ROLE.ADDED, `+${file.added}`)} ${theme.fg(ROLE.NEW, "new")}`;
-	}
-	return `${theme.fg(ROLE.ADDED, `+${file.added}`)} ${theme.fg(ROLE.REMOVED, `−${file.deleted}`)}`;
+	return `${theme.fg(ROLE.ADDED, `+${file.added}`)} ${theme.fg(ROLE.REMOVED, `-${file.deleted}`)}`;
+}
+
+function fileLabel(file: ChangedFile, theme: ChangesViewTheme, role: string): string {
+	return `${theme.fg(role, `${FILE_STATUS[file.status]} ${displayText(file.path)}`)}  ${fileCounts(file, theme)}`;
 }
 
 function fit(text: string, width: number): string {
@@ -211,9 +219,9 @@ export class WorktreeChangesView {
 			const active = index + this.listOffset === this.selected;
 			const marker = active ? theme.fg(ROLE.SELECTED, "▸") : " ";
 			const text = row.file
-				? `  - ${displayText(row.file.path)}  ${fileCounts(row.file, theme)}`
-				: `${this.expanded.has(row.tree.root) ? "▾" : "▸"} ${displayText(row.tree.branch ?? "detached")} · ${displayText(basename(row.tree.root))}`;
-			return `${marker} ${theme.fg(active ? ROLE.SELECTED : ROLE.PATH_IDLE, text)}`;
+				? `  ${fileLabel(row.file, theme, active ? ROLE.SELECTED : ROLE.PATH_IDLE)}`
+				: theme.fg(active ? ROLE.SELECTED : ROLE.PATH_IDLE, `${this.expanded.has(row.tree.root) ? "▾" : "▸"} ${displayText(row.tree.branch ?? "detached")} · ${displayText(basename(row.tree.root))}`);
+			return `${marker} ${text}`;
 		};
 		const keys = theme.fg(ROLE.KEY_TEXT, "j/k select   enter toggle/open   ← parent/fold   ctrl+j/k scroll   r refresh   esc close");
 		return renderPanes(width, height, theme, `✎ Changes · ${this.trees.length} worktrees`, leftLine, preview, keys);
@@ -307,8 +315,7 @@ export class ChangesView {
 		if (!file) return "";
 		const theme = this.deps.theme;
 		const marker = row === this.selected ? theme.fg(ROLE.SELECTED, "▸") : " ";
-		const path = theme.fg(row === this.selected ? ROLE.PATH : ROLE.PATH_IDLE, file.path);
-		return `${marker} ${path}  ${fileCounts(file, theme)}`;
+		return `${marker} ${fileLabel(file, theme, row === this.selected ? ROLE.PATH : ROLE.PATH_IDLE)}`;
 	}
 
 	private visibleDiff(rows: number): string[] {

--- a/tests/shell-changes-view.test.ts
+++ b/tests/shell-changes-view.test.ts
@@ -75,7 +75,7 @@ test("worktree accordion keeps groups and nested files beside a framed lazy diff
 	assert.equal(lines.length, 10);
 	assert.match(lines[0], /^╭─ ✎ Changes/);
 	assert.match(lines[1], /^│   ▾ main · main +│ \+\/main:same.ts +│$/);
-	assert.match(lines[2], /^│ ▸   - same.ts +\+1 −0 +│/);
+	assert.match(lines[2], /^│ ▸   M same.ts +\+1 -0 +│/);
 	assert.match(lines[3], /^│   ▸ detached · linked +│/);
 	assert.match(lines[9], /^╰─+╯$/);
 	for (const line of lines) assert.equal(visibleWidth(line), 100);
@@ -83,7 +83,7 @@ test("worktree accordion keeps groups and nested files beside a framed lazy diff
 	component.handleInput("o");
 	component.handleInput("j");
 	assert.doesNotMatch(component.render(100).join("\n"), /\+\/main:same.ts/, "header selection clears unrelated preview");
-	assert.match(component.render(100)[2], /^│     - same.ts +\+1 −0 +│/, "unselected children retain their fixed marker and indentation");
+	assert.match(component.render(100)[2], /^│     M same.ts +\+1 -0 +│/, "unselected children retain their fixed marker and indentation");
 	component.handleInput(" ");
 	component.handleInput("j");
 	await settle();
@@ -190,7 +190,7 @@ test("accordion selection scrolls flattened rows and diff scrolling does not ope
 	component.handleInput(" ");
 	for (let index = 0; index < 20; index++) component.handleInput("j");
 	await settle();
-	assert.match(component.render(100).join("\n"), /▸   - file-19.ts/);
+	assert.match(component.render(100).join("\n"), /▸   M file-19.ts/);
 	component.handleInput("\x0a");
 	assert.match(component.render(100)[1], /\+line 5/);
 	component.handleInput("\x0b");
@@ -200,6 +200,43 @@ test("accordion selection scrolls flattened rows and diff scrolling does not ope
 		for (const line of component.render(width)) assert.ok(visibleWidth(line) <= width);
 	}
 });
+
+const statusCases = [
+	[CHANGE_STATUS.MODIFIED, "M", 2, 1],
+	[CHANGE_STATUS.ADDED, "A", 3, 0],
+	[CHANGE_STATUS.DELETED, "D", 0, 4],
+	[CHANGE_STATUS.RENAMED, "R", 0, 0],
+	[CHANGE_STATUS.UNTRACKED, "??", 5, 0],
+] as const;
+
+for (const [status, code, added, deleted] of statusCases) {
+	test(`both file lists render ${status} with colored signed counts`, () => {
+		const theme = {
+			fg(role: string, text: string) {
+				const color = role === "success" ? 32 : role === "error" ? 31 : 36;
+				return `\x1b[${color}m${text}\x1b[39m`;
+			},
+		};
+		const target = file("a.ts", added, deleted, status);
+		const accordion = new WorktreeChangesView([{ root: "/main", branch: "main", model: changesModel([target]) }], {
+			theme, rows: 10, loadDiff: async () => "", onOpen() {}, onClose() {}, onRefresh() {}, requestRender() {},
+		});
+		accordion.handleInput("\r");
+		const standalone = view({ theme }, [target]).view;
+		for (const selected of [false, true]) {
+			if (selected) accordion.handleInput("j");
+			for (const [component, row] of [[accordion, 2], [standalone, 1]] as const) {
+				const line = component.render(100)[row];
+				assert.ok(stripAnsi(line).includes(`${code} a.ts  +${added} -${deleted}`));
+				assert.ok(line.includes(`\x1b[32m+${added}\x1b[39m`), "addition uses success color");
+				assert.ok(line.includes(`\x1b[31m-${deleted}\x1b[39m`), "deletion uses error color");
+				for (const width of [8, 20, 40, 100]) {
+					for (const rendered of component.render(width)) assert.ok(visibleWidth(rendered) <= width);
+				}
+			}
+		}
+	});
+}
 
 test("colorDiff drops git headers and colors hunks, additions, and removals by role", () => {
 	const lines = colorDiff(DIFF_A, taggedTheme);
@@ -220,8 +257,8 @@ test("ChangesView renders a framed two-pane layout at the requested size", async
 	for (const line of lines) assert.equal(visibleWidth(line), 80, `"${stripAnsi(line)}" is not 80 wide`);
 	const plain = lines.map(stripAnsi);
 	assert.match(plain[0], /^╭─ ✎ Changes · 2 files · \+12 −1 ─+╮$/);
-	assert.match(plain[1], /^│ ▸ lib\/a\.ts +\+2 −1 +│ @@ -1,2 \+1,3 @@ +│$/);
-	assert.match(plain[2], /^│   lib\/b\.ts +\+10 new +│  const a = 1; +│$/);
+	assert.match(plain[1], /^│ ▸ M lib\/a\.ts +\+2 -1 +│ @@ -1,2 \+1,3 @@ +│$/);
+	assert.match(plain[2], /^│   A lib\/b\.ts +\+10 -0 +│  const a = 1; +│$/);
 	assert.match(plain[11], /^╰─+╯$/);
 	assert.match(plain[10], /j\/k file .* o open in editor .* esc close/);
 });
@@ -233,11 +270,11 @@ test("ChangesView loads the selected diff lazily and moves with j/k and arrows",
 	component.handleInput("j");
 	await settle();
 	assert.deepEqual(calls, ["lib/a.ts", "lib/b.ts"]);
-	assert.match(stripAnsi(component.render(80)[2]), /^│ ▸ lib\/b\.ts/);
+	assert.match(stripAnsi(component.render(80)[2]), /^│ ▸ A lib\/b\.ts/);
 	component.handleInput("\x1b[A");
-	assert.match(stripAnsi(component.render(80)[1]), /^│ ▸ lib\/a\.ts/);
+	assert.match(stripAnsi(component.render(80)[1]), /^│ ▸ M lib\/a\.ts/);
 	component.handleInput("k");
-	assert.match(stripAnsi(component.render(80)[1]), /^│ ▸ lib\/a\.ts/);
+	assert.match(stripAnsi(component.render(80)[1]), /^│ ▸ M lib\/a\.ts/);
 	assert.ok(events.filter((event) => event === "render").length >= 2);
 });
 
@@ -278,7 +315,7 @@ test("ChangesView.update keeps the selected file, reloads moved diffs, and survi
 
 	component.update(changesModel([file("lib/a.ts", 5, 1), file("lib/b.ts", 10, 0, CHANGE_STATUS.ADDED), file("lib/c.ts", 1, 0)]));
 	await settle();
-	assert.match(stripAnsi(component.render(80)[2]), /^│ ▸ lib\/b\.ts/);
+	assert.match(stripAnsi(component.render(80)[2]), /^│ ▸ A lib\/b\.ts/);
 	assert.deepEqual(calls, ["lib/a.ts", "lib/b.ts"], "unchanged selected file must not reload");
 	component.handleInput("k");
 	await settle();


### PR DESCRIPTION
## Linked issue
Closes #770

## PR type
- [x] New feature (`type:feature`)

## Summary
- Replace per-file dashes with Git status: M, A, D, R, or ?? for untracked files.
- Show consistent green additions and red deletions, including zero counts, in both changes lists.
- Preserve worktree grouping, navigation, and terminal-width handling.

## Changes
| File | Change |
| --- | --- |
| `lib/shell-changes-view.ts` | Share status and directional count rendering across both file lists. |
| `tests/shell-changes-view.test.ts` | Cover all five statuses, colors, zeros, and narrow widths; update row expectations. |

## Test plan
- [x] `node --experimental-strip-types --test tests/shell-changes.test.ts tests/shell-changes-view.test.ts` — 35 passed, 0 failed; repeated by parent.
- [x] `git diff --check` — passed.
- [x] Behavior-first evidence: RED 25 passed/10 intended failures; GREEN 35 passed/0 failed.
- [x] Native review approved and acknowledgement completed for the unchanged two-file candidate.
- [ ] GitHub CI checks — pending.

## Contributor checklist
- [x] Linked issue has `status:approved`.
- [x] Exactly one PR type label selected.
- [x] Conventional commit; no co-author trailers.
- Shellcheck: N/A, no shell scripts changed.
- Skills/docs: N/A, bounded existing UI rendering change.
- Interactive manual smoke test: not performed; production renderer exercised by focused tests.

## Rollback
Revert this single commit to restore the previous file labels and counters. No data model or Git parsing changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - File change lists now show clear status indicators, including modified, added, deleted, renamed, and untracked states.
  - Added and deleted file counts use consistent signed formatting with color-coded values.
  - Worktree and standalone change views now use the same file-row layout and styling.
  - Directory rows display selection states and navigation arrows more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->