### PR TITLE
fix(agents): hide raw child notifications

### DIFF
--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -341,7 +341,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		askUser: (_taskId, ask, raw) => answerThroughUi(ui, ask, raw),
 		onNotification: (task, message) => {
 			if (activeSessionId() !== task.parentSessionId) return false;
-			pi.sendMessage({ customType: AGENTS_MESSAGE_TYPE, content: message, display: true, details: { gentleAgents: { taskId: task.id, agent: task.agent, parentSessionId: task.parentSessionId, kind: "notification" } } }, { deliverAs: "followUp", triggerTurn: true });
+			pi.sendMessage({ customType: AGENTS_MESSAGE_TYPE, content: message, display: false, details: { gentleAgents: { taskId: task.id, agent: task.agent, parentSessionId: task.parentSessionId, kind: "notification" } } }, { deliverAs: "followUp", triggerTurn: true });
 			return true;
 		},
 		onQuery: (task, requestId, message) => {

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -173,6 +173,7 @@ test("host query delivery exposes correlation and accepts one current-session re
 	harness.children[0].message({ id: "q1", kind: "query", message: "Which file?" });
 	await tick();
 	assert.match(String(sent.at(-1)?.message.content), new RegExp(`Task ID: ${taskId}\\nRequest ID: q1`));
+	assert.equal(sent.at(-1)?.message.display, true, "an explicit child query remains visible");
 	(ctx.sessionManager as { getSessionId(): string }).getSessionId = () => "s2";
 	assert.match((await tools.get("subagent_reply")!.execute("stale", { task_id: taskId, request_id: "q1", message: "wrong" }, undefined, undefined, ctx)).content[0].text, /unavailable/);
 	(ctx.sessionManager as { getSessionId(): string }).getSessionId = () => "s1";
@@ -319,6 +320,7 @@ test("child parent-message tooling admits notifications and the active parent pr
 	runtime.children[0].message({ id: "n1", kind: "notification", message: "raw\u001B[2J text" });
 	await tick();
 	assert.equal(parent.sent[0]?.message.content, "raw\u001B[2J text");
+	assert.equal(parent.sent[0]?.message.display, false, "ordinary child notifications remain model-visible but do not render in the transcript");
 	assert.deepEqual(parent.sent[0]?.options, { deliverAs: "followUp", triggerTurn: true });
 	const rendered = parent.renderers.get("gentle-agents.message")!(parent.sent[0]?.message, { expanded: true }, plainTheme).render(80).join("\n");
 	assert.match(rendered, /raw\\x1B\[2J text/);
@@ -1105,6 +1107,7 @@ test("background runs return at once; status, result, send_message, cancel, and 
 	assert.equal((await tools.get("subagent_result")!.execute("c7", { task_id: id }, undefined, undefined, ctx)).content[0].text, "All done.");
 	assert.equal(sent.length, 1, "a background result is delivered to the model once");
 	assert.equal(sent[0].message.customType, "gentle-agents.result");
+	assert.equal(sent[0].message.display, true, "completion cards remain visible");
 	assert.deepEqual(sent[0].options, { deliverAs: "followUp", triggerTurn: true });
 	assert.match(String(sent[0].message.content), new RegExp(`^Subagent explore \\(task ${id}, "Long job"\\) finished\\.\n\nAll done\\.$`));
 	const card = renderers.get("gentle-agents.result")!(sent[0].message, { expanded: true }, plainTheme).render(70).map(stripAnsi);


### PR DESCRIPTION
## Linked issue

Closes #834

## PR type

- [x] Bug fix (`type:bug`)

## Summary

- Hide ordinary child notifications from the user transcript while preserving follow-up delivery to the parent model.
- Keep explicit child queries and task completion cards visible.
- Add focused regression assertions for all three visibility boundaries.

## Changes

| File | Change |
| --- | --- |
| `extensions/gentle-agents.ts` | Send ordinary child notifications with `display: false` while preserving `deliverAs: "followUp"` and `triggerTurn: true`. |
| `tests/gentle-agents.test.ts` | Assert ordinary notifications are hidden while explicit queries and completion cards remain visible. |

## Test plan

- [x] `pnpm exec node --experimental-strip-types --test --test-reporter=tap --test-name-pattern "host query delivery exposes correlation|child parent-message tooling admits notifications|background runs return at once" tests/gentle-agents.test.ts` — 3 passed, 0 failed.
- [x] `git diff --check`.
- [x] Native four-lens RDD review approved and acknowledged.
- [ ] Full local Ubuntu CI remained inconclusive because the disposable WSL harness failed before executing the final job; GitHub CI is still required.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Selected exactly one PR type.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] Focused behavior tests pass.
- [x] No documentation change is required for this internal transcript-visibility correction.
- [x] Conventional commit used with no `Co-Authored-By` trailers.

## Review notes

The branch is two commits behind current `main`. A merge-tree check against current `origin/main` succeeded without conflict. Open PRs #799 and #605 touch the same two files for separate behavior but do not modify this notification visibility line.