### PR TITLE
feat(sdd-profiles): profile catalog with agent categories and builtin presets

### DIFF
--- a/lib/sdd-profiles-catalog.ts
+++ b/lib/sdd-profiles-catalog.ts
@@ -1,0 +1,168 @@
+export type ReasoningEffort =
+	| "off"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
+
+export interface ModelProfileEntry {
+	model: string;
+	effort?: ReasoningEffort;
+}
+
+export interface Profile {
+	name: string;
+	description?: string;
+	default_model?: string;
+	default_effort?: ReasoningEffort;
+	model_profiles: Record<string, ModelProfileEntry>;
+	created_at?: string;
+	updated_at?: string;
+}
+
+export type ProfileScope = "builtin" | "global" | "project";
+
+export interface ProfileSummary {
+	name: string;
+	description?: string;
+	default_model?: string;
+	agent_count: number;
+	scope: ProfileScope;
+	is_active: boolean;
+	path?: string;
+}
+
+export interface SubagentsConfigFile {
+	default_model?: string;
+	default_effort?: string;
+	active_profile?: string;
+	model_profiles?: Record<string, { model: string; effort?: string }>;
+	[key: string]: unknown;
+}
+
+export interface AgentCategory {
+	id: string;
+	name: string;
+	description: string;
+	agents: string[];
+}
+
+export const SDD_AGENT_CATEGORIES: AgentCategory[] = [
+	{
+		id: "sdd-core",
+		name: "SDD Core",
+		description: "Spec-Driven Development phase executors",
+		agents: [
+			"sdd-explore",
+			"sdd-proposal",
+			"sdd-spec",
+			"sdd-design",
+			"sdd-tasks",
+			"sdd-apply",
+			"sdd-verify",
+			"sdd-archive",
+			"sdd-init",
+			"sdd-onboard",
+			"sdd-research",
+			"sdd-status",
+			"sdd-sync",
+		],
+	},
+	{
+		id: "judgment-day",
+		name: "Judgment Day",
+		description: "Blind dual review, judges, and fix",
+		agents: ["jd-judge-a", "jd-judge-b", "jd-fix-agent"],
+	},
+	{
+		id: "reviewers",
+		name: "Reviewers and Auditors",
+		description: "Quality, security, and architecture lenses",
+		agents: [
+			"security-auditor",
+			"review-readability",
+			"review-reliability",
+			"review-resilience",
+			"review-risk",
+		],
+	},
+	{
+		id: "general",
+		name: "General Harness",
+		description: "General subagents for exploration and coding tasks",
+		agents: [
+			"gentle-ai-explore",
+			"gentle-ai-worker",
+			"gentle-ai-verify",
+			"ui-specialist",
+			"task-tracker-manager",
+		],
+	},
+];
+
+export const ALL_KNOWN_AGENTS: string[] = SDD_AGENT_CATEGORIES.flatMap((c) => c.agents);
+
+export const BUILTIN_PROFILES: Record<string, Profile> = {
+	"gentle-default": {
+		name: "gentle-default",
+		description: "Quality/cost balance for Spec-Driven Development",
+		default_model: "anthropic/claude-sonnet-5",
+		default_effort: "medium",
+		model_profiles: {
+			"sdd-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-proposal": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-design": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-tasks": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"jd-judge-b": { model: "openai/gpt-5", effort: "high" },
+			"jd-fix-agent": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"gentle-ai-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"gentle-ai-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"gentle-ai-worker": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+		},
+	},
+	"gentle-economy": {
+		name: "gentle-economy",
+		description: "Speed and low cost for fast iterations and direct tasks",
+		default_model: "openai/gpt-5-mini",
+		default_effort: "low",
+		model_profiles: {
+			"sdd-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-proposal": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-design": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-tasks": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "openai/gpt-5-mini", effort: "medium" },
+			"jd-judge-b": { model: "openai/gpt-5-mini", effort: "medium" },
+			"jd-fix-agent": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+		},
+	},
+	"gentle-reasoning": {
+		name: "gentle-reasoning",
+		description: "Maximum reasoning effort on critical design and review phases",
+		default_model: "openai/gpt-5",
+		default_effort: "high",
+		model_profiles: {
+			"sdd-explore": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-verify": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-proposal": { model: "openai/gpt-5", effort: "max" },
+			"sdd-spec": { model: "openai/gpt-5", effort: "max" },
+			"sdd-design": { model: "openai/gpt-5", effort: "max" },
+			"sdd-tasks": { model: "openai/gpt-5", effort: "high" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "openai/gpt-5", effort: "max" },
+			"jd-judge-b": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"jd-fix-agent": { model: "openai/gpt-5", effort: "max" },
+		},
+	},
+};

--- a/tests/sdd-profiles-catalog.test.ts
+++ b/tests/sdd-profiles-catalog.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	ALL_KNOWN_AGENTS,
+	BUILTIN_PROFILES,
+	SDD_AGENT_CATEGORIES,
+} from "../lib/sdd-profiles-catalog.ts";
+
+const VERIFIED_ROSTER = [
+	"gentle-ai-explore",
+	"gentle-ai-verify",
+	"gentle-ai-worker",
+	"jd-fix-agent",
+	"jd-judge-a",
+	"jd-judge-b",
+	"review-readability",
+	"review-reliability",
+	"review-resilience",
+	"review-risk",
+	"sdd-apply",
+	"sdd-archive",
+	"sdd-design",
+	"sdd-explore",
+	"sdd-init",
+	"sdd-onboard",
+	"sdd-proposal",
+	"sdd-research",
+	"sdd-spec",
+	"sdd-status",
+	"sdd-sync",
+	"sdd-tasks",
+	"sdd-verify",
+	"security-auditor",
+	"task-tracker-manager",
+	"ui-specialist",
+];
+
+test("categories list every verified agent exactly once", () => {
+	const listed = SDD_AGENT_CATEGORIES.flatMap((c) => c.agents);
+	assert.deepEqual([...listed].sort(), [...VERIFIED_ROSTER].sort());
+	assert.equal(new Set(listed).size, listed.length);
+	for (const category of SDD_AGENT_CATEGORIES) {
+		assert.ok(category.id.length > 0);
+		assert.ok(category.agents.length > 0);
+	}
+});
+
+test("ALL_KNOWN_AGENTS equals flattened categories", () => {
+	assert.deepEqual(ALL_KNOWN_AGENTS, SDD_AGENT_CATEGORIES.flatMap((c) => c.agents));
+});
+
+test("stale and retired agents are absent", () => {
+	for (const retired of ["sdd-propose", "review-validator", "review-refuter"]) {
+		assert.ok(!ALL_KNOWN_AGENTS.includes(retired), `${retired} must not be listed`);
+	}
+});
+
+test("builtin presets have name, default_model, and non-empty model_profiles", () => {
+	for (const key of ["gentle-default", "gentle-economy", "gentle-reasoning"]) {
+		const profile = BUILTIN_PROFILES[key];
+		assert.ok(profile, `${key} must exist`);
+		assert.equal(profile.name, key);
+		assert.ok(profile.default_model && profile.default_model.includes("/"), `${key} needs a provider/id default_model`);
+		assert.ok(Object.keys(profile.model_profiles).length > 0, `${key} needs entries`);
+		for (const [agent, entry] of Object.entries(profile.model_profiles)) {
+			assert.ok(entry.model.includes("/"), `${key}.${agent} needs a provider/id model`);
+		}
+	}
+});
+
+test("every agent referenced in builtins exists in ALL_KNOWN_AGENTS", () => {
+	const known = new Set(ALL_KNOWN_AGENTS);
+	for (const [key, profile] of Object.entries(BUILTIN_PROFILES)) {
+		for (const agent of Object.keys(profile.model_profiles)) {
+			assert.ok(known.has(agent), `${key} references unknown agent ${agent}`);
+		}
+	}
+});


### PR DESCRIPTION
Related to #759 (part 1 of 10, closes with part 10).

## Summary
Pure data foundation for native SDD agent configuration profiles: shared types, role-aware agent categories covering the verified 26-agent roster, and three built-in presets (gentle-default, gentle-economy, gentle-reasoning). Zero dependencies on other new modules.

## Changes
- `lib/sdd-profiles-catalog.ts` (new, 168 lines)
- `tests/sdd-profiles-catalog.test.ts` (new, 78 lines)

## Test plan
`node --test tests/sdd-profiles-catalog.test.ts` — 5 pass, 0 fail.

## Chain (stacked, merge in order)
1. 📍 catalog (this PR) → 2. manager-pure → 3. manager-core → 4. manager-actions → 5. command → 6. integration → 7. command-scope → 8. view-shell → 9. view-editor → 10. footer (Closes #759)

## Checklist
- [x] Linked issue (`Related to #759`, approved feature)
- [x] Type: feature
- [x] Tests ship with the behavior they verify
- [x] No unrelated changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a catalog of Spec-Driven Development agents organized by category.
  * Added three built-in configuration profiles: `gentle-default`, `gentle-economy`, and `gentle-reasoning`.
  * Profiles now support per-agent model selection and reasoning-effort settings.
  * Added structured profile summaries and subagent configuration details for consistent setup and management.

* **Tests**
  * Added validation to ensure agent catalogs and built-in profiles remain complete, consistent, and reference only recognized agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->