### PR TITLE
fix(startup): keep banner animation alive across pi-tui invalidation

### DIFF
--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -1051,7 +1051,7 @@ export default function (pi: ExtensionAPI) {
 
             return out;
           },
-          invalidate() {
+          dispose() {
             cleanup();
           },
         };

--- a/extensions/startup-banner.ts
+++ b/extensions/startup-banner.ts
@@ -1051,6 +1051,7 @@ export default function (pi: ExtensionAPI) {
 
             return out;
           },
+          invalidate() {},
           dispose() {
             cleanup();
           },

--- a/tests/startup-banner.test.ts
+++ b/tests/startup-banner.test.ts
@@ -18,7 +18,48 @@ test("startup branch lookup uses direct git argv and hides its Windows child", a
 		command: "git",
 		args: ["-C", "/repo with spaces & metacharacters", "branch", "--show-current"],
 		options: { encoding: "utf8", shell: false, windowsHide: true },
-	}]);
+    }]);
+});
+
+test("startup banner keeps animating after invalidate and cleans up on dispose", async (t) => {
+	t.mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+	t.mock.method(fs, "readFile", async () => JSON.stringify({ showRose: true, showTextLogo: true, color: "pink" }));
+	syncBuiltinESMExports();
+	t.after(() => { t.mock.restoreAll(); syncBuiltinESMExports(); });
+	const argv = process.argv;
+	process.argv = ["node"];
+	t.after(() => { process.argv = argv; });
+	for (const [key, value] of [["rows", 40], ["columns", 160]] as const) {
+		const descriptor = Object.getOwnPropertyDescriptor(process.stdout, key);
+		Object.defineProperty(process.stdout, key, { configurable: true, writable: true, value });
+		t.after(() => descriptor ? Object.defineProperty(process.stdout, key, descriptor) : Reflect.deleteProperty(process.stdout, key));
+	}
+	let start: Function;
+	let shutdown: Function;
+	let header: { render(width: number): string[]; invalidate(): void; dispose(): void };
+	let renders = 0;
+	startup({ on: (name: string, fn: Function) => {
+		if (name === "session_start") start = fn;
+		if (name === "session_shutdown") shutdown = fn;
+	}, registerCommand() {}, getCommands: () => [], getAllTools: () => [] } as unknown as ExtensionAPI);
+	await start!({}, { hasUI: true, cwd: "/fixture", ui: { setHeader: (factory: Function) => {
+		header = factory({ requestRender() { renders++; } }, { fg: (_role: string, text: string) => text });
+	} } });
+	t.mock.timers.tick(50);
+	const afterBoot = renders;
+	t.mock.timers.tick(25);
+	assert.ok(renders > afterBoot, "animation timer requests renders");
+	header!.invalidate();
+	const afterInvalidate = renders;
+	t.mock.timers.tick(25);
+	assert.ok(renders > afterInvalidate, "invalidate() must not stop the animation timer");
+	header!.dispose();
+	const afterDispose = renders;
+	t.mock.timers.tick(25);
+	assert.equal(renders, afterDispose, "dispose() stops the animation timer");
+	shutdown!();
+	t.mock.timers.tick(25);
+	assert.equal(renders, afterDispose, "session_shutdown cleanup stays idle");
 });
 
 // Drive the real header factory; background git/home reads never run.

--- a/tests/startup-banner.test.ts
+++ b/tests/startup-banner.test.ts
@@ -38,7 +38,7 @@ for (const showRose of [false, true]) for (const showTextLogo of [false, true]) 
 		}
 		let start: Function;
 		let shutdown: Function;
-		let header: { render(width: number): string[]; invalidate(): void };
+		let header: { render(width: number): string[]; dispose(): void };
 		const writes: string[] = [];
 		startup({ on: (name: string, fn: Function) => {
 			if (name === "session_start") start = fn;


### PR DESCRIPTION
## Summary

Root cause: pi-tui calls `invalidate()` on every component when the async cell-size response lands right after `ui.start()`. The banner used that hook to `cleanup()`, so the 25ms timer died at tick 0.

`dispose()` is the hook Pi uses for header replacement. `session_shutdown` cleanup is unchanged.

## Linked issue

Closes #836

## PR type

- [x] Bug fix (`type:bug`)

## Summary

- Stop treating pi-tui `invalidate()` as banner teardown.
- Keep the animation timer alive across the first-boot cell-size invalidation.
- Tear down only on `dispose()` and `session_shutdown`.

## Changes

| File | Change |
| --- | --- |
| `extensions/startup-banner.ts` | Move cleanup from `invalidate()` to `dispose()`. |
| `tests/startup-banner.test.ts` | Match the header lifecycle type to `dispose()`. |

## Test plan

- [x] `pnpm exec node --experimental-strip-types --test tests/startup-banner.test.ts`
- [x] `git diff --check`
- [x] Manual: start `pi` with no args and confirm the rose and wordmark animate instead of freezing on frame 0.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Selected exactly one PR type.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] No documentation change is required.
- [x] Conventional commit used with no `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup banner lifecycle handling so animations continue updating correctly and stop cleanly when the banner is disposed or the session ends.
  * Ensured cleanup actions are consistently performed during banner shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->