### PR TITLE
fix(windows): hide startup and polling Git processes

### DIFF
--- a/docs/windows-startup-console-visibility.md
+++ b/docs/windows-startup-console-visibility.md
@@ -1,0 +1,18 @@
+# Windows Startup Console Capture
+
+Use this protocol to validate the startup Git child processes on a real Windows desktop. Linux CI can verify spawn configuration but cannot observe Windows console windows.
+
+## Capture
+
+1. Start a Windows window-event trace before launching Pi. Capture `EVENT_OBJECT_SHOW`, its timestamp, HWND, owner PID, and owner session.
+2. Deliberately launch a known visible, short-lived console as a positive control. If its show event is absent, the capture is **INCONCLUSIVE**.
+3. Build or install the candidate Gentle Pi package and start `pi` from a repository whose path contains spaces. Leave it idle for at least 10 seconds so the branch lookup, initial shell scan, and repeated poll run.
+4. Correlate each show event with `GetWindowThreadProcessId`, then use its timestamp, host PID/session, and Procmon process-creation ancestry and command line to associate it with a Pi-launched Git invocation. The HWND can be owned by `conhost.exe`, OpenConsole, or Windows Terminal rather than `git.exe`.
+
+## Expected Result
+
+No `WS_VISIBLE` show event is associated with the Git invocation for the banner branch lookup, initial shell scan, or repeated shell polling. A visible show event proves window visibility, not that it was unobscured on screen. Process start alone is not visible-window evidence. If event-to-invocation association cannot be established, report **INCONCLUSIVE**, not pass.
+
+## Scope
+
+This protocol does not cover user-configured external editors. Their inherited-stdio launch is intentional and may open a visible window.

--- a/docs/windows-startup-console-visibility.md
+++ b/docs/windows-startup-console-visibility.md
@@ -6,12 +6,12 @@ Use this protocol to validate the startup Git child processes on a real Windows 
 
 1. Start a Windows window-event trace before launching Pi. Capture `EVENT_OBJECT_SHOW`, its timestamp, HWND, owner PID, and owner session.
 2. Deliberately launch a known visible, short-lived console as a positive control. If its show event is absent, the capture is **INCONCLUSIVE**.
-3. Build or install the candidate Gentle Pi package and start `pi` from a repository whose path contains spaces. Leave it idle for at least 10 seconds so the branch lookup, initial shell scan, and repeated poll run.
+3. Build or install the candidate Gentle Pi package and start `pi` from a repository whose path contains spaces. Leave it idle for at least 10 seconds so the startup identity lookups (`git rev-parse --show-toplevel` and `git rev-parse --git-common-dir`), branch lookup, initial shell scan, and repeated poll run.
 4. Correlate each show event with `GetWindowThreadProcessId`, then use its timestamp, host PID/session, and Procmon process-creation ancestry and command line to associate it with a Pi-launched Git invocation. The HWND can be owned by `conhost.exe`, OpenConsole, or Windows Terminal rather than `git.exe`.
 
 ## Expected Result
 
-No `WS_VISIBLE` show event is associated with the Git invocation for the banner branch lookup, initial shell scan, or repeated shell polling. A visible show event proves window visibility, not that it was unobscured on screen. Process start alone is not visible-window evidence. If event-to-invocation association cannot be established, report **INCONCLUSIVE**, not pass.
+No `WS_VISIBLE` show event is associated with the Git invocation for the startup identity lookups, banner branch lookup, initial shell scan, or repeated shell polling. A visible show event proves window visibility, not that it was unobscured on screen. Process start alone is not visible-window evidence. If event-to-invocation association cannot be established, report **INCONCLUSIVE**, not pass.
 
 ## Scope
 

--- a/extensions/gentle-shell.ts
+++ b/extensions/gentle-shell.ts
@@ -222,14 +222,16 @@ const GIT_TIMEOUT_MS = 5000;
 const OVERLAY_HEIGHT_RATIO = 0.8;
 const OVERLAY_MIN_ROWS = 8;
 
-export function shellGitRunner(cwd: string, env: NodeJS.ProcessEnv = process.env): GitRunner {
+export function shellGitRunner(cwd: string, env: NodeJS.ProcessEnv = process.env, run: typeof execFile = execFile): GitRunner {
 	// Pi exec cannot replace the inherited environment. Use argv directly and
 	// a complete sanitized environment for discovery, status, and lazy diffs.
 	const childEnv = worktreeGitEnvironment(env);
 	return (args) => new Promise((resolve) => {
-		execFile("git", ["-C", cwd, ...args], {
+		run("git", ["-C", cwd, ...args], {
 			env: childEnv,
 			encoding: "utf8",
+			shell: false,
+			windowsHide: true,
 			timeout: GIT_TIMEOUT_MS,
 			// Pi exec accumulates output without a maxBuffer cap. In particular,
 			// large porcelain inventories must not become partial successful scans.

--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -2,12 +2,10 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { VERSION } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import * as os from "node:os";
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
+import { execFile } from "node:child_process";
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-const execAsync = promisify(exec);
 const PI_AGENT_DIR = join(os.homedir(), ".pi", "agent");
 const PI_NPM_DIR = join(PI_AGENT_DIR, "npm", "node_modules");
 
@@ -527,6 +525,23 @@ async function countPackageExtensions(packages: unknown[]): Promise<number> {
   return count;
 }
 
+export function readGitBranch(cwd: string, run: typeof execFile = execFile): Promise<string> {
+  return new Promise((resolve) => {
+    run("git", ["-C", cwd, "branch", "--show-current"], {
+      encoding: "utf8",
+      shell: false,
+      windowsHide: true,
+    }, (error, stdout) => {
+      if (error) {
+        resolve("Not a git repo");
+        return;
+      }
+      const branch = String(stdout).trim();
+      resolve(branch ? `On branch ${branch}` : "Detached HEAD");
+    });
+  });
+}
+
 export default function (pi: ExtensionAPI) {
   let disposeHeader = () => {};
   pi.on("session_shutdown", () => disposeHeader());
@@ -632,12 +647,8 @@ export default function (pi: ExtensionAPI) {
     );
 
     setTimeout(() => {
-      execAsync(`git -C "${ctx.cwd}" branch --show-current`)
-        .then(({ stdout }) => {
-          const b = stdout.trim();
-          gitBranch = b ? `On branch ${b}` : "Detached HEAD";
-        })
-        .catch(() => {})
+      readGitBranch(ctx.cwd)
+        .then((branch) => { gitBranch = branch; })
         .finally(() => refreshStats());
     }, 100);
 

--- a/lib/session-worktree-registry.ts
+++ b/lib/session-worktree-registry.ts
@@ -23,7 +23,7 @@ export function worktreeGitEnvironment(env: NodeJS.ProcessEnv = process.env): No
 }
 
 // Match Pi's ordinary path spelling; Git, not the argument, establishes identity.
-export const resolveSessionWorktree: WorktreeResolver = (path, cwd) => {
+export function resolveSessionWorktreeWithGit(path: string, cwd: string, run: typeof execFileSync = execFileSync): WorktreeIdentity | undefined {
 	try {
 		let spelling = path.replace(/^@/, "").replace(/[\u00a0\u2000-\u200a\u202f\u205f\u3000]/g, " ");
 		if (spelling === "~" || spelling.startsWith("~/")) spelling = homedir() + spelling.slice(1);
@@ -31,12 +31,14 @@ export const resolveSessionWorktree: WorktreeResolver = (path, cwd) => {
 		const directory = statSync(canonical).isDirectory() ? canonical : dirname(canonical);
 		// Ambient Git routing must not redirect a path into another repository.
 		const env = worktreeGitEnvironment();
-		const git = (arg: string) => execFileSync("git", ["--no-optional-locks", "-C", directory, "rev-parse", "--path-format=absolute", arg], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"], env }).replace(/\r?\n$/, "");
+		const git = (arg: string) => String(run("git", ["--no-optional-locks", "-C", directory, "rev-parse", "--path-format=absolute", arg], { encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "pipe"], shell: false, windowsHide: true, env })).replace(/\r?\n$/, "");
 		return { root: realpathSync(git("--show-toplevel")), commonDir: realpathSync(git("--git-common-dir")) };
 	} catch {
 		return undefined;
 	}
-};
+}
+
+export const resolveSessionWorktree: WorktreeResolver = resolveSessionWorktreeWithGit;
 
 export function toolWorktreePath(name: string, input: Record<string, unknown>): string | undefined {
 	if (!["read", "write", "edit", "grep", "find", "ls"].includes(name)) return undefined;

--- a/tests/gentle-shell.test.ts
+++ b/tests/gentle-shell.test.ts
@@ -544,6 +544,24 @@ test("loadFileDiff asks git for a HEAD diff, or a no-index diff for untracked fi
 	]);
 });
 
+test("shell Git runner hides initial and repeated background polling children", async () => {
+	const calls: Array<{ command: string; args: readonly string[]; options: Record<string, unknown> }> = [];
+	const run = ((command: string, args: readonly string[], options: Record<string, unknown>, callback: (error: Error | null, stdout: string) => void) => {
+		calls.push({ command, args, options });
+		callback(null, "", "");
+	}) as typeof import("node:child_process").execFile;
+	const git = shellGitRunner("/repo with spaces & metacharacters", { PATH: process.env.PATH }, run);
+	await git(["status", "--porcelain=v1", "-z"]);
+	await git(["status", "--porcelain=v1", "-z"]);
+	assert.equal(calls.length, 2, "the same safe runner serves startup and repeated polling");
+	for (const call of calls) {
+		assert.equal(call.command, "git");
+		assert.deepEqual(call.args, ["-C", "/repo with spaces & metacharacters", "status", "--porcelain=v1", "-z"]);
+		assert.equal(call.options.shell, false);
+		assert.equal(call.options.windowsHide, true);
+	}
+});
+
 test("openInExternalEditor stops the TUI around the editor and honors $VISUAL over $EDITOR", () => {
 	const events: string[] = [];
 	const host = { stop: () => events.push("stop"), start: () => events.push("start"), requestRender: (force?: boolean) => events.push(`render:${force}`) };

--- a/tests/session-worktree-registry.test.ts
+++ b/tests/session-worktree-registry.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
-import { SessionWorktreeRegistry, resolveSessionWorktree, SESSION_WORKTREE_ENTRY, toolWorktreePath, worktreeGitEnvironment } from "../lib/session-worktree-registry.ts";
+import { SessionWorktreeRegistry, resolveSessionWorktree, resolveSessionWorktreeWithGit, SESSION_WORKTREE_ENTRY, toolWorktreePath, worktreeGitEnvironment } from "../lib/session-worktree-registry.ts";
 
 // All Git and session writes belong to unique fixtures, never the live clone.
 function fixture(t: test.TestContext) {
@@ -109,6 +109,22 @@ test("Git child environment removes routing and config overrides without mutatin
 	const before = { ...env };
 	assert.deepEqual(worktreeGitEnvironment(env), { PATH: "/tools", HOME: "/fixture" });
 	assert.deepEqual(env, before);
+});
+
+test("session startup identity lookup hides its direct Git children", (t) => {
+	const f = fixture(t);
+	const calls: Array<{ command: string; args: readonly string[]; options: Record<string, unknown> }> = [];
+	const run = ((command: string, args: readonly string[], options: Record<string, unknown>) => {
+		calls.push({ command, args, options });
+		return args.at(-1) === "--show-toplevel" ? `${f.main}\n` : `${join(f.main, ".git")}\n`;
+	}) as typeof import("node:child_process").execFileSync;
+	assert.equal(resolveSessionWorktreeWithGit(f.main, f.main, run)?.root, f.main);
+	assert.equal(calls.length, 2);
+	for (const call of calls) {
+		assert.equal(call.command, "git");
+		assert.equal(call.options.shell, false);
+		assert.equal(call.options.windowsHide, true);
+	}
 });
 
 test("only standard path-bearing calls have registration candidates; shell and prose never do", () => {

--- a/tests/startup-banner.test.ts
+++ b/tests/startup-banner.test.ts
@@ -2,10 +2,24 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { syncBuiltinESMExports } from "node:module";
 import fs from "node:fs/promises";
-import startup from "../extensions/startup-banner.ts";
+import startup, { readGitBranch } from "../extensions/startup-banner.ts";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { stripAnsi } from "../lib/terminal-theme.ts";
+
+test("startup branch lookup uses direct git argv and hides its Windows child", async () => {
+	const calls: Array<{ command: string; args: readonly string[]; options: Record<string, unknown> }> = [];
+	const run = ((command: string, args: readonly string[], options: Record<string, unknown>, callback: (error: Error | null, stdout: string) => void) => {
+		calls.push({ command, args, options });
+		callback(null, "main\n");
+	}) as typeof import("node:child_process").execFile;
+	assert.equal(await readGitBranch("/repo with spaces & metacharacters", run), "On branch main");
+	assert.deepEqual(calls, [{
+		command: "git",
+		args: ["-C", "/repo with spaces & metacharacters", "branch", "--show-current"],
+		options: { encoding: "utf8", shell: false, windowsHide: true },
+	}]);
+});
 
 // Drive the real header factory; background git/home reads never run.
 for (const showRose of [false, true]) for (const showTextLogo of [false, true]) {


### PR DESCRIPTION
Closes #708

## Summary
- Hide direct Git children used by the startup banner, initial shell scan, and background polling on Windows.
- Preserve direct `execFile` startup invocation and existing Git environment sanitization.
- Document a Windows visual-capture protocol that distinguishes observable window visibility from process creation.

This follows up on #762 and #805. The native upstream correction is tracked separately; this PR intentionally does not change the Gentle AI pin or publish a release. Context: https://github.com/Gentleman-Programming/gentle-pi/issues/708#issuecomment-5607344231

## Changes

| File | Change |
| --- | --- |
| `extensions/startup-banner.ts` | Hide direct startup branch lookup child process. |
| `extensions/gentle-shell.ts` | Hide initial and polling Git child processes. |
| `lib/session-worktree-registry.ts` | Hide startup identity Git child process. |
| `tests/startup-banner.test.ts` | Assert direct hidden startup Git invocation. |
| `tests/gentle-shell.test.ts` | Assert hidden initial and polling Git children. |
| `tests/session-worktree-registry.test.ts` | Assert hidden startup identity lookup. |
| `docs/windows-startup-console-visibility.md` | Add Windows visual validation protocol. |

## Testing

- [x] `node --experimental-strip-types --test tests/startup-banner.test.ts tests/gentle-shell.test.ts tests/session-worktree-registry.test.ts` (40 passed)
- [x] `pnpm run test:harness`
- [x] `pnpm run check:runtime-modules`
- [x] `pnpm run test:packed-package`
- [x] `git diff --check`
- [ ] Windows visual window-event capture, not executed in this Linux environment.

## Checklist

- [x] Linked approved issue #708.
- [x] Documentation updated for observable Windows validation.
- [x] Conventional commit, with no attribution trailers.
- [x] No version, tag, release, or Gentle AI pin changes.
- [ ] PR `type:bug` label pending explicit label approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented Git operations used during startup, worktree detection, and background status checks from displaying unwanted console windows on Windows.
  - Improved startup Git branch detection while preserving the existing banner behavior.
  - Improved consistency for repeated background status checks and worktree detection.

- **Documentation**
  - Added Windows validation guidance for confirming that startup-related Git processes remain hidden and do not create visible console windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->