### PR TITLE
feat(todo): keep collapse hints visible alongside stale status

### DIFF
--- a/lib/shell-todo.ts
+++ b/lib/shell-todo.ts
@@ -269,8 +269,9 @@ export function renderTodoCard(state: TodoState, theme: TodoTheme, width: number
 	if (state.tasks.length === 0) return [];
 	const { done, total } = todoSummary(state);
 	const stale = options.staleTurns >= STALE_AFTER_TURNS;
-	const hint = stale ? `stale · ${options.staleTurns} turns` : options.collapsed && options.collapseKey ? `${options.collapseKey} expand` : undefined;
-	const body = options.collapsed ? [collapsedRow(state, theme)] : bodyRows(state, theme);
+	const hint = options.collapseKey ? `${options.collapseKey} ${options.collapsed ? "expand" : "collapse"}` : undefined;
+	const rows = options.collapsed ? [collapsedRow(state, theme)] : bodyRows(state, theme);
+	const body = stale ? [theme.fg(NOTE_ROLE, `stale · ${options.staleTurns} turns`), ...rows] : rows;
 	return renderCard(
 		{ title: "Todos", subtitle: `${done} of ${total}`, body, tone: stale ? CARD_TONE.WARNING : CARD_TONE.INFO, glyph: TODO_GLYPH },
 		theme,

--- a/tests/gentle-todo.test.ts
+++ b/tests/gentle-todo.test.ts
@@ -92,7 +92,7 @@ test("the todo tool writes the list, shows the card after the call, and carries 
 	assert.equal((result.details.gentleTodo as { tasks: unknown[] }).tasks.length, 2);
 	await fire("tool_execution_end", ctx, { toolName: "todo" });
 	const lines = widget()!;
-	assert.match(lines[0], /^╭─ ❀ Todos · 0 of 2 ─+╮$/);
+	assert.match(lines[0], /^╭─ ❀ Todos · 0 of 2 ─+ ctrl\+shift\+t collapse ╮$/);
 	assert.match(lines[1], /◐ Write the parser · parsing/);
 	assert.match(lines[2], /○ Add tests/);
 	assert.equal(lines[lines.length - 1], "", "a blank line keeps the card off the prompt");
@@ -120,7 +120,8 @@ test("every turn carries the open tasks in the system prompt and the card goes s
 
 	const stale = (await fire("before_agent_start", ctx, { systemPrompt: "base" })) as { systemPrompt: string };
 	assert.match(stale.systemPrompt, /stale: 2 turns without an update/);
-	assert.match(widget()![0], /stale · 2 turns/);
+	assert.match(widget()![0], /ctrl\+shift\+t collapse/);
+	assert.match(widget()![1], /stale · 2 turns/);
 
 	await tools.get("todo")!.execute("c2", { action: "update", id: 1, status: "in_progress", note: "on it" }, undefined, undefined, ctx);
 	await fire("tool_execution_end", ctx, { toolName: "todo" });

--- a/tests/shell-todo.test.ts
+++ b/tests/shell-todo.test.ts
@@ -134,7 +134,7 @@ test("renderTodoCard draws the framed list with status glyphs and keeps every li
 	const lines = renderTodoCard(seeded(), plainTheme, 60, { collapsed: false, staleTurns: 0, collapseKey: "ctrl+shift+t" });
 	for (const line of lines) assert.equal(visibleWidth(line), 60, `"${stripAnsi(line)}" is not 60 wide`);
 	const plain = lines.map(stripAnsi);
-	assert.match(plain[0], /^╭─ ❀ Todos · 1 of 3 ─+╮$/);
+	assert.match(plain[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
 	assert.match(plain[1], /^│ ✓ ~Add quiet tool rendering~ +│$/);
 	assert.match(plain[2], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
 	assert.match(plain[3], /^│ ○ Show git bash tails +│$/);
@@ -157,14 +157,40 @@ test("renderTodoCard folds a long list: done tasks become one row and the open o
 	assert.match(folded[1], /^│ ✓ 40 done +│$/);
 });
 
-test("renderTodoCard marks a stale list in the top rule and collapses to the task in progress", () => {
-	const stale = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
-	assert.match(stale[0], /^╭─ ❀ Todos · 1 of 3 ─+ stale · 2 turns ╮$/);
-	const collapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
-	assert.equal(collapsed.length, 3);
-	assert.match(collapsed[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
-	assert.match(collapsed[1], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
+test("renderTodoCard keeps the configured collapse shortcut in the header while stale state remains visible", () => {
+	const freshExpanded = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
+	assert.match(freshExpanded[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
+
+	const freshCollapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
+	assert.equal(freshCollapsed.length, 3);
+	assert.match(freshCollapsed[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
+	assert.match(freshCollapsed[1], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
+
+	const staleExpanded = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
+	assert.match(staleExpanded[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(staleExpanded[1], /^│ stale · 2 turns +│$/);
+
+	const staleCollapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
+	assert.match(staleCollapsed[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
+	assert.match(staleCollapsed[1], /^│ stale · 2 turns +│$/);
+	assert.match(staleCollapsed[2], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
+
 	const idle = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "Only pending" }] }, 1).state;
 	assert.match(renderTodoCard(idle, plainTheme, 70, { collapsed: true, staleTurns: 0 }).map(stripAnsi)[1], /^│ ○ 1 open +│$/);
 	assert.deepEqual(renderTodoCard(emptyTodo(), plainTheme, 70, { collapsed: false, staleTurns: 0 }), []);
+});
+
+test("renderTodoCard uses custom shortcuts, omits disabled shortcuts, and remains width-safe when hints cannot fit", () => {
+	const custom = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 2, collapseKey: "alt+t" }).map(stripAnsi);
+	assert.match(custom[0], /alt\+t collapse/);
+	assert.match(custom[1], /stale · 2 turns/);
+
+	const disabled = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 2 }).map(stripAnsi);
+	assert.doesNotMatch(disabled[0], /(?:collapse|expand|ctrl\+shift\+t)/);
+	assert.match(disabled[1], /stale · 2 turns/);
+
+	for (const width of [0, 1, 2, 3, 4, 5, 8, 16]) {
+		const lines = renderTodoCard(seeded(), plainTheme, width, { collapsed: false, staleTurns: 2, collapseKey: "ctrl+shift+t" });
+		for (const line of lines) assert.equal(visibleWidth(line), width, `"${stripAnsi(line)}" is not ${width} wide`);
+	}
 });


### PR DESCRIPTION
## Linked issue

Refs #730 (part 1 only).

The collapse-hint work was approved in https://github.com/Gentleman-Programming/gentle-pi/issues/730#issuecomment-5591581552. This partial PR intentionally does not close #730: runtime hide/show remains pending interaction design.

## PR type

- [x] New feature

## Summary

- Show the configured collapse shortcut in the expanded Todo header and the expand shortcut in the collapsed header.
- Move the stale notice into the card body so it no longer replaces the shortcut hint.
- Preserve custom/disabled shortcut behavior and existing width-safe rendering.

## Changes

| File | Change |
| --- | --- |
| `lib/shell-todo.ts` | Separate shortcut hints from stale status rendering. |
| `tests/shell-todo.test.ts` | Cover fresh/stale and expanded/collapsed cards, custom/disabled keys, and narrow widths. |
| `tests/gentle-todo.test.ts` | Update integration expectations for header hints and stale-body placement. |

## Test plan

- [x] `node --experimental-strip-types --test tests/shell-todo.test.ts tests/gentle-todo.test.ts tests/shell-card.test.ts` (27 passed).
- [x] `git diff --check`.
- [x] Independent focused verification passed.
- [x] Manually tested the expanded hint and stale notice together in Pi.
- [x] Native review approved and acknowledged.

## Scope and limitations

- No runtime hide/show implementation or task persistence changes.
- Hints are omitted when the terminal is too narrow to fit them, preserving the existing card renderer behavior.
- No shell scripts or skills changed; shellcheck and skill-loading checks are not applicable.
- Full repository CI remains to be evaluated on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Todo cards now consistently show expand or collapse shortcut hints.
  - Stale status messages appear in the card body for clearer visibility.
  - Preserved correct rendering across expanded, collapsed, custom-shortcut, disabled-shortcut, and narrow-width layouts.

- **Tests**
  - Added coverage for shortcut hints and stale-state display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->