### PR TITLE
docs(sdd): make settlement evidence revision conditional

### DIFF
--- a/assets/sdd-orchestrator-workflow.md
+++ b/assets/sdd-orchestrator-workflow.md
@@ -220,10 +220,10 @@ Never persist caller-authored attempt counters, tokens, or state in OpenSpec art
 After the external run completes, call the compact settle with a request ID distinct from acquire, reusing an operation's own ID only for idempotent replay of that exact operation:
 
 ```text
-gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <id> --outcome <failed|interrupted|passed> --evidence-revision <sha256:...> --diagnosis <text> --harness-disposition <reused|invalidated> --cleanup-evidence <text> --process-evidence <text>
+gentle-ai sdd-attempt settle --cwd <repo> --change <change> --token <token> --request-id <id> --outcome <failed|interrupted|passed> [--evidence-revision <sha256:...>] --diagnosis <text> --harness-disposition <reused|invalidated> --cleanup-evidence <text> --process-evidence <text>
 ```
 
-Every settle field is required: `cwd`, `change`, `token`, `request-id`, `outcome`, `evidence-revision`, `diagnosis`, `harness-disposition`, `cleanup-evidence`, and `process-evidence`. `evidence-revision` is never `none`. Pass `--successor-lineage` only for a distinct approved successor; the current/bound lineage remains itself otherwise. Pass `--remediates-evidence-revision` only when repairing a specific failed evidence revision. Settle derives binding and remediation inputs; the orchestrator never invents them.
+Every settle field except `evidence-revision` is required: `cwd`, `change`, `token`, `request-id`, `outcome`, `diagnosis`, `harness-disposition`, `cleanup-evidence`, and `process-evidence`. For `failed` or `passed`, include `--evidence-revision` with the `sha256:...` evidence hash. For `interrupted`, omit the entire `--evidence-revision` flag. Pass `--successor-lineage` only for a distinct approved successor; the current/bound lineage remains itself otherwise. Pass `--remediates-evidence-revision` only when repairing a specific failed evidence revision. Settle derives binding and remediation inputs; the orchestrator never invents them.
 
 `status`, `begin`, `finish`, and `reset` are diagnostic/compatibility surfaces, not the normal runtime route. Route continuation only from the provider-returned `proceed|blocked|complete`. `reset` is never automatic and requires an explicit maintainer scope decision.
 

--- a/tests/native-sdd-attempt-authority.test.ts
+++ b/tests/native-sdd-attempt-authority.test.ts
@@ -147,7 +147,6 @@ test("workflow settle command line binds mandatory arguments and routing invaria
 		"--token <token>",
 		"--request-id <id>",
 		"--outcome <failed|interrupted|passed>",
-		"--evidence-revision <sha256:...>",
 		"--diagnosis <text>",
 		"--harness-disposition <reused|invalidated>",
 		"--cleanup-evidence <text>",
@@ -155,7 +154,13 @@ test("workflow settle command line binds mandatory arguments and routing invaria
 	]) {
 		assert.ok(settle.includes(arg), `settle command is missing ${arg}; command: ${settle}`);
 	}
-	assert.match(section, /never `none`/);
+	assert.ok(settle.includes("[--evidence-revision <sha256:...>]"));
+	assert.match(section, /Every settle field except `evidence-revision` is required/);
+	assert.match(
+		section,
+		/For `failed` or `passed`, include `--evidence-revision` with the `sha256:\.\.\.` evidence hash\./,
+	);
+	assert.match(section, /For `interrupted`, omit the entire `--evidence-revision` flag\./);
 	assert.match(section, /proceed\|blocked\|complete/);
 	assert.match(section, /--successor-lineage/);
 	assert.match(section, /--remediates-evidence-revision/);


### PR DESCRIPTION
## Linked issue
Closes #619

## PR type
- [x] Bug fix (`type:bug`): correct an invalid documented CLI invocation.

## Summary
- Require the evidence hash for failed/passed settlement; omit the entire flag for interrupted settlement.
- Preserve all three outcomes and the remaining settlement contract.
- Update regression assertions to enforce the conditional requirements.

## Changes
| File | Change |
|------|--------|
| `assets/sdd-orchestrator-workflow.md` | Make evidence-revision conditional in the invocation and explanation. |
| `tests/native-sdd-attempt-authority.test.ts` | Assert conditional evidence requirements. |

## Test plan
- [x] `node --experimental-strip-types --test tests/native-sdd-attempt-authority.test.ts` — 17 passed.
- [x] `git diff --check` — passed.
- [x] Compared the condition with `gentle-ai sdd-attempt settle --help`; no live attempt state was mutated.
- [x] Native review approved and acknowledged.
- Full suite not run; focused contract suite passed.

## Contributor checklist
- [x] Linked issue has `status:approved`.
- [x] Exactly one type label: `type:bug`.
- [x] Conventional commit; no Co-Authored-By trailers.
- [x] Documentation and regression assertions updated together.
- Shellcheck and skill-loading checks: not applicable; no shell scripts or skills changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `settle` command now allows `--evidence-revision` to be omitted for interrupted outcomes.
  * Evidence revisions remain required for passed or failed outcomes.
* **Documentation**
  * Updated command guidance to clarify when evidence revisions are required or must be omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->