### PR TITLE
fix(telemetry): hide Windows trigger console

### DIFF
--- a/lib/telemetry-trigger.ts
+++ b/lib/telemetry-trigger.ts
@@ -89,6 +89,7 @@ export interface TelemetryTriggerSpawnOptions {
 	cwd: string;
 	env: NodeJS.ProcessEnv;
 	detached: boolean;
+	windowsHide: boolean;
 	stdio: "ignore";
 }
 
@@ -129,6 +130,7 @@ export function spawnTelemetryTrigger(options: SpawnTelemetryTriggerOptions): Te
 			cwd: options.cwd,
 			env: options.env,
 			detached: true,
+			windowsHide: true,
 			stdio: "ignore",
 		});
 		child.on("error", () => {

--- a/runtime/telemetry-trigger.mjs
+++ b/runtime/telemetry-trigger.mjs
@@ -113,6 +113,7 @@ export function shouldTriggerTelemetry(env                                      
 
 
 
+
 /**
  * Nudges `<executable> telemetry trigger --json`, detached and
  * fire-and-forget. Never throws, never awaits the child's exit, and never
@@ -130,6 +131,7 @@ export function spawnTelemetryTrigger(options                              )    
 			cwd: options.cwd,
 			env: options.env,
 			detached: true,
+			windowsHide: true,
 			stdio: "ignore",
 		});
 		child.on("error", () => {

--- a/tests/telemetry-trigger.test.ts
+++ b/tests/telemetry-trigger.test.ts
@@ -73,7 +73,7 @@ test("shouldTriggerTelemetry: pure predicate table", () => {
 	}
 });
 
-test("spawnTelemetryTrigger: launches the expected argv, detached and stdio-ignored", () => {
+test("spawnTelemetryTrigger: launches the expected argv, detached, hidden, and stdio-ignored", () => {
 	const fake = fakeSpawn();
 	const result = spawnTelemetryTrigger({
 		executable: "/opt/gentle-ai/gentle-ai",
@@ -88,6 +88,7 @@ test("spawnTelemetryTrigger: launches the expected argv, detached and stdio-igno
 	assert.deepEqual(call.args, ["telemetry", "trigger", "--json"]);
 	assert.equal(call.options.cwd, "/work/project");
 	assert.equal(call.options.detached, true);
+	assert.equal(call.options.windowsHide, true);
 	assert.equal(call.options.stdio, "ignore");
 });
 
@@ -212,6 +213,7 @@ test("activation: spawns the telemetry trigger exactly once for a primary sessio
 	assert.deepEqual(call.args, ["telemetry", "trigger", "--json"]);
 	assert.equal(call.options.cwd, "/work/project");
 	assert.equal(call.options.detached, true);
+	assert.equal(call.options.windowsHide, true);
 	assert.equal(call.options.stdio, "ignore");
 });
 


### PR DESCRIPTION
Closes #708

This follows up on the closed approved issue: https://github.com/Gentleman-Programming/gentle-pi/issues/708#issuecomment-5607344231. Issue #762 covered subagent console spawning only; this PR covers the telemetry trigger path.

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Pass `windowsHide: true` when spawning the detached telemetry trigger.
- Preserve the generated runtime artifact and assert the spawn option in focused tests.

## Changes

| File | Change |
| --- | --- |
| `lib/telemetry-trigger.ts` | Hide the telemetry trigger process window on Windows. |
| `runtime/telemetry-trigger.mjs` | Regenerate the runtime implementation with the same spawn option. |
| `tests/telemetry-trigger.test.ts` | Verify direct and activation-triggered spawns set `windowsHide`. |

## Test Plan

- [x] 16 focused tests, runtime check, and diff check passed during independent verification.
- [x] Previous full suite result: 1858 passed, 10 skipped.
- [ ] Visual verification on Windows has not yet been performed.
- [ ] Receipt lifecycle is globally disabled by authorization and remains unmanaged.

## Contributor Checklist

- [x] Linked the approved issue #708.
- [ ] Added exactly one `type:*` label (pending explicit authorization for `type:bug`).
- [x] Used a conventional commit without `Co-Authored-By` trailers.
- [x] Generated runtime artifact is included with the source change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a console window from appearing on Windows when the telemetry trigger starts.
* **Tests**
  * Added coverage to verify that telemetry processes launch with hidden windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->