### PR TITLE
perf(fullscreen): cache unchanged sidebar frames

### DIFF
--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -6,8 +6,9 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join, resolve } from "node:path";
 import { keyHint, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
+import { Text, type TUI } from "@earendil-works/pi-tui";
 import { sidebarPart } from "../lib/shell-sidebar.ts";
+import { invalidateSidebar } from "../lib/shell-sidebar-layout.ts";
 import { AGENT_MODE, discoverAgents, loadAgentsConfig, resolveAgentProfile, type AgentDefinition, type AgentMode } from "../lib/agents-config.ts";
 import { isFinished, TASK_STATUS, TaskStore, type AskRequest, type TaskRecord } from "../lib/agents-protocol.ts";
 import { AgentRunner, piCommand, type AskAnswer, type RunnerDeps, type TaskRequest } from "../lib/agents-runner.ts";
@@ -256,6 +257,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	const tasksDir = historyDir(deps.home, agentHome);
 	let ui: ExtensionContext["ui"] | undefined;
 	let host: { requestRender(): void } | undefined;
+	let sidebarTui: TUI | undefined;
 	let sessions: ExtensionContext["sessionManager"] | undefined;
 	let presence: PresencePublisher | undefined;
 	const overlays = new Set<AgentsView>();
@@ -296,6 +298,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		renderQueued = true;
 		deps.schedule(() => {
 			renderQueued = false;
+			if (sidebarTui) invalidateSidebar(sidebarTui);
 			host?.requestRender();
 		}, RENDER_COALESCE_MS);
 	};
@@ -318,6 +321,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		const expiry = widgetExpiryMs(tasks, deps.now());
 		if (expiry === undefined) return;
 		cancelClock = deps.schedule(() => {
+			if (sidebarTui) invalidateSidebar(sidebarTui);
 			host?.requestRender();
 			tickClock();
 		}, expiry);
@@ -526,6 +530,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	// coalesced so a chatty child cannot flood the terminal.
 	store.subscribeSummary(() => {
 		publishActivity();
+		if (sidebarTui) invalidateSidebar(sidebarTui);
 		host?.requestRender();
 		tickClock();
 	});
@@ -536,6 +541,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		tickClock();
 		ui?.setWidget(AGENTS_WIDGET_KEY, (tui, theme) => {
 			host = tui;
+			sidebarTui = tui;
 			return sidebarPart(tui, "agents", {
 				render(width: number) {
 					const lines = renderAgentsCard(visibleTasks(), theme, width, deps.now(), { collapsed, collapseKey, maxRows: widgetRows(tui.terminal?.rows), viewKey });
@@ -718,6 +724,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			description: "Collapse or expand the agents card",
 			handler: async () => {
 				collapsed = !collapsed;
+				if (sidebarTui) invalidateSidebar(sidebarTui);
 				host?.requestRender();
 			},
 		});
@@ -757,6 +764,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		for (const view of overlays) { view.handleInput("q"); view.dispose(); }
 		overlays.clear();
 		sessions = undefined;
+		sidebarTui = undefined;
 		worktrees?.close();
 		worktrees = undefined;
 		runner.cancelAll();

--- a/extensions/gentle-shell.ts
+++ b/extensions/gentle-shell.ts
@@ -14,7 +14,7 @@ import { framePromptLines, PROMPT_HINT, PROMPT_STATE, withPromptHint, type Promp
 import { accountIdFromToken, CODEX_PROVIDER, CODEX_USAGE_URL, parseCodexUsage, parseUsageHeaders, UsageStore, type ProviderUsage } from "../lib/shell-usage.ts";
 import { UsageView } from "../lib/shell-usage-view.ts";
 import { sidebarPart } from "../lib/shell-sidebar.ts";
-import { installSidebar } from "../lib/shell-sidebar-layout.ts";
+import { installSidebar, invalidateSidebar } from "../lib/shell-sidebar-layout.ts";
 
 // Gentle Shell: the visual layer gentle-pi puts on top of pi. It installs the
 // status bar, the petal prompt, the working-tree changes widget and overlay,
@@ -29,6 +29,7 @@ export interface ShellFooterData {
 
 interface ShellRenderHost {
 	requestRender(): void;
+	invalidateSidebar?(): void;
 }
 
 interface ShellBarComponent {
@@ -126,7 +127,10 @@ export function createShellBarComponent(
 	dirty: () => number | undefined = () => undefined,
 	usage: () => ProviderUsage | undefined = () => undefined,
 ): ShellBarComponent {
-	const unsubscribe = footerData.onBranchChange(() => host.requestRender());
+	const unsubscribe = footerData.onBranchChange(() => {
+		host.invalidateSidebar?.();
+		host.requestRender();
+	});
 	return {
 		render(width: number) {
 			return renderShellBar(buildShellBarModel(pi, ctx, footerData, { dirty: dirty(), usage: usage() }), theme, width);
@@ -461,12 +465,14 @@ export default function gentleShell(pi: ExtensionAPI, env: NodeJS.ProcessEnv = p
 		const fetched = await fetchCodexUsage(token, deps.fetch, deps.now());
 		if (!fetched) return;
 		usage.record(fetched);
+		renderHost?.invalidateSidebar?.();
 		renderHost?.requestRender();
 	};
 	pi.on("after_provider_response", (event) => {
 		const parsed = parseUsageHeaders(event.headers, deps.now());
 		if (!parsed) return;
 		usage.record(parsed);
+		renderHost?.invalidateSidebar?.();
 		renderHost?.requestRender();
 	});
 	pi.registerMessageRenderer(REVIEW_PREFLIGHT_TYPE, (message, options, theme) => {
@@ -545,8 +551,8 @@ export default function gentleShell(pi: ExtensionAPI, env: NodeJS.ProcessEnv = p
 		changes = new WorktreeChangesTracker(deps.gitRunner(ctx.cwd), deps.gitRunner, lineCounter, () => sessionRegistry.roots());
 		const tracker = changes;
 		ctx.ui.setFooter((tui, theme, footerData) => {
-			renderHost = tui;
-			const bottom = createShellBarComponent(pi, ctx, tui, theme, footerData, () => tracker.model.files.length, () => usage.get(ctx.model?.provider ?? ""));
+			renderHost = { requestRender: () => tui.requestRender(), invalidateSidebar: () => invalidateSidebar(tui) };
+			const bottom = createShellBarComponent(pi, ctx, renderHost, theme, footerData, () => tracker.model.files.length, () => usage.get(ctx.model?.provider ?? ""));
 			const part = sidebarPart(tui, "footer", bottom, {
 				render: (width) => renderShellSidebarBar(buildShellBarModel(pi, ctx, footerData, { dirty: tracker.model.files.length, usage: usage.get(ctx.model?.provider ?? "") }), theme, width),
 				invalidate() {},

--- a/extensions/gentle-todo.ts
+++ b/extensions/gentle-todo.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
+import { Text, type TUI } from "@earendil-works/pi-tui";
 import { sidebarPart } from "../lib/shell-sidebar.ts";
+import { invalidateSidebar } from "../lib/shell-sidebar-layout.ts";
 import {
 	applyTodo,
 	emptyTodo,
@@ -73,6 +74,7 @@ interface TodoSession {
 	clearOnNextTurn: boolean;
 	ui: ExtensionContext["ui"] | undefined;
 	host: { requestRender(): void } | undefined;
+	tui: TUI | undefined;
 }
 
 function sessionKey(ctx: ExtensionContext): string {
@@ -88,13 +90,14 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 		const key = sessionKey(ctx);
 		let current = sessions.get(key);
 		if (!current) {
-			current = { state: emptyTodo(), turn: 0, collapsed: false, clearOnNextTurn: false, ui: undefined, host: undefined };
+			current = { state: emptyTodo(), turn: 0, collapsed: false, clearOnNextTurn: false, ui: undefined, host: undefined, tui: undefined };
 			sessions.set(key, current);
 		}
 		return current;
 	};
 
 	const show = (current: TodoSession) => {
+		if (current.tui) invalidateSidebar(current.tui);
 		if (!current.ui) return;
 		if (current.state.tasks.length === 0) {
 			current.ui.setWidget(WIDGET_KEY, undefined);
@@ -103,6 +106,7 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 		const snapshot = current;
 		current.ui.setWidget(WIDGET_KEY, (tui, theme) => {
 			snapshot.host = tui;
+			snapshot.tui = tui;
 			return sidebarPart(tui, "todo", {
 				render(width: number) {
 					const lines = renderTodoCard(snapshot.state, theme, width, { collapsed: snapshot.collapsed, staleTurns: staleTurns(snapshot.state, snapshot.turn), collapseKey });
@@ -144,6 +148,7 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 			if (!result.error) {
 				current.state = result.state;
 				current.clearOnNextTurn = false;
+				if (current.tui) invalidateSidebar(current.tui);
 			}
 			return {
 				content: [{ type: "text", text: result.text }],
@@ -158,6 +163,7 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 			handler: async (ctx) => {
 				const current = session(ctx);
 				current.collapsed = !current.collapsed;
+				if (current.tui) invalidateSidebar(current.tui);
 				current.host?.requestRender();
 			},
 		});
@@ -181,6 +187,7 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 	pi.on("before_agent_start", (event, ctx) => {
 		const current = session(ctx);
 		current.turn += 1;
+		if (current.tui) invalidateSidebar(current.tui);
 		if (current.clearOnNextTurn) {
 			current.state = { ...current.state, tasks: [] };
 			current.clearOnNextTurn = false;

--- a/lib/shell-sidebar-layout.ts
+++ b/lib/shell-sidebar-layout.ts
@@ -13,21 +13,48 @@ const NODE = Symbol.for("@earendil-works/pi-tui/layout-node");
 type LayoutNode = { type: string; entries?: unknown[]; gap?: number; align?: string };
 type LayoutRoot = Component & { [NODE]?: () => LayoutNode };
 type Host = TUI & { mode?: string; layoutRoot?: LayoutRoot };
+type SidebarCache = { revision: number };
+type PreparedRail = {
+	revision: number;
+	width: number;
+	mode: string | undefined;
+	root: LayoutRoot;
+	theme: ShellBarTheme;
+	parts: Array<[string, Component]>;
+	active: boolean;
+	lines: string[];
+};
+const CACHE = Symbol.for("gentle-pi.experimental-sidebar.cache");
+
+function sidebarCache(tui: TUI): SidebarCache {
+	const terminal = tui.terminal as unknown as Record<symbol, SidebarCache>;
+	return terminal[CACHE] ??= { revision: 0 };
+}
+
+/** Mark terminal-owned fullscreen sidebar output stale after a part state change. */
+export function invalidateSidebar(tui: TUI): void {
+	if (tui.terminal) sidebarCache(tui).revision++;
+}
 
 export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 	if (!tui.terminal) return () => {};
 	const host = tui as Host;
 	const state = sidebarState(tui);
+	const cache = sidebarCache(tui);
 	const cleanups: Array<() => void> = [];
 	const roots = new Set<LayoutRoot>();
 	let stopped = false;
 	let failed = false;
 	let railLines: string[] = [];
+	let prepared: PreparedRail | undefined;
 	state.active = false;
 	state.ownsHost = () => !stopped && host.mode === "fullscreen" && !!host.layoutRoot && roots.has(host.layoutRoot);
 	const rail: Component = {
 		render: () => railLines,
-		invalidate() { for (const part of state.parts.values()) part.invalidate(); },
+		invalidate() {
+			invalidateSidebar(tui);
+			for (const part of state.parts.values()) part.invalidate();
+		},
 	};
 	const scroll = new ScrollView(rail, {
 		follow: "none",
@@ -49,9 +76,21 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 			target: { component: scroll, originX: event.screenX - event.x, originY: event.screenY - event.y, width: event.width, height: event.height },
 		};
 	};
-	const prepare = (width: number): boolean => {
+	const prepare = (width: number, root: LayoutRoot): boolean => {
 		state.active = false;
-		if (stopped || failed || host.mode !== "fullscreen" || width < SIDEBAR_BREAKPOINT) return false;
+		if (stopped || failed || host.mode !== "fullscreen" || width < SIDEBAR_BREAKPOINT) {
+			prepared = undefined;
+			return false;
+		}
+		const parts = [...state.parts.entries()];
+		const unchanged = prepared?.revision === cache.revision &&
+			prepared.width === width && prepared.mode === host.mode && prepared.root === root && prepared.theme === theme &&
+			prepared.parts.length === parts.length && prepared.parts.every(([key, part], index) => parts[index]?.[0] === key && parts[index]?.[1] === part);
+		if (unchanged) {
+			railLines = prepared.lines;
+			state.active = prepared.active;
+			return prepared.active;
+		}
 		try {
 			const contentWidth = scroll.getContentWidth(RAIL_WIDTH);
 			const sections = ["footer", "changes", "agents", "todo"].map((key) => {
@@ -66,9 +105,10 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 				...lines.map((line) => " ".repeat(RAIL_PADDING) + line + " ".repeat(RAIL_PADDING)),
 			]);
 			// Height is owned by the native ScrollView, never by the transcript.
-			if (!railLines.length || railLines.some((line) => visibleWidth(line) > contentWidth)) return false;
-			state.active = true;
-			return true;
+			const active = railLines.length > 0 && railLines.every((line) => visibleWidth(line) <= contentWidth);
+			prepared = { revision: cache.revision, width, mode: host.mode, root, theme, parts, active, lines: railLines };
+			state.active = active;
+			return active;
 		} catch {
 			failed = true;
 			return false;
@@ -84,7 +124,7 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 			const original = root[NODE]!;
 			const descriptor = Object.getOwnPropertyDescriptor(root, NODE);
 			const left = { render: (width: number) => root.render(width), invalidate() {}, [NODE]: () => original.call(root) };
-			const replacement = () => prepare(tui.terminal.columns)
+			const replacement = () => prepare(tui.terminal.columns, root)
 				? { type: "hstack", gap: GAP, align: "stretch", entries: [
 					{ component: left, basis: 0, grow: 1, shrink: 1, minSize: 1 },
 					{ component: scroll, basis: RAIL_WIDTH, grow: 0, shrink: 0, minSize: RAIL_WIDTH },

--- a/tests/shell-sidebar-layout.test.ts
+++ b/tests/shell-sidebar-layout.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { ScrollView, visibleWidth, type TUI } from "@earendil-works/pi-tui";
+import { renderLayoutFrame } from "@earendil-works/pi-tui/dist/layout.js";
 import { installSidebar } from "../lib/shell-sidebar-layout.ts";
 import { sidebarPart, sidebarState } from "../lib/shell-sidebar.ts";
 import { renderShellSidebarBar } from "../lib/shell-bar.ts";
@@ -136,6 +137,60 @@ test("wheel scrolls the rail and is consumed at both boundaries and blank space"
 	scroll.updateLayout(1, 5, () => {});
 	assert.equal(scroll.handleMouse({ type: "wheel", wheelDelta: 1 } as Parameters<typeof scroll.handleMouse>[0])?.handled, true);
 	assert.equal(scroll.scrollTop, 0);
+});
+
+test("real layout frames reuse unchanged sidebar output and invalidate at state and breakpoint boundaries", (t) => {
+	const f = fixture();
+	const counts = { footer: 0, changes: 0, agents: 0, todo: 0 };
+	let todo = "Todo one";
+	for (const key of Object.keys(counts) as Array<keyof typeof counts>) {
+		sidebarPart(f.tui, key, {
+			render: () => {
+				counts[key]++;
+				return [`${key === "todo" ? todo : key}`];
+			},
+			invalidate() {},
+		});
+	}
+	t.after(installSidebar(f.tui, theme));
+
+	const first = renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.deepEqual(counts, { footer: 1, changes: 1, agents: 1, todo: 1 });
+	const sidebarRail = first.root.children[1]?.component as ScrollView;
+	renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.deepEqual(counts, { footer: 1, changes: 1, agents: 1, todo: 1 });
+
+	todo = "Todo two";
+	sidebarRail.invalidate();
+	const changed = renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.match(changed.lines.join("\n"), /Todo two/);
+	assert.deepEqual(counts, { footer: 2, changes: 2, agents: 2, todo: 2 });
+
+	f.host.terminal.columns = 139;
+	renderLayoutFrame(f.root, 139, 20, () => {});
+	assert.deepEqual(f.bottom.render(80), ["Status"]);
+	f.host.terminal.columns = 140;
+	renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.deepEqual(counts, { footer: 3, changes: 3, agents: 3, todo: 3 });
+
+	f.host.mode = "regular";
+	renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.deepEqual(f.bottom.render(80), ["Status"]);
+	f.host.mode = "fullscreen";
+	renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.deepEqual(counts, { footer: 4, changes: 4, agents: 4, todo: 4 });
+
+	let replacementRenders = 0;
+	sidebarPart(f.tui, "todo", {
+		render: () => {
+			replacementRenders++;
+			return ["Todo replacement"];
+		},
+		invalidate() {},
+	});
+	const replaced = renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.match(replaced.lines.join("\n"), /Todo replacement/);
+	assert.equal(replacementRenders, 1);
 });
 
 test("cleanup restores the native layout and bottom paint without disposing widgets", () => {


### PR DESCRIPTION
Closes #832

## Summary
- Cache prepared fullscreen sidebar output across unchanged render frames.
- Invalidate the cache when footer, agent, or TODO state changes.
- Preserve native narrow-mode and fullscreen breakpoint behavior.

## Changes

| File | Change |
|------|--------|
| `lib/shell-sidebar-layout.ts` | Cache prepared sidebar rails by revision, geometry, mode, root, theme, and registered part identity. |
| `extensions/gentle-shell.ts` | Invalidate sidebar output when branch or usage state changes. |
| `extensions/gentle-agents.ts` | Invalidate sidebar output for agent summary, clock, render, and collapse changes. |
| `extensions/gentle-todo.ts` | Invalidate sidebar output for TODO state, turn, and collapse changes. |
| `tests/shell-sidebar-layout.test.ts` | Prove unchanged frames reuse output and boundary/state changes recompute it. |

## Test Plan
- [x] `node --experimental-strip-types --test tests/shell-sidebar-layout.test.ts` — 10/10 passed.
- [x] `git diff --check` passed before commit.
- [x] Broad `npm test` timeout and 13 Windows path/process failures were reproduced on clean `origin/main@9ec677f1`, so they are baseline/environmental rather than candidate-caused.

## Contributor Checklist
- [x] Linked approved issue #832.
- [x] Add exactly one `type:*` label (`type:feature`).
- [x] Shellcheck is not applicable; no shell scripts changed.
- [x] Skill-loading checks are not applicable; no skills changed.
- [x] Documentation is not required for this internal performance correction.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sidebar content now refreshes reliably when shell status, usage information, todos, session state, or collapsed sections change.
  - Layout updates correctly reflect changes in terminal width, display mode, and sidebar content.

- **Performance**
  - Repeated sidebar renders reuse unchanged content, reducing unnecessary redraws while preserving accurate updates when relevant information changes.

- **Tests**
  - Added coverage for sidebar caching, invalidation, resizing, mode changes, and replacing individual sidebar sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->