### PR TITLE
test(sdd): align blocked route assertion

### DIFF
--- a/tests/review-controller.test.ts
+++ b/tests/review-controller.test.ts
@@ -208,7 +208,7 @@ test("controller SDD status treats removed OpenSpec recovery authority and delet
 	const status = await __testing.resolveControllerSddStatus(fixture.repository, changeName, false, "openspec");
 
 	assert.equal(status.dependencies.archive, "blocked");
-	assert.equal(status.nextRecommended, "Active change not found: recover-legacy-review-authority.");
+	assert.equal(status.nextRecommended, "blocked");
 	assert.match(status.blockedReasons.join("\n"), /active change not found/i);
 });
 


### PR DESCRIPTION
Closes #732

## PR type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary

- Align the remaining controller regression with the bounded SDD routing token introduced by #844.
- Preserve the original human-readable explanation assertion in `blockedReasons`.
- Restore the full `pnpm test` workflow after the post-merge CI failure.

## Changes

| File | Change |
|------|--------|
| `tests/review-controller.test.ts` | Expects `blocked` as the machine route while retaining the diagnostic assertion. |

## Test plan

- [x] `node --experimental-strip-types --test tests/review-controller.test.ts` — 9 passed
- [x] `pnpm test` — 1,927 passed, 0 failed, 18 skipped
- [x] `git diff --check`
- [x] Native four-lens review approved and acknowledged

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts changed; shellcheck is not applicable
- [x] Tests cover the changed contract
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated controller test expectations to reflect the generic “blocked” next recommendation for SDD status scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->