### PR TITLE
feat(sdd-profiles): manager read core with precedence and tombstones

### DIFF
--- a/lib/sdd-profiles-catalog.ts
+++ b/lib/sdd-profiles-catalog.ts
@@ -1,0 +1,168 @@
+export type ReasoningEffort =
+	| "off"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
+
+export interface ModelProfileEntry {
+	model: string;
+	effort?: ReasoningEffort;
+}
+
+export interface Profile {
+	name: string;
+	description?: string;
+	default_model?: string;
+	default_effort?: ReasoningEffort;
+	model_profiles: Record<string, ModelProfileEntry>;
+	created_at?: string;
+	updated_at?: string;
+}
+
+export type ProfileScope = "builtin" | "global" | "project";
+
+export interface ProfileSummary {
+	name: string;
+	description?: string;
+	default_model?: string;
+	agent_count: number;
+	scope: ProfileScope;
+	is_active: boolean;
+	path?: string;
+}
+
+export interface SubagentsConfigFile {
+	default_model?: string;
+	default_effort?: string;
+	active_profile?: string;
+	model_profiles?: Record<string, { model: string; effort?: string }>;
+	[key: string]: unknown;
+}
+
+export interface AgentCategory {
+	id: string;
+	name: string;
+	description: string;
+	agents: string[];
+}
+
+export const SDD_AGENT_CATEGORIES: AgentCategory[] = [
+	{
+		id: "sdd-core",
+		name: "SDD Core",
+		description: "Spec-Driven Development phase executors",
+		agents: [
+			"sdd-explore",
+			"sdd-proposal",
+			"sdd-spec",
+			"sdd-design",
+			"sdd-tasks",
+			"sdd-apply",
+			"sdd-verify",
+			"sdd-archive",
+			"sdd-init",
+			"sdd-onboard",
+			"sdd-research",
+			"sdd-status",
+			"sdd-sync",
+		],
+	},
+	{
+		id: "judgment-day",
+		name: "Judgment Day",
+		description: "Blind dual review, judges, and fix",
+		agents: ["jd-judge-a", "jd-judge-b", "jd-fix-agent"],
+	},
+	{
+		id: "reviewers",
+		name: "Reviewers and Auditors",
+		description: "Quality, security, and architecture lenses",
+		agents: [
+			"security-auditor",
+			"review-readability",
+			"review-reliability",
+			"review-resilience",
+			"review-risk",
+		],
+	},
+	{
+		id: "general",
+		name: "General Harness",
+		description: "General subagents for exploration and coding tasks",
+		agents: [
+			"gentle-ai-explore",
+			"gentle-ai-worker",
+			"gentle-ai-verify",
+			"ui-specialist",
+			"task-tracker-manager",
+		],
+	},
+];
+
+export const ALL_KNOWN_AGENTS: string[] = SDD_AGENT_CATEGORIES.flatMap((c) => c.agents);
+
+export const BUILTIN_PROFILES: Record<string, Profile> = {
+	"gentle-default": {
+		name: "gentle-default",
+		description: "Quality/cost balance for Spec-Driven Development",
+		default_model: "anthropic/claude-sonnet-5",
+		default_effort: "medium",
+		model_profiles: {
+			"sdd-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-proposal": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-design": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-tasks": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"jd-judge-b": { model: "openai/gpt-5", effort: "high" },
+			"jd-fix-agent": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"gentle-ai-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"gentle-ai-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"gentle-ai-worker": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+		},
+	},
+	"gentle-economy": {
+		name: "gentle-economy",
+		description: "Speed and low cost for fast iterations and direct tasks",
+		default_model: "openai/gpt-5-mini",
+		default_effort: "low",
+		model_profiles: {
+			"sdd-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-proposal": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-design": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-tasks": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "openai/gpt-5-mini", effort: "medium" },
+			"jd-judge-b": { model: "openai/gpt-5-mini", effort: "medium" },
+			"jd-fix-agent": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+		},
+	},
+	"gentle-reasoning": {
+		name: "gentle-reasoning",
+		description: "Maximum reasoning effort on critical design and review phases",
+		default_model: "openai/gpt-5",
+		default_effort: "high",
+		model_profiles: {
+			"sdd-explore": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-verify": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-proposal": { model: "openai/gpt-5", effort: "max" },
+			"sdd-spec": { model: "openai/gpt-5", effort: "max" },
+			"sdd-design": { model: "openai/gpt-5", effort: "max" },
+			"sdd-tasks": { model: "openai/gpt-5", effort: "high" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "openai/gpt-5", effort: "max" },
+			"jd-judge-b": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"jd-fix-agent": { model: "openai/gpt-5", effort: "max" },
+		},
+	},
+};

--- a/lib/sdd-profiles-manager.ts
+++ b/lib/sdd-profiles-manager.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { resolveGentlePiAgentHome } from "./agent-home.ts";
+import type {
+	ModelProfileEntry,
+	Profile,
+	ProfileScope,
+	ProfileSummary,
+	ReasoningEffort,
+	SubagentsConfigFile,
+} from "./sdd-profiles-catalog.ts";
+import { ALL_KNOWN_AGENTS, BUILTIN_PROFILES } from "./sdd-profiles-catalog.ts";
+
+export function applyProfileToConfig(
+	currentConfig: SubagentsConfigFile,
+	profile: Profile,
+): SubagentsConfigFile {
+	const nextConfig: SubagentsConfigFile = { ...currentConfig };
+	if (profile.default_model) nextConfig.default_model = profile.default_model;
+	if (profile.default_effort) nextConfig.default_effort = profile.default_effort;
+	nextConfig.active_profile = profile.name;
+	nextConfig.model_profiles = { ...profile.model_profiles };
+	return nextConfig;
+}
+
+export function extractProfileFromConfig(
+	config: SubagentsConfigFile,
+	name: string,
+	description?: string,
+): Profile {
+	const now = new Date().toISOString();
+	const modelProfiles: Record<string, ModelProfileEntry> = {};
+	if (config.model_profiles && typeof config.model_profiles === "object") {
+		for (const [agent, val] of Object.entries(config.model_profiles)) {
+			if (val && typeof val === "object" && typeof (val as { model?: unknown }).model === "string") {
+				modelProfiles[agent] = {
+					model: (val as { model: string }).model,
+					effort: (val as { effort?: ReasoningEffort }).effort,
+				};
+			}
+		}
+	}
+	return {
+		name,
+		description: description ?? `Saved from subagents.json at ${now}`,
+		default_model: typeof config.default_model === "string" ? config.default_model : undefined,
+		default_effort:
+			typeof config.default_effort === "string" ? (config.default_effort as ReasoningEffort) : undefined,
+		model_profiles: modelProfiles,
+		created_at: now,
+		updated_at: now,
+	};
+}
+
+export function applyProfileToFile(filePath: string, profile: Profile): SubagentsConfigFile {
+	const dir = path.dirname(filePath);
+	if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+	let currentConfig: SubagentsConfigFile = {};
+	if (fs.existsSync(filePath)) {
+		try {
+			currentConfig = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+		} catch {
+			currentConfig = {};
+		}
+	}
+	const updatedConfig = applyProfileToConfig(currentConfig, profile);
+	const bytes = JSON.stringify(updatedConfig, null, 2) + "\n";
+	const temp = path.join(dir, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+	const fd = fs.openSync(temp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+	try {
+		try {
+			fs.writeFileSync(fd, bytes);
+		} finally {
+			fs.closeSync(fd);
+		}
+		fs.renameSync(temp, filePath);
+	} finally {
+		try {
+			fs.unlinkSync(temp);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
+	return updatedConfig;
+}
+
+const FALLBACK_MODELS = [
+	"anthropic/claude-sonnet-4-5",
+	"anthropic/claude-haiku-4-5",
+	"anthropic/claude-opus-4-6",
+	"openai/o3-mini",
+	"openai/gpt-4o",
+	"openai/gpt-4o-mini",
+	"google/gemini-2.5-flash",
+	"google/gemini-2.5-pro",
+];
+
+export async function resolveAvailableModels(ctx?: unknown): Promise<string[]> {
+	const modelSet = new Set<string>();
+	try {
+		const registry = (ctx as { modelRegistry?: { getAvailable?: () => Promise<unknown[]> } })
+			?.modelRegistry;
+		const registryModels = await registry?.getAvailable?.();
+		if (Array.isArray(registryModels)) {
+			for (const m of registryModels) {
+				const item = m as { provider?: string; providerId?: string; id?: string; model?: string };
+				const provider = item.provider ?? item.providerId;
+				const id = item.id ?? item.model;
+				if (provider && id) modelSet.add(`${provider}/${id}`);
+			}
+		}
+	} catch {}
+	const agentHome = resolveGentlePiAgentHome();
+	const modelsJsonPath = path.join(agentHome, "models.json");
+	if (fs.existsSync(modelsJsonPath)) {
+		try {
+			const data = JSON.parse(fs.readFileSync(modelsJsonPath, "utf-8")) as {
+				providers?: Record<string, { models?: Array<{ id?: string }> }>;
+			};
+			if (data?.providers && typeof data.providers === "object") {
+				for (const [provider, pData] of Object.entries(data.providers)) {
+					if (Array.isArray(pData?.models)) {
+						for (const m of pData.models) {
+							if (m?.id) modelSet.add(`${provider}/${m.id}`);
+						}
+					}
+				}
+			}
+		} catch {}
+	}
+	const storeJsonPath = path.join(agentHome, "models-store.json");
+	if (fs.existsSync(storeJsonPath)) {
+		try {
+			const data = JSON.parse(fs.readFileSync(storeJsonPath, "utf-8")) as Record<
+				string,
+				{ models?: Array<{ id?: string }> }
+			>;
+			if (typeof data === "object" && data !== null) {
+				for (const [provider, pData] of Object.entries(data)) {
+					if (Array.isArray(pData?.models)) {
+						for (const m of pData.models) {
+							if (m?.id) modelSet.add(`${provider}/${m.id}`);
+						}
+					}
+				}
+			}
+		} catch {}
+	}
+	for (const fallback of FALLBACK_MODELS) modelSet.add(fallback);
+	return Array.from(modelSet).sort((a, b) => a.localeCompare(b));
+}
+
+export interface ManagerOptions {
+	globalDir?: string;
+	projectDir?: string;
+	builtinsDir?: string;
+	activeStatePath?: string;
+	globalSubagentsPath?: string;
+	projectSubagentsPath?: string;
+}
+
+export function sanitizeProfileName(name: string): string {
+	return name.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "-");
+}
+

--- a/lib/sdd-profiles-manager.ts
+++ b/lib/sdd-profiles-manager.ts
@@ -164,3 +164,209 @@ export function sanitizeProfileName(name: string): string {
 	return name.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "-");
 }
 
+export class SddProfileManager {
+	readonly globalDir: string;
+	readonly projectDir: string;
+	readonly builtinsDir?: string;
+	readonly activeStatePath: string;
+	readonly globalSubagentsPath: string;
+	readonly projectSubagentsPath: string;
+
+	constructor(options: ManagerOptions = {}) {
+		const agentHome = resolveGentlePiAgentHome();
+		this.globalDir = options.globalDir ?? path.join(agentHome, "profiles");
+		this.projectDir = options.projectDir ?? path.join(process.cwd(), ".pi", "profiles");
+		this.builtinsDir = options.builtinsDir;
+		this.activeStatePath = options.activeStatePath ?? path.join(this.globalDir, ".active");
+		this.globalSubagentsPath = options.globalSubagentsPath ?? path.join(agentHome, "subagents.json");
+		this.projectSubagentsPath =
+			options.projectSubagentsPath ?? path.join(process.cwd(), ".pi", "subagents.json");
+	}
+
+	sanitizeName(name: string): string {
+		return sanitizeProfileName(name);
+	}
+
+	private getDeletedProfilesPath(): string {
+		return path.join(this.globalDir, ".deleted-profiles");
+	}
+
+	private getDeletedProfiles(): Set<string> {
+		const filePath = this.getDeletedProfilesPath();
+		if (!fs.existsSync(filePath)) return new Set();
+		try {
+			const raw = fs.readFileSync(filePath, "utf-8");
+			return new Set(raw.split("\n").map((s) => this.sanitizeName(s)).filter(Boolean));
+		} catch {
+			return new Set();
+		}
+	}
+
+	private addDeletedProfile(name: string): void {
+		const set = this.getDeletedProfiles();
+		set.add(this.sanitizeName(name));
+		try {
+			if (!fs.existsSync(this.globalDir)) fs.mkdirSync(this.globalDir, { recursive: true });
+			fs.writeFileSync(this.getDeletedProfilesPath(), Array.from(set).join("\n"), "utf-8");
+		} catch {}
+	}
+
+	private removeDeletedProfile(name: string): void {
+		const set = this.getDeletedProfiles();
+		const key = this.sanitizeName(name);
+		if (set.has(key)) {
+			set.delete(key);
+			try {
+				fs.writeFileSync(this.getDeletedProfilesPath(), Array.from(set).join("\n"), "utf-8");
+			} catch {}
+		}
+	}
+
+	private readProfilesFromDir(
+		dir: string,
+		scope: ProfileScope,
+	): Map<string, { profile: Profile; path: string }> {
+		const map = new Map<string, { profile: Profile; path: string }>();
+		if (!fs.existsSync(dir)) return map;
+		const deleted = scope === "builtin" ? this.getDeletedProfiles() : new Set<string>();
+		try {
+			for (const file of fs.readdirSync(dir)) {
+				if (!file.endsWith(".json") || file.startsWith(".")) continue;
+				const filePath = path.join(dir, file);
+				try {
+					const data = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Profile;
+					if (data && typeof data === "object" && data.name) {
+						const key = this.sanitizeName(data.name);
+						if (deleted.has(key)) continue;
+						map.set(key, { profile: data, path: filePath });
+					}
+				} catch {}
+			}
+		} catch {}
+		return map;
+	}
+
+	listProfiles(): ProfileSummary[] {
+		const deleted = this.getDeletedProfiles();
+		const merged = new Map<string, { profile: Profile; scope: ProfileScope; path?: string }>();
+		for (const [key, profile] of Object.entries(BUILTIN_PROFILES)) {
+			const norm = this.sanitizeName(key);
+			if (!deleted.has(norm)) merged.set(norm, { profile, scope: "builtin" });
+		}
+		if (this.builtinsDir) {
+			for (const [key, val] of this.readProfilesFromDir(this.builtinsDir, "builtin")) {
+				merged.set(key, { profile: val.profile, scope: "builtin", path: val.path });
+			}
+		}
+		for (const [key, val] of this.readProfilesFromDir(this.globalDir, "global")) {
+			merged.set(key, { profile: val.profile, scope: "global", path: val.path });
+		}
+		for (const [key, val] of this.readProfilesFromDir(this.projectDir, "project")) {
+			merged.set(key, { profile: val.profile, scope: "project", path: val.path });
+		}
+		const active = this.getActiveProfileName();
+		const out: ProfileSummary[] = [];
+		for (const item of merged.values()) {
+			out.push({
+				name: item.profile.name,
+				description: item.profile.description,
+				default_model: item.profile.default_model,
+				agent_count: Object.keys(item.profile.model_profiles ?? {}).length,
+				scope: item.scope,
+				is_active: Boolean(
+					active && this.sanitizeName(item.profile.name) === this.sanitizeName(active),
+				),
+				path: item.path,
+			});
+		}
+		return out.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	loadProfile(name: string): Profile | null {
+		const key = this.sanitizeName(name);
+		const projectPath = path.join(this.projectDir, `${key}.json`);
+		if (fs.existsSync(projectPath)) {
+			try {
+				return JSON.parse(fs.readFileSync(projectPath, "utf-8")) as Profile;
+			} catch {}
+		}
+		const globalPath = path.join(this.globalDir, `${key}.json`);
+		if (fs.existsSync(globalPath)) {
+			try {
+				return JSON.parse(fs.readFileSync(globalPath, "utf-8")) as Profile;
+			} catch {}
+		}
+		if (!this.getDeletedProfiles().has(key)) {
+			if (this.builtinsDir) {
+				const builtinPath = path.join(this.builtinsDir, `${key}.json`);
+				if (fs.existsSync(builtinPath)) {
+					try {
+						return JSON.parse(fs.readFileSync(builtinPath, "utf-8")) as Profile;
+					} catch {}
+				}
+			}
+			const builtin = BUILTIN_PROFILES[name] ?? BUILTIN_PROFILES[key];
+			if (builtin) return { ...builtin };
+		}
+		return null;
+	}
+
+	saveProfile(profile: Profile, scope: "global" | "project" = "global"): string {
+		const targetDir = scope === "project" ? this.projectDir : this.globalDir;
+		if (!fs.existsSync(targetDir)) fs.mkdirSync(targetDir, { recursive: true });
+		const key = this.sanitizeName(profile.name);
+		this.removeDeletedProfile(key);
+		const targetPath = path.join(targetDir, `${key}.json`);
+		const now = new Date().toISOString();
+		const payload: Profile = { ...profile, name: profile.name.trim(), updated_at: now };
+		if (!payload.created_at) payload.created_at = now;
+		const bytes = JSON.stringify(payload, null, 2) + "\n";
+		const temp = path.join(targetDir, `.${key}.${randomUUID()}.tmp`);
+		const fd = fs.openSync(temp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+		try {
+			try {
+				fs.writeFileSync(fd, bytes);
+			} finally {
+				fs.closeSync(fd);
+			}
+			fs.renameSync(temp, targetPath);
+		} finally {
+			try {
+				fs.unlinkSync(temp);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			}
+		}
+		return targetPath;
+	}
+
+	getActiveProfileName(): string | null {
+		if (fs.existsSync(this.projectSubagentsPath)) {
+			try {
+				const config = JSON.parse(
+					fs.readFileSync(this.projectSubagentsPath, "utf-8"),
+				) as SubagentsConfigFile;
+				if (typeof config.active_profile === "string" && config.active_profile.trim()) {
+					return config.active_profile.trim();
+				}
+			} catch {}
+		}
+		if (fs.existsSync(this.activeStatePath)) {
+			try {
+				const content = fs.readFileSync(this.activeStatePath, "utf-8").trim();
+				if (content) return content;
+			} catch {}
+		}
+		if (fs.existsSync(this.globalSubagentsPath)) {
+			try {
+				const config = JSON.parse(
+					fs.readFileSync(this.globalSubagentsPath, "utf-8"),
+				) as SubagentsConfigFile;
+				if (typeof config.active_profile === "string" && config.active_profile.trim()) {
+					return config.active_profile.trim();
+				}
+			} catch {}
+		}
+		return null;
+	}
+}

--- a/tests/sdd-profiles-catalog.test.ts
+++ b/tests/sdd-profiles-catalog.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	ALL_KNOWN_AGENTS,
+	BUILTIN_PROFILES,
+	SDD_AGENT_CATEGORIES,
+} from "../lib/sdd-profiles-catalog.ts";
+
+const VERIFIED_ROSTER = [
+	"gentle-ai-explore",
+	"gentle-ai-verify",
+	"gentle-ai-worker",
+	"jd-fix-agent",
+	"jd-judge-a",
+	"jd-judge-b",
+	"review-readability",
+	"review-reliability",
+	"review-resilience",
+	"review-risk",
+	"sdd-apply",
+	"sdd-archive",
+	"sdd-design",
+	"sdd-explore",
+	"sdd-init",
+	"sdd-onboard",
+	"sdd-proposal",
+	"sdd-research",
+	"sdd-spec",
+	"sdd-status",
+	"sdd-sync",
+	"sdd-tasks",
+	"sdd-verify",
+	"security-auditor",
+	"task-tracker-manager",
+	"ui-specialist",
+];
+
+test("categories list every verified agent exactly once", () => {
+	const listed = SDD_AGENT_CATEGORIES.flatMap((c) => c.agents);
+	assert.deepEqual([...listed].sort(), [...VERIFIED_ROSTER].sort());
+	assert.equal(new Set(listed).size, listed.length);
+	for (const category of SDD_AGENT_CATEGORIES) {
+		assert.ok(category.id.length > 0);
+		assert.ok(category.agents.length > 0);
+	}
+});
+
+test("ALL_KNOWN_AGENTS equals flattened categories", () => {
+	assert.deepEqual(ALL_KNOWN_AGENTS, SDD_AGENT_CATEGORIES.flatMap((c) => c.agents));
+});
+
+test("stale and retired agents are absent", () => {
+	for (const retired of ["sdd-propose", "review-validator", "review-refuter"]) {
+		assert.ok(!ALL_KNOWN_AGENTS.includes(retired), `${retired} must not be listed`);
+	}
+});
+
+test("builtin presets have name, default_model, and non-empty model_profiles", () => {
+	for (const key of ["gentle-default", "gentle-economy", "gentle-reasoning"]) {
+		const profile = BUILTIN_PROFILES[key];
+		assert.ok(profile, `${key} must exist`);
+		assert.equal(profile.name, key);
+		assert.ok(profile.default_model && profile.default_model.includes("/"), `${key} needs a provider/id default_model`);
+		assert.ok(Object.keys(profile.model_profiles).length > 0, `${key} needs entries`);
+		for (const [agent, entry] of Object.entries(profile.model_profiles)) {
+			assert.ok(entry.model.includes("/"), `${key}.${agent} needs a provider/id model`);
+		}
+	}
+});
+
+test("every agent referenced in builtins exists in ALL_KNOWN_AGENTS", () => {
+	const known = new Set(ALL_KNOWN_AGENTS);
+	for (const [key, profile] of Object.entries(BUILTIN_PROFILES)) {
+		for (const agent of Object.keys(profile.model_profiles)) {
+			assert.ok(known.has(agent), `${key} references unknown agent ${agent}`);
+		}
+	}
+});

--- a/tests/sdd-profiles-manager.test.ts
+++ b/tests/sdd-profiles-manager.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import type { Profile } from "../lib/sdd-profiles-catalog.ts";
+import {
+	applyProfileToConfig,
+	applyProfileToFile,
+	extractProfileFromConfig,
+	resolveAvailableModels,
+	sanitizeProfileName,
+} from "../lib/sdd-profiles-manager.ts";
+
+const PROFILE: Profile = {
+	name: "test-profile",
+	description: "Test profile",
+	default_model: "anthropic/claude-sonnet-5",
+	default_effort: "medium",
+	model_profiles: {
+		"sdd-explore": { model: "openai/gpt-5-mini", effort: "low" },
+		"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "high" },
+	},
+};
+test("apply preserves custom props and updates model_profiles", () => {
+	const current = {
+		timeout: 5000,
+		tools: ["read"],
+		default_model: "old/model",
+		model_profiles: { "sdd-explore": { model: "old/model" } },
+	};
+	const next = applyProfileToConfig(current, PROFILE);
+	assert.equal(next.timeout, 5000);
+	assert.deepEqual(next.tools, ["read"]);
+	assert.equal(next.default_model, "anthropic/claude-sonnet-5");
+	assert.equal(next.default_effort, "medium");
+	assert.equal(next.active_profile, "test-profile");
+	assert.deepEqual(next.model_profiles, PROFILE.model_profiles);
+	assert.notEqual(next.model_profiles, PROFILE.model_profiles);
+});
+
+test("apply without defaults leaves existing defaults alone", () => {
+	const profile: Profile = { name: "bare", model_profiles: {} };
+	const next = applyProfileToConfig({ default_model: "keep/me" }, profile);
+	assert.equal(next.default_model, "keep/me");
+	assert.equal(next.default_effort, undefined);
+	assert.equal(next.active_profile, "bare");
+});
+
+test("extract round-trips config data", () => {
+	const config = applyProfileToConfig({ custom: true }, PROFILE);
+	const extracted = extractProfileFromConfig(config, "round-trip");
+	assert.equal(extracted.name, "round-trip");
+	assert.equal(extracted.default_model, PROFILE.default_model);
+	assert.equal(extracted.default_effort, PROFILE.default_effort);
+	assert.deepEqual(extracted.model_profiles, PROFILE.model_profiles);
+	const reapplied = applyProfileToConfig({}, extracted);
+	assert.deepEqual(reapplied.model_profiles, PROFILE.model_profiles);
+});
+
+test("extract skips entries without a model string", () => {
+	const extracted = extractProfileFromConfig(
+		{ model_profiles: { good: { model: "a/b" }, bad: {} } },
+		"partial",
+		"desc",
+	);
+	assert.deepEqual(extracted.model_profiles, { good: { model: "a/b", effort: undefined } });
+	assert.equal(extracted.description, "desc");
+});
+
+test("applyToFile writes valid JSON to a tmp dir", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sdd-profile-"));
+	const filePath = path.join(dir, "sub", "subagents.json");
+	const returned = applyProfileToFile(filePath, PROFILE);
+	const onDisk = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	assert.deepEqual(onDisk, returned);
+	assert.equal(onDisk.active_profile, "test-profile");
+	assert.deepEqual(onDisk.model_profiles, PROFILE.model_profiles);
+	const leftovers = fs.readdirSync(path.join(dir, "sub")).filter((f) => f.endsWith(".tmp"));
+	assert.deepEqual(leftovers, []);
+});
+
+test("applyToFile preserves custom props already on disk", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sdd-profile-"));
+	const filePath = path.join(dir, "subagents.json");
+	fs.writeFileSync(filePath, JSON.stringify({ timeout: 9000, tools: ["x"] }));
+	const next = applyProfileToFile(filePath, PROFILE);
+	assert.equal(next.timeout, 9000);
+	assert.deepEqual(next.tools, ["x"]);
+});
+
+test("sanitize normalizes names", () => {
+	assert.equal(sanitizeProfileName("  My Profile! "), "my-profile-");
+	assert.equal(sanitizeProfileName("UPPER_under-score"), "upper_under-score");
+	assert.equal(sanitizeProfileName("a/b c"), "a-b-c");
+});
+
+test("resolveAvailableModels merges registry discovery with fallback", async () => {
+	const ctx = {
+		modelRegistry: {
+			getAvailable: async () => [
+				{ provider: "acme", id: "model-a" },
+				{ providerId: "other", model: "model-b" },
+			],
+		},
+	};
+	const models = await resolveAvailableModels(ctx);
+	assert.ok(models.includes("acme/model-a"));
+	assert.ok(models.includes("other/model-b"));
+	assert.ok(models.includes("openai/gpt-4o"));
+	assert.deepEqual(models, [...models].sort((a, b) => a.localeCompare(b)));
+});

--- a/tests/sdd-profiles-manager.test.ts
+++ b/tests/sdd-profiles-manager.test.ts
@@ -10,6 +10,7 @@ import {
 	extractProfileFromConfig,
 	resolveAvailableModels,
 	sanitizeProfileName,
+	SddProfileManager,
 } from "../lib/sdd-profiles-manager.ts";
 
 const PROFILE: Profile = {
@@ -22,6 +23,7 @@ const PROFILE: Profile = {
 		"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "high" },
 	},
 };
+
 test("apply preserves custom props and updates model_profiles", () => {
 	const current = {
 		timeout: 5000,
@@ -93,6 +95,83 @@ test("sanitize normalizes names", () => {
 	assert.equal(sanitizeProfileName("  My Profile! "), "my-profile-");
 	assert.equal(sanitizeProfileName("UPPER_under-score"), "upper_under-score");
 	assert.equal(sanitizeProfileName("a/b c"), "a-b-c");
+});
+
+function makeManagerDirs() {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "sdd-mgr-"));
+	const globalDir = path.join(root, "global");
+	const projectDir = path.join(root, "project");
+	const builtinsDir = path.join(root, "builtins");
+	fs.mkdirSync(globalDir, { recursive: true });
+	fs.mkdirSync(projectDir, { recursive: true });
+	fs.mkdirSync(builtinsDir, { recursive: true });
+	return {
+		root,
+		globalDir,
+		projectDir,
+		builtinsDir,
+		activeStatePath: path.join(root, ".active"),
+		globalSubagentsPath: path.join(root, "global-subagents.json"),
+		projectSubagentsPath: path.join(root, "project-subagents.json"),
+	};
+}
+
+function writeProfile(dir: string, profile: Profile): void {
+	fs.writeFileSync(path.join(dir, `${profile.name}.json`), JSON.stringify(profile));
+}
+
+const MIN_PROFILE = (name: string, model = "a/b"): Profile => ({ name, model_profiles: { x: { model } } });
+
+test("listProfiles includes embedded builtins", () => {
+	const d = makeManagerDirs();
+	const mgr = new SddProfileManager({ ...d });
+	const names = new Map(mgr.listProfiles().map((p) => [p.name, p]));
+	assert.ok(names.has("gentle-default"));
+	assert.equal(names.get("gentle-default")?.scope, "builtin");
+	assert.equal(names.get("gentle-default")?.is_active, false);
+});
+
+test("listProfiles precedence is project over global over builtin", () => {
+	const d = makeManagerDirs();
+	writeProfile(d.globalDir, { ...MIN_PROFILE("gentle-default"), default_model: "global/m" });
+	writeProfile(d.projectDir, { ...MIN_PROFILE("gentle-default"), default_model: "project/m" });
+	const mgr = new SddProfileManager({ ...d });
+	const found = mgr.listProfiles().find((p) => p.name === "gentle-default");
+	assert.equal(found?.scope, "project");
+	assert.equal(found?.default_model, "project/m");
+});
+
+test("listProfiles hides tombstoned builtin", () => {
+	const d = makeManagerDirs();
+	fs.writeFileSync(path.join(d.globalDir, ".deleted-profiles"), "gentle-default\n");
+	const mgr = new SddProfileManager({ ...d });
+	assert.ok(!mgr.listProfiles().some((p) => p.name === "gentle-default"));
+	assert.equal(mgr.loadProfile("gentle-default"), null);
+});
+
+test("loadProfile falls back project, global, builtinsDir, embedded", () => {
+	const d = makeManagerDirs();
+	writeProfile(d.builtinsDir, { ...MIN_PROFILE("custom"), default_model: "builtins/m" });
+	const mgr = new SddProfileManager({ ...d });
+	assert.equal(mgr.loadProfile("custom")?.default_model, "builtins/m");
+	writeProfile(d.globalDir, { ...MIN_PROFILE("custom"), default_model: "global/m" });
+	assert.equal(mgr.loadProfile("custom")?.default_model, "global/m");
+	writeProfile(d.projectDir, { ...MIN_PROFILE("custom"), default_model: "project/m" });
+	assert.equal(mgr.loadProfile("custom")?.default_model, "project/m");
+	assert.equal(mgr.loadProfile("gentle-economy")?.name, "gentle-economy");
+	assert.equal(mgr.loadProfile("missing"), null);
+});
+
+test("getActiveProfileName prefers project subagents.json over .active file", () => {
+	const d = makeManagerDirs();
+	fs.writeFileSync(d.activeStatePath, "from-active\n");
+	fs.writeFileSync(d.projectSubagentsPath, JSON.stringify({ active_profile: "from-project" }));
+	const mgr = new SddProfileManager({ ...d });
+	assert.equal(mgr.getActiveProfileName(), "from-project");
+	fs.unlinkSync(d.projectSubagentsPath);
+	assert.equal(mgr.getActiveProfileName(), "from-active");
+	fs.unlinkSync(d.activeStatePath);
+	assert.equal(mgr.getActiveProfileName(), null);
 });
 
 test("resolveAvailableModels merges registry discovery with fallback", async () => {


### PR DESCRIPTION
Related to #759 (part 3 of 10 — cumulative stack, review the top commit on top of #809).

## Summary
SddProfileManager read core: listProfiles (builtin/dir/global/project merge), loadProfile fallback order, getActiveProfileName (project subagents.json, .active, global), builtin tombstones. Home via resolveGentlePiAgentHome (no hardcoded paths). Own delta: +181 lib, +80 tests (tmp-dir fixtures).

## Test plan
Manager 13 pass (precedence covered), catalog green.

## Checklist
- [x] Related to #759 (approved feature) | Type: feature (maintainer label)
- [x] Tests ship with the behavior they verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile management for configuring subagent models and reasoning effort.
  * Added built-in profiles for default, economy, and reasoning-focused setups.
  * Added support for global and project-specific profiles, including active-profile selection.
  * Added model discovery and profile summaries across available scopes.
  * Added categorized listings of supported SDD agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->