### PR TITLE
feat(review): make consent prompts concise and scannable

### DIFF
--- a/lib/review-consent-component.ts
+++ b/lib/review-consent-component.ts
@@ -1,0 +1,247 @@
+import {
+	isKeyRelease,
+	matchesKey,
+	type KeybindingsManager,
+	wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+
+export interface ReviewConsentAction {
+	readonly label: string;
+	readonly effect: string;
+}
+
+export interface ReviewConsentContent {
+	readonly headline: string;
+	readonly reason: string;
+	readonly value: string;
+	readonly risk: string;
+	readonly target: string;
+	readonly projection: string;
+	readonly evidence: readonly string[];
+	readonly ownership: string;
+	readonly offPathNote: string;
+	readonly offPathCommand: string;
+	readonly actions: readonly [ReviewConsentAction, ReviewConsentAction, ReviewConsentAction];
+}
+
+export interface ReviewConsentComponentTheme {
+	fg(color: "accent" | "dim" | "mdHeading" | "muted", text: string): string;
+	bold(text: string): string;
+}
+
+export interface ReviewConsentComponentOptions {
+	readonly content: ReviewConsentContent;
+	readonly theme: ReviewConsentComponentTheme;
+	readonly keybindings: KeybindingsManager | undefined;
+	readonly terminalRows: () => number;
+	readonly onSelect: (index: number) => void;
+	readonly onCancel: () => void;
+}
+
+type LineKind = "body" | "header" | "action";
+interface Line { text: string; kind: LineKind; action?: number; }
+
+function wrap(prefix: string, text: string, width: number): string[] {
+	if (width <= prefix.length) return wrapTextWithAnsi(prefix + text, width);
+	const indent = " ".repeat(prefix.length);
+	return wrapTextWithAnsi(text, width - prefix.length).map((line, index) => index === 0 ? prefix + line : indent + line);
+}
+
+export class ReviewConsentComponent {
+	private readonly options: ReviewConsentComponentOptions;
+	private selected = 0;
+	private mode: "actions" | "details" = "actions";
+	private detailsScroll = 0;
+	private actionScroll = 0;
+	private actionLines: Line[] = [];
+	private actionRanges: Array<{ start: number; end: number }> = [];
+	private details: Line[] = [];
+	private bodyHeight = 1;
+	private contextHeight = 1;
+	private actionHeight = 1;
+	private renderedWidth: number | undefined;
+	private renderedRows: number | undefined;
+	private canConfirm = false;
+
+	constructor(options: ReviewConsentComponentOptions) {
+		this.options = options;
+	}
+
+	getActionOptions(): readonly string[] {
+		return this.options.content.actions.map((action, index) => `${index + 1}. ${action.label}\nEffect: ${action.effect}`);
+	}
+
+	handleInput(data: string): void {
+		if (isKeyRelease(data)) return;
+		if (this.matches(data, "tui.select.cancel")) return this.options.onCancel();
+		if (data === "d" || data === "D") {
+			this.mode = this.mode === "actions" ? "details" : "actions";
+			this.detailsScroll = 0;
+			this.canConfirm = false;
+			return;
+		}
+		if (this.matches(data, "tui.select.confirm")) {
+			if (this.mode === "actions" && this.canConfirm) this.options.onSelect(this.selected);
+			return;
+		}
+		if (this.mode === "actions") {
+			if (this.matches(data, "tui.select.up")) this.moveSelection(-1);
+			else if (this.matches(data, "tui.select.down")) this.moveSelection(1);
+			return;
+		}
+		if (this.matches(data, "tui.select.up") || matchesKey(data, "pageUp")) this.detailsScroll -= this.matches(data, "tui.select.up") ? 1 : this.step();
+		else if (this.matches(data, "tui.select.down") || matchesKey(data, "pageDown")) this.detailsScroll += this.matches(data, "tui.select.down") ? 1 : this.step();
+		this.canConfirm = false;
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const rows = Math.max(1, this.options.terminalRows());
+		if (this.renderedWidth !== safeWidth || this.renderedRows !== rows) {
+			this.renderedWidth = safeWidth;
+			this.renderedRows = rows;
+			this.canConfirm = false;
+		}
+		const actions = this.buildActions(safeWidth);
+		this.actionLines = actions.lines;
+		this.actionRanges = actions.ranges;
+		this.details = this.buildDetails(safeWidth);
+		if (this.mode === "details") return this.renderDetailsScreen(safeWidth, rows);
+		if (rows < 8) return this.renderCompact(safeWidth, rows);
+		this.bodyHeight = rows;
+		return this.renderScreen(safeWidth).slice(0, rows);
+	}
+
+	invalidate(): void {}
+
+	private renderScreen(width: number): string[] {
+		const title = wrapTextWithAnsi("Review consent", width).map((line) => this.options.theme.fg("mdHeading", this.options.theme.bold(line)));
+		const wrappedHeadline = wrapTextWithAnsi(this.options.content.headline, width);
+		const question = this.options.content.headline === "Review consent" || wrappedHeadline.length > 2 ? [] : wrappedHeadline;
+		const reason = wrapTextWithAnsi(this.options.content.reason, width);
+		const footer = wrapTextWithAnsi("↑↓ choose · Enter confirm · Esc cancel · D details", width).map((line) => this.options.theme.fg("dim", line));
+		const primary = [...title, ...question, ...this.actionLines.map((line) => this.style(line)), "", ...footer];
+		const lines = [...title, ...question, ...reason, ...this.actionLines.map((line) => this.style(line)), "", ...footer];
+		const height = Math.min(20, this.bodyHeight);
+		if (lines.length > height) {
+			if (primary.length <= height) {
+				this.canConfirm = true;
+				return primary;
+			}
+			this.canConfirm = false;
+			return [...title, ...this.safeActions(width).map((line) => this.style(line))];
+		}
+		this.canConfirm = true;
+		return lines;
+	}
+
+	private renderDetailsScreen(width: number, rows: number): string[] {
+		const title = wrapTextWithAnsi("Details (read-only)", width).map((line) => this.options.theme.fg("mdHeading", this.options.theme.bold(line)));
+		const footer = wrapTextWithAnsi("PgUp/PgDn · D return · Esc", width).map((line) => this.options.theme.fg("dim", line));
+		const height = rows - title.length - footer.length;
+		if (height < 1) return wrapTextWithAnsi("Details; resize; D return; Esc cancel.", width).slice(0, rows);
+		this.contextHeight = height;
+		this.detailsScroll = Math.max(0, Math.min(this.detailsScroll, Math.max(0, this.details.length - height)));
+		return [...title, ...this.renderDetails(height), ...footer];
+	}
+
+	private renderActions(width: number, height: number): string[] {
+		const range = this.actionRanges[this.selected];
+		if (!range || range.end - range.start + 1 > height) {
+			this.canConfirm = false;
+			return this.safeActions(width).slice(0, height).map((line) => this.style(line));
+		}
+		if (range.start < this.actionScroll) this.actionScroll = range.start;
+		if (range.end >= this.actionScroll + height) this.actionScroll = range.end - height + 1;
+		this.actionScroll = Math.max(0, Math.min(this.actionScroll, Math.max(0, this.actionLines.length - height)));
+		this.canConfirm = range.start >= this.actionScroll && range.end < this.actionScroll + height;
+		return this.actionLines.slice(this.actionScroll, this.actionScroll + height).map((line) => this.style(line));
+	}
+
+	private renderDetails(height: number): string[] {
+		this.detailsScroll = Math.max(0, Math.min(this.detailsScroll, Math.max(0, this.details.length - height)));
+		return this.details.slice(this.detailsScroll, this.detailsScroll + height).map((line) => this.style(line));
+	}
+
+	private renderCompact(width: number, rows: number): string[] {
+		this.canConfirm = false;
+		return this.safeActions(width).slice(0, rows).map((line) => this.style(line));
+	}
+
+	private renderTiny(width: number, rows: number): string[] {
+		this.canConfirm = false;
+		return wrapTextWithAnsi("Resize; Esc cancel; Enter off.", width).slice(0, rows);
+	}
+
+	private buildActions(width: number): { lines: Line[]; ranges: Array<{ start: number; end: number }> } {
+		const lines: Line[] = [];
+		const ranges: Array<{ start: number; end: number }> = [];
+		const add = (prefix: string, text: string, kind: LineKind = "body", action?: number) => {
+			for (const value of wrap(prefix, text, width)) lines.push({ text: value, kind, action });
+		};
+		for (const [index, action] of this.options.content.actions.entries()) {
+			const start = lines.length;
+			add(`${index === this.selected ? "→ " : "  "}${index + 1}. `, action.label, "action", index);
+			ranges.push({ start, end: lines.length - 1 });
+		}
+		lines.push({ text: "", kind: "body" });
+		add("Effect: ", this.options.content.actions[this.selected].effect, "action", this.selected);
+		return { lines, ranges };
+	}
+
+	private safeActions(width: number): Line[] {
+		return [
+			...wrap("", "Resize; Esc cancel; Enter off.", width).map((text) => ({ text, kind: "body" as const })),
+			...wrap("", `Action ${this.selected + 1}/3 needs its full effect.`, width).map((text) => ({ text, kind: "action" as const, action: this.selected })),
+			...wrap("", "D opens details.", width).map((text) => ({ text, kind: "body" as const })),
+		];
+	}
+
+	private buildDetails(width: number): Line[] {
+		const lines: Line[] = [];
+		const add = (prefix: string, text: string, kind: LineKind = "body") => {
+			for (const value of wrap(prefix, text, width)) lines.push({ text: value, kind });
+		};
+		add("Provider headline: ", this.options.content.headline);
+		add("Reason: ", this.options.content.reason);
+		add("Value: ", this.options.content.value);
+		add("Risk: ", this.options.content.risk);
+		add("Target: ", this.options.content.target);
+		add("Projection: ", this.options.content.projection);
+		add("", "Risk evidence:");
+		for (const item of this.options.content.evidence) add("  - ", item);
+		add("Ownership: ", this.options.content.ownership);
+		add("Off-path note: ", this.options.content.offPathNote);
+		add("Off-path command: ", this.options.content.offPathCommand);
+		add("", "Action consequences (read-only):", "header");
+		for (const action of this.options.content.actions) {
+			add("Action: ", action.label);
+			add("Effect: ", action.effect);
+			lines.push({ text: "", kind: "body" });
+		}
+		return lines;
+	}
+
+	private moveSelection(delta: number): void {
+		this.selected = Math.max(0, Math.min(2, this.selected + delta));
+		this.canConfirm = false;
+	}
+
+	private style(line: Line): string {
+		if (line.kind === "header") return this.options.theme.fg("accent", this.options.theme.bold(line.text));
+		if (line.kind === "action" && line.action === this.selected) return this.options.theme.fg("accent", line.text);
+		return line.text;
+	}
+
+	private step(): number {
+		return Math.max(1, this.contextHeight - 1);
+	}
+
+	private matches(data: string, binding: "tui.select.up" | "tui.select.down" | "tui.select.confirm" | "tui.select.cancel"): boolean {
+		if (this.options.keybindings) return this.options.keybindings.matches(data, binding);
+		const key = binding === "tui.select.up" ? "up"
+			: binding === "tui.select.down" ? "down"
+				: binding === "tui.select.confirm" ? "enter" : "escape";
+		return matchesKey(data, key);
+	}
+}

--- a/lib/review-consent-ui.ts
+++ b/lib/review-consent-ui.ts
@@ -1,10 +1,14 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { ReviewConsentComponent, type ReviewConsentContent } from "./review-consent-component.ts";
 import type { ReviewConsentEnvelope, ReviewConsentV3 } from "./review-integration-v2.ts";
 
-export const HOST_REVIEW_SESSION_PERMISSION_LABEL = "Run this review and allow reviews for this Pi session";
+export const HOST_REVIEW_SESSION_PERMISSION_LABEL = "Review and allow this session";
 
 const HOST_REVIEW_SESSION_PERMISSION_EFFECT =
-	"Runs the provider's exact grant for this frozen candidate, then lets the Pi host use each later candidate's fresh validated provider grant once while this exact Pi session and canonical Git repository identity, including sibling worktrees, remain active. Reload keeps it; new, resume, fork, quit, process restart, or explicit revocation ends it. It grants no verdict, acknowledgement, maintenance, delivery, or cross-repository authority.";
+	"Reviews this change and allows later reviews in this session and repository; revoke anytime.";
+
+const HOST_REVIEW_SESSION_PERMISSION_OWNERSHIP =
+	"The first two actions are provider-owned and apply only to this candidate. The third action is owned by the Pi host. It runs the current provider grant for this frozen candidate and lets the host use one fresh validated provider grant for each later candidate while this exact Pi session and canonical Git repository identity, including sibling worktrees, remain active. Reload preserves it; new, resume, fork, quit, process restart, or explicit revocation ends it. It grants no verdict, acknowledgement, maintenance, delivery, or cross-repository authority.";
 
 export type ReviewConsentUiSelection =
 	| { kind: "provider"; answer: "granted" | "declined" }
@@ -13,6 +17,7 @@ export type ReviewConsentUiSelection =
 export interface ReviewConsentUiModel {
 	readonly title: string;
 	readonly options: readonly [string, string, string];
+	readonly content: ReviewConsentContent;
 }
 
 export function isPiConsentV3(consent: ReviewConsentEnvelope): consent is ReviewConsentV3 {
@@ -32,18 +37,36 @@ export function formatReviewConsentUi(consent: ReviewConsentV3): ReviewConsentUi
 		"Risk evidence:",
 		evidence,
 		"",
-		"Ownership: The first two actions are provider-owned and apply only to this candidate. The third action is owned by the Pi host and controls only an in-memory permission for this exact Pi session and canonical Git repository identity, including sibling worktrees.",
+		`Ownership: ${HOST_REVIEW_SESSION_PERMISSION_OWNERSHIP}`,
 		"",
 		`Off-path note: ${consent.offPath.note}`,
 		`Off-path command: ${consent.offPath.command}`,
 	].join("\n");
+	const options = [
+		`1. ${consent.choices[0].label}\nEffect: ${consent.choices[0].effect}`,
+		`2. ${consent.choices[1].label}\nEffect: ${consent.choices[1].effect}`,
+		`3. ${HOST_REVIEW_SESSION_PERMISSION_LABEL}\nEffect: ${HOST_REVIEW_SESSION_PERMISSION_EFFECT}`,
+	] as const;
 	return {
 		title,
-		options: [
-			`1. ${consent.choices[0].label}\nEffect: ${consent.choices[0].effect}`,
-			`2. ${consent.choices[1].label}\nEffect: ${consent.choices[1].effect}`,
-			`3. ${HOST_REVIEW_SESSION_PERMISSION_LABEL}\nEffect: ${HOST_REVIEW_SESSION_PERMISSION_EFFECT}`,
-		],
+		options,
+		content: {
+			headline: consent.headline,
+			reason: consent.reason,
+			value: consent.value,
+			risk: `${consent.riskLevel}; ${consent.changedFiles} changed file(s), ${consent.changedLines} changed line(s).`,
+			target: consent.targetIdentity,
+			projection: consent.projection,
+			evidence: consent.riskEvidence,
+			ownership: HOST_REVIEW_SESSION_PERMISSION_OWNERSHIP,
+			offPathNote: consent.offPath.note,
+			offPathCommand: consent.offPath.command,
+			actions: [
+				{ label: consent.choices[0].label, effect: consent.choices[0].effect },
+				{ label: consent.choices[1].label, effect: consent.choices[1].effect },
+				{ label: HOST_REVIEW_SESSION_PERMISSION_LABEL, effect: HOST_REVIEW_SESSION_PERMISSION_EFFECT },
+			],
+		},
 	};
 }
 
@@ -54,6 +77,28 @@ export async function presentReviewConsentUi(
 	if (!isPiConsentV3(consent)) return undefined;
 	const model = formatReviewConsentUi(consent);
 	try {
+		if (context.mode === "tui") {
+			return await context.ui.custom<ReviewConsentUiSelection | undefined>((tui, theme, keybindings, done) => {
+				const component = new ReviewConsentComponent({
+					content: model.content,
+					theme,
+					keybindings,
+					terminalRows: () => tui.terminal.rows,
+					onSelect: (index) => done(index === 0 ? { kind: "provider", answer: "granted" }
+						: index === 1 ? { kind: "provider", answer: "declined" } : { kind: "host-session" }),
+					onCancel: () => done(undefined),
+				});
+				return {
+					getActionOptions: () => component.getActionOptions(),
+					render: (width) => component.render(width),
+					invalidate: () => component.invalidate(),
+					handleInput: (data) => {
+						component.handleInput(data);
+						tui.requestRender();
+					},
+				};
+			});
+		}
 		const selected = await context.ui.select(model.title, [...model.options]);
 		if (selected === model.options[0]) return { kind: "provider", answer: "granted" };
 		if (selected === model.options[1]) return { kind: "provider", answer: "declined" };

--- a/tests/review-consent-ui.test.ts
+++ b/tests/review-consent-ui.test.ts
@@ -1,0 +1,352 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { ReviewConsentComponent } from "../lib/review-consent-component.ts";
+import { formatReviewConsentUi } from "../lib/review-consent-ui.ts";
+import { decodeReviewConsentV3 } from "../lib/review-integration-v2.ts";
+
+function consent() {
+	const path = join(process.cwd(), "tests", "fixtures", "devbinary", "consent-v3.captured.json");
+	const raw = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+	raw.agent = "pi";
+	return formatReviewConsentUi(decodeReviewConsentV3(raw, "pi"));
+}
+
+function createComponent(
+	rows: number,
+	selected: number[] = [],
+	cancelled: number[] = [],
+	content = consent().content,
+) {
+	return new ReviewConsentComponent({
+		content,
+		theme: { fg: (_color, text) => text, bold: (text) => text },
+		keybindings: undefined,
+		terminalRows: () => rows,
+		onSelect: (index) => selected.push(index),
+		onCancel: () => cancelled.push(1),
+	});
+}
+
+function joined(lines: string[]): string {
+	return lines.join(" ").replaceAll("→ ", "").replace(/\s+/g, " ");
+}
+
+function assertBounded(lines: string[], width: number, height: number): void {
+	assert.ok(lines.length <= height, `${width}x${height} must fit its terminal`);
+	for (const line of lines) assert.ok(visibleWidth(line) <= width, `${width}: ${line}`);
+}
+
+test("primary consent is compact by default and opens exact details only with D", () => {
+	const base = consent().content;
+	const content = {
+		...base,
+		headline: "Review this change now?",
+		reason: "This is the exact provider reason.",
+		actions: [
+			{ label: "Review this change", effect: "Reviews only this change; delivery stays separate." },
+			{ label: "Skip this time", effect: "Skips only this change; no preference is saved." },
+			{ label: "Review and allow this session", effect: "Reviews this change and permits later session reviews." },
+		] as typeof base.actions,
+	};
+	const selected: number[] = [];
+	const component = createComponent(24, selected, [], content);
+	const primary = component.render(80);
+	assertBounded(primary, 80, 24);
+	assert.deepEqual(component.render(80), primary, "80x24 is stable without terminal-height padding");
+	assert.deepEqual(createComponent(40, [], [], content).render(80), primary, "80x40 keeps the same compact primary content");
+	assert.ok(primary.length >= 9 && primary.length <= 12, "the concise fixture keeps its provider reason within the primary row budget");
+	assert.ok(joined(primary).includes(content.headline));
+	assert.ok(joined(primary).includes(content.reason), "the exact provider reason is visible without opening details");
+	assert.ok(!joined(primary).includes("CONTEXT"));
+	assert.ok(!joined(primary).includes("Provider headline:"));
+	for (const action of content.actions) assert.ok(joined(primary).includes(action.label));
+	assert.ok(joined(primary).includes(content.actions[0].effect));
+	assert.ok(!joined(primary).includes(content.actions[1].effect));
+	assert.match(joined(primary), /Enter confirm.*Esc cancel.*D details/);
+	component.handleInput("d");
+	const details = component.render(80);
+	assert.ok(joined(details).includes("Details (read-only)"));
+	assert.ok(joined(details).includes(content.reason));
+	assert.ok(joined(details).includes("Provider headline:"));
+	component.handleInput("\r");
+	assert.deepEqual(selected, [], "details cannot confirm");
+	component.handleInput("D");
+	component.handleInput("\r");
+	assert.deepEqual(selected, [], "returning to main recomputes its visible-confirm guard");
+	component.render(80);
+	component.handleInput("\r");
+	assert.deepEqual(selected, [0]);
+});
+
+test("context and complete effects precede enabled consent, while short terminals stay safe", () => {
+	const selected: number[] = [];
+	const full = createComponent(24, selected);
+	const initial = full.render(80);
+	const content = consent().content;
+	assertBounded(initial, 80, 24);
+	for (const text of [content.headline, content.actions[0].effect]) {
+		assert.ok(joined(initial).includes(text), `initial screen preserves ${text}`);
+	}
+	assert.ok(joined(initial).includes(content.reason), "primary keeps the exact provider reason visible");
+	assert.ok(!joined(initial).includes("CONTEXT"), "primary has no permanent context block");
+	full.handleInput("\r");
+	assert.deepEqual(selected, [0], "a complete visible grant may be confirmed");
+
+	for (const width of [20, 40, 80]) {
+		const shortSelected: number[] = [];
+		const cancelled: number[] = [];
+		const short = createComponent(7, shortSelected, cancelled);
+		const view = short.render(width);
+		assertBounded(view, width, 7);
+		assert.ok(joined(view).includes("Action 1/3"), "safe view names the unavailable action without partial labels");
+		assert.ok(joined(view).includes("Resize; Esc cancel; Enter off"), "safe view explains disabled confirmation");
+		short.handleInput("\r");
+		short.handleInput("\u001b");
+		assert.deepEqual(shortSelected, [], "compact screens never hide effects then confirm");
+		assert.deepEqual(cancelled, [1], "compact screens retain cancellation");
+	}
+
+	const tiny = createComponent(4);
+	const tinyView = tiny.render(20);
+	assertBounded(tinyView, 20, 4);
+	assert.ok(joined(tinyView).includes("Resize; Esc cancel; Enter off"), "tiny fallback leads with resize and cancellation guidance");
+	const oneRowCancelled: number[] = [];
+	const oneRow = createComponent(1, [], oneRowCancelled);
+	assert.ok(joined(oneRow.render(20)).includes("Resize; Esc cancel"), "one-row fallback leads with resize and cancellation guidance");
+	oneRow.handleInput("\u001b");
+	assert.deepEqual(oneRowCancelled, [1], "one-row fallback retains cancellation");
+});
+
+test("primary preserves provider risk reasons without paraphrasing", () => {
+	const base = consent().content;
+	for (const reason of [
+		"These changes may affect execution; review can help detect problems.",
+		"Security-sensitive changes need an authoritative review decision.",
+		"Behavior updates may warrant review before delivery.",
+	]) {
+		const primary = createComponent(24, [], [], { ...base, reason }).render(80);
+		assert.ok(joined(primary).includes(reason), `80x24 shows the exact provider reason: ${reason}`);
+		assert.ok(!joined(primary).includes("Reason:"), "primary does not add a context label around the reason");
+	}
+});
+
+test("selection anchors fitting effects despite long context and invalidates rapid confirmation", () => {
+	const base = consent().content;
+	const content = {
+		...base,
+		headline: "Question?",
+		reason: "long provider context ".repeat(200),
+		actions: [
+			{ label: "one", effect: "one effect" },
+			{ label: "two", effect: "two effect" },
+			{ label: "three", effect: "three effect" },
+		] as typeof base.actions,
+	};
+	const anchorActions = (width: number) => {
+		const selected: number[] = [];
+		const component = createComponent(24, selected, [], content);
+		assert.ok(!joined(component.render(width)).includes("long provider context"), `${width}x24 keeps provider context in details`);
+		assert.ok(joined(component.render(width)).includes(content.actions[0].effect), `${width}x24 keeps the selected consequence visible`);
+		component.handleInput("\r");
+		assert.deepEqual(selected, [0], "a separately visible complete action may confirm without scrolling the long context");
+		for (const [input, index, effect] of [
+			["\u001b[A", 0, content.actions[0].effect],
+			["\u001b[B", 1, content.actions[1].effect],
+			["\u001b[B", 2, content.actions[2].effect],
+		] as const) {
+			component.handleInput(input);
+			const before = [...selected];
+			component.handleInput("\r");
+			assert.deepEqual(selected, before, "rapid navigation invalidates confirmation");
+			assert.ok(joined(component.render(width)).includes(effect), `choice ${index + 1} anchors at ${width} columns`);
+			component.handleInput("\r");
+			assert.equal(selected.at(-1), index);
+		}
+		return { component, selected };
+	};
+	const { component, selected } = anchorActions(80);
+	anchorActions(40);
+	component.handleInput("d");
+	assert.ok(joined(component.render(80)).includes("long provider context"), "D opens complete provider context");
+	component.handleInput("D");
+	component.handleInput("\u001b[A");
+	component.render(60);
+	assert.ok(joined(component.render(80)).includes(content.actions[1].effect), "resize back anchors the selected consequence");
+
+	component.handleInput("d");
+	const details = component.render(12);
+	assertBounded(details, 12, 24);
+	component.handleInput("\r");
+	assert.deepEqual(selected, [0, 0, 1, 2], "details never confirm a hidden action");
+	let sawOffPath = false;
+	for (let row = 0; row < 200; row += 1) {
+		sawOffPath ||= joined(component.render(12)).includes("Off-path");
+		component.handleInput("\u001b[6~");
+	}
+	assert.ok(sawOffPath, "long fixture off-path details remain reachable");
+	const risk = createComponent(40);
+	risk.render(12);
+	risk.handleInput("d");
+	let sawRiskEvidence = false;
+	for (let row = 0; row < 200; row += 1) {
+		const riskDetails = risk.render(12);
+		assertBounded(riskDetails, 12, 40);
+		sawRiskEvidence ||= joined(riskDetails).includes("Risk evidence:");
+		risk.handleInput("\u001b[B");
+	}
+	assert.ok(sawRiskEvidence, "context scrolling exposes risk-evidence headings at twelve columns");
+	const original = consent().content;
+	const shortContent = {
+		...original,
+		reason: "short provider context",
+		value: "short provider value",
+		actions: [
+			{ label: "one", effect: "one" },
+			{ label: "two", effect: "two" },
+			{ label: "three", effect: "three" },
+		] as typeof original.actions,
+	};
+	assertBounded(createComponent(40, [], [], shortContent).render(12), 12, 40);
+
+	const oneLineDetails = createComponent(4);
+	oneLineDetails.render(20);
+	oneLineDetails.handleInput("d");
+	const before = oneLineDetails.render(20);
+	oneLineDetails.handleInput("\u001b[6~");
+	assert.notDeepEqual(oneLineDetails.render(20), before, "one-line details still page forward");
+
+	const resized = createComponent(7);
+	resized.render(80);
+	resized.handleInput("\u001b[B");
+	resized.handleInput("\u001b[B");
+	const resizedView = resized.render(20);
+	assertBounded(resizedView, 20, 7);
+	assert.ok(joined(resizedView).includes("Action 3/3"), "resize keeps the selected action identifiable without partial labels");
+	assert.ok(joined(resizedView).includes("Resize; Esc cancel; Enter off"), "resize disables hidden confirmation with guidance");
+});
+
+test("fixed title separates an enormous provider context from anchored consent actions", () => {
+	const base = consent().content;
+	const content = {
+		...base,
+		headline: "ENORMOUS PROVIDER HEADLINE: review authority for a frozen candidate needs explicit consent before any reviewer can inspect immutable evidence, with no summary substituted by Pi.",
+		reason: "The provider requires an explicit decision because the frozen candidate changes review-sensitive behavior and the user must see the complete reason before choosing.",
+		value: "A bounded review can identify candidate-caused defects while preserving ordinary repository delivery decisions and no automatic approval.",
+		evidence: [
+			"Risk evidence: the candidate changes authority-bearing review behavior.",
+			"Risk evidence: the provider recorded a scoped immutable target identity.",
+		],
+		offPathNote: "OFF PATH UNIQUE: cancellation declines this prompt only and does not change the review switch.",
+		actions: [
+			{ label: "Grant this frozen candidate review", effect: "GRANT UNIQUE: starts only this provider-bound review for the frozen candidate; it creates no delivery approval or standing permission." },
+			{ label: "Decline this frozen candidate review", effect: "DECLINE UNIQUE: declines only this candidate; no review starts and no preference is saved." },
+			{ label: "Grant one Pi-session review permission", effect: "SESSION UNIQUE: runs this exact provider grant, then permits later fresh validated candidates only for this Pi session and canonical repository identity; it grants no verdict, delivery, or cross-repository authority." },
+		] as typeof base.actions,
+	};
+	const selected: number[] = [];
+	const component = createComponent(24, selected, [], content);
+	const initial = component.render(80);
+	assertBounded(initial, 80, 24);
+	assert.equal(initial[0], "Review consent", "the visual title is app-owned and never becomes the provider headline");
+	assert.ok(!initial.includes("CONTEXT"), "provider fields are absent from the default primary");
+	assert.ok(!joined(initial).includes("Provider headline:"), "the provider headline is not a primary option");
+	assert.ok(joined(initial).includes("GRANT UNIQUE"), "the selected action's complete consequence is readable beside the context viewport");
+	component.handleInput("d");
+	for (let row = 0; row < 200; row += 1) component.handleInput("\u001b[6~");
+	const scrolled = component.render(80);
+	assertBounded(scrolled, 80, 24);
+	assert.equal(scrolled[0], "Details (read-only)", "details use their own fixed read-only title");
+	assert.ok(scrolled.includes("Details (read-only)"), "details retain a read-only heading while scrolling");
+	assert.ok(joined(scrolled).includes("OFF PATH UNIQUE"), "the complete provider context is recoverable through its viewport");
+	component.handleInput("\r");
+	assert.deepEqual(selected, [], "context details cannot confirm an action");
+	component.handleInput("D");
+	component.handleInput("\u001b[B");
+	const second = component.render(80);
+	assert.ok(joined(second).includes("DECLINE UNIQUE"), "navigation anchors each selected action's exact consequence");
+	component.handleInput("\r");
+	assert.deepEqual(selected, [1], "a rendered complete selected action remains confirmable after context recovery");
+
+	const tallComponent = createComponent(40, [], [], content);
+	tallComponent.render(80);
+	tallComponent.handleInput("\u001b[B");
+	tallComponent.handleInput("\u001b[B");
+	const tall = tallComponent.render(80);
+	assertBounded(tall, 80, 40);
+	assert.equal(tall[0], "Review consent", "80x40 keeps the same fixed brief title");
+	assert.ok(joined(tall).includes("SESSION UNIQUE"), "80x40 exposes the realistic session-permission consequence in the action area");
+});
+
+test("fixed title uses a heading token without recoloring context or selection", () => {
+	const foregrounds: Array<{ color: string; text: string }> = [];
+	const component = new ReviewConsentComponent({
+		content: consent().content,
+		theme: {
+			fg: (color, text) => {
+				foregrounds.push({ color, text });
+				return text;
+			},
+			bold: (text) => `**${text}**`,
+		},
+		keybindings: undefined,
+		terminalRows: () => 24,
+		onSelect: () => {},
+		onCancel: () => {},
+	});
+	const lines = component.render(80);
+	assert.equal(lines[0], "**Review consent**", "fixed title retains bold styling");
+	assert.deepEqual(foregrounds.find(({ text }) => text === "**Review consent**"), {
+		color: "mdHeading",
+		text: "**Review consent**",
+	}, "fixed title uses the heading semantic token");
+	assert.ok(foregrounds.some(({ color, text }) => color === "accent" && text.startsWith("→ 1.")), "selected action remains accent styled");
+	assert.ok(!foregrounds.some(({ text }) => text.startsWith("Provider headline:")), "common body remains unstyled");
+});
+
+test("oversized selected consequences stay complete in read-only context without enabling consent", () => {
+	const base = consent().content;
+	const effects = [
+		"OVERSIZED ONE BEGIN " + "one-context-token ".repeat(140) + "OVERSIZED_ONE_COMPLETE_END",
+		"OVERSIZED TWO BEGIN " + "two-context-token ".repeat(140) + "OVERSIZED_TWO_COMPLETE_END",
+		"OVERSIZED THREE BEGIN " + "three-context-token ".repeat(140) + "OVERSIZED_THREE_COMPLETE_END",
+	] as const;
+	const content = {
+		...base,
+		actions: [
+			{ label: "Oversized grant action", effect: effects[0] },
+			{ label: "Oversized decline action", effect: effects[1] },
+			{ label: "Oversized session action", effect: effects[2] },
+		] as typeof base.actions,
+	};
+	for (const rows of [24, 40]) {
+		const selected: number[] = [];
+		const component = createComponent(rows, selected, [], content);
+		const initial = component.render(80);
+		assertBounded(initial, 80, rows);
+		assert.ok(joined(initial).includes("Action 1/3 needs its full effect"), `${rows} rows uses safe action guidance for an oversized effect`);
+		component.handleInput("\r");
+		assert.deepEqual(selected, [], `${rows} rows never confirms a hidden oversized effect`);
+		component.handleInput("d");
+		let sawActionConsequences = false;
+		const visited = new Set<string>();
+		for (let page = 0; page < 700; page += 1) {
+			const view = component.render(80);
+			assertBounded(view, 80, rows);
+			const text = joined(view);
+			sawActionConsequences ||= text.includes("Action consequences");
+			for (const marker of ["OVERSIZED ONE BEGIN", "OVERSIZED_ONE_COMPLETE_END", "OVERSIZED TWO BEGIN", "OVERSIZED_TWO_COMPLETE_END", "OVERSIZED THREE BEGIN", "OVERSIZED_THREE_COMPLETE_END"]) {
+				if (text.includes(marker)) visited.add(marker);
+			}
+			component.handleInput("\u001b[B");
+		}
+		assert.ok(sawActionConsequences, `${rows} rows labels read-only action consequences in context`);
+		assert.deepEqual([...visited].sort(), ["OVERSIZED ONE BEGIN", "OVERSIZED_ONE_COMPLETE_END", "OVERSIZED THREE BEGIN", "OVERSIZED_THREE_COMPLETE_END", "OVERSIZED TWO BEGIN", "OVERSIZED_TWO_COMPLETE_END"].sort(), `${rows} rows exposes every oversized effect boundary through context paging`);
+		const afterDetails = component.render(80);
+		assert.ok(afterDetails.includes("Details (read-only)"), `${rows} rows retains a read-only details heading while paging`);
+		component.handleInput("\r");
+		assert.deepEqual(selected, [], `${rows} rows keeps details read-only after paging`);
+	}
+});

--- a/tests/review-session-standing-permission-controller.test.ts
+++ b/tests/review-session-standing-permission-controller.test.ts
@@ -41,6 +41,31 @@ function nonPiV3Consent() {
 	return decodeReviewConsentV3(consentFixture(), "claude-code");
 }
 
+function consentCustom(select: (title: string, options: string[]) => Promise<string | undefined>) {
+	return async (factory: (...args: never[]) => unknown) => {
+		let result: unknown;
+		const component = factory(
+			{ terminal: { rows: 24 }, requestRender() {} },
+			{ fg: (_color: string, text: string) => text, bold: (text: string) => text },
+			undefined,
+			(value: unknown) => { result = value; },
+		) as { getActionOptions(): readonly string[]; render(width: number): string[]; handleInput?(data: string): void };
+		component.render(80);
+		const options = [...component.getActionOptions()];
+		const selected = await select("", options);
+		const index = options.indexOf(selected ?? "");
+		if (index === -1) component.handleInput?.("\u001b");
+		else {
+			for (let current = 0; current < index; current += 1) {
+				component.handleInput?.("\u001b[B");
+				component.render(80);
+			}
+			component.handleInput?.("\r");
+		}
+		return result;
+	};
+}
+
 test("host UI preserves the complete provider envelope and adds a separately owned third action", () => {
 	const envelope = consent();
 	const before = structuredClone(envelope.raw);
@@ -54,9 +79,16 @@ test("host UI preserves the complete provider envelope and adds a separately own
 		assert.ok(model.options[index]!.includes(choice.label));
 		assert.ok(model.options[index]!.includes(choice.effect));
 	}
+	assert.equal(model.content.actions[2]?.label, "Review and allow this session");
+	assert.equal(model.content.actions[2]?.effect, "Reviews this change and allows later reviews in this session and repository; revoke anytime.");
 	assert.ok(model.options[2]!.includes(HOST_REVIEW_SESSION_PERMISSION_LABEL));
 	assert.match(model.title, /The first two actions are provider-owned and apply only to this candidate/);
 	assert.match(model.title, /The third action is owned by the Pi host/);
+	assert.match(model.content.ownership, /runs the current provider grant for this frozen candidate/);
+	assert.match(model.content.ownership, /one fresh validated provider grant for each later candidate/);
+	assert.match(model.content.ownership, /canonical Git repository identity, including sibling worktrees/);
+	assert.match(model.content.ownership, /Reload preserves it; new, resume, fork, quit, process restart, or explicit revocation ends it/);
+	assert.match(model.content.ownership, /no verdict, acknowledgement, maintenance, delivery, or cross-repository authority/);
 	assert.equal(envelope.choices.length, 2, "the decoded provider envelope must remain a two-choice contract");
 	assert.deepEqual(envelope.raw, before, "formatting must not mutate or append to the provider envelope");
 });
@@ -83,11 +115,27 @@ test("selection maps only exact displayed actions and cancellation or UI failure
 		undefined,
 	];
 	for (let index = 0; index < selections.length; index += 1) {
-		const ctx = { ui: { select: async () => selections[index] } } as unknown as ExtensionContext;
+		const ctx = { mode: "tui", ui: { custom: consentCustom(async () => selections[index]) } } as unknown as ExtensionContext;
 		assert.deepEqual(await presentReviewConsentUi(ctx, envelope), expected[index]);
 	}
-	const failed = { ui: { select: async () => { throw new Error("UI unavailable"); } } } as unknown as ExtensionContext;
+	const failed = { mode: "tui", ui: { custom: consentCustom(async () => { throw new Error("UI unavailable"); }) } } as unknown as ExtensionContext;
 	assert.equal(await presentReviewConsentUi(failed, envelope), undefined);
+});
+
+test("non-TUI selection preserves the existing action and cancellation mapping", async () => {
+	const envelope = consent();
+	const model = formatReviewConsentUi(envelope);
+	const selections = [model.options[0], model.options[1], model.options[2], undefined] as const;
+	const expected = [
+		{ kind: "provider", answer: "granted" },
+		{ kind: "provider", answer: "declined" },
+		{ kind: "host-session" },
+		undefined,
+	];
+	for (let index = 0; index < selections.length; index += 1) {
+		const ctx = { mode: "rpc", ui: { select: async () => selections[index] } } as unknown as ExtensionContext;
+		assert.deepEqual(await presentReviewConsentUi(ctx, envelope), expected[index]);
+	}
 });
 
 interface RegisteredTool {
@@ -253,7 +301,7 @@ function interactiveContext(cwd: string, manager: object, select: (title: string
 		mode: "tui",
 		hasUI: true,
 		sessionManager: Object.assign(manager, { getSessionId: () => sessionId }),
-		ui: { select, notify() {}, setStatus() {}, theme: { fg: (_color: string, text: string) => text } },
+		ui: { custom: consentCustom(select), notify() {}, setStatus() {}, theme: { fg: (_color: string, text: string) => text } },
 	} as unknown as ExtensionContext;
 }
 
@@ -484,7 +532,7 @@ test("headless, child, and changed post-UI identity never use host permission", 
 		hasUI: true,
 		sessionManager: manager,
 		ui: {
-			select: async (_title: string, options: string[]) => { manager.sessionId = "after"; return options[2]; },
+			custom: consentCustom(async (_title: string, options: string[]) => { manager.sessionId = "after"; return options[2]; }),
 			notify() {},
 			setStatus() {},
 			theme: { fg: (_color: string, text: string) => text },


### PR DESCRIPTION
## Linked issue

Closes #680

Companion provider copy change: Gentleman-Programming/gentle-ai#4417.

## PR type

- [x] New feature (`type:feature`)

## Summary

- Show a compact consent prompt with a contrasting title, the exact provider reason, three choices, and the selected consequence.
- Keep complete technical context available through **D**, while preventing confirmation of hidden or partially visible consequences.
- Preserve provider answers, session-permission boundaries, and the non-TUI/RPC selector fallback.

## Changes

| File | Change |
| --- | --- |
| `lib/review-consent-component.ts` | Compact, theme-aware TUI with bounded rendering, optional details, and safe selection. |
| `lib/review-consent-ui.ts` | Integrate TUI presentation and concise host-session wording; retain RPC behavior. |
| `tests/review-consent-ui.test.ts` | Rendering, visibility, detail access, resizing, and rapid-input regressions. |
| `tests/review-session-standing-permission-controller.test.ts` | Presentation and permission-lifecycle compatibility coverage. |

## Test plan

- [x] Focused consent, permission, and selector tests: **35 passed**; independently rerun.
- [x] Independent rendering probes: **20 combinations** of terminal width and height passed.
- [x] Provider-contract check passed.
- [x] Runtime-module check passed; all six generated modules match.
- [x] `pnpm test` exited successfully; Node tests reported **1844 passed, 10 skipped**.
- [x] Whitespace checks passed, including new files.
- [x] Maintainer manually evaluated the shared component through a local, display-only preview.
- [ ] Complete runtime-harness execution is not independently established: the process exited zero without a completion marker.

Tests used isolated configuration directories. This PR does not install or update the Gentle AI binary. The local preview command is intentionally excluded from production changes.

## Review scope

The maintainer explicitly approved `size:exception` for **716 changed lines (704 additions, 12 deletions)**. The component, integration, and behavior tests form one cohesive work unit; tests were not removed or compressed to meet a line budget.

RDD is disabled for this repository; delivery is unmanaged by RDD. Independent technical verification is recorded above, not a native review receipt.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Selected exactly one PR type.
- [x] Conventional commit; no attribution trailers.
- [x] No shell scripts, skills, dependency manifests, generated runtime modules, or permission state machines changed.
- [x] No merge or auto-merge is authorized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a terminal consent screen with selectable actions, confirmation safeguards, cancellation, and keyboard navigation.
  - Added a read-only details view showing rationale, risk, evidence, ownership, and alternative-path information.
  - Added responsive layouts for compact and constrained terminal sizes, including scrolling and context paging.
  - Clarified the distinction between provider-owned actions and host-owned session permissions.
- **Bug Fixes**
  - Prevented confirmation of actions with missing or incomplete consequences.
  - Preserved consent details and cancellation access on small terminals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->