### PR TITLE
refactor(models): migrate saved routing consumers to shared authority

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1785,7 +1785,10 @@ function parseModelExport(value: unknown): AgentModelConfig | undefined {
 }
 
 async function exportSavedModelConfig(ctx: ExtensionContext): Promise<number> {
-	const saved = await readSavedModelConfigAsync(ctx.cwd);
+	const saved = await readModelRoutingAuthorityAsync(
+		modelConfigPath(ctx.cwd),
+		legacyProjectModelConfigPath(ctx.cwd),
+	);
 	if (saved.status === "invalid") throw new Error(`Invalid model config: ${saved.path}`);
 	const agents = saved.status === "valid" ? saved.config : {};
 	const path = modelExportPath(ctx.cwd);
@@ -2863,7 +2866,10 @@ async function showSddModelPanel(
 
 async function handleModelsCommand(ctx: ExtensionContext): Promise<void> {
 	migrateLegacyProjectModelOverrides(ctx.cwd);
-	const savedConfig = await readSavedModelConfigAsync(ctx.cwd);
+	const savedConfig = await readModelRoutingAuthorityAsync(
+		modelConfigPath(ctx.cwd),
+		legacyProjectModelConfigPath(ctx.cwd),
+	);
 	if (savedConfig.status === "invalid") {
 		ctx.ui.notify(
 			`el Gentleman cannot open model config because ${savedConfig.path} is invalid JSON or not an object. Fix or remove the file, then run /gentle:models again.`,
@@ -7350,7 +7356,10 @@ function createGentleAiExtensionForTesting(
 			const openspecConfigured = existsSync(
 				join(ctx.cwd, "openspec", "config.yaml"),
 			);
-			const modelConfig = await readModelConfigAsync(ctx.cwd);
+			const savedConfig = await readModelRoutingAuthorityAsync(
+				modelConfigPath(ctx.cwd),
+				legacyProjectModelConfigPath(ctx.cwd),
+			);
 			const devBinary = await describeDevBinaryOverride();
 			ctx.ui.notify(
 				[
@@ -7360,9 +7369,10 @@ function createGentleAiExtensionForTesting(
 					...assetLines,
 					`OpenSpec config: ${openspecConfigured ? "present" : "missing"}`,
 					`Global model config: ${existsSync(modelConfigPath(ctx.cwd)) ? "present" : "missing"}`,
-					...describeModelConfig(ctx.cwd, modelConfig),
+					`Saved model routing: ${savedConfig.status}${savedConfig.status === "invalid" ? ` (${savedConfig.path})` : ""}`,
+					...(savedConfig.status === "invalid" ? [] : describeModelConfig(ctx.cwd, savedConfig.status === "valid" ? savedConfig.config : {})),
 				].join("\n"),
-				assetLines.some((line) => line.startsWith("warn:")) || devBinary.state !== "inactive" ? "warning" : "info",
+				savedConfig.status === "invalid" || assetLines.some((line) => line.startsWith("warn:")) || devBinary.state !== "inactive" ? "warning" : "info",
 			);
 		},
 	});

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -204,6 +204,148 @@ test("registered Gentle Review tools preserve result envelopes and redact collap
 	}
 });
 
+function routingConsumerFixture(t: test.TestContext) {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-routing-consumers-"));
+	const configHome = join(root, "global");
+	const agentHome = join(root, "agent-home");
+	const projectPath = join(root, ".pi", "gentle-ai", "models.json");
+	const globalPath = join(configHome, "models.json");
+	const exportPath = join(configHome, "models.export.json");
+	for (const dir of [dirname(projectPath), join(root, "agents"), join(agentHome, "agents"), join(agentHome, "subagents")]) {
+		mkdirSync(dir, { recursive: true });
+	}
+	writeMarkdown(join(root, ".pi", "agents", "worker.md"), "---\nname: worker\ndescription: Worker\n---\nbody\n");
+	const previousConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	process.env.GENTLE_PI_CONFIG_HOME = configHome;
+	process.env.GENTLE_PI_AGENT_HOME = agentHome;
+	t.after(() => {
+		if (previousConfigHome === undefined) delete process.env.GENTLE_PI_CONFIG_HOME;
+		else process.env.GENTLE_PI_CONFIG_HOME = previousConfigHome;
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		rmSync(root, { recursive: true, force: true });
+	});
+	const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
+	createGentleAiExtension({ nativeReviewCli: null })({
+		on() {},
+		registerTool() {},
+		registerCommand(name, command) { commands.set(name, command); },
+	} as ExtensionAPI);
+	const notifications: Array<{ message: string; severity: string }> = [];
+	let panelVisits = 0;
+	const panels: string[] = [];
+	let onPanel = () => ({ type: "cancel", config: {} });
+	const ctx = {
+		cwd: root,
+		hasUI: true,
+		modelRegistry: { getAvailable: async () => [] },
+		ui: {
+			notify(message: string, severity: string) { notifications.push({ message, severity }); },
+			custom: async (factory: (tui: unknown, theme: Theme, keybindings: unknown, done: () => void) => { render(width: number): string[] }) => {
+				panels.push(stripAnsi(renderComponent(factory(undefined, { fg: (_color: string, text: string) => text } as unknown as Theme, undefined, () => {}))));
+				panelVisits += 1;
+				return onPanel();
+			},
+		},
+	} as unknown as Parameters<Parameters<ExtensionAPI["registerCommand"]>[1]["handler"]>[1];
+	return {
+		configHome, projectPath, globalPath, exportPath, notifications, panels,
+		panelVisits: () => panelVisits,
+		onPanel(action: typeof onPanel) { onPanel = action; },
+		run: (name: string) => commands.get(name)!.handler("", ctx),
+	};
+}
+
+test("models rejects invalid project routing with its selected source path", async (t) => {
+	const fixture = routingConsumerFixture(t);
+	writeFileSync(fixture.projectPath, "[]");
+	await fixture.run("gentle:models");
+	assert.equal(fixture.notifications[0]?.severity, "warning");
+	assert.ok(fixture.notifications[0]?.message.includes(fixture.projectPath));
+	assert.equal(fixture.panelVisits(), 0);
+});
+
+test("export re-reads saved routing and rejects invalid project before creating its destination parent", async (t) => {
+	const fixture = routingConsumerFixture(t);
+	writeFileSync(fixture.projectPath, '{"worker":"openai/gpt-5"}');
+	fixture.onPanel(() => {
+		if (fixture.panelVisits() > 1) return { type: "cancel", config: {} };
+		writeFileSync(fixture.projectPath, "[]");
+		return { type: "export", config: {} };
+	});
+	await fixture.run("gentle:models");
+	assert.equal(fixture.notifications[0]?.severity, "warning");
+	assert.ok(fixture.notifications[0]?.message.includes(`Invalid model config: ${fixture.projectPath}`));
+	assert.equal(existsSync(fixture.exportPath), false);
+	assert.equal(existsSync(fixture.configHome), false);
+});
+
+test("status reports invalid saved routing path instead of default agent routing", async (t) => {
+	const fixture = routingConsumerFixture(t);
+	writeFileSync(fixture.projectPath, "[]");
+	await fixture.run("gentle:status");
+	const report = fixture.notifications.at(-1)!;
+	assert.match(report.message, /Saved model routing: invalid/);
+	assert.ok(report.message.includes(fixture.projectPath));
+	assert.equal(report.severity, "warning");
+	assert.doesNotMatch(report.message, /worker: model=/);
+});
+
+test("models exports missing, normalized project, and global-precedence saved routing", async (t) => {
+	for (const source of ["missing", "project", "global"] as const) {
+		await t.test(source, async (t) => {
+			const fixture = routingConsumerFixture(t);
+			if (source !== "missing") writeFileSync(fixture.projectPath, '{"worker":" openai/gpt-5 ","ignored":null}');
+			if (source === "global") writeMarkdown(fixture.globalPath, '{"worker":{"model":" anthropic/opus ","thinking":"high"}}');
+			fixture.onPanel(() => ({ type: fixture.panelVisits() === 1 ? "export" : "cancel", config: {} }));
+			await fixture.run("gentle:models");
+			const agents = source === "missing" ? {} : source === "project"
+				? { worker: { model: "openai/gpt-5" } }
+				: { worker: { model: "anthropic/opus", thinking: "high" } };
+			assert.deepEqual(JSON.parse(readFileSync(fixture.exportPath, "utf8")).agents, agents);
+			assert.equal(fixture.notifications[0]?.severity, "info");
+			assert.match(fixture.notifications[0]!.message, /exported/);
+			assert.equal(fixture.panelVisits(), 2);
+			await fixture.run("gentle:status");
+			const report = fixture.notifications.at(-1)!.message;
+			assert.ok(report.includes(`Saved model routing: ${source === "missing" ? "missing" : "valid"}`));
+			assert.ok(report.includes(`Global model config: ${source === "global" ? "present" : "missing"}`));
+			const expectedRouting = source === "missing" ? "inherit, effort=inherit"
+				: source === "project" ? "openai/gpt-5, effort=inherit" : "anthropic/opus, effort=high";
+			assert.ok(report.includes(`worker: model=${expectedRouting}`), report);
+			assert.ok(fixture.panels[0].includes(`model=${expectedRouting}`), fixture.panels[0]);
+		});
+	}
+});
+
+test("invalid global routing overrides valid project in models, status, and export re-read", async (t) => {
+	for (const atExport of [false, true]) {
+		await t.test(atExport ? "invalidated during panel" : "invalid before panel", async (t) => {
+			const fixture = routingConsumerFixture(t);
+			writeFileSync(fixture.projectPath, '{"worker":"openai/gpt-5"}');
+			if (!atExport) writeMarkdown(fixture.globalPath, "[]");
+			fixture.onPanel(() => {
+				if (fixture.panelVisits() > 1) return { type: "cancel", config: {} };
+				writeMarkdown(fixture.globalPath, "[]");
+				return { type: "export", config: {} };
+			});
+			await fixture.run("gentle:models");
+			assert.equal(fixture.notifications[0]?.severity, "warning");
+			assert.ok(fixture.notifications[0]?.message.includes(fixture.globalPath));
+			assert.match(fixture.notifications[0]!.message, atExport ? /export failed/ : /cannot open model config/);
+			assert.equal(fixture.panelVisits(), atExport ? 2 : 0);
+			assert.equal(existsSync(fixture.exportPath), false);
+			await fixture.run("gentle:status");
+			const report = fixture.notifications.at(-1)!;
+			assert.match(report.message, /Global model config: present\nSaved model routing: invalid/);
+			assert.ok(report.message.includes(fixture.globalPath));
+			assert.doesNotMatch(report.message, /worker: model=/);
+			assert.equal(report.severity, "warning");
+		});
+	}
+});
+
 test("session startup reports invalid project routing without mutating the profile", async (t) => {
 	const root = mkdtempSync(join(tmpdir(), "gentle-pi-model-routing-startup-"));
 	const configHome = join(root, "global");
@@ -267,6 +409,21 @@ test("session startup reports invalid project routing without mutating the profi
 	assert.ok(warning, JSON.stringify(notifications));
 	assert.equal(warning!.severity, "warning");
 	assert.match(warning!.message, /skipped model config/);
+	assert.equal(readFileSync(profilePath, "utf8"), before);
+
+	writeFileSync(join(projectConfigDir, "models.json"), '{"worker":"openai/gpt-5"}');
+	const globalPath = join(configHome, "models.json");
+	writeFileSync(globalPath, "[]");
+	notifications.length = 0;
+	await sessionStart!({}, {
+		cwd: root,
+		hasUI: true,
+		ui: { notify(message: string, severity: string) { notifications.push({ message, severity }); } },
+	} as unknown as ExtensionContext);
+	const globalWarning = notifications.find((entry) => entry.message.includes(globalPath));
+	assert.ok(globalWarning, JSON.stringify(notifications));
+	assert.equal(globalWarning.severity, "warning");
+	assert.match(globalWarning.message, /skipped model config/);
 	assert.equal(readFileSync(profilePath, "utf8"), before);
 });
 

--- a/tests/model-routing-authority.test.ts
+++ b/tests/model-routing-authority.test.ts
@@ -94,6 +94,18 @@ test("model routing authority normalizes and preserves sync/async source status"
 		path: invalidGlobalPath,
 	});
 
+	const sourceCases = [
+		[missingPath, missingPath, { status: "missing" }],
+		[missingPath, projectPath, { status: "valid", config: { project: { model: "google/gemini" } } }],
+		[validGlobalPath, projectPath, validSync],
+		[missingPath, invalidGlobalPath, { status: "invalid", path: invalidGlobalPath }],
+		[invalidGlobalPath, projectPath, { status: "invalid", path: invalidGlobalPath }],
+	] as const;
+	for (const [globalSource, projectSource, expected] of sourceCases) {
+		assert.deepEqual(authority.readSavedModelConfig(globalSource, projectSource), expected);
+		assert.deepEqual(await authority.readSavedModelConfigAsync(globalSource, projectSource), expected);
+	}
+
 	const previousConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
 	process.env.GENTLE_PI_CONFIG_HOME = globalDir;
 	t.after(() => {


### PR DESCRIPTION
## Summary

Closes #395.
Refs #389, #396, #391, #382, #381.

- Route the real saved-routing export, `/gentle:models`, and `/gentle:status` through the existing status-carrying authority instead of compatibility wrappers that mask invalid project configuration.
- Reject invalid exports before creating the destination directory or file, including when a source becomes invalid after the models panel opens.
- Preserve missing/valid behavior, global precedence, and the existing startup/apply path; report invalid routing with its selected source path.

## Context and scope

This is the consumer/export slice of the routing work, not another authority extraction. The prerequisites are already merged: #389 through #398 and #396 through #408. Both predecessor commits are ancestors of the implementation base `61487bde`.

```text
main
 └── #389: shared routing authority (merged via #398)
      └── #396: fail-closed apply and profile safety (merged via #408)
           └── 📍 #395: export and UI/lifecycle consumers (this PR)
                └── #391: canonical names and target authority (separate follow-up)
                     └── durable write / materialization (later slices)
```

Compatibility wrappers retain their established behavior and preservation assertions. The shared authority, normalization/parser grammar, target paths, writes, migration ordering, profile materialization, JSON `null`, literal `inherit`, and omission semantics are unchanged. `/gentle:doctor` is outside this issue's named consumer list and remains unchanged.

Session startup already reaches the shared authority through `applySavedModelConfig`; this PR adds global-invalid precedence coverage rather than rewriting that correct path. Invalid status reporting no longer presents default agent assignments as if invalid saved routing were an empty configuration. Missing routing retains the existing default display.

## Changes

| File | Change |
| --- | --- |
| `extensions/gentle-ai.ts` | Direct shared-authority reads in export/models/status; explicit status/path reporting and warning severity |
| `tests/gentle-ai.test.ts` | Actual registered handlers, real panel rendering/export, source invalidation during export, missing/valid/invalid combinations, startup precedence |
| `tests/model-routing-authority.test.ts` | Sync/async source-selection characterization; existing compatibility/apply-safety guards retained |

**Review size: 185 additions + 6 deletions = 191 / 400 lines.** No size exception requested. This PR resolves only #395; it does not resolve the referenced prerequisites, trackers, or later slices.

## Observed TDD

Each consumer cycle used `node --experimental-strip-types --test tests/gentle-ai.test.ts` with an isolated `TMPDIR`.

| Cycle | Observed assertion-level RED | GREEN |
| --- | --- | --- |
| Models | Invalid project configuration did not produce the expected warning | Direct authority read; 23 tests passed |
| Export | Invalidation after panel entry produced an informational export result instead of a warning | Export re-read rejects invalid source; 24 tests passed |
| Status | Output lacked `Saved model routing: invalid` | Status/path propagation; 25 tests passed |

Triangulation covered missing and normalized valid sources, global-over-project precedence, invalid-global no-fallback, invalid export no-directory/no-file creation, actual panel rendering, and startup invalid-source reporting. The reader parity additions are characterization, not claimed as new failing behavior. A test-theme instrumentation mismatch was corrected separately and is not counted as functional RED.

## Verification

Dependencies were hydrated with `pnpm@11.1.1`; the `@earendil-works/pi-tui` ESM import passed before implementation. Baseline: authority 3 passed, gentle-ai 22 passed, runtime harness passed.

| Command | Result |
| --- | --- |
| `node --experimental-strip-types --test tests/model-routing-authority.test.ts` | 3 passed |
| `node --experimental-strip-types --test tests/gentle-ai.test.ts` | 32 passed |
| `pnpm run test:harness` | Passed |
| `pnpm test` | 1,929 passed, 18 skipped, 0 failed; provider-contract check and harness passed |
| `pnpm run check:runtime-modules` | Six modules match |
| `node --experimental-strip-types --check extensions/gentle-ai.ts` | Syntax check passed, not a typecheck |
| `git diff --check` | Passed |

The two focused files were also rerun together after implementation: 35 passed, 0 failed. Native independent review completed for the unchanged source candidate before commit.

The 18 full-suite skips include unavailable package-local native-binary and platform-specific cases; those cases are not claimed as executed. No full-suite baseline was run to classify skip-count changes. Git merge-tree against the fetched upstream `main` reported no conflicts, but CI still needs to validate the merged/current-main result.

## Rollback and maintainer metadata

The rollback boundary is the consumer wiring and its tests in these three files. It does not require reverting the shared authority or fail-closed apply predecessors. No shell scripts, skill definitions, packaging, or dependencies changed.

Suggested label: **`type:refactor`**. My upstream access is read-only, so label application remains with a maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid model-routing configuration files are now surfaced instead of being treated as empty valid configurations.
  * Model exports report configuration errors clearly.
  * Model management commands warn and stop when project routing configuration is invalid.
  * Status reporting identifies invalid routing configuration paths with elevated notification severity.
  * Invalid global routing configuration is reported during startup without changing the active profile.
  * Routing exports now consistently reflect applicable saved configuration and precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->