### PR TITLE
feat(sdd-profiles): gentle-sdd-profile command with five subcommands

### DIFF
--- a/extensions/gentle-sdd-profile.ts
+++ b/extensions/gentle-sdd-profile.ts
@@ -1,0 +1,192 @@
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Profile, ProfileSummary } from "../lib/sdd-profiles-catalog.ts";
+import { SddProfileManager } from "../lib/sdd-profiles-manager.ts";
+
+export const GENTLE_SDD_PROFILE_COMMAND = "gentle-sdd-profile";
+export const SDD_PROFILE_TOOL_LIST = "sdd_profile_list";
+export const SDD_PROFILE_TOOL_USE = "sdd_profile_use";
+export const SDD_PROFILE_TOOL_RENAME = "sdd_profile_rename";
+export const SDD_PROFILE_TOOL_DELETE = "sdd_profile_delete";
+export const GENTLE_SDD_PROFILE_LIST_COMMAND = "gentle-sdd-profile-list";
+export const GENTLE_SDD_PROFILE_SAVE_COMMAND = "gentle-sdd-profile-save";
+export const GENTLE_SDD_PROFILE_RENAME_COMMAND = "gentle-sdd-profile-rename";
+export const GENTLE_SDD_PROFILE_DELETE_COMMAND = "gentle-sdd-profile-delete";
+
+const SDD_PROFILE_SHORTCUT_DEFAULT_DARWIN = "ctrl+shift+m";
+const SDD_PROFILE_SHORTCUT_DEFAULT = "alt+m";
+
+export function sddProfileShortcut(
+	env: NodeJS.ProcessEnv = process.env,
+	platform: NodeJS.Platform = process.platform,
+): string | undefined {
+	const value = env.GENTLE_PI_SDD_PROFILES_KEY?.trim();
+	if (value === undefined) {
+		return platform === "darwin" ? SDD_PROFILE_SHORTCUT_DEFAULT_DARWIN : SDD_PROFILE_SHORTCUT_DEFAULT;
+	}
+	return value === "" || value.toLowerCase() === "off" ? undefined : value;
+}
+
+const USAGE =
+	"Usage: /gentle-sdd-profile list | show <name> | use <name> [--project|--global] | save <name> [description] [--project|--global] | create <name> [default_model] [effort] [--project] | set <profile> <agent> <model> [effort] | rename <old> <new> | delete <name>";
+
+function getManager(ctx?: ExtensionContext): SddProfileManager {
+	const cwd =
+		ctx?.sessionManager?.getCwd?.() ?? (ctx as { cwd?: string })?.cwd ?? process.cwd();
+	const extra = ctx as unknown as {
+		globalDir?: string;
+		activeStatePath?: string;
+		globalSubagentsPath?: string;
+	};
+	return new SddProfileManager({
+		globalDir: extra?.globalDir,
+		projectDir: join(cwd, ".pi", "profiles"),
+		projectSubagentsPath: join(cwd, ".pi", "subagents.json"),
+		activeStatePath: extra?.activeStatePath,
+		globalSubagentsPath: extra?.globalSubagentsPath,
+	});
+}
+
+function formatProfileList(profiles: ProfileSummary[], activeName: string | null): string {
+	if (profiles.length === 0) {
+		return "No profiles. Save one: /gentle-sdd-profile save <name>.";
+	}
+	const lines = ["SDD profiles:"];
+	for (const p of profiles) {
+		const isActive = Boolean(
+			activeName && p.name.toLowerCase() === activeName.toLowerCase(),
+		);
+		const marker = isActive ? "*" : " ";
+		const detail = p.default_model ? `default ${p.default_model}` : `${p.agent_count} agents`;
+		const desc = p.description ? ` - ${p.description}` : "";
+		lines.push(`${marker} ${p.name} [${p.scope}] (${detail})${desc}`);
+	}
+	return lines.join("\n");
+}
+
+function notify(
+	ctx: ExtensionContext,
+	message: string,
+	level: "info" | "warning" | "error",
+): string {
+	ctx.ui?.notify?.(message, level);
+	return message;
+}
+
+function listProfilesText(ctx: ExtensionContext): string {
+	const manager = getManager(ctx);
+	return formatProfileList(manager.listProfiles(), manager.getActiveProfileName());
+}
+
+function formatProfileDetail(profile: Profile, isActive: boolean): string {
+	const lines = [
+		`Profile: ${profile.name}${isActive ? " (active)" : ""}`,
+		`Description: ${profile.description ?? "None"}`,
+		`Default model: ${profile.default_model ?? "None"}`,
+		`Default effort: ${profile.default_effort ?? "None"}`,
+		`Updated: ${profile.updated_at ?? "N/A"}`,
+		"Agents:",
+	];
+	const entries = Object.entries(profile.model_profiles ?? {});
+	if (entries.length === 0) {
+		lines.push("  (none, inherits default)");
+	} else {
+		for (const [agent, cfg] of entries) {
+			const effort = cfg.effort ? ` [effort: ${cfg.effort}]` : "";
+			lines.push(`  - ${agent}: ${cfg.model}${effort}`);
+		}
+	}
+	return lines.join("\n");
+}
+export default function gentleSddProfile(pi: ExtensionAPI, env: NodeJS.ProcessEnv = process.env): void {
+	pi.registerCommand(GENTLE_SDD_PROFILE_COMMAND, {
+		description: "Manage SDD model profiles for subagents.",
+		handler: async (args: string, ctx: ExtensionContext) => {
+			const manager = getManager(ctx);
+			const trimmed = (args || "").trim();
+			if (!trimmed) return listProfilesText(ctx);
+
+			const parts = trimmed.split(/\s+/);
+			const sub = parts[0].toLowerCase();
+			const scope = parts.includes("--project") ? "project" : "global";
+
+			if (sub === "modal") return listProfilesText(ctx);
+
+			switch (sub) {
+				case "list": {
+					const profiles = manager.listProfiles();
+					return formatProfileList(profiles, manager.getActiveProfileName());
+				}
+
+				case "use": {
+					const name = parts[1];
+					if (!name || name.startsWith("--")) {
+						return notify(
+							ctx,
+							"Usage: /gentle-sdd-profile use <name> [--project|--global]",
+							"warning",
+						);
+					}
+					const result = manager.activateProfile(name, scope);
+					return notify(ctx, result.message, result.success ? "info" : "error");
+				}
+				case "save": {
+					const name = parts[1];
+					if (!name || name.startsWith("--")) {
+						return notify(
+							ctx,
+							"Usage: /gentle-sdd-profile save <name> [description] [--project|--global]",
+							"warning",
+						);
+					}
+					const words = parts.slice(2).filter((w) => w !== "--project" && w !== "--global");
+					const description = words.length > 0 ? words.join(" ") : undefined;
+					const result = manager.saveCurrentAsProfile(name, description, scope);
+					return notify(ctx, result.message, result.success ? "info" : "error");
+				}
+				case "rename": {
+					const oldName = parts[1];
+					const newName = parts[2];
+					if (!oldName || !newName) {
+						return notify(
+							ctx,
+							"Usage: /gentle-sdd-profile rename <old> <new>",
+							"warning",
+						);
+					}
+					const res = manager.renameProfile(oldName, newName);
+					return notify(ctx, res.message, res.success ? "info" : "warning");
+				}
+
+				case "delete": {
+					const name = parts[1];
+					if (!name) {
+						return notify(ctx, "Usage: /gentle-sdd-profile delete <name>", "warning");
+					}
+					if (!manager.loadProfile(name)) {
+						return notify(ctx, `Profile "${name}" not found.`, "warning");
+					}
+					const active = manager.getActiveProfileName();
+					if (active && manager.sanitizeName(active) === manager.sanitizeName(name)) {
+						return notify(
+							ctx,
+							`Cannot delete active profile "${name}". Activate another profile first.`,
+							"warning",
+						);
+					}
+					const deleted = manager.deleteProfile(name);
+					return notify(
+						ctx,
+						deleted ? `Deleted profile "${name}".` : `Could not delete profile "${name}".`,
+						deleted ? "info" : "warning",
+					);
+				}
+
+				default: {
+					if (!manager.loadProfile(parts[0])) return notify(ctx, USAGE, "warning");
+					const result = manager.activateProfile(parts[0], scope);
+					return notify(ctx, result.message, result.success ? "info" : "error");
+				}
+			}
+		},
+	});}

--- a/lib/sdd-profiles-catalog.ts
+++ b/lib/sdd-profiles-catalog.ts
@@ -1,0 +1,168 @@
+export type ReasoningEffort =
+	| "off"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh"
+	| "max";
+
+export interface ModelProfileEntry {
+	model: string;
+	effort?: ReasoningEffort;
+}
+
+export interface Profile {
+	name: string;
+	description?: string;
+	default_model?: string;
+	default_effort?: ReasoningEffort;
+	model_profiles: Record<string, ModelProfileEntry>;
+	created_at?: string;
+	updated_at?: string;
+}
+
+export type ProfileScope = "builtin" | "global" | "project";
+
+export interface ProfileSummary {
+	name: string;
+	description?: string;
+	default_model?: string;
+	agent_count: number;
+	scope: ProfileScope;
+	is_active: boolean;
+	path?: string;
+}
+
+export interface SubagentsConfigFile {
+	default_model?: string;
+	default_effort?: string;
+	active_profile?: string;
+	model_profiles?: Record<string, { model: string; effort?: string }>;
+	[key: string]: unknown;
+}
+
+export interface AgentCategory {
+	id: string;
+	name: string;
+	description: string;
+	agents: string[];
+}
+
+export const SDD_AGENT_CATEGORIES: AgentCategory[] = [
+	{
+		id: "sdd-core",
+		name: "SDD Core",
+		description: "Spec-Driven Development phase executors",
+		agents: [
+			"sdd-explore",
+			"sdd-proposal",
+			"sdd-spec",
+			"sdd-design",
+			"sdd-tasks",
+			"sdd-apply",
+			"sdd-verify",
+			"sdd-archive",
+			"sdd-init",
+			"sdd-onboard",
+			"sdd-research",
+			"sdd-status",
+			"sdd-sync",
+		],
+	},
+	{
+		id: "judgment-day",
+		name: "Judgment Day",
+		description: "Blind dual review, judges, and fix",
+		agents: ["jd-judge-a", "jd-judge-b", "jd-fix-agent"],
+	},
+	{
+		id: "reviewers",
+		name: "Reviewers and Auditors",
+		description: "Quality, security, and architecture lenses",
+		agents: [
+			"security-auditor",
+			"review-readability",
+			"review-reliability",
+			"review-resilience",
+			"review-risk",
+		],
+	},
+	{
+		id: "general",
+		name: "General Harness",
+		description: "General subagents for exploration and coding tasks",
+		agents: [
+			"gentle-ai-explore",
+			"gentle-ai-worker",
+			"gentle-ai-verify",
+			"ui-specialist",
+			"task-tracker-manager",
+		],
+	},
+];
+
+export const ALL_KNOWN_AGENTS: string[] = SDD_AGENT_CATEGORIES.flatMap((c) => c.agents);
+
+export const BUILTIN_PROFILES: Record<string, Profile> = {
+	"gentle-default": {
+		name: "gentle-default",
+		description: "Quality/cost balance for Spec-Driven Development",
+		default_model: "anthropic/claude-sonnet-5",
+		default_effort: "medium",
+		model_profiles: {
+			"sdd-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-proposal": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-design": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-tasks": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"jd-judge-b": { model: "openai/gpt-5", effort: "high" },
+			"jd-fix-agent": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"gentle-ai-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"gentle-ai-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"gentle-ai-worker": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+		},
+	},
+	"gentle-economy": {
+		name: "gentle-economy",
+		description: "Speed and low cost for fast iterations and direct tasks",
+		default_model: "openai/gpt-5-mini",
+		default_effort: "low",
+		model_profiles: {
+			"sdd-explore": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-verify": { model: "openai/gpt-5-mini", effort: "low" },
+			"sdd-proposal": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-design": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-tasks": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "openai/gpt-5-mini", effort: "medium" },
+			"jd-judge-b": { model: "openai/gpt-5-mini", effort: "medium" },
+			"jd-fix-agent": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+		},
+	},
+	"gentle-reasoning": {
+		name: "gentle-reasoning",
+		description: "Maximum reasoning effort on critical design and review phases",
+		default_model: "openai/gpt-5",
+		default_effort: "high",
+		model_profiles: {
+			"sdd-explore": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-verify": { model: "anthropic/claude-sonnet-5", effort: "medium" },
+			"sdd-proposal": { model: "openai/gpt-5", effort: "max" },
+			"sdd-spec": { model: "openai/gpt-5", effort: "max" },
+			"sdd-design": { model: "openai/gpt-5", effort: "max" },
+			"sdd-tasks": { model: "openai/gpt-5", effort: "high" },
+			"sdd-apply": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"sdd-archive": { model: "openai/gpt-5-mini", effort: "low" },
+			"jd-judge-a": { model: "openai/gpt-5", effort: "max" },
+			"jd-judge-b": { model: "anthropic/claude-sonnet-5", effort: "high" },
+			"jd-fix-agent": { model: "openai/gpt-5", effort: "max" },
+		},
+	},
+};

--- a/lib/sdd-profiles-manager.ts
+++ b/lib/sdd-profiles-manager.ts
@@ -369,4 +369,185 @@ export class SddProfileManager {
 		}
 		return null;
 	}
+
+	setActiveProfileName(name: string): void {
+		try {
+			const dir = path.dirname(this.activeStatePath);
+			if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(this.activeStatePath, name.trim(), "utf-8");
+		} catch {}
+	}
+
+	clearActiveProfileName(): void {
+		if (fs.existsSync(this.activeStatePath)) {
+			try {
+				fs.unlinkSync(this.activeStatePath);
+			} catch {}
+		}
+		const clean = (filePath: string) => {
+			if (!fs.existsSync(filePath)) return;
+			try {
+				const config = JSON.parse(fs.readFileSync(filePath, "utf-8")) as SubagentsConfigFile;
+				if (config.active_profile) {
+					delete config.active_profile;
+				fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+				}
+			} catch {}
+		};
+		clean(this.projectSubagentsPath);
+		clean(this.globalSubagentsPath);
+	}
+
+	deleteProfile(name: string, force = false): boolean {
+		const key = this.sanitizeName(name);
+		const active = this.getActiveProfileName();
+		if (!force && active && this.sanitizeName(active) === key) return false;
+		let deleted = false;
+		for (const dir of [this.projectDir, this.globalDir]) {
+			const filePath = path.join(dir, `${key}.json`);
+			if (fs.existsSync(filePath)) {
+				try {
+					fs.unlinkSync(filePath);
+					deleted = true;
+				} catch {}
+			}
+		}
+		const isBuiltin =
+			Boolean(BUILTIN_PROFILES[name] ?? BUILTIN_PROFILES[key]) ||
+			Boolean(this.builtinsDir && fs.existsSync(path.join(this.builtinsDir, `${key}.json`)));
+		if (isBuiltin && !this.getDeletedProfiles().has(key)) {
+			this.addDeletedProfile(key);
+			deleted = true;
+		}
+		if (deleted) {
+			const current = this.getActiveProfileName();
+			if (current && this.sanitizeName(current) === key) this.clearActiveProfileName();
+		}
+		return deleted;
+	}
+
+	renameProfile(oldName: string, newName: string): { success: boolean; message: string; targetPath?: string } {
+		const trimmedNew = newName.trim();
+		if (!trimmedNew) return { success: false, message: "New name must not be empty." };
+		const oldKey = this.sanitizeName(oldName);
+		const newKey = this.sanitizeName(trimmedNew);
+		if (oldKey === newKey) return { success: false, message: "New name must differ." };
+		const original = this.loadProfile(oldName);
+		if (!original) return { success: false, message: `Profile "${oldName}" not found.` };
+		if (this.loadProfile(trimmedNew)) {
+			return { success: false, message: `Profile "${trimmedNew}" already exists.` };
+		}
+		const targetScope: "project" | "global" = fs.existsSync(path.join(this.projectDir, `${oldKey}.json`))
+			? "project"
+			: "global";
+		const updated: Profile = { ...original, name: trimmedNew, updated_at: new Date().toISOString() };
+		const savedPath = this.saveProfile(updated, targetScope);
+		const active = this.getActiveProfileName();
+		const wasActive = Boolean(active && this.sanitizeName(active) === oldKey);
+		this.deleteProfile(oldName, true);
+		const bump = (filePath: string) => {
+			if (!fs.existsSync(filePath)) return;
+			try {
+				const config = JSON.parse(fs.readFileSync(filePath, "utf-8")) as SubagentsConfigFile;
+				if (config.active_profile && this.sanitizeName(config.active_profile) === oldKey) {
+					config.active_profile = trimmedNew;
+					fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+				}
+			} catch {}
+		};
+		bump(this.projectSubagentsPath);
+		bump(this.globalSubagentsPath);
+		if (wasActive) this.setActiveProfileName(trimmedNew);
+		return { success: true, message: `Renamed "${oldName}" to "${trimmedNew}".`, targetPath: savedPath };
+	}
+
+	activateProfile(name: string, target: "global" | "project" = "global"): { success: boolean; profile?: Profile; message: string } {
+		const profile = this.loadProfile(name);
+		if (!profile) return { success: false, message: `Profile "${name}" not found.` };
+		const targetPath = target === "project" ? this.projectSubagentsPath : this.globalSubagentsPath;
+		applyProfileToFile(targetPath, profile);
+		this.setActiveProfileName(profile.name);
+		return { success: true, profile, message: `Activated "${profile.name}" on ${target} subagents.json.` };
+	}
+
+	saveCurrentAsProfile(name: string, description?: string, scope: "global" | "project" = "global"): { success: boolean; path?: string; profile?: Profile; message: string } {
+		let sourcePath = this.globalSubagentsPath;
+		if (fs.existsSync(this.projectSubagentsPath)) sourcePath = this.projectSubagentsPath;
+		let config: SubagentsConfigFile = {};
+		if (fs.existsSync(sourcePath)) {
+			try {
+				config = JSON.parse(fs.readFileSync(sourcePath, "utf-8"));
+			} catch {
+				config = {};
+			}
+		}
+		const profile = extractProfileFromConfig(config, name, description);
+		const savedPath = this.saveProfile(profile, scope);
+		this.setActiveProfileName(profile.name);
+		return { success: true, path: savedPath, profile, message: `Saved "${profile.name}" to ${savedPath}.` };
+	}
+
+	createProfile(params: {
+		name: string;
+		description?: string;
+		default_model?: string;
+		default_effort?: ReasoningEffort;
+		model_profiles?: Record<string, ModelProfileEntry>;
+		scope?: "global" | "project";
+	}): { success: boolean; path?: string; profile?: Profile; message: string } {
+		const trimmed = params.name.trim();
+		if (!trimmed) return { success: false, message: "Profile name must not be empty." };
+		if (this.loadProfile(trimmed)) {
+			return { success: false, message: `Profile "${trimmed}" already exists.` };
+		}
+		const scope = params.scope ?? "global";
+		const now = new Date().toISOString();
+		const newProfile: Profile = {
+			name: trimmed,
+			description: params.description?.trim() || undefined,
+			default_model: params.default_model?.trim() || undefined,
+			default_effort: params.default_effort,
+			model_profiles: params.model_profiles ?? {},
+			created_at: now,
+			updated_at: now,
+		};
+		const savedPath = this.saveProfile(newProfile, scope);
+		return {
+			success: true,
+			path: savedPath,
+			profile: newProfile,
+			message: `Created "${newProfile.name}" in ${scope} (${savedPath}).`,
+		};
+	}
+
+	setAgentInProfile(params: {
+		profileName: string;
+		agentName: string;
+		model: string;
+		effort?: ReasoningEffort;
+	}): { success: boolean; profile?: Profile; message: string } {
+		const profile = this.loadProfile(params.profileName);
+		if (!profile) return { success: false, message: `Profile "${params.profileName}" not found.` };
+		const agent = params.agentName.trim();
+		if (!ALL_KNOWN_AGENTS.includes(agent)) {
+			return { success: false, message: `Unknown agent "${params.agentName}".` };
+		}
+		const model = params.model.trim();
+		if (!model) return { success: false, message: "Model must not be empty." };
+		const updatedProfile: Profile = {
+			...profile,
+			model_profiles: { ...profile.model_profiles, [agent]: { model, effort: params.effort } },
+			updated_at: new Date().toISOString(),
+		};
+		const key = this.sanitizeName(profile.name);
+		const origin: "global" | "project" = fs.existsSync(path.join(this.projectDir, `${key}.json`))
+			? "project"
+			: "global";
+		this.saveProfile(updatedProfile, origin);
+		return {
+			success: true,
+			profile: updatedProfile,
+			message: `Set "${agent}" to "${model}" in "${profile.name}".`,
+		};
+	}
 }

--- a/lib/sdd-profiles-manager.ts
+++ b/lib/sdd-profiles-manager.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { resolveGentlePiAgentHome } from "./agent-home.ts";
+import type {
+	ModelProfileEntry,
+	Profile,
+	ProfileScope,
+	ProfileSummary,
+	ReasoningEffort,
+	SubagentsConfigFile,
+} from "./sdd-profiles-catalog.ts";
+import { ALL_KNOWN_AGENTS, BUILTIN_PROFILES } from "./sdd-profiles-catalog.ts";
+
+export function applyProfileToConfig(
+	currentConfig: SubagentsConfigFile,
+	profile: Profile,
+): SubagentsConfigFile {
+	const nextConfig: SubagentsConfigFile = { ...currentConfig };
+	if (profile.default_model) nextConfig.default_model = profile.default_model;
+	if (profile.default_effort) nextConfig.default_effort = profile.default_effort;
+	nextConfig.active_profile = profile.name;
+	nextConfig.model_profiles = { ...profile.model_profiles };
+	return nextConfig;
+}
+
+export function extractProfileFromConfig(
+	config: SubagentsConfigFile,
+	name: string,
+	description?: string,
+): Profile {
+	const now = new Date().toISOString();
+	const modelProfiles: Record<string, ModelProfileEntry> = {};
+	if (config.model_profiles && typeof config.model_profiles === "object") {
+		for (const [agent, val] of Object.entries(config.model_profiles)) {
+			if (val && typeof val === "object" && typeof (val as { model?: unknown }).model === "string") {
+				modelProfiles[agent] = {
+					model: (val as { model: string }).model,
+					effort: (val as { effort?: ReasoningEffort }).effort,
+				};
+			}
+		}
+	}
+	return {
+		name,
+		description: description ?? `Saved from subagents.json at ${now}`,
+		default_model: typeof config.default_model === "string" ? config.default_model : undefined,
+		default_effort:
+			typeof config.default_effort === "string" ? (config.default_effort as ReasoningEffort) : undefined,
+		model_profiles: modelProfiles,
+		created_at: now,
+		updated_at: now,
+	};
+}
+
+export function applyProfileToFile(filePath: string, profile: Profile): SubagentsConfigFile {
+	const dir = path.dirname(filePath);
+	if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+	let currentConfig: SubagentsConfigFile = {};
+	if (fs.existsSync(filePath)) {
+		try {
+			currentConfig = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+		} catch {
+			currentConfig = {};
+		}
+	}
+	const updatedConfig = applyProfileToConfig(currentConfig, profile);
+	const bytes = JSON.stringify(updatedConfig, null, 2) + "\n";
+	const temp = path.join(dir, `.${path.basename(filePath)}.${randomUUID()}.tmp`);
+	const fd = fs.openSync(temp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+	try {
+		try {
+			fs.writeFileSync(fd, bytes);
+		} finally {
+			fs.closeSync(fd);
+		}
+		fs.renameSync(temp, filePath);
+	} finally {
+		try {
+			fs.unlinkSync(temp);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
+	return updatedConfig;
+}
+
+const FALLBACK_MODELS = [
+	"anthropic/claude-sonnet-4-5",
+	"anthropic/claude-haiku-4-5",
+	"anthropic/claude-opus-4-6",
+	"openai/o3-mini",
+	"openai/gpt-4o",
+	"openai/gpt-4o-mini",
+	"google/gemini-2.5-flash",
+	"google/gemini-2.5-pro",
+];
+
+export async function resolveAvailableModels(ctx?: unknown): Promise<string[]> {
+	const modelSet = new Set<string>();
+	try {
+		const registry = (ctx as { modelRegistry?: { getAvailable?: () => Promise<unknown[]> } })
+			?.modelRegistry;
+		const registryModels = await registry?.getAvailable?.();
+		if (Array.isArray(registryModels)) {
+			for (const m of registryModels) {
+				const item = m as { provider?: string; providerId?: string; id?: string; model?: string };
+				const provider = item.provider ?? item.providerId;
+				const id = item.id ?? item.model;
+				if (provider && id) modelSet.add(`${provider}/${id}`);
+			}
+		}
+	} catch {}
+	const agentHome = resolveGentlePiAgentHome();
+	const modelsJsonPath = path.join(agentHome, "models.json");
+	if (fs.existsSync(modelsJsonPath)) {
+		try {
+			const data = JSON.parse(fs.readFileSync(modelsJsonPath, "utf-8")) as {
+				providers?: Record<string, { models?: Array<{ id?: string }> }>;
+			};
+			if (data?.providers && typeof data.providers === "object") {
+				for (const [provider, pData] of Object.entries(data.providers)) {
+					if (Array.isArray(pData?.models)) {
+						for (const m of pData.models) {
+							if (m?.id) modelSet.add(`${provider}/${m.id}`);
+						}
+					}
+				}
+			}
+		} catch {}
+	}
+	const storeJsonPath = path.join(agentHome, "models-store.json");
+	if (fs.existsSync(storeJsonPath)) {
+		try {
+			const data = JSON.parse(fs.readFileSync(storeJsonPath, "utf-8")) as Record<
+				string,
+				{ models?: Array<{ id?: string }> }
+			>;
+			if (typeof data === "object" && data !== null) {
+				for (const [provider, pData] of Object.entries(data)) {
+					if (Array.isArray(pData?.models)) {
+						for (const m of pData.models) {
+							if (m?.id) modelSet.add(`${provider}/${m.id}`);
+						}
+					}
+				}
+			}
+		} catch {}
+	}
+	for (const fallback of FALLBACK_MODELS) modelSet.add(fallback);
+	return Array.from(modelSet).sort((a, b) => a.localeCompare(b));
+}
+
+export interface ManagerOptions {
+	globalDir?: string;
+	projectDir?: string;
+	builtinsDir?: string;
+	activeStatePath?: string;
+	globalSubagentsPath?: string;
+	projectSubagentsPath?: string;
+}
+
+export function sanitizeProfileName(name: string): string {
+	return name.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "-");
+}
+

--- a/lib/sdd-profiles-manager.ts
+++ b/lib/sdd-profiles-manager.ts
@@ -164,3 +164,209 @@ export function sanitizeProfileName(name: string): string {
 	return name.trim().toLowerCase().replace(/[^a-z0-9_-]/g, "-");
 }
 
+export class SddProfileManager {
+	readonly globalDir: string;
+	readonly projectDir: string;
+	readonly builtinsDir?: string;
+	readonly activeStatePath: string;
+	readonly globalSubagentsPath: string;
+	readonly projectSubagentsPath: string;
+
+	constructor(options: ManagerOptions = {}) {
+		const agentHome = resolveGentlePiAgentHome();
+		this.globalDir = options.globalDir ?? path.join(agentHome, "profiles");
+		this.projectDir = options.projectDir ?? path.join(process.cwd(), ".pi", "profiles");
+		this.builtinsDir = options.builtinsDir;
+		this.activeStatePath = options.activeStatePath ?? path.join(this.globalDir, ".active");
+		this.globalSubagentsPath = options.globalSubagentsPath ?? path.join(agentHome, "subagents.json");
+		this.projectSubagentsPath =
+			options.projectSubagentsPath ?? path.join(process.cwd(), ".pi", "subagents.json");
+	}
+
+	sanitizeName(name: string): string {
+		return sanitizeProfileName(name);
+	}
+
+	private getDeletedProfilesPath(): string {
+		return path.join(this.globalDir, ".deleted-profiles");
+	}
+
+	private getDeletedProfiles(): Set<string> {
+		const filePath = this.getDeletedProfilesPath();
+		if (!fs.existsSync(filePath)) return new Set();
+		try {
+			const raw = fs.readFileSync(filePath, "utf-8");
+			return new Set(raw.split("\n").map((s) => this.sanitizeName(s)).filter(Boolean));
+		} catch {
+			return new Set();
+		}
+	}
+
+	private addDeletedProfile(name: string): void {
+		const set = this.getDeletedProfiles();
+		set.add(this.sanitizeName(name));
+		try {
+			if (!fs.existsSync(this.globalDir)) fs.mkdirSync(this.globalDir, { recursive: true });
+			fs.writeFileSync(this.getDeletedProfilesPath(), Array.from(set).join("\n"), "utf-8");
+		} catch {}
+	}
+
+	private removeDeletedProfile(name: string): void {
+		const set = this.getDeletedProfiles();
+		const key = this.sanitizeName(name);
+		if (set.has(key)) {
+			set.delete(key);
+			try {
+				fs.writeFileSync(this.getDeletedProfilesPath(), Array.from(set).join("\n"), "utf-8");
+			} catch {}
+		}
+	}
+
+	private readProfilesFromDir(
+		dir: string,
+		scope: ProfileScope,
+	): Map<string, { profile: Profile; path: string }> {
+		const map = new Map<string, { profile: Profile; path: string }>();
+		if (!fs.existsSync(dir)) return map;
+		const deleted = scope === "builtin" ? this.getDeletedProfiles() : new Set<string>();
+		try {
+			for (const file of fs.readdirSync(dir)) {
+				if (!file.endsWith(".json") || file.startsWith(".")) continue;
+				const filePath = path.join(dir, file);
+				try {
+					const data = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Profile;
+					if (data && typeof data === "object" && data.name) {
+						const key = this.sanitizeName(data.name);
+						if (deleted.has(key)) continue;
+						map.set(key, { profile: data, path: filePath });
+					}
+				} catch {}
+			}
+		} catch {}
+		return map;
+	}
+
+	listProfiles(): ProfileSummary[] {
+		const deleted = this.getDeletedProfiles();
+		const merged = new Map<string, { profile: Profile; scope: ProfileScope; path?: string }>();
+		for (const [key, profile] of Object.entries(BUILTIN_PROFILES)) {
+			const norm = this.sanitizeName(key);
+			if (!deleted.has(norm)) merged.set(norm, { profile, scope: "builtin" });
+		}
+		if (this.builtinsDir) {
+			for (const [key, val] of this.readProfilesFromDir(this.builtinsDir, "builtin")) {
+				merged.set(key, { profile: val.profile, scope: "builtin", path: val.path });
+			}
+		}
+		for (const [key, val] of this.readProfilesFromDir(this.globalDir, "global")) {
+			merged.set(key, { profile: val.profile, scope: "global", path: val.path });
+		}
+		for (const [key, val] of this.readProfilesFromDir(this.projectDir, "project")) {
+			merged.set(key, { profile: val.profile, scope: "project", path: val.path });
+		}
+		const active = this.getActiveProfileName();
+		const out: ProfileSummary[] = [];
+		for (const item of merged.values()) {
+			out.push({
+				name: item.profile.name,
+				description: item.profile.description,
+				default_model: item.profile.default_model,
+				agent_count: Object.keys(item.profile.model_profiles ?? {}).length,
+				scope: item.scope,
+				is_active: Boolean(
+					active && this.sanitizeName(item.profile.name) === this.sanitizeName(active),
+				),
+				path: item.path,
+			});
+		}
+		return out.sort((a, b) => a.name.localeCompare(b.name));
+	}
+
+	loadProfile(name: string): Profile | null {
+		const key = this.sanitizeName(name);
+		const projectPath = path.join(this.projectDir, `${key}.json`);
+		if (fs.existsSync(projectPath)) {
+			try {
+				return JSON.parse(fs.readFileSync(projectPath, "utf-8")) as Profile;
+			} catch {}
+		}
+		const globalPath = path.join(this.globalDir, `${key}.json`);
+		if (fs.existsSync(globalPath)) {
+			try {
+				return JSON.parse(fs.readFileSync(globalPath, "utf-8")) as Profile;
+			} catch {}
+		}
+		if (!this.getDeletedProfiles().has(key)) {
+			if (this.builtinsDir) {
+				const builtinPath = path.join(this.builtinsDir, `${key}.json`);
+				if (fs.existsSync(builtinPath)) {
+					try {
+						return JSON.parse(fs.readFileSync(builtinPath, "utf-8")) as Profile;
+					} catch {}
+				}
+			}
+			const builtin = BUILTIN_PROFILES[name] ?? BUILTIN_PROFILES[key];
+			if (builtin) return { ...builtin };
+		}
+		return null;
+	}
+
+	saveProfile(profile: Profile, scope: "global" | "project" = "global"): string {
+		const targetDir = scope === "project" ? this.projectDir : this.globalDir;
+		if (!fs.existsSync(targetDir)) fs.mkdirSync(targetDir, { recursive: true });
+		const key = this.sanitizeName(profile.name);
+		this.removeDeletedProfile(key);
+		const targetPath = path.join(targetDir, `${key}.json`);
+		const now = new Date().toISOString();
+		const payload: Profile = { ...profile, name: profile.name.trim(), updated_at: now };
+		if (!payload.created_at) payload.created_at = now;
+		const bytes = JSON.stringify(payload, null, 2) + "\n";
+		const temp = path.join(targetDir, `.${key}.${randomUUID()}.tmp`);
+		const fd = fs.openSync(temp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL, 0o600);
+		try {
+			try {
+				fs.writeFileSync(fd, bytes);
+			} finally {
+				fs.closeSync(fd);
+			}
+			fs.renameSync(temp, targetPath);
+		} finally {
+			try {
+				fs.unlinkSync(temp);
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			}
+		}
+		return targetPath;
+	}
+
+	getActiveProfileName(): string | null {
+		if (fs.existsSync(this.projectSubagentsPath)) {
+			try {
+				const config = JSON.parse(
+					fs.readFileSync(this.projectSubagentsPath, "utf-8"),
+				) as SubagentsConfigFile;
+				if (typeof config.active_profile === "string" && config.active_profile.trim()) {
+					return config.active_profile.trim();
+				}
+			} catch {}
+		}
+		if (fs.existsSync(this.activeStatePath)) {
+			try {
+				const content = fs.readFileSync(this.activeStatePath, "utf-8").trim();
+				if (content) return content;
+			} catch {}
+		}
+		if (fs.existsSync(this.globalSubagentsPath)) {
+			try {
+				const config = JSON.parse(
+					fs.readFileSync(this.globalSubagentsPath, "utf-8"),
+				) as SubagentsConfigFile;
+				if (typeof config.active_profile === "string" && config.active_profile.trim()) {
+					return config.active_profile.trim();
+				}
+			} catch {}
+		}
+		return null;
+	}
+}

--- a/tests/gentle-sdd-profile.test.ts
+++ b/tests/gentle-sdd-profile.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import installGentleSddProfile, {
+	GENTLE_SDD_PROFILE_COMMAND,
+	GENTLE_SDD_PROFILE_DELETE_COMMAND,
+	GENTLE_SDD_PROFILE_LIST_COMMAND,
+	GENTLE_SDD_PROFILE_RENAME_COMMAND,
+	GENTLE_SDD_PROFILE_SAVE_COMMAND,
+	SDD_PROFILE_TOOL_DELETE,
+	SDD_PROFILE_TOOL_LIST,
+	SDD_PROFILE_TOOL_RENAME,
+	SDD_PROFILE_TOOL_USE,
+	sddProfileShortcut,
+} from "../extensions/gentle-sdd-profile.ts";
+import { SddProfileManager } from "../lib/sdd-profiles-manager.ts";
+
+type Handler = (args: string, ctx: any) => Promise<string | void>;
+
+interface Setup {
+	handler: Handler;
+	commands: Map<string, { handler: Handler }>;
+	ctx: any;
+	manager: SddProfileManager;
+	notices: Array<{ message: string; level?: string }>;
+	shortcuts: Map<string, { handler: (ctx: any) => Promise<unknown> }>;
+	tools: Map<string, { execute: (...args: any[]) => Promise<any> }>;
+	events: Map<string, (...args: any[]) => unknown>;
+	pi: any;
+}
+
+function setup(env: NodeJS.ProcessEnv = {}): Setup {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "gentle-sdd-profile-"));
+	const cwd = path.join(root, "work");
+	const globalDir = path.join(root, "global-profiles");
+	fs.mkdirSync(cwd, { recursive: true });
+	const notices: Setup["notices"] = [];
+	const commands = new Map<string, { handler: Handler }>();
+	const shortcuts: Setup["shortcuts"] = new Map();
+	const tools: Setup["tools"] = new Map();
+	const events: Setup["events"] = new Map();
+	const pi: any = {
+		registerCommand(name: string, registration: { handler: Handler }) {
+			commands.set(name, registration);
+		},
+		registerShortcut(name: string, registration: { handler: (ctx: any) => Promise<unknown> }) {
+			shortcuts.set(name, registration);
+		},
+		registerTool(definition: { name: string; execute: (...args: any[]) => Promise<any> }) {
+			tools.set(definition.name, definition);
+		},
+		on(event: string, handler: (...args: any[]) => unknown) {
+			events.set(event, handler);
+		},
+	};
+	(installGentleSddProfile as (pi: unknown, env?: unknown) => void)(pi, env);
+	assert.ok(commands.has(GENTLE_SDD_PROFILE_COMMAND), "command registered");
+	const handler = commands.get(GENTLE_SDD_PROFILE_COMMAND)!.handler;
+	const ctx = {
+		cwd,
+		globalDir,
+		activeStatePath: path.join(globalDir, ".active"),
+		globalSubagentsPath: path.join(root, "subagents.json"),
+		sessionManager: { getCwd: () => cwd },
+		ui: {
+			notify: (message: string, level?: string) => {
+				notices.push({ message, level });
+			},
+		},
+	};
+	const manager = new SddProfileManager({
+		globalDir,
+		projectDir: path.join(cwd, ".pi", "profiles"),
+		projectSubagentsPath: path.join(cwd, ".pi", "subagents.json"),
+		activeStatePath: path.join(globalDir, ".active"),
+		globalSubagentsPath: path.join(root, "subagents.json"),
+	});
+	return { handler, ctx, manager, notices, shortcuts, tools, events, pi, commands };
+}
+
+function saveForTest(manager: SddProfileManager, name: string): void {
+	manager.saveProfile(
+		{ name, description: `${name} fixture`, model_profiles: {} },
+		"global",
+	);
+}
+
+test("list names profiles and marks the active one", async () => {
+	const { handler, ctx, manager } = setup();
+	saveForTest(manager, "alpha");
+	saveForTest(manager, "beta");
+	manager.activateProfile("alpha");
+
+	const out = (await handler("list", ctx)) as string;
+	assert.match(out, /alpha/);
+	assert.match(out, /beta/);
+	assert.match(out, /gentle-default/);
+	assert.match(out, /\* alpha/);
+	assert.doesNotMatch(out, /\* beta/);
+});
+
+test("use activates a profile and reports", async () => {
+	const { handler, ctx, manager, notices } = setup();
+	const out = (await handler("use gentle-economy", ctx)) as string;
+	assert.match(out, /gentle-economy/);
+	assert.equal(manager.getActiveProfileName(), "gentle-economy");
+	assert.ok(notices.some((n) => n.message === out && n.level === "info"));
+});
+
+test("use of a missing profile reports not-found", async () => {
+	const { handler, ctx, notices } = setup();
+	const out = (await handler("use nope", ctx)) as string;
+	assert.match(out, /not found/i);
+	assert.ok(notices.some((n) => n.message === out && n.level === "error"));
+});
+
+test("save persists so loadProfile finds it", async () => {
+	const { handler, ctx, manager } = setup();
+	const out = (await handler("save snap snap description", ctx)) as string;
+	assert.match(out, /snap/);
+	const loaded = manager.loadProfile("snap");
+	assert.ok(loaded, "saved profile loads back");
+	assert.equal(loaded.description, "snap description");
+});
+
+test("rename moves the profile", async () => {
+	const { handler, ctx, manager } = setup();
+	saveForTest(manager, "old");
+	const out = (await handler("rename old new", ctx)) as string;
+	assert.match(out, /new/);
+	assert.ok(manager.loadProfile("new"), "renamed profile loads");
+	assert.equal(manager.loadProfile("old"), null);
+});
+
+test("delete of the active profile refuses", async () => {
+	const { handler, ctx, manager } = setup();
+	saveForTest(manager, "live");
+	manager.activateProfile("live");
+	const out = (await handler("delete live", ctx)) as string;
+	assert.match(out, /active/i);
+	assert.ok(manager.loadProfile("live"), "active profile kept");
+});
+
+test("delete of a missing profile reports not-found", async () => {
+	const { handler, ctx, notices } = setup();
+	const out = (await handler("delete ghost", ctx)) as string;
+	assert.match(out, /not found/i);
+	assert.ok(notices.some((n) => n.message === out && n.level === "warning"));
+});
+
+test("bare profile name activates it, unknown token prints usage", async () => {
+	const { handler, ctx, manager } = setup();
+	const activated = (await handler("gentle-economy", ctx)) as string;
+	assert.match(activated, /gentle-economy/);
+	assert.equal(manager.getActiveProfileName(), "gentle-economy");
+	const usage = (await handler("frobnicate", ctx)) as string;
+	assert.match(usage, /Usage:/);
+});

--- a/tests/sdd-profiles-catalog.test.ts
+++ b/tests/sdd-profiles-catalog.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	ALL_KNOWN_AGENTS,
+	BUILTIN_PROFILES,
+	SDD_AGENT_CATEGORIES,
+} from "../lib/sdd-profiles-catalog.ts";
+
+const VERIFIED_ROSTER = [
+	"gentle-ai-explore",
+	"gentle-ai-verify",
+	"gentle-ai-worker",
+	"jd-fix-agent",
+	"jd-judge-a",
+	"jd-judge-b",
+	"review-readability",
+	"review-reliability",
+	"review-resilience",
+	"review-risk",
+	"sdd-apply",
+	"sdd-archive",
+	"sdd-design",
+	"sdd-explore",
+	"sdd-init",
+	"sdd-onboard",
+	"sdd-proposal",
+	"sdd-research",
+	"sdd-spec",
+	"sdd-status",
+	"sdd-sync",
+	"sdd-tasks",
+	"sdd-verify",
+	"security-auditor",
+	"task-tracker-manager",
+	"ui-specialist",
+];
+
+test("categories list every verified agent exactly once", () => {
+	const listed = SDD_AGENT_CATEGORIES.flatMap((c) => c.agents);
+	assert.deepEqual([...listed].sort(), [...VERIFIED_ROSTER].sort());
+	assert.equal(new Set(listed).size, listed.length);
+	for (const category of SDD_AGENT_CATEGORIES) {
+		assert.ok(category.id.length > 0);
+		assert.ok(category.agents.length > 0);
+	}
+});
+
+test("ALL_KNOWN_AGENTS equals flattened categories", () => {
+	assert.deepEqual(ALL_KNOWN_AGENTS, SDD_AGENT_CATEGORIES.flatMap((c) => c.agents));
+});
+
+test("stale and retired agents are absent", () => {
+	for (const retired of ["sdd-propose", "review-validator", "review-refuter"]) {
+		assert.ok(!ALL_KNOWN_AGENTS.includes(retired), `${retired} must not be listed`);
+	}
+});
+
+test("builtin presets have name, default_model, and non-empty model_profiles", () => {
+	for (const key of ["gentle-default", "gentle-economy", "gentle-reasoning"]) {
+		const profile = BUILTIN_PROFILES[key];
+		assert.ok(profile, `${key} must exist`);
+		assert.equal(profile.name, key);
+		assert.ok(profile.default_model && profile.default_model.includes("/"), `${key} needs a provider/id default_model`);
+		assert.ok(Object.keys(profile.model_profiles).length > 0, `${key} needs entries`);
+		for (const [agent, entry] of Object.entries(profile.model_profiles)) {
+			assert.ok(entry.model.includes("/"), `${key}.${agent} needs a provider/id model`);
+		}
+	}
+});
+
+test("every agent referenced in builtins exists in ALL_KNOWN_AGENTS", () => {
+	const known = new Set(ALL_KNOWN_AGENTS);
+	for (const [key, profile] of Object.entries(BUILTIN_PROFILES)) {
+		for (const agent of Object.keys(profile.model_profiles)) {
+			assert.ok(known.has(agent), `${key} references unknown agent ${agent}`);
+		}
+	}
+});

--- a/tests/sdd-profiles-manager.test.ts
+++ b/tests/sdd-profiles-manager.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import test from "node:test";
+import type { Profile } from "../lib/sdd-profiles-catalog.ts";
+import {
+	applyProfileToConfig,
+	applyProfileToFile,
+	extractProfileFromConfig,
+	resolveAvailableModels,
+	sanitizeProfileName,
+} from "../lib/sdd-profiles-manager.ts";
+
+const PROFILE: Profile = {
+	name: "test-profile",
+	description: "Test profile",
+	default_model: "anthropic/claude-sonnet-5",
+	default_effort: "medium",
+	model_profiles: {
+		"sdd-explore": { model: "openai/gpt-5-mini", effort: "low" },
+		"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "high" },
+	},
+};
+test("apply preserves custom props and updates model_profiles", () => {
+	const current = {
+		timeout: 5000,
+		tools: ["read"],
+		default_model: "old/model",
+		model_profiles: { "sdd-explore": { model: "old/model" } },
+	};
+	const next = applyProfileToConfig(current, PROFILE);
+	assert.equal(next.timeout, 5000);
+	assert.deepEqual(next.tools, ["read"]);
+	assert.equal(next.default_model, "anthropic/claude-sonnet-5");
+	assert.equal(next.default_effort, "medium");
+	assert.equal(next.active_profile, "test-profile");
+	assert.deepEqual(next.model_profiles, PROFILE.model_profiles);
+	assert.notEqual(next.model_profiles, PROFILE.model_profiles);
+});
+
+test("apply without defaults leaves existing defaults alone", () => {
+	const profile: Profile = { name: "bare", model_profiles: {} };
+	const next = applyProfileToConfig({ default_model: "keep/me" }, profile);
+	assert.equal(next.default_model, "keep/me");
+	assert.equal(next.default_effort, undefined);
+	assert.equal(next.active_profile, "bare");
+});
+
+test("extract round-trips config data", () => {
+	const config = applyProfileToConfig({ custom: true }, PROFILE);
+	const extracted = extractProfileFromConfig(config, "round-trip");
+	assert.equal(extracted.name, "round-trip");
+	assert.equal(extracted.default_model, PROFILE.default_model);
+	assert.equal(extracted.default_effort, PROFILE.default_effort);
+	assert.deepEqual(extracted.model_profiles, PROFILE.model_profiles);
+	const reapplied = applyProfileToConfig({}, extracted);
+	assert.deepEqual(reapplied.model_profiles, PROFILE.model_profiles);
+});
+
+test("extract skips entries without a model string", () => {
+	const extracted = extractProfileFromConfig(
+		{ model_profiles: { good: { model: "a/b" }, bad: {} } },
+		"partial",
+		"desc",
+	);
+	assert.deepEqual(extracted.model_profiles, { good: { model: "a/b", effort: undefined } });
+	assert.equal(extracted.description, "desc");
+});
+
+test("applyToFile writes valid JSON to a tmp dir", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sdd-profile-"));
+	const filePath = path.join(dir, "sub", "subagents.json");
+	const returned = applyProfileToFile(filePath, PROFILE);
+	const onDisk = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+	assert.deepEqual(onDisk, returned);
+	assert.equal(onDisk.active_profile, "test-profile");
+	assert.deepEqual(onDisk.model_profiles, PROFILE.model_profiles);
+	const leftovers = fs.readdirSync(path.join(dir, "sub")).filter((f) => f.endsWith(".tmp"));
+	assert.deepEqual(leftovers, []);
+});
+
+test("applyToFile preserves custom props already on disk", () => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sdd-profile-"));
+	const filePath = path.join(dir, "subagents.json");
+	fs.writeFileSync(filePath, JSON.stringify({ timeout: 9000, tools: ["x"] }));
+	const next = applyProfileToFile(filePath, PROFILE);
+	assert.equal(next.timeout, 9000);
+	assert.deepEqual(next.tools, ["x"]);
+});
+
+test("sanitize normalizes names", () => {
+	assert.equal(sanitizeProfileName("  My Profile! "), "my-profile-");
+	assert.equal(sanitizeProfileName("UPPER_under-score"), "upper_under-score");
+	assert.equal(sanitizeProfileName("a/b c"), "a-b-c");
+});
+
+test("resolveAvailableModels merges registry discovery with fallback", async () => {
+	const ctx = {
+		modelRegistry: {
+			getAvailable: async () => [
+				{ provider: "acme", id: "model-a" },
+				{ providerId: "other", model: "model-b" },
+			],
+		},
+	};
+	const models = await resolveAvailableModels(ctx);
+	assert.ok(models.includes("acme/model-a"));
+	assert.ok(models.includes("other/model-b"));
+	assert.ok(models.includes("openai/gpt-4o"));
+	assert.deepEqual(models, [...models].sort((a, b) => a.localeCompare(b)));
+});

--- a/tests/sdd-profiles-manager.test.ts
+++ b/tests/sdd-profiles-manager.test.ts
@@ -174,6 +174,100 @@ test("getActiveProfileName prefers project subagents.json over .active file", ()
 	assert.equal(mgr.getActiveProfileName(), null);
 });
 
+test("saveProfile round-trips and clears tombstone", () => {
+const d = makeManagerDirs();
+fs.writeFileSync(path.join(d.globalDir, ".deleted-profiles"), "gentle-default\n");
+const mgr = new SddProfileManager({ ...d });
+assert.equal(mgr.loadProfile("gentle-default"), null);
+mgr.saveProfile({ ...MIN_PROFILE("gentle-default"), default_model: "new/m" }, "global");
+assert.equal(mgr.loadProfile("gentle-default")?.default_model, "new/m");
+assert.ok(mgr.listProfiles().some((p) => p.name === "gentle-default"));
+const loaded = mgr.loadProfile("gentle-default");
+assert.ok(loaded?.created_at);
+assert.ok(loaded?.updated_at);
+});
+
+test("activateProfile writes subagents.json and sets active", () => {
+const d = makeManagerDirs();
+const mgr = new SddProfileManager({ ...d });
+mgr.saveProfile({ ...MIN_PROFILE("custom-v1"), default_model: "custom/m" }, "global");
+const res = mgr.activateProfile("custom-v1", "global");
+assert.equal(res.success, true);
+assert.equal(mgr.getActiveProfileName(), "custom-v1");
+const onDisk = JSON.parse(fs.readFileSync(d.globalSubagentsPath, "utf-8"));
+assert.equal(onDisk.active_profile, "custom-v1");
+assert.equal(onDisk.default_model, "custom/m");
+assert.equal(mgr.activateProfile("nope", "global").success, false);
+});
+
+test("deleteProfile refuses active and tombstones builtins", () => {
+const d = makeManagerDirs();
+const mgr = new SddProfileManager({ ...d });
+mgr.saveProfile(MIN_PROFILE("mine"), "global");
+mgr.activateProfile("mine", "global");
+assert.equal(mgr.deleteProfile("mine"), false);
+assert.ok(mgr.loadProfile("mine"));
+assert.equal(mgr.deleteProfile("gentle-default"), true);
+assert.ok(!mgr.listProfiles().some((p) => p.name === "gentle-default"));
+assert.equal(mgr.loadProfile("gentle-default"), null);
+});
+
+test("renameProfile moves file and follows active pointer", () => {
+const d = makeManagerDirs();
+const mgr = new SddProfileManager({ ...d });
+mgr.saveProfile(MIN_PROFILE("old-name"), "global");
+mgr.activateProfile("old-name", "global");
+const res = mgr.renameProfile("old-name", "new-name");
+assert.equal(res.success, true);
+assert.equal(mgr.loadProfile("old-name"), null);
+assert.ok(mgr.loadProfile("new-name"));
+assert.equal(mgr.getActiveProfileName(), "new-name");
+assert.equal(mgr.renameProfile("new-name", "new-name").success, false);
+assert.equal(mgr.renameProfile("missing", "other").success, false);
+});
+
+test("saveCurrentAsProfile snapshots config and marks active", () => {
+const d = makeManagerDirs();
+const mgr = new SddProfileManager({ ...d });
+mgr.saveProfile({ ...MIN_PROFILE("base"), default_model: "snap/m" }, "global");
+mgr.activateProfile("base", "global");
+const res = mgr.saveCurrentAsProfile("snap", "Snapshot", "global");
+assert.equal(res.success, true);
+assert.equal(mgr.loadProfile("snap")?.default_model, "snap/m");
+assert.equal(mgr.getActiveProfileName(), "snap");
+});
+
+test("createProfile creates and refuses duplicates", () => {
+const d = makeManagerDirs();
+const mgr = new SddProfileManager({ ...d });
+const res = mgr.createProfile({ name: "fresh", default_model: "a/b", scope: "global" });
+assert.equal(res.success, true);
+assert.equal(mgr.loadProfile("fresh")?.default_model, "a/b");
+assert.equal(mgr.createProfile({ name: "fresh" }).success, false);
+assert.equal(mgr.createProfile({ name: "   " }).success, false);
+});
+
+test("setAgentInProfile persists model+effort and validates", () => {
+const d = makeManagerDirs();
+const mgr = new SddProfileManager({ ...d });
+mgr.createProfile({ name: "agents", scope: "global" });
+const res = mgr.setAgentInProfile({ profileName: "agents", agentName: "sdd-explore", model: "a/b", effort: "high" });
+assert.equal(res.success, true);
+assert.deepEqual(mgr.loadProfile("agents")?.model_profiles?.["sdd-explore"], { model: "a/b", effort: "high" });
+assert.equal(mgr.setAgentInProfile({ profileName: "agents", agentName: "nope", model: "a/b" }).success, false);
+assert.equal(mgr.setAgentInProfile({ profileName: "missing", agentName: "sdd-explore", model: "a/b" }).success, false);
+});
+
+test("setAgentInProfile saves back to project origin", () => {
+const d = makeManagerDirs();
+const mgr = new SddProfileManager({ ...d });
+mgr.createProfile({ name: "agents", scope: "project" });
+const res = mgr.setAgentInProfile({ profileName: "agents", agentName: "sdd-spec", model: "c/d" });
+assert.equal(res.success, true);
+assert.ok(fs.existsSync(path.join(d.projectDir, "agents.json")));
+assert.ok(!fs.existsSync(path.join(d.globalDir, "agents.json")));
+});
+
 test("resolveAvailableModels merges registry discovery with fallback", async () => {
 	const ctx = {
 		modelRegistry: {

--- a/tests/sdd-profiles-manager.test.ts
+++ b/tests/sdd-profiles-manager.test.ts
@@ -10,6 +10,7 @@ import {
 	extractProfileFromConfig,
 	resolveAvailableModels,
 	sanitizeProfileName,
+	SddProfileManager,
 } from "../lib/sdd-profiles-manager.ts";
 
 const PROFILE: Profile = {
@@ -22,6 +23,7 @@ const PROFILE: Profile = {
 		"sdd-spec": { model: "anthropic/claude-sonnet-5", effort: "high" },
 	},
 };
+
 test("apply preserves custom props and updates model_profiles", () => {
 	const current = {
 		timeout: 5000,
@@ -93,6 +95,83 @@ test("sanitize normalizes names", () => {
 	assert.equal(sanitizeProfileName("  My Profile! "), "my-profile-");
 	assert.equal(sanitizeProfileName("UPPER_under-score"), "upper_under-score");
 	assert.equal(sanitizeProfileName("a/b c"), "a-b-c");
+});
+
+function makeManagerDirs() {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "sdd-mgr-"));
+	const globalDir = path.join(root, "global");
+	const projectDir = path.join(root, "project");
+	const builtinsDir = path.join(root, "builtins");
+	fs.mkdirSync(globalDir, { recursive: true });
+	fs.mkdirSync(projectDir, { recursive: true });
+	fs.mkdirSync(builtinsDir, { recursive: true });
+	return {
+		root,
+		globalDir,
+		projectDir,
+		builtinsDir,
+		activeStatePath: path.join(root, ".active"),
+		globalSubagentsPath: path.join(root, "global-subagents.json"),
+		projectSubagentsPath: path.join(root, "project-subagents.json"),
+	};
+}
+
+function writeProfile(dir: string, profile: Profile): void {
+	fs.writeFileSync(path.join(dir, `${profile.name}.json`), JSON.stringify(profile));
+}
+
+const MIN_PROFILE = (name: string, model = "a/b"): Profile => ({ name, model_profiles: { x: { model } } });
+
+test("listProfiles includes embedded builtins", () => {
+	const d = makeManagerDirs();
+	const mgr = new SddProfileManager({ ...d });
+	const names = new Map(mgr.listProfiles().map((p) => [p.name, p]));
+	assert.ok(names.has("gentle-default"));
+	assert.equal(names.get("gentle-default")?.scope, "builtin");
+	assert.equal(names.get("gentle-default")?.is_active, false);
+});
+
+test("listProfiles precedence is project over global over builtin", () => {
+	const d = makeManagerDirs();
+	writeProfile(d.globalDir, { ...MIN_PROFILE("gentle-default"), default_model: "global/m" });
+	writeProfile(d.projectDir, { ...MIN_PROFILE("gentle-default"), default_model: "project/m" });
+	const mgr = new SddProfileManager({ ...d });
+	const found = mgr.listProfiles().find((p) => p.name === "gentle-default");
+	assert.equal(found?.scope, "project");
+	assert.equal(found?.default_model, "project/m");
+});
+
+test("listProfiles hides tombstoned builtin", () => {
+	const d = makeManagerDirs();
+	fs.writeFileSync(path.join(d.globalDir, ".deleted-profiles"), "gentle-default\n");
+	const mgr = new SddProfileManager({ ...d });
+	assert.ok(!mgr.listProfiles().some((p) => p.name === "gentle-default"));
+	assert.equal(mgr.loadProfile("gentle-default"), null);
+});
+
+test("loadProfile falls back project, global, builtinsDir, embedded", () => {
+	const d = makeManagerDirs();
+	writeProfile(d.builtinsDir, { ...MIN_PROFILE("custom"), default_model: "builtins/m" });
+	const mgr = new SddProfileManager({ ...d });
+	assert.equal(mgr.loadProfile("custom")?.default_model, "builtins/m");
+	writeProfile(d.globalDir, { ...MIN_PROFILE("custom"), default_model: "global/m" });
+	assert.equal(mgr.loadProfile("custom")?.default_model, "global/m");
+	writeProfile(d.projectDir, { ...MIN_PROFILE("custom"), default_model: "project/m" });
+	assert.equal(mgr.loadProfile("custom")?.default_model, "project/m");
+	assert.equal(mgr.loadProfile("gentle-economy")?.name, "gentle-economy");
+	assert.equal(mgr.loadProfile("missing"), null);
+});
+
+test("getActiveProfileName prefers project subagents.json over .active file", () => {
+	const d = makeManagerDirs();
+	fs.writeFileSync(d.activeStatePath, "from-active\n");
+	fs.writeFileSync(d.projectSubagentsPath, JSON.stringify({ active_profile: "from-project" }));
+	const mgr = new SddProfileManager({ ...d });
+	assert.equal(mgr.getActiveProfileName(), "from-project");
+	fs.unlinkSync(d.projectSubagentsPath);
+	assert.equal(mgr.getActiveProfileName(), "from-active");
+	fs.unlinkSync(d.activeStatePath);
+	assert.equal(mgr.getActiveProfileName(), null);
 });
 
 test("resolveAvailableModels merges registry discovery with fallback", async () => {


### PR DESCRIPTION
Related to #759 (part 5 of 10 — cumulative stack, review the top commit on top of #811).

## Summary
New `gentle-sdd-profile` command (gentle- prefix per repo convention): list/use/save/rename/delete plus bare-name activation, English usage, active-profile guardrails. Own delta: `extensions/gentle-sdd-profile.ts` (192), tests (160).

## Test plan
Extension suite 8 pass (mock pi/ctx, tmp dirs).

## Checklist
- [x] Related to #759 (approved feature) | Type: feature (maintainer label)
- [x] Tests ship with the behavior they verify