### PR TITLE
feat(agents): retain completed groups and add presence foundation

### DIFF
--- a/lib/agents-view.ts
+++ b/lib/agents-view.ts
@@ -141,6 +141,7 @@ export class AgentsView {
 	private footerPage = 0;
 	private readonly actionRegions = new Map<string, NativePointerRegion>();
 	private readonly expanded = new Map<string, boolean>();
+	private readonly observedActiveGroups = new Set<string>();
 	private listScroll = 0;
 	private readonly manualListOffsets = new Map<string, number>();
 	private scope: ViewScope;
@@ -459,6 +460,12 @@ export class AgentsView {
 	private refreshTasks(): void {
 		const now = this.deps.now();
 		this.tasks = this.deps.store.list().filter((task) => this.inScope(task, now));
+		const groups = this.sessionGroups();
+		const present = new Set(groups.map((group) => group.id));
+		for (const id of this.observedActiveGroups) if (!present.has(id)) this.observedActiveGroups.delete(id);
+		for (const group of groups) {
+			if (group.tasks.some((task) => !isFinished(task.status))) this.observedActiveGroups.add(group.id);
+		}
 		const rows = this.allRows();
 		if (this.narrowGroup && !this.sessionGroups().some((group) => group.id === this.narrowGroup)) this.narrowGroup = undefined;
 		if (!this.selectedId || (!this.selectedTask() && !rows.some((row) => row.id === this.selectedId))) {
@@ -478,6 +485,9 @@ export class AgentsView {
 			const group = groups.get(id) ?? { id, sessionId, tasks: [] };
 			if (!groups.has(id)) groups.set(id, group);
 			group.tasks.push(task);
+		}
+		for (const group of groups.values()) {
+			group.tasks.sort((a, b) => b.createdAt - a.createdAt || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 		}
 		return [...groups.values()];
 	}
@@ -507,7 +517,7 @@ export class AgentsView {
 	}
 
 	private isExpanded(group: SessionGroup): boolean {
-		return this.expanded.get(group.id) ?? group.tasks.some((task) => !isFinished(task.status));
+		return this.expanded.get(group.id) ?? this.observedActiveGroups.has(group.id);
 	}
 
 	private setExpanded(group: SessionGroup, expanded: boolean): void {

--- a/lib/orchestrator-presence.ts
+++ b/lib/orchestrator-presence.ts
@@ -1,0 +1,337 @@
+import { createHash, randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+
+// Same-profile OS-user trust boundary, not an authorization channel. POSIX modes
+// restrict newly created storage; Windows deployments must supply their own ACLs.
+// Synchronous bounded I/O serializes publication/disposal without promise races.
+export const ACTIVITY_LIMIT = 16 * 1024 * 1024;
+const HEADER_LIMIT = 16 * 1024;
+const HASH = /^[a-f0-9]{64}$/;
+const UUID = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/;
+const STATUSES = ["running", "queued", "waiting", "completed", "failed", "cancelled", "timed_out"];
+type ObjectValue = Record<string, any>;
+/** Remote records belong in a separate read-only store, never the local TaskStore.
+ * Key them by (header.sessionHash, header.incarnation, summary.id), not bare task ID.
+ * The header supplies parent identity; callers project only that session's tasks. */
+export interface RemoteSummary {
+	id: string; agent: string; label: string; status: string; model: string;
+	createdAt: number; startedAt: number | null; endedAt: number | null; lastActivityAt: number;
+}
+export interface ActivityInput {
+	task: RemoteSummary;
+	thread: { version: number; dropped: number; items: readonly object[] };
+}
+export interface Activity { tasks: { summary: ActivityInput["task"]; thread: {
+	version: number; dropped: number; items: ObjectValue[];
+} }[] }
+export interface Target { sessionHash: string; incarnation: string }
+export interface Header extends Target {
+	schema: 1; label: string; heartbeat: number; generation: number;
+	counts: { running: number; queued: number; waiting: number; finished: number };
+	digest: string | null; unavailable: "activity-too-large" | null;
+}
+
+const object = (v: unknown): v is ObjectValue => !!v && typeof v === "object" && !Array.isArray(v);
+const integer = (v: unknown) => Number.isSafeInteger(v) && (v as number) >= 0;
+const keys = (v: ObjectValue, names: string[]) => Object.keys(v).length === names.length && names.every((k) => Object.hasOwn(v, k));
+const digest = (data: string | Buffer) => createHash("sha256").update(data).digest("hex");
+function label(text: string) {
+	const clean = stripVTControlCharacters(text).replace(/[\p{Cc}\p{Cf}]/gu, " ").replace(/\s+/g, " ").trim();
+	return Array.from(clean).slice(0, 120).join("").trimEnd();
+}
+const pick = (v: ObjectValue, names: string[]) => Object.fromEntries(names.map((k) => [k, v[k]]));
+const summaryTextKeys = ["id", "agent", "label", "status", "model"];
+const summaryKeys = [...summaryTextKeys, "createdAt", "startedAt", "endedAt", "lastActivityAt"];
+const toolKeys = ["kind", "callId", "name", "output", "running", "isError"];
+
+/** Retains every item and every output character; no prompt fallback or invocation
+ * args (which can embed subagent prompts), session metadata, or control handles.
+ * This is a field whitelist, not content redaction: retained text can contain secrets. */
+export function projectActivity(input: readonly ActivityInput[]): Activity {
+	const activity = { tasks: input.map(({ task, thread }) => ({
+		summary: pick(task, summaryKeys) as ActivityInput["task"],
+		thread: { version: thread.version, dropped: thread.dropped,
+			items: thread.items.map((item) => pick(item, (item as ObjectValue).kind === "tool" ? toolKeys : ["kind", "text"])) },
+	})) };
+	if (!validActivity(activity)) throw new Error("malformed-activity");
+	return activity;
+}
+
+function validActivity(value: unknown): value is Activity {
+	return object(value) && keys(value, ["tasks"]) && Array.isArray(value.tasks) && value.tasks.every((row: unknown) => {
+		if (!object(row) || !keys(row, ["summary", "thread"])) return false;
+		const { summary: s, thread: t } = row;
+		return object(s) && keys(s, summaryKeys) && summaryTextKeys.every((k) => typeof s[k] === "string") && STATUSES.includes(s.status)
+			&& integer(s.createdAt) && integer(s.lastActivityAt)
+			&& [s.startedAt, s.endedAt].every((time) => time === null || integer(time))
+			&& object(t) && keys(t, ["version", "dropped", "items"]) && integer(t.version) && integer(t.dropped)
+			&& Array.isArray(t.items) && t.items.every((item: unknown) => object(item) && (item.kind === "tool"
+				? keys(item, toolKeys) && ["callId", "name", "output"].every((k) => typeof item[k] === "string")
+					&& typeof item.running === "boolean" && typeof item.isError === "boolean"
+				: ["text", "thinking", "note"].includes(item.kind) && keys(item, ["kind", "text"]) && typeof item.text === "string"));
+	});
+}
+
+function validTarget(value: Target) {
+	return object(value) && typeof value.sessionHash === "string" && HASH.test(value.sessionHash)
+		&& typeof value.incarnation === "string" && UUID.test(value.incarnation);
+}
+function validHeader(h: unknown): h is Header {
+	if (!object(h) || !keys(h, ["schema", "sessionHash", "incarnation", "label", "heartbeat", "generation", "counts", "digest", "unavailable"])) return false;
+	return validTarget(h as Header) && h.schema === 1 && typeof h.label === "string" && h.label === label(h.label)
+		&& integer(h.heartbeat) && integer(h.generation) && h.generation > 0
+		&& object(h.counts) && keys(h.counts, ["running", "queued", "waiting", "finished"]) && Object.values(h.counts).every(integer)
+		&& ((h.unavailable === null && typeof h.digest === "string" && HASH.test(h.digest))
+			|| (h.unavailable === "activity-too-large" && h.digest === null));
+}
+function filename(target: Target, kind: "header" | "activity") {
+	if (!validTarget(target)) throw new Error("malformed");
+	return `${target.sessionHash}.${target.incarnation}.${kind}.json`;
+}
+
+function directory(path: string, privateMode = false, owned = privateMode) {
+	const stat = fs.lstatSync(path);
+	if (!stat.isDirectory() || stat.isSymbolicLink() || (owned && process.platform !== "win32"
+		&& ((stat.mode & (privateMode ? 0o077 : 0o022)) !== 0 || stat.uid !== process.getuid?.()))) throw new Error("unsafe-directory");
+}
+function rootFor(profile: string, create = false) {
+	const absolute = resolve(profile);
+	// Reject symlink ancestors too. The caller supplies an existing profile root.
+	for (let path = absolute;; path = dirname(path)) {
+		directory(path);
+		if (dirname(path) === path) break;
+	}
+	const shared = join(absolute, "gentle-agents");
+	const root = join(shared, "presence");
+	// History may already own a 0755 shared root. Never change its permissions.
+	for (const path of [shared, root]) {
+		if (create) {
+			try { fs.mkdirSync(path, { mode: 0o700 }); }
+			catch (error) { if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error; }
+		}
+		directory(path, path === root, true);
+	}
+	return root;
+}
+function regular(stat: fs.Stats) {
+	if (!stat.isFile() || stat.nlink !== 1 || (process.platform !== "win32" && stat.uid !== process.getuid?.())) throw new Error("unsafe-file");
+}
+function boundedRead(path: string, limit: number) {
+	const before = fs.lstatSync(path);
+	regular(before);
+	if (before.size > limit) throw new Error("oversized");
+	const fd = fs.openSync(path, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0) | (fs.constants.O_NONBLOCK ?? 0));
+	try {
+		const stat = fs.fstatSync(fd);
+		regular(stat);
+		if (stat.ino !== before.ino || stat.dev !== before.dev) throw new Error("unsafe-file");
+		if (stat.size > limit) throw new Error("oversized");
+		const bytes = Buffer.alloc(stat.size + 1);
+		let used = 0;
+		while (used < bytes.length) {
+			const count = fs.readSync(fd, bytes, used, bytes.length - used, null);
+			if (!count) break;
+			used += count;
+		}
+		if (used !== stat.size) throw new Error("changed-file");
+		return bytes.subarray(0, used);
+	} finally { fs.closeSync(fd); }
+}
+function reason(error: unknown) {
+	const code = (error as NodeJS.ErrnoException).code;
+	return code === "ENOENT" ? "missing" : code ? "io-error" : error instanceof SyntaxError ? "malformed" : (error as Error).message;
+}
+function atomicWrite(root: string, name: string, bytes: string) {
+	directory(root, true);
+	const destination = join(root, name);
+	try { regular(fs.lstatSync(destination)); }
+	catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+	const temp = join(root, `.${name}.${randomUUID()}.tmp`);
+	const fd = fs.openSync(temp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+	try {
+		try { fs.writeFileSync(fd, bytes); } finally { fs.closeSync(fd); }
+		fs.renameSync(temp, destination);
+	} finally {
+		try { fs.unlinkSync(temp); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+	}
+}
+
+export interface PresencePage {
+	entries: (Header & { recent: boolean })[];
+	scanned: number; rejected: number; overflow: boolean; unavailable?: string;
+}
+function emptyPage(): PresencePage {
+	return { entries: [], scanned: 0, rejected: 0, overflow: false };
+}
+
+/** A bounded, process-local continuation: each next() examines at most 128 entries.
+ * Exhaustion closes automatically; callers abandoning traversal must close in finally.
+ * Overflow means the page budget was exhausted; the next page may be empty.
+ * A stable directory is traversed once in OS order. Concurrent mutations can cause
+ * misses/duplicates: deduplicate activation keys and open a fresh cursor on refresh.
+ * This is not a snapshot or a liveness guarantee. No stale files are deleted. */
+export class PresenceCursor {
+	private dir?: fs.Dir;
+	private readonly profile: string;
+	private readonly identity: fs.Stats;
+	constructor(profile: string) {
+		this.profile = resolve(profile);
+		const root = rootFor(this.profile);
+		this.identity = fs.lstatSync(root);
+		this.dir = fs.opendirSync(root);
+	}
+	next(now = Date.now()): PresencePage {
+		const result = emptyPage();
+		if (!this.dir) return { ...result, unavailable: "closed" };
+		try {
+			const stat = fs.lstatSync(rootFor(this.profile));
+			if (stat.dev !== this.identity.dev || stat.ino !== this.identity.ino) throw new Error("changed-directory");
+			while (result.scanned < 128) {
+				const entry = this.dir.readSync();
+				if (!entry) { this.close(); return result; }
+				result.scanned++;
+				if (!entry.name.endsWith(".header.json") || entry.name.startsWith(".")) continue;
+				try {
+					const h = JSON.parse(boundedRead(join(this.dir.path, entry.name), HEADER_LIMIT).toString("utf8"));
+					if (!validHeader(h) || filename(h, "header") !== entry.name) throw new Error("malformed");
+					result.entries.push({ ...h, recent: now >= h.heartbeat && now - h.heartbeat <= 15_000 });
+				} catch { result.rejected++; }
+			}
+			result.overflow = true;
+		} catch (error) { result.unavailable = reason(error); this.close(); }
+		return result;
+	}
+	close() {
+		const dir = this.dir;
+		this.dir = undefined;
+		dir?.closeSync();
+	}
+}
+
+/** First-page convenience only. Use PresenceCursor when overflow is visible. */
+export function listPresence(profile: string, now = Date.now()): PresencePage {
+	try {
+		const cursor = new PresenceCursor(profile);
+		try { return cursor.next(now); } finally { cursor.close(); }
+	} catch (error) { return { ...emptyPage(), unavailable: reason(error) }; }
+}
+
+/** The selection pins both activation and generation; never fall back to another session. */
+export function readActivity(profile: string, selection: Header): { activity?: Activity; unavailable?: string } {
+	try {
+		// Directory list adds only this reader-owned display hint.
+		const { recent: _recent, ...h } = selection as Header & { recent?: boolean };
+		if (!validHeader(h)) throw new Error("malformed");
+		if (h.unavailable) return { unavailable: h.unavailable };
+		const bytes = boundedRead(join(rootFor(profile), filename(h, "activity")), ACTIVITY_LIMIT);
+		const value = JSON.parse(bytes.toString("utf8"));
+		if (object(value) && integer(value.generation) && value.generation !== h.generation) throw new Error("generation-mismatch");
+		if (digest(bytes) !== h.digest) throw new Error("digest-mismatch");
+		if (!object(value) || !keys(value, ["schema", "sessionHash", "incarnation", "generation", "activity"])
+			|| value.schema !== 1 || value.generation !== h.generation || value.sessionHash !== h.sessionHash
+			|| value.incarnation !== h.incarnation || !validActivity(value.activity)) throw new Error("malformed");
+		return { activity: value.activity };
+	} catch (error) { return { unavailable: reason(error) }; }
+}
+
+export class PresencePublisher {
+	readonly target: Readonly<Target>;
+	private readonly profile: string;
+	private readonly displayLabel: string;
+	private header!: Header;
+	private published = "";
+	private pending = "";
+	private timer?: ReturnType<typeof setTimeout>;
+	private heartbeat?: ReturnType<typeof setInterval>;
+	private disposed = false;
+	private owned = new Map<string, { dev: number; ino: number }>();
+	/** Timer I/O failures stop publication; consumers still apply the recent TTL. */
+	error?: string;
+
+	private constructor(options: { profile: string; sessionId: string; label: string }) {
+		this.profile = options.profile;
+		this.displayLabel = label(options.label);
+		this.target = Object.freeze({ sessionHash: digest(options.sessionId), incarnation: randomUUID() });
+	}
+	static start(options: { profile: string; sessionId: string; label: string; activity: readonly ActivityInput[] }) {
+		const publisher = new PresencePublisher(options);
+		try {
+			rootFor(options.profile, true);
+			publisher.pending = JSON.stringify(projectActivity(options.activity));
+			publisher.flush();
+			publisher.heartbeat = setInterval(() => publisher.guarded(() => publisher.publishHeader()), 5000);
+			publisher.heartbeat.unref();
+			return publisher;
+		} catch (error) { publisher.dispose(); throw error; }
+	}
+	/** Eagerly projects/serializes each supplied snapshot to detach caller-owned data.
+	 * Only disk publication is coalesced; callers should avoid unrelated invalidations. */
+	update(input: readonly ActivityInput[]) {
+		if (this.disposed) throw new Error("disposed");
+		const next = JSON.stringify(projectActivity(input));
+		if (next === this.pending) return;
+		this.pending = next;
+		if (!this.timer && next !== this.published) {
+			this.timer = setTimeout(() => {
+				this.timer = undefined;
+				this.guarded(() => this.flush());
+			}, 400);
+			this.timer.unref();
+		}
+	}
+	private guarded(action: () => void) {
+		if (this.disposed) return;
+		try { action(); } catch (error) { this.error = reason(error); this.dispose(); }
+	}
+	private write(kind: "header" | "activity", bytes: string) {
+		const root = rootFor(this.profile);
+		const name = filename(this.target, kind);
+		atomicWrite(root, name, bytes);
+		const { dev, ino } = fs.lstatSync(join(root, name));
+		this.owned.set(name, { dev, ino });
+	}
+	private publishHeader() {
+		const header = { ...this.header, heartbeat: Date.now() };
+		if (!validHeader(header)) throw new Error("malformed-header");
+		this.write("header", JSON.stringify(header));
+		this.header = header;
+	}
+	private flush() {
+		if (this.pending === this.published) return;
+		const activity: Activity = JSON.parse(this.pending);
+		const generation = (this.header?.generation ?? 0) + 1;
+		const bytes = JSON.stringify({ schema: 1, ...this.target, generation, activity });
+		const oversized = Buffer.byteLength(bytes) > ACTIVITY_LIMIT;
+		const counts = { running: 0, queued: 0, waiting: 0, finished: 0 };
+		for (const { summary } of activity.tasks) {
+			const status = summary.status;
+			if (status === "running" || status === "queued" || status === "waiting") counts[status]++;
+			else counts.finished++;
+		}
+		if (!oversized) this.write("activity", bytes);
+		this.header = { schema: 1, ...this.target, label: this.displayLabel, heartbeat: Date.now(), generation,
+			counts, digest: oversized ? null : digest(bytes), unavailable: oversized ? "activity-too-large" : null };
+		this.publishHeader();
+		this.published = this.pending;
+	}
+	/** Idempotent, non-recursive cleanup, limited to files this activation published.
+	 * Replaced or linked files are deliberately left for their owner to handle. */
+	dispose() {
+		if (this.disposed) return;
+		this.disposed = true;
+		clearTimeout(this.timer);
+		clearInterval(this.heartbeat);
+		this.pending = this.published = "";
+		for (const [name, identity] of this.owned) {
+			try {
+				const path = join(rootFor(this.profile), name);
+				const stat = fs.lstatSync(path);
+				regular(stat);
+				if (stat.dev === identity.dev && stat.ino === identity.ino) fs.unlinkSync(path);
+			} catch { /* Never follow or remove a replacement when storage becomes unsafe. */ }
+		}
+		this.owned.clear();
+	}
+}

--- a/tests/agents-grouping.test.ts
+++ b/tests/agents-grouping.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { type TuiMouseEvent } from "@earendil-works/pi-tui";
 import { TASK_STATUS, TaskStore, type TaskRecord } from "../lib/agents-protocol.ts";
-import { AgentsView } from "../lib/agents-view.ts";
+import { AgentsView, SESSION_FINISHED_TTL_MS } from "../lib/agents-view.ts";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 
 const plainTheme = { fg: (_color: string, text: string) => text };
@@ -35,14 +35,14 @@ function task(id: string, parentSessionId: string, overrides: Partial<TaskRecord
 	};
 }
 
-function harness(rows = 12) {
+function harness(rows = 12, now = () => 10_000) {
 	const store = new TaskStore();
 	const view = new AgentsView({
 		theme: plainTheme,
 		rows,
 		store,
 		sessionId: "current-session-id",
-		now: () => 10_000,
+		now,
 		onCancel: () => {},
 		onOpen: () => {},
 		onClose: () => {},
@@ -94,7 +94,7 @@ test("AgentsView never infers unknown parent sessions and keeps manual terminal 
 
 test("AgentsView keeps headings non-actionable and clears a hidden selected child thread", () => {
 	const { store, view } = harness();
-	store.add(task("first", "current-session-id", { lastActivityAt: 200 }));
+	store.add(task("first", "current-session-id", { createdAt: 2000, lastActivityAt: 200 }));
 	store.add(task("child", "current-session-id", { lastActivityAt: 100 }));
 	assert.equal(view.selectedTask()?.id, "first", "the first visible child starts selected");
 	view.handleInput("k");
@@ -105,6 +105,55 @@ test("AgentsView keeps headings non-actionable and clears a hidden selected chil
 	assert.equal(view.selectedTask(), undefined, "expanding preserves heading focus until a child is selected");
 	view.handleInput("s");
 	view.handleInput("o");
+	view.dispose();
+});
+
+test("AgentsView retains observed live children until the session TTL and forgets absent groups", () => {
+	let now = 10_000;
+	const { store, view } = harness(12, () => now);
+	store.add(task("live", "current-session-id", { agent: "retained" }));
+	store.add(task("other", "other-session", { agent: "excluded" }));
+	store.apply("live", { type: "text", text: "kept thread" }, now);
+	store.update("live", { status: TASK_STATUS.COMPLETED, endedAt: now });
+	for (const elapsed of [0, SESSION_FINISHED_TTL_MS - 1]) {
+		now = 10_000 + elapsed;
+		const output = view.render(100).map(stripAnsi).join("\n");
+		assert.match(output, /Subagent retained/);
+		assert.match(output, /kept thread/);
+		assert.doesNotMatch(output, /excluded/);
+		assert.equal(view.selectedTask()?.id, "live");
+	}
+	now = 10_000 + SESSION_FINISHED_TTL_MS;
+	assert.doesNotMatch(view.render(100).join("\n"), /Subagent retained/);
+	assert.equal(view.selectedTask(), undefined);
+	store.add(task("archive", "current-session-id", { agent: "archived", status: TASK_STATUS.COMPLETED, endedAt: now }));
+	assert.doesNotMatch(view.render(100).join("\n"), /Subagent archived/, "absent groups lose implicit expansion");
+	view.dispose();
+});
+
+test("AgentsView respects explicit collapse after the final live child finishes", () => {
+	const { store, view } = harness();
+	store.add(task("live", "current-session-id", { agent: "hidden" }));
+	view.render(100);
+	view.handleInput("k");
+	view.handleInput("\x1b[D");
+	store.update("live", { status: TASK_STATUS.COMPLETED, endedAt: 10_000 });
+	assert.doesNotMatch(view.render(100).join("\n"), /Subagent hidden/);
+	view.handleInput("\x1b[C");
+	assert.match(view.render(100).join("\n"), /Subagent hidden/);
+	view.dispose();
+});
+
+test("AgentsView orders children by creation then ID, not renewed activity", () => {
+	const { store, view } = harness();
+	store.add(task("old", "current-session-id", { agent: "old", createdAt: 100 }));
+	store.add(task("b", "current-session-id", { agent: "new-b", createdAt: 200 }));
+	store.add(task("a", "current-session-id", { agent: "new-a", createdAt: 200 }));
+	store.update("old", { lastActivityAt: 20_000 });
+	const output = view.render(100).join("\n");
+	assert.ok(output.indexOf("Subagent new-a") < output.indexOf("Subagent new-b"));
+	assert.ok(output.indexOf("Subagent new-b") < output.indexOf("Subagent old"));
+	assert.equal(view.selectedTask()?.id, "old", "reordering preserves selection");
 	view.dispose();
 });
 

--- a/tests/orchestrator-presence.test.ts
+++ b/tests/orchestrator-presence.test.ts
@@ -1,0 +1,389 @@
+import assert from "node:assert/strict";
+import { fork } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { historyDir, saveTask } from "../lib/agents-history.ts";
+import { TASK_STATUS, TaskStore, type TaskRecord } from "../lib/agents-protocol.ts";
+import * as presence from "../lib/orchestrator-presence.ts";
+import {
+	ACTIVITY_LIMIT, PresencePublisher, listPresence, projectActivity, readActivity,
+} from "../lib/orchestrator-presence.ts";
+
+function fixture(t: test.TestContext) {
+	const profile = fs.mkdtempSync(join(fs.realpathSync(tmpdir()), "presence-test-"));
+	// Each fixture owns precisely these files; never traverse a linked directory.
+	t.after(() => {
+		const root = join(profile, "gentle-agents");
+		if (fs.existsSync(root) && !fs.lstatSync(root).isSymbolicLink()) {
+			for (const name of fs.readdirSync(root)) {
+				const path = join(root, name);
+				if (["tasks", "presence"].includes(name) && fs.lstatSync(path).isDirectory()) {
+					for (const file of fs.readdirSync(path)) fs.unlinkSync(join(path, file));
+					fs.rmdirSync(path);
+				} else fs.unlinkSync(path);
+			}
+			fs.rmdirSync(root);
+		} else if (fs.existsSync(root)) fs.unlinkSync(root);
+		for (const name of fs.readdirSync(profile)) fs.unlinkSync(join(profile, name));
+		fs.rmdirSync(profile);
+	});
+	return profile;
+}
+
+function rows(text = "full retained output") {
+	return [{ task: { id: "t", agent: "worker", label: "summary", status: "running", model: "model",
+		createdAt: 1000, startedAt: 1100, endedAt: null, lastActivityAt: 1200,
+		prompt: "PRIVATE_PROMPT", sessionPath: "/private/session", cwd: "/private/cwd", cancel: "CAPABILITY" },
+		thread: { version: 1, dropped: 2, items: [
+			{ kind: "text", text }, { kind: "thinking", text: "reasoning" }, { kind: "note", text: "note" },
+			{ kind: "tool", callId: "c", name: "read", output: "complete tool output", running: false,
+				isError: false, args: { prompt: "PRIVATE_PROMPT" }, sessionPath: "/private/session" },
+		] } }];
+}
+
+function realTask(): TaskRecord {
+	return { ...rows()[0].task, status: TASK_STATUS.RUNNING, mode: "task", parentSessionId: "same session",
+		thinking: undefined, error: null, result: null, lastStep: "read", turns: 0, toolCalls: 0, tokens: 0, cost: 0 };
+}
+
+function publisher(t: test.TestContext, profile: string, activity = rows()) {
+	const value = PresencePublisher.start({ profile, sessionId: "same session", label: "Workspace", activity });
+	t.after(() => value.dispose());
+	return value;
+}
+
+function paths(profile: string, header: { sessionHash: string; incarnation: string }) {
+	const stem = `${header.sessionHash}.${header.incarnation}`;
+	return { header: join(profile, "gentle-agents", "presence", `${stem}.header.json`),
+		activity: join(profile, "gentle-agents", "presence", `${stem}.activity.json`) };
+}
+
+function header(profile: string) {
+	const result = listPresence(profile);
+	assert.equal(result.unavailable, undefined);
+	assert.equal(result.entries.length, 1);
+	return result.entries[0];
+}
+
+if (process.env.PRESENCE_TEST_CHILD !== "1") {
+test("projection whitelists summaries and all retained text, excluding invocation payloads", () => {
+	const input = rows();
+	const projected = projectActivity(input);
+	const json = JSON.stringify(projected);
+	assert.doesNotMatch(json, /PRIVATE_PROMPT|private\/|CAPABILITY|sessionPath|cancel|args/);
+	assert.equal(projected.tasks[0].thread.items.length, 4);
+	assert.equal(projected.tasks[0].thread.dropped, 2);
+	input[0].thread.items[0].text = "mutated";
+	assert.equal(projected.tasks[0].thread.items[0].text, "full retained output");
+});
+
+test("headers are private, lightweight, sanitized and recent at the inclusive TTL boundary", (t) => {
+	t.mock.timers.enable({ apis: ["Date", "setInterval", "setTimeout"], now: 100_000 });
+	const profile = fixture(t);
+	const pub = PresencePublisher.start({ profile, sessionId: "/private/session", label: "\x1b[31mWork\nspace", activity: rows() });
+	t.after(() => pub.dispose());
+	const h = header(profile);
+	assert.equal(h.label, "Work space");
+	assert.equal(h.sessionHash, createHash("sha256").update("/private/session").digest("hex"));
+	assert.equal(h.counts.running, 1);
+	assert.doesNotMatch(fs.readFileSync(paths(profile, h).header, "utf8"), /private\/|full retained/);
+	assert.equal(listPresence(profile, 115_000).entries[0].recent, true);
+	assert.equal(listPresence(profile, 115_001).entries[0].recent, false);
+	assert.equal(listPresence(profile, 99_999).entries[0].recent, false);
+	if (process.platform !== "win32") {
+		assert.equal(fs.statSync(join(profile, "gentle-agents", "presence")).mode & 0o777, 0o700);
+		assert.equal(fs.statSync(paths(profile, h).header).mode & 0o777, 0o600);
+	}
+});
+
+test("long display labels remain schema-valid when clipping lands on whitespace or Unicode", (t) => {
+	const profile = fixture(t);
+	const pub = PresencePublisher.start({ profile, sessionId: "s", label: `${"a".repeat(119)} tail`, activity: [] });
+	assert.equal(header(profile).label, "a".repeat(119));
+	pub.dispose();
+	const unicode = PresencePublisher.start({ profile, sessionId: "s", label: "🟢".repeat(121), activity: [] });
+	t.after(() => unicode.dispose());
+	assert.equal(header(profile).label, "🟢".repeat(120));
+});
+
+test("updates coalesce, snapshot caller data, and heartbeat never serializes or replaces activity", (t) => {
+	t.mock.timers.enable({ apis: ["Date", "setInterval", "setTimeout"], now: 100_000 });
+	const profile = fixture(t);
+	const pub = publisher(t, profile);
+	const first = header(profile);
+	const path = paths(profile, first).activity;
+	const original = fs.readFileSync(path, "utf8");
+	const inode = fs.statSync(path).ino;
+	pub.update(rows());
+	const stringify = JSON.stringify;
+	const serialization = t.mock.method(JSON, "stringify", (value: any) => {
+		assert.equal(value?.activity ?? value?.tasks, undefined, "heartbeat must not serialize activity");
+		return stringify(value);
+	});
+	t.mock.timers.tick(5000);
+	serialization.mock.restore();
+	assert.equal(header(profile).heartbeat, 105_000);
+	assert.equal(header(profile).generation, first.generation);
+	assert.equal(fs.statSync(path).ino, inode);
+	assert.equal(fs.readFileSync(path, "utf8"), original);
+	pub.update(rows("older"));
+	const latest = rows("latest");
+	pub.update(latest);
+	latest[0].thread.items[0].text = "caller mutation";
+	t.mock.timers.tick(399);
+	assert.equal(header(profile).generation, first.generation);
+	t.mock.timers.tick(1);
+	const next = header(profile);
+	assert.equal(next.generation, first.generation + 1);
+	assert.equal(readActivity(profile, next).activity?.tasks[0].thread.items[0].text, "latest");
+	assert.equal(readActivity(profile, first).unavailable, "generation-mismatch");
+	pub.update(rows("transient"));
+	pub.update(rows("latest"));
+	t.mock.timers.tick(400);
+	assert.equal(header(profile).generation, next.generation, "reverting a pending change publishes nothing");
+	pub.update(rows("discarded"));
+	pub.dispose();
+	t.mock.timers.tick(10_000);
+	assert.deepEqual(listPresence(profile).entries, []);
+	assert.throws(() => pub.update(rows()), /disposed/);
+});
+
+test("full under-limit payload is admitted; oversize is explicit and never truncated", (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+	const profile = fixture(t);
+	const text = "x".repeat(ACTIVITY_LIMIT - 2048);
+	const pub = publisher(t, profile, rows(text));
+	assert.equal(readActivity(profile, header(profile)).activity?.tasks[0].thread.items[0].text, text);
+	pub.update(rows("x".repeat(ACTIVITY_LIMIT)));
+	t.mock.timers.tick(400);
+	assert.equal(header(profile).unavailable, "activity-too-large");
+	assert.equal(readActivity(profile, header(profile)).unavailable, "activity-too-large");
+	pub.update(rows("recovered"));
+	t.mock.timers.tick(400);
+	assert.equal(readActivity(profile, header(profile)).activity?.tasks[0].thread.items[0].text, "recovered");
+});
+
+test("reader rejects malformed, oversized, wrong digest/schema and unsafe exact targets", (t) => {
+	const profile = fixture(t);
+	publisher(t, profile);
+	const h = header(profile);
+	const p = paths(profile, h);
+	const original = fs.readFileSync(p.activity);
+	fs.writeFileSync(p.activity, "{}");
+	assert.equal(readActivity(profile, h).unavailable, "digest-mismatch");
+	const malformed = Buffer.from('{"schema":1,"generation":1,"activity":{"tasks":[{}]}}');
+	fs.writeFileSync(p.activity, malformed);
+	assert.equal(readActivity(profile, { ...h, digest: createHash("sha256").update(malformed).digest("hex") }).unavailable, "malformed");
+	fs.writeFileSync(p.activity, Buffer.alloc(ACTIVITY_LIMIT + 1));
+	assert.equal(readActivity(profile, h).unavailable, "oversized");
+	assert.equal(readActivity(profile, { ...h, incarnation: "../../escape" }).unavailable, "malformed");
+	fs.writeFileSync(p.activity, original);
+	fs.writeFileSync(p.header, "{");
+	assert.equal(listPresence(profile).rejected, 1);
+	fs.writeFileSync(p.header, " ".repeat(16 * 1024 + 1));
+	assert.equal(listPresence(profile).rejected, 1);
+	const { recent: _recent, ...storedHeader } = h;
+	fs.writeFileSync(p.header, JSON.stringify({ ...storedHeader, sessionPath: "/private" }));
+	assert.equal(listPresence(profile).rejected, 1);
+	fs.writeFileSync(p.header, JSON.stringify({ ...storedHeader, sessionHash: "0".repeat(64) }));
+	assert.equal(listPresence(profile).rejected, 1, "header identity must match its basename");
+	const invalid = JSON.parse(original.toString("utf8"));
+	invalid.activity.tasks[0].thread.items[0].sessionPath = "/private";
+	const injected = JSON.stringify(invalid);
+	fs.writeFileSync(p.activity, injected);
+	assert.equal(readActivity(profile, { ...h, digest: createHash("sha256").update(injected).digest("hex") }).unavailable, "malformed");
+});
+
+test("bounded directory scan reports overflow and ignores partial/temp files", (t) => {
+	const profile = fixture(t);
+	publisher(t, profile);
+	const root = join(profile, "gentle-agents", "presence");
+	fs.writeFileSync(join(root, ".partial.tmp"), "{");
+	assert.equal(listPresence(profile).rejected, 0);
+	for (let i = 0; i < 130; i++) fs.writeFileSync(join(root, `junk-${i}`), "{}");
+	const result = listPresence(profile);
+	assert.equal(result.scanned, 128);
+	assert.equal(result.overflow, true);
+});
+
+test("symlinks, hardlinks, directories and non-private managed roots fail closed", { skip: process.platform === "win32" }, (t) => {
+	const profile = fixture(t);
+	const pub = publisher(t, profile);
+	const h = header(profile);
+	const p = paths(profile, h);
+	const outside = join(profile, "outside");
+	fs.writeFileSync(outside, "untouched");
+	fs.unlinkSync(p.activity);
+	fs.symlinkSync(outside, p.activity);
+	assert.equal(readActivity(profile, h).unavailable, "unsafe-file");
+	fs.unlinkSync(p.activity);
+	fs.linkSync(outside, p.activity);
+	assert.equal(readActivity(profile, h).unavailable, "unsafe-file");
+	pub.dispose();
+	assert.equal(fs.readFileSync(outside, "utf8"), "untouched");
+	assert.ok(fs.existsSync(p.activity), "cleanup refuses a replaced unsafe file");
+	fs.unlinkSync(p.activity);
+	fs.symlinkSync(outside, p.header);
+	assert.equal(listPresence(profile).rejected, 1);
+	fs.unlinkSync(p.header);
+	fs.linkSync(outside, p.header);
+	assert.equal(listPresence(profile).rejected, 1);
+	fs.unlinkSync(p.header);
+	fs.mkdirSync(p.activity);
+	assert.equal(readActivity(profile, h).unavailable, "unsafe-file");
+	fs.rmdirSync(p.activity);
+	fs.chmodSync(join(profile, "gentle-agents", "presence"), 0o755);
+	assert.equal(listPresence(profile).unavailable, "unsafe-directory");
+	fs.rmdirSync(join(profile, "gentle-agents", "presence"));
+	fs.symlinkSync(profile, join(profile, "gentle-agents", "presence"));
+	assert.equal(listPresence(profile).unavailable, "unsafe-directory");
+	assert.throws(() => publisher(t, profile), /unsafe-directory/);
+	fs.unlinkSync(join(profile, "gentle-agents", "presence"));
+	fs.chmodSync(join(profile, "gentle-agents"), 0o777);
+	assert.equal(listPresence(profile).unavailable, "unsafe-directory", "shared root cannot be writable by other users");
+	fs.chmodSync(join(profile, "gentle-agents"), 0o700);
+	fs.rmdirSync(join(profile, "gentle-agents"));
+	fs.symlinkSync(profile, join(profile, "gentle-agents"));
+	assert.throws(() => publisher(t, profile), /unsafe-directory/, "shared root cannot be a symlink");
+});
+
+test("publication failure stops timers without overwriting linked files or another activation", { skip: process.platform === "win32" }, (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout", "setInterval"] });
+	const profile = fixture(t);
+	const pub = publisher(t, profile);
+	const selected = header(profile);
+	const sibling = publisher(t, profile);
+	const target = paths(profile, selected).activity;
+	const outside = join(profile, "replacement");
+	fs.writeFileSync(outside, "untouched");
+	fs.unlinkSync(target);
+	fs.linkSync(outside, target);
+	pub.update(rows("must not publish"));
+	t.mock.timers.tick(400);
+	assert.equal(pub.error, "unsafe-file");
+	t.mock.timers.tick(10_000);
+	assert.equal(fs.readFileSync(outside, "utf8"), "untouched");
+	assert.deepEqual(listPresence(profile).entries.map((h) => h.incarnation), [sibling.target.incarnation]);
+	assert.equal(readActivity(profile, selected).unavailable, "unsafe-file");
+});
+
+test("history created under umask 022 coexists with a dedicated private presence namespace", async (t) => {
+	const profile = fixture(t);
+	const store = new TaskStore();
+	const task = realTask();
+	store.add(task);
+	const mask = process.umask(0o022);
+	try { await saveTask(historyDir(profile, profile), task, store.thread(task.id)); }
+	finally { process.umask(mask); }
+	const shared = join(profile, "gentle-agents");
+	const before = fs.statSync(shared).mode;
+	if (process.platform !== "win32") assert.equal(before & 0o777, 0o755);
+	const pub = publisher(t, profile);
+	assert.equal(fs.statSync(shared).mode, before, "must not chmod the shared history directory");
+	const privateRoot = join(shared, "presence");
+	assert.ok(fs.statSync(privateRoot).isDirectory());
+	if (process.platform !== "win32") assert.equal(fs.statSync(privateRoot).mode & 0o777, 0o700);
+	pub.dispose();
+	assert.ok(fs.existsSync(join(historyDir(profile, profile), `${task.id}.json`)));
+});
+
+test("real TaskStore projection preserves remote sorting/retention timestamps and header identity", (t) => {
+	const profile = fixture(t);
+	const store = new TaskStore();
+	const task = realTask();
+	store.add(task);
+	store.apply(task.id, { type: "text", text: "retained" }, 2000);
+	store.update(task.id, { status: TASK_STATUS.COMPLETED, endedAt: 2500 });
+	const activity = store.list(task.parentSessionId).map((task) => ({ task, thread: store.thread(task.id) }));
+	const projected = projectActivity(activity);
+	assert.throws(() => projectActivity([{ ...activity[0], task: { ...activity[0].task, endedAt: NaN } }]), /malformed-activity/);
+	assert.deepEqual(projected.tasks[0].summary, { id: "t", agent: "worker", label: "summary", model: "model",
+		status: TASK_STATUS.COMPLETED, createdAt: 1000, startedAt: 1100, endedAt: 2500, lastActivityAt: 2000 });
+	const pub = PresencePublisher.start({ profile, sessionId: task.parentSessionId, label: "Work", activity });
+	t.after(() => pub.dispose());
+	const h = header(profile);
+	assert.equal(h.sessionHash, createHash("sha256").update(task.parentSessionId).digest("hex"));
+	assert.deepEqual(readActivity(profile, h).activity, projected);
+	assert.doesNotMatch(JSON.stringify(projected), /parentSessionId|PRIVATE_PROMPT|sessionPath|cwd|cancel|args/);
+});
+
+test("bounded continuation reaches a live peer beyond 128 stale headers without deleting them", (t) => {
+	const profile = fixture(t);
+	const pub = publisher(t, profile);
+	const { recent: _recent, ...base } = header(profile);
+	pub.dispose();
+	const root = join(profile, "gentle-agents", "presence");
+	fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+	for (let i = 0; i < 140; i++) {
+		const h = { ...base, incarnation: randomUUID(), heartbeat: 0 };
+		fs.writeFileSync(join(root, `${h.sessionHash}.${h.incarnation}.header.json`), JSON.stringify(h));
+	}
+	// Choose the late peer from actual filesystem order, not lexical/insertion assumptions.
+	const fixtureDir = fs.opendirSync(root);
+	let late = "";
+	try {
+		for (let i = 0; i < 141; i++) {
+			const entry = fixtureDir.readSync();
+			if (!entry) break;
+			late = entry.name;
+		}
+	} finally { fixtureDir.closeSync(); }
+	const live = { ...JSON.parse(fs.readFileSync(join(root, late), "utf8")), heartbeat: Date.now() };
+	fs.writeFileSync(join(root, late), JSON.stringify(live));
+	const cursor = new presence.PresenceCursor(profile);
+	t.after(() => cursor.close());
+	const first = cursor.next();
+	assert.equal(first.scanned, 128);
+	assert.equal(first.overflow, true);
+	assert.equal(first.entries.some((h) => h.recent), false);
+	const second = cursor.next();
+	assert.equal(second.scanned, 12);
+	assert.equal(second.overflow, false);
+	assert.deepEqual(second.entries.filter((h) => h.recent).map((h) => h.incarnation), [live.incarnation]);
+	assert.equal(cursor.next().unavailable, "closed");
+	assert.equal(fs.readdirSync(root).length, 140, "stale entries are not deleted");
+	const abandoned = new presence.PresenceCursor(profile);
+	abandoned.close();
+	abandoned.close();
+	assert.equal(abandoned.next().unavailable, "closed");
+	if (process.platform !== "win32") {
+		const unsafe = new presence.PresenceCursor(profile);
+		fs.chmodSync(root, 0o755);
+		assert.equal(unsafe.next().unavailable, "unsafe-directory");
+		assert.equal(unsafe.next().unavailable, "closed", "a failed cursor closes its handle");
+	}
+});
+}
+
+// Execute this same module in isolated Node processes, without an extra fixture file.
+if (process.env.PRESENCE_TEST_CHILD === "1") {
+	const pub = PresencePublisher.start({ profile: process.argv[2], sessionId: "shared", label: "Child", activity: rows() });
+	process.send?.(pub.target);
+	process.on("message", () => { pub.dispose(); process.exit(0); });
+} else {
+	test("two real processes with the same session ID stay distinct and clean up only their incarnation", async (t) => {
+		const profile = fixture(t);
+		const children = [0, 1].map(() => fork(new URL(import.meta.url), [profile], {
+			execArgv: ["--experimental-strip-types"], env: { PRESENCE_TEST_CHILD: "1" }, silent: true,
+		}));
+		t.after(() => { for (const child of children) if (child.exitCode === null) child.kill(); });
+		const targets = await Promise.all(children.map((child) => new Promise<any>((resolve, reject) => {
+			child.once("message", resolve);
+			child.once("error", reject);
+			child.once("exit", (code) => reject(new Error(`child exited before readiness: ${code}`)));
+		})));
+		assert.equal(targets[0].sessionHash, targets[1].sessionHash);
+		assert.notEqual(targets[0].incarnation, targets[1].incarnation);
+		assert.equal(listPresence(profile).entries.length, 2);
+		const survivor = listPresence(profile).entries.find((h) => h.incarnation === targets[1].incarnation)!;
+		assert.ok(readActivity(profile, survivor).activity);
+		await new Promise<void>((resolve) => { children[0].once("exit", () => resolve()); children[0].send("dispose"); });
+		assert.deepEqual(listPresence(profile).entries.map((h) => h.incarnation), [survivor.incarnation]);
+		assert.ok(readActivity(profile, survivor).activity);
+		await new Promise<void>((resolve) => { children[1].once("exit", () => resolve()); children[1].send("dispose"); });
+		assert.deepEqual(fs.readdirSync(join(profile, "gentle-agents", "presence")), []);
+	});
+}


### PR DESCRIPTION
Closes #785

## PR type
- [x] New feature (`type:feature`)

## Summary
- Keep groups observed active expanded after their final child completes, respecting explicit user collapse and the existing 15-minute session visibility window. Sort children newest-created-first with deterministic ID ties.
- Add an independent read-only, same-profile presence/activity foundation with per-activation identity, private atomic files, bounded cursor discovery and exact-generation snapshot reading.
- Cover existing history permissions, real TaskStore projection, late peers behind stale records, and two real processes sharing one session.

## Changes
| File | Change |
| --- | --- |
| `lib/agents-view.ts` | Preserve implicit live-group expansion and order child tasks by creation |
| `tests/agents-grouping.test.ts` | Completion, TTL, manual collapse and sorting regressions |
| `lib/orchestrator-presence.ts` | Presence publisher, whitelist projection, bounded cursor and exact-target reader |
| `tests/orchestrator-presence.test.ts` | Filesystem, schema, lifecycle and real-process coverage |

## Scope and non-goals
This is a FOUNDATION, not the complete All sessions feature. No publisher lifecycle wiring, live-session directory UI, remote TaskStore adapter, remote task controls, peer messaging, or new dependency is included. Existing child messaging stays unchanged. Card expiry and global disk-history retention are untouched.

A heartbeat younger than 15 seconds is recent activity evidence, not proof of process liveness. Activity is complete within a visible 16 MiB admission limit or explicitly unavailable; no silent slicing. Whitelisting excludes invocation args/session paths but does not redact secrets inside retained text.

## Verification
- [x] `node --experimental-strip-types --test tests/orchestrator-presence.test.ts`: 13 passed; independently rerun and parent spot-checked.
- [x] `node --experimental-strip-types --test tests/agents-grouping.test.ts tests/agents-view.test.ts tests/agents-widget.test.ts`: 40 passed; independently rerun.
- [x] `node scripts/verify-package-files.mjs`: 167 files and 68 byte-pinned artifacts passed.
- [x] `git diff --check`: passed; new files also checked before staging.
- [x] Behavioral RED/GREEN: completion/order 38 pass / 2 fail -> 40 pass; foundation compatibility/timestamps/continuation 10 pass / 3 fail -> 13 pass.
- [x] Native four-lens review `review-7dd5ec2e2647fb57` approved and acknowledged for the full four-file candidate.
- [ ] Full GitHub CI/packed installation: pending.
- [ ] Windows, performance benchmarks, and live manual TUI validation: not performed locally.

## Known limits
- Eager projection/serialization happens on each update; only disk publication coalesces. Synchronous I/O is not benchmarked.
- Cursor traversal is complete for a stable directory, not snapshot-consistent during mutations; callers must deduplicate, refresh and close abandoned cursors.
- Stale files are not reclaimed; continuation avoids fixed-first-page starvation.
- Windows relies on inherited profile ACLs, not POSIX permission guarantees.
- Remote adapter/ownership isolation is future integration work, not established by this foundation.

## Review budget and rollback
795 authored changed lines: retention 69, foundation 726. Maintainer explicitly approved up to 750 new foundation lines / 819 combined, retaining tests rather than compressing code. Two work-unit commits keep rollback boundaries independent: retention touches view/grouping tests; foundation consists solely of its two new files.

## Contributor checklist
- [x] Approved matching issue linked; exactly one type label.
- [x] Explicit size exception recorded and labeled.
- [x] Conventional commits with tests; no Co-Authored-By trailers.
- [x] Scripts/skills unchanged: shellcheck/skill-loading checks not applicable.
- [x] Foundation contract and limitations documented in source and this PR; no unimplemented UI behavior advertised in README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added orchestrator presence tracking, allowing active runs to publish status and recent activity for monitoring.
  * Added safe browsing and paging of available orchestrator presence information.
  * Preserved session group expansion after tasks finish.
  * Sorted tasks newest first, with deterministic ordering for matching timestamps.

* **Bug Fixes**
  * Explicitly collapsed session groups remain collapsed after child tasks complete.
  * Presence updates now handle malformed, oversized, stale, or unavailable data safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->