### PR TITLE
fix(sdd): keep planning routes executable

### DIFF
--- a/assets/sdd-orchestrator-workflow.md
+++ b/assets/sdd-orchestrator-workflow.md
@@ -35,9 +35,26 @@ Rules:
 - `/gentle-sdd-status` is a debug/status command, not the main UX.
 - `/gentle-sdd-continue` is the native dispatcher command: resolve status, choose the next ready phase, and carry status/instructions into the subagent prompt.
 - `sdd-apply`, `sdd-verify`, `sdd-sync`, and `sdd-archive` must obey parent-provided native status; they must not reconstruct readiness from prompt inference when status JSON is present.
-- Do not launch a phase when native status marks that dependency `blocked`.
+- Apply the Bounded Planning Routing contract below: a blocked apply dependency is not a blanket veto on planning. Non-planning phases must still obey their own dependency gates.
 - `sdd-archive` cannot proceed unless native status says `dependencies.archive` is `ready` or `all_done` — UNLESS the store carve-out is active (`nextRecommended: "resolve-via-engram"`), in which case resolve archive readiness from Engram instead of treating `not_applicable` as a gate failure.
 - **Non-authoritative store carve-out:** when `nextRecommended: "resolve-via-engram"` is set, native status is **not authoritative**. This applies to `artifactStore: engram`, `artifactStore: none`, and `artifactStore: both` when the `openspec/` directory does not exist. For non-authoritative stores: resolve readiness from Engram using the Engram memory tools injected by the memory provider on the change topic keys (`sdd/{change-name}/proposal`, `sdd/{change-name}/spec`, `sdd/{change-name}/design`, `sdd/{change-name}/tasks`, etc.). Do **not** treat `blockedReasons` or `not_applicable` dependency states from the native engine as real blockers when the store carve-out is active.
+
+## Bounded Planning Routing
+
+For authoritative native status, route only by the bounded `nextRecommended` token and dependency states; never infer a route from prose. Keep human diagnostics in `blockedReasons`, not in `nextRecommended`, and report them without discarding them to enable a route.
+
+| `nextRecommended` | Planning route |
+| --- | --- |
+| `sdd-propose` | `sdd-proposal` |
+| `sdd-spec` | `sdd-spec` |
+| `sdd-design` | `sdd-design` |
+| `sdd-tasks` | `sdd-tasks` |
+
+These planning routes remain runnable when missing planning artifacts leave `dependencies.apply: blocked`; do not require apply readiness to produce those artifacts. This is a planning-only exception, not permission to run apply or another blocked non-planning phase.
+
+Before any planning launch, stop for ambiguous change selection, unresolved session preflight, or unsafe action context. Carry `actionContext` and prove planned writes are within the authoritative workspace or allowed edit roots; workspace-planning without allowed edit roots remains read-only. Planning does not bypass the init guard, pre-proposal gate, or phase approval requirements.
+
+For non-planning phases, stop when that phase's dependency is `blocked`. When `nextRecommended` is `blocked` or `resolve-blockers`, report `blockedReasons` and stop, even if a planning artifact is missing. Unknown tokens do not authorize a launch. Non-empty `blockedReasons` forbid apply, sync, and archive work; `sdd-verify` may run only when `nextRecommended` is `sdd-verify` and its dependency permits it, to remediate or refresh evidence for the blockers. The non-authoritative `resolve-via-engram` store carve-out remains separate; it does not bypass preflight, selection, or action-context safety.
 
 ## SDD Status Contract
 

--- a/assets/support/sdd-status-contract.md
+++ b/assets/support/sdd-status-contract.md
@@ -19,9 +19,26 @@ Any phase that selects, continues, applies, verifies, syncs, or archives an SDD 
 - For non-authoritative stores (`engram`, `none`, and `both` without an `openspec/` directory), do not treat disk status output as authoritative; follow Engine Authority by Store below.
 - Runtime-attempt authority is different from artifact dispatch: normal runtime-bearing OpenSpec and Engram continuations MUST bracket external execution with `gentle-ai sdd-attempt acquire|settle --cwd <repo> --change <change>`. Their bounded result contains only `proceed`, `blocked`, or `complete` plus an opaque continuation token when required, and MAY carry `settle_obligation` on a `proceed`. The Git-common-dir immutable chain remains the sole authority for ordinals, cumulative attempt/line budgets, runtime evidence, and atomic bound remediation.
 - A phase actor launched BY a parent that already holds a `proceed`-state acquire for that exact work unit is a distinct call/process, not a fresh continuation: it MUST NOT `acquire` again blind. Colliding with its own parent's active attempt is not a genuine `blocked: active_attempt` (#2291). It authenticates as that SAME attempt by passing the parent's returned token on its own `acquire --token <token>` call: a token matching the ledger's live active attempt returns `proceed` with that same token and zero mutation, while a non-matching token gets the ordinary `blocked: active_attempt` naming the real active token.
-- When `blockedReasons` is non-empty, do not proceed to terminal, archive, or apply work. Return or report `blockedReasons` and stop unless `nextRecommended` is `verify`, in which case verification may run only to remediate or refresh evidence for the blockers. When `nextRecommended` is `resolve-blockers`, always report `blockedReasons` and stop. When `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase — missing planning artifacts are the expected output of those phases, not genuine blockers.
+- Apply the Bounded Planning Routing contract below: a blocked apply dependency is not a blanket veto on planning. Non-planning phases must still obey their own dependency gates.
 - `nextRecommended` is a bounded machine token for routing, not human prose. Route only by `nextRecommended` and dependency states. Human-readable explanation belongs in `blockedReasons`, not `nextRecommended`.
 - If the binary is unavailable, fall back to this prompt contract and the manual status schema below. Manual fallback status MUST stay shape-compatible with the native status JSON even when values are reconstructed manually.
+
+## Bounded Planning Routing
+
+For authoritative native status, route only by the bounded `nextRecommended` token and dependency states; never infer a route from prose. Keep human diagnostics in `blockedReasons`, not in `nextRecommended`, and report them without discarding them to enable a route.
+
+| `nextRecommended` | Planning route |
+| --- | --- |
+| `sdd-propose` | `sdd-proposal` |
+| `sdd-spec` | `sdd-spec` |
+| `sdd-design` | `sdd-design` |
+| `sdd-tasks` | `sdd-tasks` |
+
+These planning routes remain runnable when missing planning artifacts leave `dependencies.apply: blocked`; do not require apply readiness to produce those artifacts. This is a planning-only exception, not permission to run apply or another blocked non-planning phase.
+
+Before any planning launch, stop for ambiguous change selection, unresolved session preflight, or unsafe action context. Carry `actionContext` and prove planned writes are within the authoritative workspace or allowed edit roots; workspace-planning without allowed edit roots remains read-only. Planning does not bypass the init guard, pre-proposal gate, or phase approval requirements.
+
+For non-planning phases, stop when that phase's dependency is `blocked`. When `nextRecommended` is `blocked` or `resolve-blockers`, report `blockedReasons` and stop, even if a planning artifact is missing. Unknown tokens do not authorize a launch. Non-empty `blockedReasons` forbid apply, sync, and archive work; `sdd-verify` may run only when `nextRecommended` is `sdd-verify` and its dependency permits it, to remediate or refresh evidence for the blockers. The non-authoritative `resolve-via-engram` store carve-out remains separate; it does not bypass preflight, selection, or action-context safety.
 
 ## Status Schema
 

--- a/lib/sdd-status.ts
+++ b/lib/sdd-status.ts
@@ -14,6 +14,12 @@ export type ArtifactState = "missing" | "done" | "partial";
 export type DependencyState = "blocked" | "ready" | "all_done" | "not_applicable";
 export type ApplyState = "blocked" | "ready" | "all_done" | "not_applicable";
 export type SddPhase = "apply" | "verify" | "sync" | "archive";
+export type SddNextRecommended =
+	| `sdd-${"propose" | "spec" | "design" | "tasks" | SddPhase}`
+	| "fix-task-ownership-marker"
+	| "archived"
+	| "resolve-via-engram"
+	| "blocked";
 
 export interface SddArtifactPaths {
 	proposal: string[];
@@ -107,7 +113,7 @@ export interface SddStatus {
 	 * When set, `nextRecommended` is "archived" and no further phase is recommended.
 	 */
 	archived?: { path: string };
-	nextRecommended: string;
+	nextRecommended: SddNextRecommended;
 	instructions?: SddPhaseInstructions;
 	blockedReasons: string[];
 	/**
@@ -258,6 +264,15 @@ function reportIsClearlyPassing(path: string | undefined): boolean {
 	return hasPassSignal && !hasBlocker;
 }
 
+// Planning routes repair the first incomplete prerequisite; diagnostics remain separate.
+function planningRecommendation(artifacts: SddStatus["artifacts"], taskTotal: number): SddNextRecommended {
+	if (artifacts.proposal !== "done") return "sdd-propose";
+	if (artifacts.specs !== "done") return "sdd-spec";
+	if (artifacts.design !== "done") return "sdd-design";
+	if (artifacts.tasks !== "done" || taskTotal === 0) return "sdd-tasks";
+	return "blocked";
+}
+
 function emptyStatus(cwd: string, changeName: string | null, blockedReasons: string[], artifactStore: SddArtifactStore = "openspec", isNonAuthoritative = false): SddStatus {
 	const root = resolve(cwd);
 	const changesDir = join(root, "openspec", "changes");
@@ -299,7 +314,7 @@ function emptyStatus(cwd: string, changeName: string | null, blockedReasons: str
 			sameDomainActiveChanges: [],
 		},
 		collisions: [],
-		nextRecommended: blockedReasons[0] ?? "Start an SDD change.",
+		nextRecommended: "blocked",
 		blockedReasons,
 		isNonAuthoritative,
 	};
@@ -594,7 +609,7 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 		archive: coreArtifactsReady && verifyClean && syncClean && taskProgress.remaining === 0 && !taskArtifactBlocked ? "ready" : "blocked",
 	};
 	const archiveReady = dependencies.archive === "ready";
-	const nextRecommended = taskArtifactBlocked
+	const nextRecommended: SddNextRecommended = taskArtifactBlocked
 		? "fix-task-ownership-marker"
 		: dependencies.apply === "ready"
 			? "sdd-apply"
@@ -604,7 +619,7 @@ export function resolveSddStatus(options: ResolveSddStatusOptions): SddStatus {
 					? "sdd-sync"
 					: archiveReady
 						? "sdd-archive"
-						: blockedReasons[0] ?? "Resolve blockers.";
+						: planningRecommendation(artifacts, taskProgress.total);
 
 	const status: SddStatus = {
 		schemaName: "gentle-pi.sdd-status",

--- a/tests/sdd-planning-routing-contract.test.ts
+++ b/tests/sdd-planning-routing-contract.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const paths = [
+	"assets/sdd-orchestrator-workflow.md",
+	"assets/support/sdd-status-contract.md",
+];
+const documents = paths.map((path) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8"));
+
+function routingContract(document: string): string {
+	const section = document.match(/## Bounded Planning Routing\n([\s\S]*?)(?=\n## |$)/);
+	assert.ok(section, "explicit bounded planning routing contract is required");
+	return section[1].trim();
+}
+
+for (const [index, path] of paths.entries()) {
+	test(`${path}: missing apply artifacts do not block bounded planning routes`, () => {
+		const contract = routingContract(documents[index]);
+		for (const [token, phase] of [
+			["sdd-propose", "sdd-proposal"],
+			["sdd-spec", "sdd-spec"],
+			["sdd-design", "sdd-design"],
+			["sdd-tasks", "sdd-tasks"],
+		]) {
+			assert.ok(contract.includes(`| \`${token}\` | \`${phase}\` |`));
+		}
+		assert.match(contract, /missing planning artifacts leave `dependencies\.apply: blocked`/);
+		assert.match(contract, /do not require apply readiness to produce those artifacts/);
+	});
+
+	test(`${path}: planning does not weaken stop conditions or diagnostic ownership`, () => {
+		const contract = routingContract(documents[index]);
+		for (const guard of [
+			"stop for ambiguous change selection, unresolved session preflight, or unsafe action context",
+			"prove planned writes are within the authoritative workspace or allowed edit roots",
+			"workspace-planning without allowed edit roots remains read-only",
+			"Planning does not bypass the init guard, pre-proposal gate, or phase approval requirements",
+			"For non-planning phases, stop when that phase's dependency is `blocked`",
+			"When `nextRecommended` is `blocked` or `resolve-blockers`, report `blockedReasons` and stop",
+			"Unknown tokens do not authorize a launch",
+			"Non-empty `blockedReasons` forbid apply, sync, and archive work",
+			"`sdd-verify` may run only when `nextRecommended` is `sdd-verify` and its dependency permits it",
+			"never infer a route from prose",
+			"Keep human diagnostics in `blockedReasons`, not in `nextRecommended`",
+			"report them without discarding them to enable a route",
+			"store carve-out remains separate; it does not bypass preflight, selection, or action-context safety",
+		]) {
+			assert.ok(contract.includes(guard), `missing guard: ${guard}`);
+		}
+		assert.doesNotMatch(documents[index], /Do not launch a phase when native status marks that dependency `blocked`/);
+		assert.doesNotMatch(documents[index], /stop unless `nextRecommended` is `verify`/);
+	});
+}
+
+test("workflow and support contract agree on bounded planning routing", () => {
+	assert.equal(routingContract(documents[0]), routingContract(documents[1]));
+});

--- a/tests/sdd-status.test.ts
+++ b/tests/sdd-status.test.ts
@@ -40,6 +40,55 @@ function seedChange(cwd: string, change = "add-auth"): string {
 	return root;
 }
 
+test("planning recommendations are executable tokens with separate diagnostics", async () => {
+	const cwd = await workspace();
+	const root = join(cwd, "openspec", "changes", "planning");
+	mkdirSync(root, { recursive: true });
+	for (const [route, diagnostic, artifact] of [
+		["sdd-propose", "proposal.md is missing.", "proposal.md"],
+		["sdd-spec", "domain specs are missing or partial.", "specs/auth/spec.md"],
+		["sdd-design", "design.md is missing.", "design.md"],
+		["sdd-tasks", "tasks.md is missing.", "tasks.md"],
+	] as const) {
+		const status = resolveSddStatus({ cwd });
+		assert.equal(status.nextRecommended, route);
+		assert.ok(status.blockedReasons.includes(diagnostic));
+		assert.equal(status.dependencies.apply, "blocked");
+		write(join(root, artifact), "# Artifact\n- [ ] Implement\n");
+	}
+	assert.equal(resolveSddStatus({ cwd }).nextRecommended, "sdd-apply");
+});
+
+test("partial planning artifacts route to their repair phase", async () => {
+	for (const [artifact, route] of [
+		["proposal.md", "sdd-propose"],
+		["specs/auth/spec.md", "sdd-spec"],
+		["design.md", "sdd-design"],
+		["tasks.md", "sdd-tasks"],
+	] as const) {
+		const cwd = await workspace();
+		const root = seedChange(cwd);
+		write(join(root, artifact), " \n");
+		const status = resolveSddStatus({ cwd });
+		assert.equal(status.nextRecommended, route);
+		assert.ok(status.blockedReasons.length > 0);
+		assert.equal(status.applyState, "blocked");
+		assert.match(renderSddDispatcherMarkdown(status), new RegExp(`nextPhase: ${route}`));
+	}
+});
+
+test("unresolved change selection returns blocked rather than diagnostic prose", async () => {
+	const cwd = await workspace();
+	mkdirSync(join(cwd, "openspec", "changes"), { recursive: true });
+	assert.equal(resolveSddStatus({ cwd }).nextRecommended, "blocked");
+	assert.equal(resolveSddStatus({ cwd, changeName: "absent" }).nextRecommended, "blocked");
+	seedChange(cwd, "first");
+	seedChange(cwd, "second");
+	const ambiguous = resolveSddStatus({ cwd });
+	assert.equal(ambiguous.nextRecommended, "blocked");
+	assert.match(ambiguous.blockedReasons[0], /ambiguous/);
+});
+
 test("listActiveOpenSpecChanges excludes archive and sorts active changes", async () => {
 	const cwd = await workspace();
 	mkdirSync(join(cwd, "openspec", "changes", "b-change"), { recursive: true });
@@ -229,6 +278,7 @@ test("resolveSddStatus blocks apply when tasks has no checkboxes", async () => {
 	assert.equal(status.applyState, "blocked");
 	assert.equal(status.dependencies.apply, "blocked");
 	assert.match(status.blockedReasons.join("\n"), /no implementation task checkboxes/);
+	assert.equal(status.nextRecommended, "sdd-tasks");
 });
 
 test("resolveSddStatus marks legacy flat specs partial and blocks sync", async () => {
@@ -242,6 +292,7 @@ test("resolveSddStatus marks legacy flat specs partial and blocks sync", async (
 	const status = resolveSddStatus({ cwd, changeName: "legacy" });
 
 	assert.equal(status.artifacts.specs, "partial");
+	assert.equal(status.nextRecommended, "sdd-spec");
 	assert.match(status.blockedReasons.join("\n"), /Legacy flat spec/);
 	assert.equal(status.dependencies.sync, "blocked");
 });


### PR DESCRIPTION
Closes #727
Closes #732

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Restrict local SDD recommendations to executable machine tokens.
- Keep planning phases runnable while missing planning artifacts still block apply.
- Preserve human-readable diagnostics in `blockedReasons` instead of routing fields.

## Changes

| File | Change |
|------|--------|
| `lib/sdd-status.ts` | Adds bounded planning recommendation tokens. |
| `tests/sdd-status.test.ts` | Covers planning progression and malformed states. |
| `assets/sdd-orchestrator-workflow.md` | Replaces the blanket dependency veto with phase-aware routing. |
| `assets/support/sdd-status-contract.md` | Aligns the support contract with native `sdd-*` tokens. |
| `tests/sdd-planning-routing-contract.test.ts` | Pins workflow/contract agreement and safety stops. |

## Test plan

- [x] `node --experimental-strip-types --test tests/sdd-status.test.ts tests/sdd-planning-routing-contract.test.ts` — 56 passed
- [x] `git diff --check`
- [x] Native `review-reliability` review approved and acknowledged
- [x] No shell scripts changed; shellcheck is not applicable

## Contributor checklist

- [x] Linked approved issues
- [x] Added exactly one `type:*` label
- [x] Tests cover the changed behavior
- [x] Docs updated with the behavior
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded routing recommendations for SDD planning phases, including propose, specification, design, and task planning.
  * Planning can proceed when expected planning artifacts are missing, while execution remains gated by dependency and safety checks.
  * Added explicit handling for ambiguous change selection, unresolved preflight checks, blocked states, and unsafe action contexts.
  * Improved status recommendations for incomplete artifacts, missing task checkboxes, and legacy specifications.

* **Tests**
  * Added coverage for planning routes, blocker diagnostics, safety gates, and status recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->