### PR TITLE
feat(telemetry): add one-shot runtime observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,19 +855,19 @@ Memory contract for SDD delegation:
 
 ## Telemetry
 
-`gentle-pi` does not collect anything itself. [gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) owns anonymous usage telemetry end to end — install and heartbeat events, what fields are sent, rate limiting, and every opt-out. See its README/docs for the exact contract.
+`gentle-pi` observes approved sanitized runtime usage fields in memory and asynchronously invokes `gentle-ai telemetry runtime send --json` once per accepted event. It never persists metric data, retries, or waits for delivery in provider callbacks; busy or failed attempts are silently discarded. [gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) owns native delivery and the existing opt-out policy. See [Telemetry](docs/telemetry.md) for fields and source limitations.
 
-At session start, for a primary session only (never for a named or SDD sub-agent), Gentle Pi asks the local `gentle-ai` binary to send its own telemetry: it spawns `gentle-ai telemetry trigger --json` detached, with a 3 s deadline, discards its output, and never blocks session start or surfaces an error — an older binary without the verb is silently treated as nothing to do. This runs at most once per process.
+Separately, at primary session start (never for a named or SDD sub-agent), Gentle Pi asks the local `gentle-ai` binary to handle its own install/heartbeat telemetry: it spawns `gentle-ai telemetry trigger --json` detached, with a 3 s deadline, discards its output, and never blocks session start or surfaces an error — an older binary without the verb is silently treated as nothing to do. This runs at most once per process.
 
 Install counts for `gentle-pi` and `gentle-engram` come from npm download statistics; the package itself never emits an install event.
 
 To opt out:
 
 - `/gentle:telemetry disable` — asks the local `gentle-ai` binary to disable telemetry (also `status` and `preview` to inspect it without leaving Pi).
-- `DO_NOT_TRACK=1` — Gentle Pi itself will not spawn the trigger, and `gentle-ai` also honors this standard on its own.
+- `DO_NOT_TRACK=1` — Gentle Pi suppresses runtime usage telemetry and the install/heartbeat trigger; `gentle-ai` also honors this standard independently.
 - `GENTLE_AI_TELEMETRY=0` — same effect, `gentle-ai`'s own environment switch.
 
-`CI=true` also suppresses the trigger, since automated runs are not a real usage signal.
+`CI=true` also suppresses runtime usage telemetry and the trigger, since automated runs are not a real usage signal.
 
 ## Package contents
 

--- a/contracts/telemetry/runtime-aggregate-v1.schema.json
+++ b/contracts/telemetry/runtime-aggregate-v1.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "gentle-ai.telemetry-runtime-aggregate/v1",
+  "description": "Sanitized stdin for gentle-ai telemetry runtime send --json. Maximum UTF-8 input 16384 bytes. One best-effort send attempt, no client persistence or retry. Rows are independent observations, not a session composition. No caller identity is accepted.",
+  "type": "object", "additionalProperties": false,
+  "required": ["schema", "registry", "host", "rows"],
+  "properties": {
+    "schema": {"const": "gentle-ai.telemetry-runtime-aggregate/v1"},
+    "registry": {"const": 1},
+    "host": {"enum": ["claude-code", "opencode", "codex", "pi"]},
+    "rows": {"type": "array", "minItems": 1, "maxItems": 32, "items": {"$ref": "#/$defs/row"}}
+  },
+  "$defs": {
+    "metric": {"oneOf": [{"type": "integer", "minimum": 0, "maximum": 999999999999}, {"type": "null"}, {"const": "unsupported"}]},
+    "count": {"type": "integer", "minimum": 0, "maximum": 999999999999},
+    "token": {
+      "type": "object", "additionalProperties": false,
+      "required": ["reported", "unavailable", "unsupported", "sum"],
+      "properties": {
+        "reported": {"$ref": "#/$defs/count"}, "unavailable": {"$ref": "#/$defs/count"},
+        "unsupported": {"$ref": "#/$defs/count"}, "sum": {"$ref": "#/$defs/count"}
+      },
+      "if": {"properties": {"reported": {"const": 0}}},
+      "then": {"properties": {"sum": {"const": 0}}}
+    },
+    "duration": {
+      "type": "object", "additionalProperties": false, "required": ["kind", "measured_count", "sum_ms"],
+      "properties": {"kind": {}, "measured_count": {}, "sum_ms": {}},
+      "oneOf": [
+        {"properties": {"kind": {"const": "unavailable"}, "measured_count": {"const": 0}, "sum_ms": {"type": "null"}}},
+        {"properties": {"kind": {"enum": ["request", "message"]}, "measured_count": {"type": "integer", "minimum": 1, "maximum": 999999999999}, "sum_ms": {"type": "number", "minimum": 0, "maximum": 999999999999}}}
+      ]
+    },
+    "effort": {"enum": ["off", "minimal", "low", "medium", "high", "xhigh", "max", "not_selected", "unknown", "custom", "unavailable", "unsupported"]},
+    "model": {
+      "type": "object", "additionalProperties": false, "required": ["provider", "id"],
+      "properties": {"provider": {"type": "string"}, "id": {"type": "string"}},
+      "oneOf": [
+        {"properties": {"provider": {"const": "anthropic"}, "id": {"enum": ["claude-opus-5", "claude-haiku-4-5", "claude-haiku-4-5-20251001", "claude-sonnet-5"]}}},
+        {"properties": {"provider": {"enum": ["openai", "openai-codex"]}, "id": {"enum": ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex-spark", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2", "gpt-5.3-codex", "gpt-5.6"]}}},
+        {"properties": {"provider": {"const": "opencode"}, "id": {"const": "custom"}}},
+        {"properties": {"provider": {"const": "unknown"}, "id": {"const": "unknown"}}},
+        {"properties": {"provider": {"const": "custom"}, "id": {"const": "custom"}}}
+      ]
+    },
+    "row": {
+      "type": "object", "additionalProperties": false,
+      "required": ["model", "model_evidence", "agent_kind", "agent_class", "selected_effort", "effective_effort", "launches", "responses", "input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens", "reasoning_tokens", "total_tokens", "error_category", "duration"],
+      "properties": {
+        "reasoning_tokens": {"$ref": "#/$defs/token"},
+        "total_tokens": {"$ref": "#/$defs/token"},
+        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-apply", "sdd-archive", "sdd-design", "sdd-explore", "sdd-init", "sdd-onboard", "sdd-proposal", "sdd-research", "sdd-spec", "sdd-status", "sdd-sync", "sdd-tasks", "sdd-verify", "review-readability", "review-reliability", "review-resilience", "review-risk", "jd-fix-agent", "jd-judge-a", "jd-judge-b"]},
+        "error_category": {"enum": ["none", "unknown", "auth", "output_length", "aborted", "api", "rate_limit", "server"]},
+        "duration": {"$ref": "#/$defs/duration"},
+        "model": {"$ref": "#/$defs/model"},
+        "model_evidence": {"enum": ["selected", "response", "unknown"]},
+        "agent_kind": {"enum": ["orchestrator", "built_in", "custom", "unknown"]},
+        "selected_effort": {"$ref": "#/$defs/effort"}, "effective_effort": {"$ref": "#/$defs/effort"},
+        "launches": {"$ref": "#/$defs/metric", "description": "Source-observed event count only; null when not observed. Never reconstructed from sessions."}, "responses": {"$ref": "#/$defs/metric", "description": "Source-observed response occurrence count, independent of token coverage and success."},
+        "input_tokens": {"$ref": "#/$defs/token"}, "output_tokens": {"$ref": "#/$defs/token"},
+        "cache_read_tokens": {"$ref": "#/$defs/token"}, "cache_creation_tokens": {"$ref": "#/$defs/token"}
+      }
+    }
+  }
+}

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,6 +1,62 @@
 # Telemetry
 
-`gentle-pi` does not collect anything itself. [`gentle-ai`](https://github.com/Gentleman-Programming/gentle-ai) (issue [#4309](https://github.com/Gentleman-Programming/gentle-ai/issues/4309)) owns anonymous usage telemetry end to end: install and heartbeat events, the exact fields sent, rate limiting, and every opt-out. See gentle-ai's own README/docs for that contract. Gentle Pi's only involvement is a best-effort nudge that asks the local binary to act.
+Runtime usage telemetry is best effort: an available usage event gets at most one
+asynchronous attempt through `gentle-ai telemetry runtime send --json`. Busy,
+failed, disabled, or cancelled attempts are discarded silently. There is no
+metrics disk storage, outbox, retry, backoff, cooldown, daemon, or session reconstruction.
+
+The production encoder uses the byte-identical [native schema mirror](../contracts/telemetry/runtime-aggregate-v1.schema.json).
+[The synthetic fixture](../tests/fixtures/runtime-metrics-native-batches.json) pins its
+SHA-256 and exact one-shot stdin bytes. No old intake fallback is used. These are
+fake-subprocess tests, not a live collector or deployment verification.
+
+## Runtime usage flow
+
+1. A finalized primary assistant message or child completion supplies available usage.
+   Child-host extensions do not independently consume primary usage.
+2. Pi builds event-local sanitized rows, not cumulative session totals. An occupied
+   attempt slot discards the event; it never queues it for later.
+3. One cancellable immediate defers binary verification and subprocess launch beyond
+   the provider callback. The native command owns fresh policy and exactly one POST.
+4. Only `stored`, `duplicate`, `discarded`, or `disabled` results are recognized.
+   All are terminal. `stored` and `duplicate` reflect collector acknowledgement,
+   not client persistence; Pi retains nothing and never retries.
+
+There is no policy or capability subprocess before send, and no ingest or flush call.
+The packaged binary is verified; development overrides are refused for runtime usage.
+Missing binaries and unsupported commands discard without installation or fallback.
+
+Replacement and shutdown cancel an unstarted attempt or request termination of its
+child immediately, without a wait loop or final send. The process slot remains busy
+until actual close, preventing overlap even if a cancelled process is slow to exit.
+A one-second process timeout requests termination; it is not a retry timer or a hard
+bound on synchronous binary verification or event-loop stalls.
+
+## Data and source limits
+
+Wire fields are the schema/registry, host, public model with evidence, available
+selected/effective effort, orchestrator or known built-in subagent class, source
+launch/response occurrence coverage, six token coverages, explicitly reported typed
+duration, and a sanitized error category. Occurrences never represent sessions.
+Prompts, responses, code, paths, private names, source IDs, and raw errors never enter
+the payload. There is no `batch_id`; native creates the remote `delivery_id`.
+
+One event produces 1–32 rows within 16 KiB. Oversized or invalid events discard
+whole rather than splitting into multiple sends. Child launch selection is a separate
+row with zero response-token coverage, never substituted for per-response evidence.
+
+- Token coverage distinguishes reported, unavailable, and unsupported values. Pi's
+  SDK-positive counters are usable; zero defaults and absence do not prove reported zero.
+- Selected model/effort is captured at the request hook, separately from response
+  model and effective-effort evidence. Ambiguous request sequences discard selection.
+- Pi hooks do not correlate requests/retries reliably, so this adapter does not infer duration.
+- Child configuration classification uses packaged built-in definitions, not agent names.
+  Launch configuration is not proof of the model or selected effort of each child response.
+- Bounded live child observations remain in RAM until completion. No completed child
+  event is retained for forwarding. A completion without usage creates no usage send.
+- Primary object deduplication uses weak tombstones; copied objects are distinct.
+  Child completion tombstones are capped at 256 per extension session. Source IDs
+  stay local and are never exported. No session history is read or reconstructed.
 
 ## What Gentle Pi does
 

--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -24,6 +24,9 @@ import { CARD_TONE, renderCard } from "../lib/shell-card.ts";
 import { openInExternalEditor } from "./gentle-shell.ts";
 import { resolveGentlePiAgentHome } from "../lib/agent-home.ts";
 import { researchAgent, resolveResearchCapabilities, renderResearchCapabilities, RESEARCH_CHILD_TOOLS_ENV } from "../lib/sdd-research-capabilities.ts";
+import { CHILD_METRICS_EVENT, CHILD_METRICS_REVOKED, childEvent, launchSelection, type LaunchSelection } from "../lib/runtime-metrics-children.ts";
+import { lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
+import { runtimeMetricsEnvAllows, type RuntimeMetricsPolicyDeps } from "../lib/runtime-metrics-policy.ts";
 
 // Gentle Agents: subagents as isolated `pi --mode rpc` children, a task
 // store that notifies per task, and a Gentle Shell card above the editor.
@@ -47,6 +50,9 @@ export interface AgentsDeps extends RunnerDeps {
 	childIpc?: IpcEndpoint;
 	env: NodeJS.ProcessEnv;
 	resolveWorktree: WorktreeResolver;
+	runtimeMetricsPolicy?: RuntimeMetricsPolicyDeps;
+	metricsNow?: () => number;
+	metricsSchedule?: RunnerDeps["schedule"];
 }
 
 export function agentRuntimePaths(home: string, agentHome = join(home, ".pi", "agent")): { sessions: string; transcripts: string } {
@@ -285,6 +291,26 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	const ownedTaskIds = new Set<string>();
 	const stoppingTaskIds = new Set<string>();
 	const yieldedTaskIds = new Set<string>();
+	const metricsNow = deps.metricsNow ?? (() => performance.now());
+	let metricsOwner = {};
+	const metricTasks = new Map<string, { selection?: LaunchSelection; started: number; launched: boolean; finished: boolean; current(): boolean; valid(): boolean }>();
+	const unsubscribeMetrics = pi.events.on(CHILD_METRICS_REVOKED, id => {
+		if (id === activeSessionId()) {
+			metricsOwner = {};
+			for (const taskId of metricTasks.keys()) runner.discardResponseObservations(taskId);
+			metricTasks.clear();
+		}
+	});
+	const clearTaskMetrics = () => {
+		metricsOwner = {};
+		for (const taskId of metricTasks.keys()) runner.discardResponseObservations(taskId);
+		metricTasks.clear();
+	};
+	pi.on("session_start", clearTaskMetrics);
+	pi.on("session_shutdown", () => {
+		clearTaskMetrics();
+		unsubscribeMetrics();
+	});
 	let stopAllConfirmation: Promise<void> | undefined;
 
 	// The card and its clock follow the session pi has open right now; a task
@@ -367,12 +393,27 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			if (!root || root !== childRoot || !worktrees.roots().includes(root)) return;
 			recordReviewMutation(pi, sessions, root, { source: "subagent", taskId: task.id, toolName: tool.toolName, toolCallId: tool.toolCallId });
 		},
-		onFinish: (task) => {
-			ownedTaskIds.delete(task.id);
-			requestRender();
-			persist(task);
-			const yielded = yieldedTaskIds.delete(task.id);
-			if ((task.mode === AGENT_MODE.BACKGROUND && task.status !== TASK_STATUS.CANCELLED) || (yielded && task.status !== TASK_STATUS.CANCELLED && activeSessionId() === task.parentSessionId)) deliver(task);
+		onFinish: (task, observations) => {
+			// Completion is the only forwarding opportunity. No pending event, policy
+			// query or promise survives this callback; the receiver drops when busy.
+			const { id, parentSessionId, status } = task;
+			const metrics = metricTasks.get(id);
+			metricTasks.delete(id); // Deliver at most once, even if forwarding fails.
+			try {
+				const authorized = metrics?.valid();
+				if (metrics) metrics.finished = true;
+				if (authorized && metrics?.launched && metrics.selection && observations) {
+					const event = childEvent(parentSessionId, id, metrics.selection, status, observations, metrics.started);
+					if (event && metrics.current()) pi.events.emit(CHILD_METRICS_EVENT, event);
+				}
+			} catch { /* Metrics must never interrupt task finalization. */ }
+			try {
+				ownedTaskIds.delete(task.id);
+				requestRender();
+				persist(task);
+				const yielded = yieldedTaskIds.delete(task.id);
+				if ((task.mode === AGENT_MODE.BACKGROUND && task.status !== TASK_STATUS.CANCELLED) || (yielded && task.status !== TASK_STATUS.CANCELLED && activeSessionId() === task.parentSessionId)) deliver(task);
+			} catch { /* Best-effort completion bookkeeping cannot strand runner waiters. */ }
 		},
 	});
 
@@ -609,7 +650,27 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	};
 
 	const launch = async (ctx: ExtensionContext, request: TaskRequest): Promise<ToolText> => {
-		const task = runner.run(request);
+		// Bounded live observation only. Native send owns the fresh policy decision;
+		// child execution never starts a telemetry policy process or renewal timer.
+		const owner = metricsOwner;
+		const metrics = { selection: undefined as LaunchSelection | undefined,
+			started: 0, launched: false, finished: false,
+			current: () => owner === metricsOwner && request.parentSessionId === activeSessionId() && runtimeMetricsEnvAllows(deps.env),
+			valid: () => !metrics.finished && metrics.current() };
+		const observe = runtimeMetricsEnvAllows(deps.env) && metricTasks.size < 256;
+		const task = runner.run({ ...request, collectResponseObservations: false,
+			onLaunch: () => { metrics.launched = true; request.onLaunch?.(); },
+			...(observe ? { canCollectResponseObservations: metrics.valid, prepareResponseObservations: async () => {
+				if (metrics.finished || owner !== metricsOwner || request.parentSessionId !== activeSessionId() || !runtimeMetricsEnvAllows(deps.env)) return false;
+				try { await lookupPiCatalogName({ provider: "openai", modelId: "gpt-4o" }); }
+				catch { return false; }
+				if (!metrics.valid()) return false;
+				metrics.selection = launchSelection(request.agent, request.model, request.thinking);
+				metrics.started = metricsNow();
+				return metrics.valid();
+			} } : {}),
+		});
+		if (observe) metricTasks.set(task.id, metrics);
 		ownedTaskIds.add(task.id);
 		store.subscribe(task.id, () => { publishActivity(); requestRender(); });
 		if (request.mode === AGENT_MODE.BACKGROUND) return text(`Started ${task.agent} in the background as task ${task.id}. Use subagent_status or subagent_result with that id.`, taskDetails(task));

--- a/extensions/runtime-metrics.ts
+++ b/extensions/runtime-metrics.ts
@@ -1,0 +1,120 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { EFFORTS, RuntimeMetrics, type FinalResponse, type TokenMeasurement } from "../lib/runtime-metrics.ts";
+import { lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
+import { CHILD_METRICS_EVENT, CHILD_METRICS_REVOKED, snapshotChildEvent, type ChildLaunchBucket } from "../lib/runtime-metrics-children.ts";
+import { RuntimeMetricsAttempt } from "../lib/runtime-metrics-delivery.ts";
+import { sendNativeRuntimeEvent, type NativeRuntimeTransportDeps } from "../lib/runtime-metrics-native.ts";
+import { runtimeMetricsEnvAllows } from "../lib/runtime-metrics-policy.ts";
+
+/** Available final usage -> one deferred attempt -> discard. No history reads,
+ * cumulative session accounting, policy leases, delivery queue or shutdown join.
+ * Pi hooks lack request correlation: latency and SDK-zero presence are unknown.
+ */
+export default function runtimeMetrics(pi: ExtensionAPI, env = process.env,
+	{ lookup = lookupPiCatalogName, native, send = sendNativeRuntimeEvent, now = () => performance.now() }:
+	{ lookup?: typeof lookupPiCatalogName; native?: NativeRuntimeTransportDeps;
+		send?: typeof sendNativeRuntimeEvent; now?: () => number } = {}): void {
+	const allows = () => env.GENTLE_PI_AGENTS_CHILD !== "1" && runtimeMetricsEnvAllows(env);
+	if (!allows()) return;
+	type Selection = Pick<FinalResponse, "selectedModelId" | "selectedProvider" | "effort">;
+	let selection: Selection | undefined;
+	let active = false;
+	let requestSeen = false;
+	let ambiguous = false;
+	let live: { id: string; started: number; ctx: ExtensionContext; attempt: RuntimeMetricsAttempt;
+		seen: WeakSet<object>; children: Set<string>; catalog: boolean } | undefined;
+	const missing = { state: "unavailable" } as const;
+	function invalidate() { selection = undefined; ambiguous = true; }
+	function dispose() { live?.attempt.dispose(); live = undefined; active = false; invalidate(); }
+	function current(ctx: ExtensionContext) {
+		if (!allows() || live?.id !== ctx.sessionManager.getSessionId()) dispose();
+		return live;
+	}
+	function submit(owner: NonNullable<typeof live>, responses: FinalResponse[], launches?: ChildLaunchBucket[]) {
+		if (!responses.length || live !== owner || !current(owner.ctx)) return;
+		// Ephemeral event-local accounting only; source IDs never enter these rows.
+		const metrics = new RuntimeMetrics();
+		for (const [index, row] of responses.entries()) metrics.record({ ...row, responseId: String(index) });
+		const rows = metrics.snapshot();
+		if (!rows.length) return;
+		const cwd = owner.ctx.cwd;
+		owner.attempt.offer(async signal => {
+			if (live !== owner || !current(owner.ctx) || signal.aborted) return;
+			await send(rows, cwd, { ...native, launches, env, signal,
+				current: () => live === owner && current(owner.ctx) === owner });
+		});
+	}
+	const offChild = pi.events.on(CHILD_METRICS_EVENT, value => {
+		try {
+			const owner = live && current(live.ctx);
+			const event = snapshotChildEvent(value);
+			if (!owner || !event || event.parentSessionId !== owner.id || event.launchedAt < owner.started
+				|| owner.children.has(event.taskId) || owner.children.size >= 256) return;
+			owner.children.add(event.taskId); // Busy/failed completions stay consumed.
+			submit(owner, event.responses, [{ ...event.launch, evidence: "launch_configuration", launches: 1 }]);
+		} catch { /* No telemetry error enters the shared event bus. */ }
+	});
+	const offRevoke = pi.events.on(CHILD_METRICS_REVOKED, id => {
+		if (live?.id === id) {
+			live.attempt.dispose();
+			live.attempt = new RuntimeMetricsAttempt();
+			invalidate();
+		}
+	});
+	pi.on("session_start", async (_event, ctx) => {
+		dispose();
+		if (!allows()) return;
+		const owner = { id: ctx.sessionManager.getSessionId(), started: now(), ctx,
+			attempt: new RuntimeMetricsAttempt(), seen: new WeakSet<object>(), children: new Set<string>(), catalog: false };
+		live = owner;
+		try {
+			await lookup({ provider: "openai", modelId: "gpt-4o" });
+			if (live === owner) owner.catalog = true;
+		} catch { /* Public catalog failure stays silent. */ }
+	});
+	pi.on("session_shutdown", () => { dispose(); offChild(); offRevoke(); });
+	pi.on("turn_start", () => { ambiguous = active; active = true; requestSeen = false; selection = undefined; });
+	pi.on("turn_end", () => { active = false; invalidate(); });
+	pi.on("agent_end", () => { active = false; invalidate(); });
+	pi.on("session_before_compact", invalidate);
+	pi.on("session_before_tree", invalidate);
+	pi.on("before_provider_request", (_event, ctx) => {
+		const owner = current(ctx);
+		if (!owner) return;
+		if (requestSeen) invalidate();
+		requestSeen = true;
+		if (!active || ambiguous) return;
+		let effort: FinalResponse["effort"] = "unavailable";
+		try { const value = pi.getThinkingLevel(); if (EFFORTS.includes(value)) effort = value; } catch { /* No evidence. */ }
+		selection = { selectedProvider: owner.catalog ? ctx.model?.provider as FinalResponse["provider"] ?? "unknown" : "unknown",
+			selectedModelId: owner.catalog && typeof ctx.model?.id === "string" && ctx.model.id.length <= 128 ? ctx.model.id : undefined, effort };
+	});
+	function token(value: unknown): TokenMeasurement {
+		return typeof value === "number" && Number.isSafeInteger(value) && value > 0 && value <= 1_000_000_000
+			? { state: "reported", value } : missing;
+	}
+	pi.on("message_end", (event, ctx) => {
+		try {
+			const owner = current(ctx);
+			const message = event.message;
+			if (!owner || message.role !== "assistant" || message.stopReason === "pending" || message.stopReason === "deferred"
+				|| owner.seen.has(message)) return;
+			owner.seen.add(message);
+			const selected = active && !ambiguous ? selection : undefined;
+			submit(owner, [{ kind: "final_assistant_response", responseId: "0",
+				selectedProvider: selected?.selectedProvider ?? "unknown", selectedModelId: selected?.selectedModelId,
+				effort: selected?.effort ?? "unavailable",
+				executor: env.GENTLE_PI_AGENTS_CHILD === undefined ? "orchestrator" : "unknown",
+				agentClass: env.GENTLE_PI_AGENTS_CHILD === undefined ? "orchestrator" : "unknown",
+				observedModelId: message.model, responseModelId: message.responseModel,
+				providerThinkingLevel: EFFORTS.includes(message.providerThinkingLevel as FinalResponse["effort"])
+					? message.providerThinkingLevel as FinalResponse["effort"] : "unavailable",
+				provider: message.provider as FinalResponse["provider"], modelFamily: "unknown",
+				error: message.stopReason === "aborted" ? "aborted" : message.stopReason === "error" ? "unknown" : "none",
+				tokens: { input: token(message.usage?.input), output: token(message.usage?.output), cacheRead: token(message.usage?.cacheRead),
+					cacheWrite: token(message.usage?.cacheWrite), reasoning: token(message.usage?.reasoning), totalTokens: token(message.usage?.totalTokens) },
+				responseHeadersMs: missing, fullResponseMs: missing }]);
+			invalidate();
+		} catch { /* Provider hooks never expose telemetry failures. */ }
+	});
+}

--- a/lib/agents-protocol.ts
+++ b/lib/agents-protocol.ts
@@ -32,6 +32,7 @@ export const TASK_EVENT = {
 	ASK: "ask",
 	NOTE: "note",
 	USAGE: "usage",
+	RESPONSE_OBSERVATION: "response_observation",
 } as const;
 
 export type TaskEventType = (typeof TASK_EVENT)[keyof typeof TASK_EVENT];
@@ -69,7 +70,24 @@ export interface AskEvent { type: typeof TASK_EVENT.ASK; request: AskRequest }
 export interface NoteEvent { type: typeof TASK_EVENT.NOTE; text: string }
 export interface UsageEvent { type: typeof TASK_EVENT.USAGE; tokens: number; cost: number }
 
-export type TaskEvent = TextEvent | ThinkingEvent | ToolStartEvent | ToolUpdateEvent | ToolEndEvent | TurnEndEvent | AgentEndEvent | AgentSettledEvent | ErrorEvent | AskEvent | NoteEvent | UsageEvent;
+export type ChildUnavailable = Readonly<{ state: "unavailable" }>;
+export type ChildMetadata = Readonly<{ state: "observed"; value: string }> | ChildUnavailable;
+export type ChildTokenMeasurement = Readonly<{ state: "reported"; value: number }> | ChildUnavailable;
+export interface ChildResponseObservation {
+	/** SDK message metadata, not authenticated route or selected-model evidence. */
+	readonly provider: ChildMetadata;
+	readonly model: ChildMetadata;
+	readonly responseModel: ChildMetadata;
+	/** Exact provider-native effort when supplied, NOT Pi's selected effort. */
+	readonly providerThinkingLevel: ChildMetadata;
+	readonly selected: Readonly<{ provider: ChildUnavailable; model: ChildUnavailable; effort: ChildUnavailable }>;
+	readonly stopReason: "stop" | "length" | "toolUse" | "error" | "aborted";
+	/** Reasoning is a subset of output, not an additional token total. */
+	readonly tokens: Readonly<Record<"input" | "output" | "cacheRead" | "cacheWrite" | "totalTokens" | "reasoning", ChildTokenMeasurement>>;
+}
+export interface ResponseObservationEvent { type: typeof TASK_EVENT.RESPONSE_OBSERVATION; observation: ChildResponseObservation }
+
+export type TaskEvent = ResponseObservationEvent | TextEvent | ThinkingEvent | ToolStartEvent | ToolUpdateEvent | ToolEndEvent | TurnEndEvent | AgentEndEvent | AgentSettledEvent | ErrorEvent | AskEvent | NoteEvent | UsageEvent;
 
 export interface TextItem { kind: typeof THREAD_ITEM.TEXT; text: string }
 export interface ThinkingItem { kind: typeof THREAD_ITEM.THINKING; text: string }
@@ -174,9 +192,39 @@ function askRequest(raw: Raw): AskRequest {
 	return { id: String(raw.id ?? ""), method: String(raw.method ?? ""), title };
 }
 
+const CHILD_UNAVAILABLE: ChildUnavailable = Object.freeze({ state: "unavailable" });
+const CHILD_SELECTION = Object.freeze({ provider: CHILD_UNAVAILABLE, model: CHILD_UNAVAILABLE, effort: CHILD_UNAVAILABLE });
+
+function childMetadata(value: unknown, max: number): ChildMetadata {
+	// Retain bounded identifier fields only; do not truncate into another identity.
+	return typeof value === "string" && value.length <= max && /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/.test(value)
+		? Object.freeze({ state: "observed", value }) : CHILD_UNAVAILABLE;
+}
+
+function childTokens(value: unknown): ChildTokenMeasurement {
+	// SDK default zeros are not provider-presence evidence (same as primary adapter).
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0 && value <= 1_000_000_000
+		? Object.freeze({ state: "reported", value }) : CHILD_UNAVAILABLE;
+}
+
+function childResponse(message: Raw): ChildResponseObservation | undefined {
+	const reason = message.stopReason;
+	if (reason !== "stop" && reason !== "length" && reason !== "toolUse" && reason !== "error" && reason !== "aborted") return undefined;
+	const usage = message.usage as Raw | undefined;
+	return Object.freeze({
+		provider: childMetadata(message.provider, 32), model: childMetadata(message.model, 128),
+		responseModel: childMetadata(message.responseModel, 128), providerThinkingLevel: childMetadata(message.providerThinkingLevel, 32),
+		// RPC has no per-request selected state; get_state observes launch only.
+		selected: CHILD_SELECTION, stopReason: reason,
+		tokens: Object.freeze({ input: childTokens(usage?.input), output: childTokens(usage?.output),
+			cacheRead: childTokens(usage?.cacheRead), cacheWrite: childTokens(usage?.cacheWrite),
+			totalTokens: childTokens(usage?.totalTokens), reasoning: childTokens(usage?.reasoning) }),
+	});
+}
+
 // One RPC line in, zero or more deltas out. Streaming deltas carry only the
 // chunk; whole-message payloads that pi repeats on every update are ignored.
-export function normalizeRpcEvent(raw: unknown): TaskEvent[] {
+export function normalizeRpcEvent(raw: unknown, options: { observeResponses?: boolean } = {}): TaskEvent[] {
 	if (!raw || typeof raw !== "object") return [];
 	const event = raw as Raw;
 	switch (event.type) {
@@ -200,9 +248,16 @@ export function normalizeRpcEvent(raw: unknown): TaskEvent[] {
 		case "message_end": {
 			const message = event.message as Raw | undefined;
 			const usage = message?.role === "assistant" ? (message.usage as Raw | undefined) : undefined;
-			if (!usage) return [];
-			const cost = usage.cost as Raw | undefined;
-			return [{ type: TASK_EVENT.USAGE, tokens: Number(usage.totalTokens ?? 0) || 0, cost: Number(cost?.total ?? 0) || 0 }];
+			const events: TaskEvent[] = [];
+			if (usage) {
+				const cost = usage.cost as Raw | undefined;
+				events.push({ type: TASK_EVENT.USAGE, tokens: Number(usage.totalTokens ?? 0) || 0, cost: Number(cost?.total ?? 0) || 0 });
+			}
+			if (options.observeResponses === true && message?.role === "assistant") {
+				const observation = childResponse(message);
+				if (observation) events.push({ type: TASK_EVENT.RESPONSE_OBSERVATION, observation });
+			}
+			return events;
 		}
 		case "turn_end":
 			return [{ type: TASK_EVENT.TURN_END }];

--- a/lib/agents-runner.ts
+++ b/lib/agents-runner.ts
@@ -2,7 +2,7 @@ import type { Duplex, Readable, Writable } from "node:stream";
 import { AGENT_MODE, formatModelRef, type AgentDefinition, type AgentMode, type ModelRef } from "./agents-config.ts";
 import { CHILD_QUERY_MAX_INFLIGHT, CHILD_QUERY_TIMEOUT_MS, parseChildFrame, validChildMessage, validChildQueryId } from "./agents-messaging.ts";
 import { ParentStandingReviewPermissionBroker } from "./review-session-standing-permission-ipc.ts";
-import { isFinished, normalizeRpcEvent, TASK_EVENT, TASK_STATUS, taskLabel, type AskRequest, type TaskRecord, type TaskStore } from "./agents-protocol.ts";
+import { isFinished, normalizeRpcEvent, TASK_EVENT, TASK_STATUS, taskLabel, type AskRequest, type ChildResponseObservation, type TaskRecord, type TaskStore } from "./agents-protocol.ts";
 
 // Gentle Agents runner. Every subagent is its own `pi --mode rpc` process:
 // the host never runs subagent work on the TUI thread. It writes JSON
@@ -67,9 +67,32 @@ export interface TaskQuery {
 	requestId: string;
 }
 
+export const MAX_CHILD_RESPONSE_OBSERVATIONS = 128;
+
+/** Local producer snapshot only; never native workflow success or export authority.
+ * Scope excludes tools, compaction, hidden provider retries and history replay.
+ * Each message_end is retained separately; RPC supplies no stable dedupe key.
+ * Unsettled shutdown may lose in-flight responses even when droppedResponses is 0.
+ */
+export interface ChildObservationSnapshot {
+	readonly coverage: "final_assistant_messages_only";
+	readonly agentSettled: boolean;
+	readonly responses: readonly ChildResponseObservation[];
+	readonly droppedResponses: number;
+}
+interface ChildObservationBuffer {
+	agentSettled: boolean;
+	responses: ChildResponseObservation[];
+	droppedResponses: number;
+}
+
 export interface RunnerHooks {
 	askUser(taskId: string, request: AskRequest, raw: Record<string, unknown>): Promise<AskAnswer>;
-	onFinish?(task: TaskRecord): void;
+	/** Optional immutable snapshot, delivered once at existing finalization.
+	 * Undefined when collection was disabled or no child handle was created.
+	 * Parent must check task.status AND agentSettled; observations are not success.
+	 */
+	onFinish?(task: TaskRecord, observations?: ChildObservationSnapshot): void;
 	// Accepts a child notification only while the originating parent session is active.
 	onNotification?(task: TaskRecord, message: string): boolean | void;
 	onQuery?(task: TaskRecord, requestId: string, message: string): boolean | void;
@@ -92,6 +115,21 @@ export interface TaskRequest {
 	env: NodeJS.ProcessEnv;
 	// Captures the originating session; invoked only after successful OS spawn.
 	onLaunch?: () => void;
+	/** Default off. Parent owns policy before opting into bounded local buffering,
+	 * and must recheck policy/catalog privacy before recording or forwarding.
+	 * This flag does not authorize telemetry export or perform policy subprocesses.
+	 */
+	collectResponseObservations?: boolean;
+	/** Optional parallel preparation after dequeue; never delays OS spawn.
+	 * Unready at the first observation checkpoint permanently drops collection. */
+	prepareResponseObservations?: () => Promise<boolean>;
+	/** Optional synchronous parent-local grant check; never perform I/O here.
+	 * Parent checks environment, known revocation and a monotonic expiry against
+	 * its fresh native policy grant. False/throw permanently discards this task's
+	 * buffer. Checked once ready, on RPC values, and finish; this is not a watcher.
+	 * Omission preserves the explicit opt-in producer API, not policy authority.
+	 */
+	canCollectResponseObservations?: () => boolean;
 	// This closure stays only in the parent process. Its presence creates an
 	// inherited fd, never an environment boolean or model-visible permission.
 	authorizeParentStandingReviewPermission?: (repositoryIdentity: string) => boolean;
@@ -118,6 +156,9 @@ interface PendingReply {
 
 interface LiveTask {
 	child: ChildLike;
+	observations?: ChildObservationBuffer;
+	observationGuard?: () => boolean;
+	observationPreparation?: () => boolean;
 	pending: Map<string, Pending>;
 	queries: Map<string, PendingQuery>;
 	replies: Map<string, PendingReply>;
@@ -330,6 +371,13 @@ export class AgentRunner {
 		return true;
 	}
 
+	/** Parent-known revocation clears buffered metadata immediately, including
+	 * during an idle provider call. No task/store/status mutation. */
+	discardResponseObservations(id: string): void {
+		const live = this.live.get(id);
+		if (live) { live.observations = undefined; live.observationGuard = undefined; }
+	}
+
 	cancelAll(): number {
 		const ids = [...this.queue.map((entry) => entry.task.id), ...this.live.keys()];
 		return ids.filter((id) => this.cancel(id)).length;
@@ -345,7 +393,9 @@ export class AgentRunner {
 	private pump(): void {
 		while (this.live.size < this.limits.maxConcurrency && this.queue.length > 0) {
 			const entry = this.queue.shift();
-			if (entry) this.launch(entry.task.id, entry.request);
+			if (!entry) continue;
+			const { task, request } = entry;
+			this.launch(task.id, request);
 		}
 	}
 
@@ -375,6 +425,17 @@ export class AgentRunner {
 		}
 		const processGroup = detached && typeof child.pid === "number" && child.pid > 0 ? child.pid : undefined;
 		const live: LiveTask = { child, mutationStarts: new Map(), pending: new Map(), queries: new Map(), replies: new Map(), cancelStall: () => {}, cancelGrace: () => {}, processGroup, terminal: undefined, childExit: undefined, cleanupDeadlineAt: undefined, quarantined: false, nextId: 0, ipcClosed: false, acknowledgedIpcIds: new Set(), acknowledgedIpcOrder: [] };
+		if (request.prepareResponseObservations) {
+			let ready = false;
+			live.observationPreparation = () => ready;
+			void Promise.resolve().then(() => this.live.get(id) === live && !live.terminal
+				? request.prepareResponseObservations!() : false).then(allowed => { ready = allowed === true; }).catch(() => {});
+		}
+		if (request.collectResponseObservations === true || request.prepareResponseObservations) {
+			live.observationGuard = request.canCollectResponseObservations;
+			live.observations = { agentSettled: false, responses: [], droppedResponses: 0 };
+			if (!request.prepareResponseObservations) this.checkObservationGrant(live);
+		}
 		this.live.set(id, live);
 		const permissionPipe = child.stdio?.[3];
 		if (hasParentPermissionChannel && permissionPipe !== undefined && permissionPipe !== null) {
@@ -541,12 +602,26 @@ export class AgentRunner {
 		}
 	}
 
+	private checkObservationGrant(live: LiveTask): void {
+		if (live.observationPreparation) {
+			if (!live.observationPreparation()) live.observations = undefined;
+			live.observationPreparation = undefined; // One chance; late readiness cannot attach.
+		}
+		if (!live.observations || !live.observationGuard) return;
+		try {
+			if (live.observationGuard() === true) return;
+		} catch { /* Policy bookkeeping must not interrupt child execution. */ }
+		live.observations = undefined;
+		live.observationGuard = undefined;
+	}
+
 	private receive(id: string, request: TaskRequest, value: unknown): void {
 		const live = this.live.get(id);
 		if (!live || live.terminal || !value || typeof value !== "object") return;
 		const raw = value as Record<string, unknown>;
 		this.armStall(id, live);
 		if (raw.type === "response") {
+			if (!live.observationPreparation) this.checkObservationGrant(live);
 			const pending = typeof raw.id === "string" ? live.pending.get(raw.id) : undefined;
 			if (pending) {
 				live.pending.delete(raw.id as string);
@@ -554,7 +629,16 @@ export class AgentRunner {
 			}
 			return;
 		}
-		for (const event of normalizeRpcEvent(raw)) {
+		this.checkObservationGrant(live);
+		for (const event of normalizeRpcEvent(raw, { observeResponses: live.observations !== undefined })) {
+			if (event.type === TASK_EVENT.RESPONSE_OBSERVATION) {
+				const buffer = live.observations;
+				if (buffer) {
+					if (buffer.responses.length < MAX_CHILD_RESPONSE_OBSERVATIONS) buffer.responses.push(event.observation);
+					else buffer.droppedResponses = Math.min(Number.MAX_SAFE_INTEGER, buffer.droppedResponses + 1);
+				}
+				continue; // Separate from store persistence, UI totals and notifications.
+			}
 			this.store.apply(id, event, this.deps.now());
 			if (event.type === TASK_EVENT.TOOL_START && event.callId) {
 				live.mutationStarts.delete(event.callId);
@@ -573,6 +657,7 @@ export class AgentRunner {
 			}
 			if (event.type === TASK_EVENT.ASK) void this.answer(id, request, live, event.request, raw);
 			if (event.type === TASK_EVENT.AGENT_SETTLED) {
+				if (live.observations) live.observations.agentSettled = true;
 				const terminal = this.store.get(id);
 				if (terminal?.error) this.requestStop(id, TASK_STATUS.FAILED, terminal.error);
 				else if (terminal?.result) this.requestStop(id, TASK_STATUS.COMPLETED, null);
@@ -650,7 +735,7 @@ export class AgentRunner {
 			if (this.deps.now() >= (live.cleanupDeadlineAt ?? 0)) {
 				live.cancelGrace();
 				live.quarantined = true;
-				this.finish(id, TASK_STATUS.FAILED, `process cleanup unconfirmed after ${GROUP_CONFIRM_DEADLINE_MS}ms; capacity quarantined`);
+				this.finish(id, TASK_STATUS.FAILED, `process cleanup unconfirmed after ${GROUP_CONFIRM_DEADLINE_MS}ms; capacity quarantined`, live);
 				return;
 			}
 			live.cancelGrace = this.deps.schedule(() => this.confirmGroupExit(id, live), GROUP_CONFIRM_MS);
@@ -673,7 +758,7 @@ export class AgentRunner {
 		live.cancelStall();
 		live.cancelGrace();
 		this.live.delete(id);
-		this.finish(id, TASK_STATUS.FAILED, `could not start pi: ${error.message}`);
+		this.finish(id, TASK_STATUS.FAILED, `could not start pi: ${error.message}`, live);
 	}
 
 	private exited(id: string, code: number | null): void {
@@ -699,15 +784,25 @@ export class AgentRunner {
 			return;
 		}
 		const terminal = live.terminal;
-		this.finish(id, terminal ? terminal.status : TASK_STATUS.FAILED, terminal ? terminal.error : `pi exited with code ${live.childExit ?? "unknown"} before agent_settled`);
+		this.finish(id, terminal ? terminal.status : TASK_STATUS.FAILED, terminal ? terminal.error : `pi exited with code ${live.childExit ?? "unknown"} before agent_settled`, live);
 	}
 
-	private finish(id: string, status: TaskRecord["status"], error: string | null): void {
+	private finish(id: string, status: TaskRecord["status"], error: string | null, live?: LiveTask): void {
 		const current = this.store.get(id);
 		if (!current || isFinished(current.status)) return;
 		const finished = this.store.update(id, { status, endedAt: this.deps.now(), error, lastStep: error ?? "done" });
 		if (finished) {
-			this.hooks.onFinish?.(finished);
+			if (live) this.checkObservationGrant(live);
+			const buffer = live?.observations;
+			const snapshot: ChildObservationSnapshot | undefined = buffer ? Object.freeze({
+				coverage: "final_assistant_messages_only", agentSettled: buffer.agentSettled,
+				responses: Object.freeze(buffer.responses.slice()), droppedResponses: buffer.droppedResponses,
+			}) : undefined;
+			if (live) {
+				live.observations = undefined; // Also release quarantined buffers.
+				live.observationGuard = undefined;
+			}
+			this.hooks.onFinish?.(finished, snapshot);
 			for (const resolve of this.waiters.get(id) ?? []) resolve(finished);
 			this.waiters.delete(id);
 			for (const resolve of this.queryWaiters.get(id) ?? []) resolve(undefined);

--- a/lib/runtime-metrics-children.ts
+++ b/lib/runtime-metrics-children.ts
@@ -1,0 +1,190 @@
+import { readFileSync } from "node:fs";
+import { parseAgentDefinition, type AgentDefinition, type ModelRef } from "./agents-config.ts";
+import type { ChildObservationSnapshot } from "./agents-runner.ts";
+import { FINISHED_STATUSES, type TaskStatus } from "./agents-protocol.ts";
+import { AGENT_CLASSES, EFFORTS, RuntimeMetrics, validRuntimeResponse, type AgentClass, type FinalResponse, type RuntimeMetricBucket } from "./runtime-metrics.ts";
+import { classifyPiCatalogName } from "./runtime-metrics-pi-identity.ts";
+export const CHILD_METRICS_EVENT = "gentle:runtime-metrics:child/v1";
+// Local revocation notification invalidates active observations. Contains only
+// the local session join, never policy output.
+export const CHILD_METRICS_REVOKED = "gentle:runtime-metrics:revoked/v1";
+const missing = { state: "unavailable" } as const;
+const providers = ["anthropic", "openai", "openai-codex", "google", "google-vertex", "amazon-bedrock", "openrouter", "custom", "unknown"];
+const tokenFields = ["input", "output", "cacheRead", "cacheWrite", "reasoning", "totalTokens"] as const;
+const builtinFiles = AGENT_CLASSES.filter(name => name !== "orchestrator" && name !== "unknown")
+	.map(name => [name, ["worker", "explore", "verify"].includes(name) ? `gentle-ai-${name}` : name] as const);
+
+/** Compare the runtime definition against this package's fixed assets, not its
+ * public-looking name/path. Normalize only model/thinking routing, which the
+ * package's gentle-ai.ts updateFrontmatterRouting writer changes on installation
+ * and model configuration. Instructions, tools, description and mode must match.
+ * No installed files are read; this class is not execution/review authority.
+ * Only the fixed package catalog is cached; runtime instructions are not retained.
+ */
+let definitions: Array<{ agentClass: AgentClass; fingerprint: string }> | undefined;
+function fingerprint(agent: AgentDefinition): string {
+	return JSON.stringify([agent.name, agent.description, agent.instructions, agent.tools, agent.mode]);
+}
+export function classifyBuiltinAgent(agent: AgentDefinition): AgentClass {
+	try {
+		definitions ??= builtinFiles.map(([agentClass, file]) => {
+			const path = new URL(`../assets/agents/${file}.md`, import.meta.url);
+			const parsed = parseAgentDefinition(readFileSync(path, "utf8"), path.pathname, "global");
+			if (!("instructions" in parsed)) throw new Error("Invalid packaged definition");
+			return { agentClass, fingerprint: fingerprint(parsed) };
+		});
+		return definitions.find(entry => entry.fingerprint === fingerprint(agent))?.agentClass ?? "unknown";
+	} catch { return "unknown"; }
+}
+function provider(value: unknown): FinalResponse["provider"] {
+	return providers.includes(value as string) ? value as FinalResponse["provider"] : value ? "custom" : "unknown";
+}
+function modelId(namespace: unknown, value: unknown): string {
+	if (value === "unknown" || value === undefined) return "unknown";
+	return classifyPiCatalogName({ provider: namespace, modelId: value }).modelId;
+}
+function effort(value: unknown): FinalResponse["effort"] {
+	return EFFORTS.includes(value as FinalResponse["effort"]) ? value as FinalResponse["effort"] : "unavailable";
+}
+export interface LaunchSelection {
+	agentClass: AgentClass;
+	selectedProvider: FinalResponse["provider"];
+	selectedModelId: string;
+	selectedEffort: FinalResponse["effort"];
+}
+export interface ChildLaunchBucket extends LaunchSelection {
+	evidence: "launch_configuration";
+	launches: number;
+}
+export function launchSelection(agent: AgentDefinition, model: ModelRef | undefined, thinking: unknown): LaunchSelection {
+	return { agentClass: classifyBuiltinAgent(agent), selectedProvider: provider(model?.provider),
+		selectedModelId: modelId(model?.provider, model?.id), selectedEffort: effort(thinking) };
+}
+/** LOCAL event only: these two bounded join IDs must never enter output/export. */
+export interface ChildMetricsEvent {
+	schema: typeof CHILD_METRICS_EVENT;
+	parentSessionId: string;
+	taskId: string;
+	launchedAt: number;
+	launch: LaunchSelection;
+	status: TaskStatus;
+	agentSettled: boolean;
+	coverage: "final_assistant_messages_only";
+	droppedResponses: number;
+	responses: FinalResponse[];
+}
+export function childEvent(parentSessionId: string, taskId: string, launch: LaunchSelection, status: TaskStatus,
+	snapshot: ChildObservationSnapshot, launchedAt = 0): ChildMetricsEvent | undefined {
+	const result: ChildMetricsEvent = { schema: CHILD_METRICS_EVENT, parentSessionId, taskId, launchedAt, launch: { ...launch }, status,
+		agentSettled: snapshot.agentSettled, coverage: snapshot.coverage, droppedResponses: snapshot.droppedResponses,
+		responses: snapshot.responses.slice(0, 128).map((row, index) => {
+			const namespace = row.provider.state === "observed" ? row.provider.value : undefined;
+			const name = (value: typeof row.model) => value.state === "observed" ? modelId(namespace, value.value) : undefined;
+			return { kind: "final_assistant_response", responseId: String(index), agentClass: launch.agentClass,
+				executor: "worker", provider: provider(namespace), modelFamily: "unknown", observedModelId: name(row.model),
+				responseModelId: name(row.responseModel), providerThinkingLevel: effort(row.providerThinkingLevel.state === "observed" ? row.providerThinkingLevel.value : undefined),
+				selectedProvider: "unknown", effort: "unavailable", error: row.stopReason === "error" ? "unknown" : row.stopReason === "aborted" ? "aborted" : "none",
+				tokens: Object.fromEntries(tokenFields.map(field => [field, { ...row.tokens[field] }])) as FinalResponse["tokens"],
+				responseHeadersMs: missing, fullResponseMs: missing };
+		}) };
+	return validEvent(result) ? result : undefined;
+}
+function validEvent(value: unknown): value is ChildMetricsEvent {
+	if (!value || typeof value !== "object") return false;
+	const e = value as ChildMetricsEvent;
+	const id = (value: unknown) => typeof value === "string" && value.length > 0 && value.length <= 128;
+	const l = e.launch;
+	return e.schema === CHILD_METRICS_EVENT && id(e.taskId) && id(e.parentSessionId)
+		&& Number.isFinite(e.launchedAt) && e.launchedAt >= 0
+		&& e.coverage === "final_assistant_messages_only" && typeof e.agentSettled === "boolean"
+		&& FINISHED_STATUSES.includes(e.status) && Number.isSafeInteger(e.droppedResponses) && e.droppedResponses >= 0
+		&& e.droppedResponses <= Number.MAX_SAFE_INTEGER && !!l && AGENT_CLASSES.includes(l.agentClass) && l.agentClass !== "orchestrator"
+		&& provider(l.selectedProvider) === l.selectedProvider && modelId(l.selectedProvider, l.selectedModelId) === l.selectedModelId
+		&& effort(l.selectedEffort) === l.selectedEffort && Array.isArray(e.responses) && e.responses.length <= 128
+		&& e.responses.every(row => validRuntimeResponse(row) && row.agentClass === l.agentClass
+			&& row.executor === "worker" && row.effort === "unavailable" && row.selectedProvider === "unknown" && row.selectedModelId === undefined
+			&& provider(row.provider) === row.provider && effort(row.providerThinkingLevel) === row.providerThinkingLevel
+			&& (row.observedModelId === undefined || modelId(row.provider, row.observedModelId) === row.observedModelId)
+			&& (row.responseModelId === undefined || modelId(row.provider, row.responseModelId) === row.responseModelId)
+			&& row.fullResponseMs.state === "unavailable" && row.responseHeadersMs.state === "unavailable");
+}
+/** Copy only validated local fields at the completion callback.
+ * Do not clone arbitrary event properties or retain a caller-mutable bus object.
+ */
+export function snapshotChildEvent(value: unknown): ChildMetricsEvent | undefined {
+	if (!validEvent(value)) return undefined;
+	const l = value.launch;
+	return { schema: CHILD_METRICS_EVENT, parentSessionId: value.parentSessionId, taskId: value.taskId, launchedAt: value.launchedAt,
+		launch: { agentClass: l.agentClass, selectedProvider: l.selectedProvider, selectedModelId: l.selectedModelId, selectedEffort: l.selectedEffort },
+		status: value.status, agentSettled: value.agentSettled, coverage: value.coverage, droppedResponses: value.droppedResponses,
+		responses: value.responses.map((row, index) => ({ kind: "final_assistant_response", responseId: String(index),
+			agentClass: row.agentClass, executor: "worker", provider: row.provider, observedModelId: row.observedModelId,
+			responseModelId: row.responseModelId, providerThinkingLevel: row.providerThinkingLevel, modelFamily: "unknown",
+			selectedProvider: "unknown", effort: "unavailable", error: row.error,
+			tokens: Object.fromEntries(tokenFields.map(field => {
+				const t = row.tokens[field];
+				return [field, t?.state === "reported" ? { state: "reported", value: t.value } : { state: t?.state ?? "unavailable" }];
+			})) as FinalResponse["tokens"], responseHeadersMs: missing, fullResponseMs: missing })) };
+}
+
+/** Export-facing shape: no IDs, paths, task labels, or raw agent/model names.
+ * Rankings are descending counts, NOT quality/success comparisons. Native
+ * transport is deliberately absent. Response buckets never inherit launch effort.
+ */
+export interface ChildCompositionSnapshot {
+	launches: ChildLaunchBucket[];
+	responses: RuntimeMetricBucket[];
+	settled: number;
+	statuses: Record<"completed" | "failed" | "cancelled" | "timed_out", number>;
+	droppedResponses: number;
+	saturated: boolean;
+}
+export class ChildComposition {
+	#seen = new Set<string>();
+	#pending = new WeakSet<object>();
+	#metrics = new RuntimeMetrics();
+	#launches = new Map<string, ChildLaunchBucket>();
+	#count = 0;
+	#settled = 0;
+	#statuses = { completed: 0, failed: 0, cancelled: 0, timed_out: 0 };
+	#dropped = 0;
+	#saturated = false;
+	reserve(value: unknown, session: string): value is ChildMetricsEvent {
+		if (!validEvent(value) || value.parentSessionId !== session || this.#seen.has(value.taskId)) return false;
+		if (this.#seen.size >= 256) { this.#saturated = true; return false; }
+		this.#seen.add(value.taskId);
+		this.#pending.add(value);
+		return true;
+	}
+	record(event: ChildMetricsEvent): void {
+		if (!this.#pending.delete(event) || !validEvent(event)) return;
+		const key = JSON.stringify(event.launch);
+		let bucket = this.#launches.get(key);
+		if (!bucket && this.#launches.size < 64) {
+			bucket = { ...event.launch, evidence: "launch_configuration", launches: 0 };
+			this.#launches.set(key, bucket);
+		}
+		if (bucket) bucket.launches++;
+		else this.#saturated = true;
+		this.#settled += Number(event.agentSettled);
+		this.#statuses[event.status as keyof ChildCompositionSnapshot["statuses"]]++;
+		this.#dropped = Math.min(Number.MAX_SAFE_INTEGER, this.#dropped + event.droppedResponses);
+		for (const row of event.responses) {
+			if (this.#metrics.record({ ...row, responseId: String(this.#count + 1) }) === "recorded") this.#count++;
+			else { this.#dropped = Math.min(Number.MAX_SAFE_INTEGER, this.#dropped + 1); this.#saturated = true; }
+		}
+	}
+	clear(): void {
+		this.#metrics = new RuntimeMetrics();
+		this.#pending = new WeakSet();
+		this.#launches.clear();
+		this.#count = this.#settled = this.#dropped = 0;
+		this.#statuses = { completed: 0, failed: 0, cancelled: 0, timed_out: 0 };
+		// Bounded tombstones survive revocation; denied tasks cannot replay.
+	}
+	snapshot(): ChildCompositionSnapshot {
+		return structuredClone({ launches: [...this.#launches.values()].sort((a, b) => b.launches - a.launches),
+			responses: this.#metrics.snapshot().sort((a, b) => b.responses - a.responses),
+			settled: this.#settled, statuses: this.#statuses, droppedResponses: this.#dropped, saturated: this.#saturated });
+	}
+}

--- a/lib/runtime-metrics-delivery.ts
+++ b/lib/runtime-metrics-delivery.ts
@@ -1,0 +1,38 @@
+// Shared across extension instances, including a cancelled process still exiting.
+let busy = false;
+
+/** One accepted attempt, never a queue. Defer resolver/process work beyond the
+ * provider callback. Busy events are discarded rather than captured for later.
+ * The transport must settle only after its process exits; disposal never waits.
+ */
+export class RuntimeMetricsAttempt {
+	#closed = false;
+	#scheduled?: ReturnType<typeof setImmediate>;
+	#abort?: AbortController;
+	offer(work: (signal: AbortSignal) => Promise<unknown>): boolean {
+		if (this.#closed || busy) return false;
+		busy = true;
+		const abort = new AbortController();
+		this.#abort = abort;
+		this.#scheduled = setImmediate(() => {
+			this.#scheduled = undefined;
+			void (async () => {
+				try { if (!abort.signal.aborted) await work(abort.signal); }
+				catch { /* An attempt is always best effort; never retry or report. */ }
+				finally { this.#abort = undefined; busy = false; }
+			})();
+		});
+		return true;
+	}
+	dispose(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		if (this.#scheduled) {
+			clearImmediate(this.#scheduled);
+			this.#scheduled = undefined;
+			busy = false;
+		}
+		this.#abort?.abort();
+		this.#abort = undefined;
+	}
+}

--- a/lib/runtime-metrics-native.ts
+++ b/lib/runtime-metrics-native.ts
@@ -1,0 +1,166 @@
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from "node:child_process";
+import { resolveGentleAiBinary } from "./gentle-ai-binary.ts";
+import { runtimeMetricsEnvAllows } from "./runtime-metrics-policy.ts";
+import type { RuntimeMetricBucket } from "./runtime-metrics.ts";
+import type { ChildLaunchBucket } from "./runtime-metrics-children.ts";
+
+import schema from "../contracts/telemetry/runtime-aggregate-v1.schema.json" with { type: "json" };
+
+export type NativeRuntimeResult = "stored" | "duplicate" | "discarded" | "disabled";
+export const NATIVE_SEND_ACK_SCHEMA = "gentle-ai.telemetry-runtime-send/v1";
+const MAX_METRIC = schema.$defs.count.maximum;
+const count = (value: number) => Number.isSafeInteger(value) && value >= 0 && value <= MAX_METRIC;
+function publicModel(provider: string, id: string) {
+	const matches = (rule: { const?: string; enum?: string[] }, value: string) => rule.const === value || rule.enum?.includes(value);
+	if (schema.$defs.model.oneOf.some(({ properties }) => matches(properties.provider, provider) && matches(properties.id, id))) return { provider, id };
+	const kind = !id || id === "unknown" ? "unknown" : "custom";
+	return { provider: kind, id: kind };
+}
+
+/** Closed field projection of one event, not a session snapshot. Oversized or
+ * invalid events discard whole; never split into queued sends or invent IDs.
+ */
+export function encodeNativeRuntimeEvent(source: readonly RuntimeMetricBucket[], launches: readonly ChildLaunchBucket[] = []): string | undefined {
+	if (!Array.isArray(source) || !Array.isArray(launches) || source.length < 1
+		|| source.length + launches.length > schema.properties.rows.maxItems) return undefined;
+	try {
+		const rows: Array<Record<string, unknown>> = source.map(row => {
+			if (!count(row.responses)) throw new Error("Invalid occurrence coverage");
+			const token = (field: keyof RuntimeMetricBucket["tokens"]) => {
+				const t = row.tokens[field];
+				const coverage = { reported: t.reported, unavailable: t.unavailable, unsupported: t.unsupported, sum: t.sum };
+				if (!Object.values(coverage).every(count) || (!coverage.reported && coverage.sum !== 0)) throw new Error("Invalid coverage");
+				return coverage;
+			};
+			const agentClass = schema.$defs.row.properties.agent_class.enum.includes(row.agentClass) ? row.agentClass : "unknown";
+			const effort = (value: string) => schema.$defs.effort.enum.includes(value) ? value : "unavailable";
+			const response = typeof row.responseModelId === "string" && row.responseModelId !== "unknown" && row.responseModelId !== "";
+			const selected = typeof row.selectedModelId === "string" && row.selectedModelId !== "unknown" && row.selectedModelId !== "";
+			const model = response ? publicModel(row.provider, row.responseModelId)
+				: selected ? publicModel(row.selectedProvider, row.selectedModelId) : { provider: "unknown", id: "unknown" };
+			const time = row.fullResponseMs;
+			if (!count(time.measured) || !Number.isFinite(time.sum) || time.sum < 0 || time.sum > MAX_METRIC
+				|| (!time.measured && time.sum !== 0)) throw new Error("Invalid duration");
+			return { model, model_evidence: response ? "response" : selected ? "selected" : "unknown",
+				agent_kind: agentClass === "orchestrator" || agentClass === "unknown" ? agentClass : "built_in", agent_class: agentClass,
+				selected_effort: effort(row.effort), effective_effort: effort(row.providerThinkingLevel),
+				launches: null, responses: row.responses,
+				input_tokens: token("input"), output_tokens: token("output"), cache_read_tokens: token("cacheRead"),
+				cache_creation_tokens: token("cacheWrite"), reasoning_tokens: token("reasoning"), total_tokens: token("totalTokens"),
+				error_category: row.error === "authentication" ? "auth" : ["none", "aborted", "rate_limit"].includes(row.error) ? row.error : "unknown",
+				duration: time.measured > 0 ? { kind: "request", measured_count: time.measured, sum_ms: time.sum }
+					: { kind: "unavailable", measured_count: 0, sum_ms: null } };
+		});
+		for (const launch of launches) {
+			if (!count(launch.launches) || launch.evidence !== "launch_configuration") return undefined;
+			const agentClass = schema.$defs.row.properties.agent_class.enum.includes(launch.agentClass) ? launch.agentClass : "unknown";
+			const empty = { reported: 0, unavailable: 0, unsupported: 0, sum: 0 };
+			rows.push({ model: publicModel(launch.selectedProvider, launch.selectedModelId), model_evidence: "selected",
+				agent_kind: agentClass === "orchestrator" || agentClass === "unknown" ? agentClass : "built_in", agent_class: agentClass,
+				selected_effort: schema.$defs.effort.enum.includes(launch.selectedEffort) ? launch.selectedEffort : "unavailable",
+				effective_effort: "unavailable", launches: launch.launches, responses: null,
+				input_tokens: empty, output_tokens: empty, cache_read_tokens: empty, cache_creation_tokens: empty,
+				reasoning_tokens: empty, total_tokens: empty, error_category: "unknown",
+				duration: { kind: "unavailable", measured_count: 0, sum_ms: null } });
+		}
+		const payload = JSON.stringify({ schema: schema.properties.schema.const, registry: schema.properties.registry.const, host: "pi", rows });
+		return Buffer.byteLength(payload) <= 16384 ? payload : undefined;
+	} catch { return undefined; }
+}
+export interface NativeRuntimeTransportDeps {
+	/** Observed launch occurrence accompanying this child completion, not totals. */
+	launches?: readonly ChildLaunchBucket[];
+	env?: NodeJS.ProcessEnv;
+	signal?: AbortSignal;
+	current?: () => boolean;
+	/** Injected test seams; production uses the verified pin or validated dev override. */
+	resolve?: () => string;
+	encode?: typeof encodeNativeRuntimeEvent;
+	spawn?: (file: string, args: string[], options: SpawnOptionsWithoutStdio) => ChildProcessWithoutNullStreams;
+}
+let busy = false;
+
+/** Native owns fresh policy and exactly one POST. No policy/capability probe,
+ * disk intake, flush, queue or retry. Call via RuntimeMetricsAttempt so binary
+ * verification is outside the provider callback. Cancellation requests a kill;
+ * the slot stays occupied until close, never permitting overlapping processes.
+ */
+export async function sendNativeRuntimeEvent(rows: readonly RuntimeMetricBucket[], cwd: string,
+	deps: NativeRuntimeTransportDeps = {}): Promise<NativeRuntimeResult> {
+	const env = deps.env ?? process.env;
+	if (!runtimeMetricsEnvAllows(env)) return "disabled";
+	if (busy || deps.signal?.aborted || deps.current?.() === false) return "discarded";
+	busy = true;
+	try {
+		const payload = (deps.encode ?? encodeNativeRuntimeEvent)(rows, deps.launches);
+		if (!payload || Buffer.byteLength(payload) > 16384) return "discarded";
+		const file = (deps.resolve ?? resolveGentleAiBinary)();
+		if (!runtimeMetricsEnvAllows(env)) return "disabled";
+		if (deps.signal?.aborted || deps.current?.() === false) return "discarded";
+		return await sendProcess(file, cwd, payload, env, deps.spawn ?? spawn, deps.signal);
+	} catch { return "discarded"; }
+	finally { busy = false; }
+}
+
+function sendProcess(file: string, cwd: string, payload: string, env: NodeJS.ProcessEnv,
+	launch: NonNullable<NativeRuntimeTransportDeps["spawn"]>, signal?: AbortSignal): Promise<NativeRuntimeResult> {
+	return new Promise(done => {
+		let child: ChildProcessWithoutNullStreams | undefined;
+		let output = "";
+		let rejected = false;
+		let settled = false;
+		const ignore = () => {};
+		const finish = (result: NativeRuntimeResult) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", cancel);
+			output = "";
+			if (child) {
+				for (const stream of [child.stdin, child.stdout, child.stderr]) {
+					stream.on("error", ignore);
+					try { stream.destroy(); } catch { /* Best effort cleanup. */ }
+				}
+				try { child.unref(); } catch { /* No diagnostics. */ }
+			}
+			done(result);
+		};
+		const cancel = () => {
+			if (rejected || settled) return;
+			rejected = true;
+			output = "";
+			try { child?.kill("SIGKILL"); } catch { /* Keep busy until close. */ }
+		};
+		const timer = setTimeout(cancel, 1000);
+		timer.unref();
+		try {
+			child = launch(file, ["telemetry", "runtime", "send", "--json"],
+				{ cwd, env, shell: false, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] });
+			child.on("error", cancel);
+			for (const stream of [child.stdin, child.stdout, child.stderr]) stream.on("error", cancel);
+			child.stdout.on("data", (chunk: Buffer) => {
+				if (rejected || settled) return;
+				if (Buffer.byteLength(output) + chunk.length > 2048) { cancel(); return; }
+				output += chunk.toString("utf8");
+			});
+			child.stderr.on("data", cancel); // Do not retain or expose raw errors.
+			child.on("close", (code: number | null, exitSignal: NodeJS.Signals | null) => {
+				let result: NativeRuntimeResult = "discarded";
+				if (!rejected && code === 0 && exitSignal === null) {
+					try {
+						const value = JSON.parse(output);
+						if (Object.keys(value).sort().join(",") === "decision,schema" && value.schema === NATIVE_SEND_ACK_SCHEMA
+							&& ["stored", "duplicate", "discarded", "disabled"].includes(value.decision)) result = value.decision;
+					} catch { /* Invalid/old acknowledgements discard. */ }
+				}
+				finish(result);
+			});
+			signal?.addEventListener("abort", cancel, { once: true });
+			if (signal?.aborted) cancel();
+			if (!rejected) child.stdin.end(payload, "utf8");
+		} catch {
+			if (child) cancel();
+			else finish("discarded");
+		}
+	});
+}

--- a/lib/runtime-metrics-pi-identity.ts
+++ b/lib/runtime-metrics-pi-identity.ts
@@ -1,0 +1,84 @@
+import { findPackageJSON } from "node:module";
+
+// Catalog-name privacy classification ONLY. No identity issuance, route evidence,
+// registry reads, SDK hooks, auth resolution, network, or injected catalogs.
+export interface PiCatalogName {
+	readonly classification: "catalog_public" | "custom" | "unknown";
+	readonly modelId: string;
+}
+
+const UNKNOWN: PiCatalogName = Object.freeze({ classification: "unknown", modelId: "unknown" });
+const CUSTOM: PiCatalogName = Object.freeze({ classification: "custom", modelId: "custom" });
+// Initial provider coverage matches the accumulator. Other providers are custom;
+// additions require deliberate review. These are providers, not model-ID lists.
+const CATALOGS = ["anthropic", "openai", "openai-codex", "google", "google-vertex", "amazon-bedrock", "openrouter"] as const;
+const MAX_MODELS = 4096;
+
+function object(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function text(value: unknown, max: number): value is string {
+	return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+function key(provider: string, modelId: string): string {
+	return JSON.stringify([provider, modelId]);
+}
+
+let catalogPromise: Promise<ReadonlyMap<string, PiCatalogName>> | undefined;
+let loadedCatalog: ReadonlyMap<string, PiCatalogName> | undefined;
+async function loadCatalog(): Promise<ReadonlyMap<string, PiCatalogName>> {
+	// Node >=22.19 supports findPackageJSON. Verify ESM lookup from this module
+	// selects Pi's own pi-ai package; fail rather than silently use another copy.
+	const pi = import.meta.resolve("@earendil-works/pi-coding-agent");
+	const ownPackage = findPackageJSON("@earendil-works/pi-ai", import.meta.url);
+	if (!ownPackage || ownPackage !== findPackageJSON("@earendil-works/pi-ai", pi)) {
+		throw new Error("Pi catalog dependency mismatch");
+	}
+	const entries = new Map<string, PiCatalogName>();
+	let count = 0;
+	for (const provider of CATALOGS) {
+		// pi-ai 0.85.1 providers/* has an import-only export condition: use ESM,
+		// never require.resolve. Generated modules load packaged JSON, not registry
+		// overrides. Specifiers and export names come only from the fixed list.
+		const module = await import(`@earendil-works/pi-ai/providers/${provider}.models`);
+		const models: unknown = module[`${provider.replaceAll("-", "_").toUpperCase()}_MODELS`];
+		if (!object(models)) throw new Error("Invalid packaged model catalog");
+		for (const model of Object.values(models)) {
+			if (++count > MAX_MODELS) throw new RangeError("Packaged model catalog exceeds capacity");
+			if (!object(model) || model.provider !== provider || !text(model.id, 128)) {
+				throw new Error("Invalid packaged model name");
+			}
+			entries.set(key(provider, model.id), Object.freeze({ classification: "catalog_public", modelId: model.id }));
+		}
+	}
+	return entries;
+}
+
+/**
+ * Returns only a privacy-safe catalog name, NOT the model actually dispatched.
+ * Matching a public ID remains a public-name fact even on a custom endpoint;
+ * origin/API/endpoint strings are ignored, never treated as provenance evidence.
+ * Missing/malformed names are unknown; non-catalog names/aliases are custom.
+ * No modelVersion is invented. This labels a caller-observed selection only;
+ * actual dispatch/response identity requires separate future host evidence.
+ * One cached snapshot retains <=4096 names of <=128 code units; no input is kept.
+ * Missing/incompatible dependencies and catalog overflow reject, never skip.
+ */
+export async function lookupPiCatalogName(input: unknown): Promise<PiCatalogName> {
+	if (!object(input) || !text(input.provider, 32) || !text(input.modelId, 128)) return UNKNOWN;
+	if (!CATALOGS.includes(input.provider as typeof CATALOGS[number])) return CUSTOM;
+	catalogPromise ??= loadCatalog();
+	loadedCatalog = await catalogPromise;
+	return classifyPiCatalogName(input);
+}
+
+/** Pure lookup after async catalog loading; unknown until initialization succeeds.
+ * Always recheck membership, never trust a caller's classification/public label.
+ */
+export function classifyPiCatalogName(input: unknown): PiCatalogName {
+	if (!object(input) || !text(input.provider, 32) || !text(input.modelId, 128)) return UNKNOWN;
+	if (!CATALOGS.includes(input.provider as typeof CATALOGS[number])) return CUSTOM;
+	return loadedCatalog ? loadedCatalog.get(key(input.provider, input.modelId)) ?? CUSTOM : UNKNOWN;
+}

--- a/lib/runtime-metrics-policy.ts
+++ b/lib/runtime-metrics-policy.ts
@@ -1,0 +1,51 @@
+import { gentleAiDevBinaryOverrideConfigured, resolveGentleAiBinary } from "./gentle-ai-binary.ts";
+import { createNodeExecFileAdapter, type ExecFileAdapter } from "./native-review-cli.ts";
+
+export interface RuntimeMetricsPolicyDeps { resolve?: () => string; exec?: ExecFileAdapter }
+
+export function runtimeMetricsEnvAllows(env: NodeJS.ProcessEnv): boolean {
+	// Unknown nonempty spellings veto too: never weaken a native environment veto.
+	const truthy = (value: string | undefined) => !["", "0", "false", "no", "off"].includes(value?.trim().toLowerCase() ?? "");
+	return !truthy(env.DO_NOT_TRACK) && !truthy(env.CI) && !truthy(env.GITHUB_ACTIONS)
+		&& env.GENTLE_AI_TELEMETRY?.trim() !== "0";
+}
+
+function publishedBinary(): string {
+	// This feature must not select an unpublished development binary or install one.
+	if (gentleAiDevBinaryOverrideConfigured()) throw new Error("Policy binary unavailable");
+	return resolveGentleAiBinary();
+}
+
+/** Only a validated boolean crosses this boundary; never raw stdout or errors.
+ * The shared adapter and outer timer bound asynchronous process waiting, NOT
+ * end-to-end time: the supported resolver synchronously reads/hashes the binary
+ * on every check. It exposes no supported validation cache. Keep verification
+ * intact rather than cache an unchecked path or invent stat-based trust.
+ * No retries, status/preview fallback, enrollment, installation or polling.
+ */
+export async function readRuntimeMetricsPolicy(cwd: string,
+	{ resolve = publishedBinary, exec = createNodeExecFileAdapter() }: RuntimeMetricsPolicyDeps = {}): Promise<boolean> {
+	const controller = new AbortController();
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const deadline = new Promise<false>(done => {
+			timer = setTimeout(() => { controller.abort(); done(false); }, 1000);
+		});
+		const probe = async () => {
+			const result = await exec({ file: resolve(), arguments: ["telemetry", "policy", "--json"],
+				cwd, timeoutMs: 1000, maxBufferBytes: 2048, signal: controller.signal });
+			if (result.exitCode !== 0 || result.signal !== null || result.timedOut !== false
+				|| result.outputLimitExceeded !== false || result.stderr !== ""
+				|| typeof result.stdout !== "string" || Buffer.byteLength(result.stdout) > 2048) return false;
+			const value: unknown = JSON.parse(result.stdout);
+			if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+			const row = value as Record<string, unknown>;
+			return Object.keys(row).sort().join(",") === "enabled,operation,reason,schema,source"
+				&& row.schema === "gentle-ai.telemetry-policy/v1" && row.operation === "policy"
+				&& typeof row.enabled === "boolean" && row.enabled && row.reason === "enabled"
+				&& ["DO_NOT_TRACK", "GENTLE_AI_TELEMETRY", "CI", "state", "default"].includes(row.source as string);
+		};
+		return await Promise.race([probe(), deadline]);
+	} catch { return false; }
+	finally { clearTimeout(timer); }
+}

--- a/lib/runtime-metrics.ts
+++ b/lib/runtime-metrics.ts
@@ -1,0 +1,195 @@
+import { classifyPiCatalogName } from "./runtime-metrics-pi-identity.ts";
+
+// Pure local accounting, not a telemetry transport or Pi event adapter.
+// Callers supply finalized assistant responses and authoritative classifications.
+// Never infer executor, usage availability, or measured timings from SDK defaults.
+const EXECUTORS = ["orchestrator", "worker", "reviewer", "unknown"] as const;
+const PROVIDERS = ["anthropic", "openai", "openai-codex", "google", "google-vertex", "amazon-bedrock", "openrouter", "custom", "unknown"] as const;
+// Stable families, not model IDs/versions: new models need no catalog update.
+// Callers map known native metadata to families; private aliases stay custom.
+const FAMILIES = ["claude", "gpt", "o-series", "gemini", "llama", "qwen", "deepseek", "kimi", "custom", "unknown"] as const;
+// Pi 0.85.1 docs/models.md, Thinking Level Map. These are selected Pi levels,
+// not inferred provider effort or a claim that each model supports every level.
+export const EFFORTS = ["off", "minimal", "low", "medium", "high", "xhigh", "max", "not_selected", "unsupported", "unavailable"] as const;
+const ERRORS = ["none", "aborted", "rate_limit", "authentication", "network", "provider", "unknown"] as const;
+const TOKEN_FIELDS = ["input", "output", "cacheRead", "cacheWrite", "reasoning", "totalTokens"] as const;
+export const AGENT_CLASSES = ["orchestrator", "worker", "explore", "verify", "unknown",
+	"sdd-apply", "sdd-archive", "sdd-design", "sdd-explore", "sdd-init", "sdd-onboard", "sdd-proposal",
+	"sdd-research", "sdd-spec", "sdd-status", "sdd-sync", "sdd-tasks", "sdd-verify",
+	"review-readability", "review-reliability", "review-resilience", "review-risk", "jd-fix-agent", "jd-judge-a", "jd-judge-b"] as const;
+export type AgentClass = typeof AGENT_CLASSES[number];
+
+type Missing = { state: "unavailable" | "unsupported" };
+export type TokenMeasurement = Missing | { state: "reported"; value: number };
+export type DurationMeasurement = Missing | { state: "measured"; value: number };
+export interface FinalResponse {
+	kind: "final_assistant_response";
+	/** Local dedupe only: 1..128 UTF-16 code units; never exported. */
+	responseId: string;
+	/** Caller-observed selected SDK model ID, never dispatched/response identity.
+	 * Catalog must be loaded before accounting; only public catalog names survive.
+	 */
+	selectedModelId?: string;
+	/** Selection namespace, independent from observed response provider.
+	 * Omission preserves legacy same-provider callers; adapters must pass it explicitly.
+	 */
+	selectedProvider?: typeof PROVIDERS[number];
+	agentClass?: AgentClass;
+	/** Public catalog names from SDK response metadata, never endpoint proof. */
+	observedModelId?: string;
+	responseModelId?: string;
+	providerThinkingLevel?: typeof EFFORTS[number];
+	executor: typeof EXECUTORS[number];
+	provider: typeof PROVIDERS[number];
+	modelFamily: typeof FAMILIES[number];
+	effort: typeof EFFORTS[number];
+	error: typeof ERRORS[number];
+	/** Separate native counters; do not add cached tokens into input here. */
+	tokens: Record<"input" | "output" | "cacheRead" | "cacheWrite", TokenMeasurement>
+		& Partial<Record<"reasoning" | "totalTokens", TokenMeasurement>>;
+	/** Request start to response headers; not first token or full response. */
+	responseHeadersMs: DurationMeasurement;
+	/** Same request start to completed response; only explicitly measured values. */
+	fullResponseMs: DurationMeasurement;
+}
+
+interface TokenTotals { reported: number; unavailable: number; unsupported: number; sum: number }
+interface DurationTotals { measured: number; unavailable: number; unsupported: number; sum: number }
+export interface RuntimeMetricBucket {
+	hostAgent: "pi";
+	agentClass: AgentClass;
+	observedModelId: string;
+	responseModelId: string;
+	providerThinkingLevel: typeof EFFORTS[number];
+	selectedModelId: string;
+	selectedProvider: FinalResponse["provider"];
+	executor: FinalResponse["executor"];
+	provider: FinalResponse["provider"];
+	modelFamily: FinalResponse["modelFamily"];
+	effort: FinalResponse["effort"];
+	error: FinalResponse["error"];
+	responses: number;
+	tokens: Record<typeof TOKEN_FIELDS[number], TokenTotals>;
+	responseHeadersMs: DurationTotals;
+	fullResponseMs: DurationTotals;
+}
+
+function object(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function member<T extends string>(values: readonly T[], value: unknown): value is T {
+	return typeof value === "string" && values.includes(value as T);
+}
+
+function category<T extends string>(values: readonly T[], value: unknown, fallback: T): T {
+	return member(values, value) ? value : fallback;
+}
+
+function measurement(value: unknown, present: "reported" | "measured"): boolean {
+	if (!object(value)) return false;
+	if (value.state === "unavailable" || value.state === "unsupported") return !("value" in value);
+	if (value.state !== present || typeof value.value !== "number") return false;
+	const n = value.value;
+	// Hard ceilings keep every sum finite/exact for integer counters, even at capacity.
+	return Number.isFinite(n) && n >= 0 && (present === "reported"
+		? Number.isSafeInteger(n) && n <= 1_000_000_000
+		: n <= 86_400_000);
+}
+
+export function validRuntimeResponse(value: unknown): value is FinalResponse {
+	if (!object(value) || value.kind !== "final_assistant_response") return false;
+	if (typeof value.responseId !== "string" || value.responseId.length < 1 || value.responseId.length > 128) return false;
+	if (!member(EFFORTS, value.effort) || !member(ERRORS, value.error)) return false;
+	const tokens = value.tokens;
+	if (!object(tokens) || !TOKEN_FIELDS.every(key => measurement(tokens[key] === undefined && ["reasoning", "totalTokens"].includes(key)
+		? { state: "unavailable" } : tokens[key], "reported"))) return false;
+	if (!measurement(value.responseHeadersMs, "measured") || !measurement(value.fullResponseMs, "measured")) return false;
+	const headers = value.responseHeadersMs as DurationMeasurement;
+	const full = value.fullResponseMs as DurationMeasurement;
+	return headers.state !== "measured" || full.state !== "measured" || headers.value <= full.value;
+}
+
+function tokenTotals(): TokenTotals {
+	return { reported: 0, unavailable: 0, unsupported: 0, sum: 0 };
+}
+
+function durationTotals(): DurationTotals {
+	return { measured: 0, unavailable: 0, unsupported: 0, sum: 0 };
+}
+
+function addDuration(totals: DurationTotals, value: DurationMeasurement): void {
+	totals[value.state] += 1;
+	if (value.state === "measured") totals.sum += value.value;
+}
+
+/**
+ * At most 1024 accepted responses/IDs, 64 dimension buckets, and 128 code units
+ * per ID. No eviction: once capacity is reached, new records are rejected
+ * atomically (including existing buckets); accepted IDs remain deduplicated.
+ * Invalid/rejected IDs are not reserved. A new instance starts a new accounting
+ * window with NO cross-instance/lifetime dedupe guarantee. No reset/flush API:
+ * window ownership and delivery remain future work. Runtime consumption stays
+ * separate from deterministic SDD/RDD counts; no closure attribution or bridge.
+ * Snapshots contain only closed dimensions and bounded numeric aggregates.
+ */
+export class RuntimeMetrics {
+	#ids = new Set<string>();
+	#buckets = new Map<string, RuntimeMetricBucket>();
+	#maxResponses: number;
+	#maxBuckets: number;
+
+	constructor({ maxResponses = 1024, maxBuckets = 64 }: { maxResponses?: number; maxBuckets?: number } = {}) {
+		if (!Number.isInteger(maxResponses) || maxResponses < 1 || maxResponses > 1024
+			|| !Number.isInteger(maxBuckets) || maxBuckets < 1 || maxBuckets > 64) {
+			throw new RangeError("Invalid runtime metrics capacity");
+		}
+		this.#maxResponses = maxResponses;
+		this.#maxBuckets = maxBuckets;
+	}
+
+	record(response: FinalResponse): "recorded" | "duplicate" | "invalid" | "capacity" {
+		if (!validRuntimeResponse(response)) return "invalid";
+		if (this.#ids.has(response.responseId)) return "duplicate";
+		const selectedProvider = response.selectedProvider ?? response.provider;
+		const dimensions = {
+			hostAgent: "pi" as const,
+			agentClass: category(AGENT_CLASSES, response.agentClass, "unknown"),
+			observedModelId: classifyPiCatalogName({ provider: response.provider, modelId: response.observedModelId }).modelId,
+			responseModelId: classifyPiCatalogName({ provider: response.provider, modelId: response.responseModelId }).modelId,
+			providerThinkingLevel: category(EFFORTS, response.providerThinkingLevel, "unavailable"),
+			selectedModelId: classifyPiCatalogName({ provider: selectedProvider, modelId: response.selectedModelId }).modelId,
+			selectedProvider: category(PROVIDERS, selectedProvider, typeof selectedProvider === "string" && selectedProvider ? "custom" : "unknown"),
+			executor: category(EXECUTORS, response.executor, "unknown"),
+			provider: category(PROVIDERS, response.provider, typeof response.provider === "string" && response.provider ? "custom" : "unknown"),
+			modelFamily: category(FAMILIES, response.modelFamily, typeof response.modelFamily === "string" && response.modelFamily ? "custom" : "unknown"),
+			effort: response.effort,
+			error: response.error,
+		};
+		const key = JSON.stringify(dimensions);
+		let bucket = this.#buckets.get(key);
+		if (this.#ids.size >= this.#maxResponses || (!bucket && this.#buckets.size >= this.#maxBuckets)) return "capacity";
+		if (!bucket) {
+			bucket = {
+				...dimensions, responses: 0,
+				tokens: { input: tokenTotals(), output: tokenTotals(), cacheRead: tokenTotals(), cacheWrite: tokenTotals(), reasoning: tokenTotals(), totalTokens: tokenTotals() },
+				responseHeadersMs: durationTotals(), fullResponseMs: durationTotals(),
+			};
+			this.#buckets.set(key, bucket);
+		}
+		this.#ids.add(response.responseId);
+		bucket.responses += 1;
+		for (const field of TOKEN_FIELDS) {
+			const value = response.tokens[field] ?? { state: "unavailable" as const };
+			bucket.tokens[field][value.state] += 1;
+			if (value.state === "reported") bucket.tokens[field].sum += value.value;
+		}
+		addDuration(bucket.responseHeadersMs, response.responseHeadersMs);
+		addDuration(bucket.fullResponseMs, response.fullResponseMs);
+		return "recorded";
+	}
+
+	snapshot(): RuntimeMetricBucket[] {
+		return structuredClone([...this.#buckets.values()]);
+	}
+}

--- a/scripts/build-runtime-modules.mjs
+++ b/scripts/build-runtime-modules.mjs
@@ -38,6 +38,14 @@ async function main() {
 	if ((mode !== "--write" && mode !== "--check") || process.argv.length !== 3) {
 		throw new Error("usage: build-runtime-modules.mjs --write|--check");
 	}
+	// Pi loads these directly as TypeScript. Check syntax without generating
+	// another runtime copy or expanding the published module boundary.
+	for (const path of ["lib/runtime-metrics-delivery.ts", "lib/runtime-metrics-native.ts",
+		"lib/runtime-metrics-children.ts", "extensions/runtime-metrics.ts"]) {
+		const source = await readFile(join(root, path), "utf8");
+		assertNoTrailingWhitespace(source, path);
+		stripTypeScriptTypes(source, { mode: "strip" });
+	}
 	const runtime = join(root, "runtime");
 	if (mode === "--write") await mkdir(runtime, { recursive: true });
 	const drift = [];
@@ -59,7 +67,7 @@ async function main() {
 	if (drift.length > 0) {
 		throw new Error(`generated runtime is stale: ${drift.join(", ")}`);
 	}
-	process.stdout.write(`runtime ${mode === "--write" ? "generated" : "matches TypeScript sources"} (${sources.length} modules)\n`);
+	process.stdout.write(`runtime ${mode === "--write" ? "generated" : "matches TypeScript sources"} (${sources.length} generated modules; one-shot metrics sources validated)\n`);
 }
 
 main().catch((error) => {

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -180,6 +180,7 @@ const contractHashes = {
   "contracts/review-integration/v2/schemas/repair.schema.json": "98a85fd45a8ae7f6211ffeeb3f9c478fa1dd1c17f385751f15f2111e6c3ab167",
   "contracts/review-integration/v2/schemas/start.schema.json": "2991e3fcca672d9257d61b6a336fb34e58b15a8e03f8a09a7adf892cae6a8085",
   "contracts/review-integration/v2/schemas/status.schema.json": "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
+  "contracts/telemetry/runtime-aggregate-v1.schema.json": "bf834d891028df69086ecfe5224ded8cf536959fe663e4e86c00d7d2fd8c91fb",
   "docs/review-integration.md": "95a3df92785bc4d9f3b99e702aaf817ae0440bd16c83218d2c3f2aca67c280fb",
 };
 

--- a/tests/agents-protocol.test.ts
+++ b/tests/agents-protocol.test.ts
@@ -67,6 +67,51 @@ test("normalizeRpcEvent maps pi RPC events to task deltas and ignores the rest",
 	assert.deepEqual(normalizeRpcEvent("garbage"), []);
 });
 
+test("response observations are opt-in, finalized, field-specific and content-free", () => {
+	const message = { role: "assistant", provider: "openai", model: "gpt-4o", responseModel: "gpt-4o-2024-08-06",
+		providerThinkingLevel: "high", stopReason: "stop", content: [{ type: "text", text: "private response" }],
+		errorMessage: "private error", responseId: "private id", modelVersion: "invented",
+		usage: { input: 12, output: 4, cacheRead: 0, cacheWrite: -1, totalTokens: 16, reasoning: 2 } };
+	const raw = { type: "message_end", message };
+	assert.deepEqual(normalizeRpcEvent(raw), [{ type: TASK_EVENT.USAGE, tokens: 16, cost: 0 }]);
+	const events = normalizeRpcEvent(raw, { observeResponses: true });
+	assert.equal(events.length, 2);
+	const observation = events.find((event) => event.type === "response_observation")?.observation;
+	assert.ok(observation);
+	assert.deepEqual(observation.provider, { state: "observed", value: "openai" });
+	assert.deepEqual(observation.model, { state: "observed", value: "gpt-4o" });
+	assert.deepEqual(observation.responseModel, { state: "observed", value: message.responseModel });
+	assert.deepEqual(observation.providerThinkingLevel, { state: "observed", value: "high" });
+	assert.deepEqual(observation.selected, { provider: { state: "unavailable" }, model: { state: "unavailable" }, effort: { state: "unavailable" } });
+	assert.deepEqual(observation.tokens, { input: { state: "reported", value: 12 }, output: { state: "reported", value: 4 },
+		cacheRead: { state: "unavailable" }, cacheWrite: { state: "unavailable" }, totalTokens: { state: "reported", value: 16 },
+		reasoning: { state: "reported", value: 2 } });
+	assert.doesNotMatch(JSON.stringify(observation), /private|invented|modelVersion|content|responseId/);
+	for (const stopReason of ["stop", "length", "toolUse", "error", "aborted"]) {
+		const [event] = normalizeRpcEvent({ type: "message_end", message: { role: "assistant", stopReason } }, { observeResponses: true });
+		assert.ok(event?.type === "response_observation", "missing usage still exposes a response");
+		assert.equal(event.observation.stopReason, stopReason);
+	}
+	for (const stopReason of ["pending", "deferred", undefined, "private error"]) {
+		assert.deepEqual(normalizeRpcEvent({ type: "message_end", message: { role: "assistant", stopReason } }, { observeResponses: true }), []);
+	}
+	for (const type of ["message_start", "message_update", "turn_end", "agent_end"]) {
+		assert.ok(!normalizeRpcEvent({ type, message, messages: [message] }, { observeResponses: true }).some((event) => event.type === "response_observation"));
+	}
+	assert.deepEqual(normalizeRpcEvent({ type: "message_end", message: { ...message, role: "toolResult" } }, { observeResponses: true }), []);
+});
+
+test("response observations reject malformed counters and unbounded metadata without coercion", () => {
+	for (const value of [0, -1, 1.5, NaN, Infinity, "12", null, undefined, 1_000_000_001]) {
+		const [event] = normalizeRpcEvent({ type: "message_end", message: { role: "assistant", stopReason: "error",
+			provider: "x".repeat(33), model: "x".repeat(129), responseModel: "private\ntext", providerThinkingLevel: {},
+			usage: { input: value, output: value, cacheRead: value, cacheWrite: value, totalTokens: value, reasoning: value } } }, { observeResponses: true }).filter((event) => event.type === "response_observation");
+		assert.ok(event);
+		for (const field of Object.values(event.observation.tokens)) assert.deepEqual(field, { state: "unavailable" });
+		for (const field of ["provider", "model", "responseModel", "providerThinkingLevel"] as const) assert.deepEqual(event.observation[field], { state: "unavailable" });
+	}
+});
+
 test("taskLabel prefers an explicit label and otherwise takes the prompt's first sentence", () => {
 	assert.equal(taskLabel("Map the repo. Then report.", "  map  the repo "), "map the repo");
 	assert.equal(taskLabel("Repeat a fresh read-only exploration of lib. Own runtime architecture: extensions, hooks."), "Repeat a fresh read-only exploration of lib");

--- a/tests/agents-runner.test.ts
+++ b/tests/agents-runner.test.ts
@@ -25,7 +25,7 @@ interface Harness {
 	spawnOptions: Array<{ env: NodeJS.ProcessEnv; stdio?: string[] }>;
 }
 
-function harness(options: { maxConcurrency?: number; answer?: Record<string, unknown>; exitOnKill?: boolean; state?: Record<string, unknown>; stateSuccess?: boolean; onNotification?: RunnerHooks["onNotification"]; onSuccessfulMutation?: RunnerHooks["onSuccessfulMutation"] } = {}): Harness {
+function harness(options: { maxConcurrency?: number; answer?: Record<string, unknown>; exitOnKill?: boolean; state?: Record<string, unknown>; stateSuccess?: boolean; onNotification?: RunnerHooks["onNotification"]; onSuccessfulMutation?: RunnerHooks["onSuccessfulMutation"]; onFinish?: RunnerHooks["onFinish"] } = {}): Harness {
 	const children: FakeChild[] = [];
 	const timers: Harness["timers"] = [];
 	const asks: Harness["asks"] = [];
@@ -64,7 +64,7 @@ function harness(options: { maxConcurrency?: number; answer?: Record<string, unk
 			asks.push({ taskId, method: ask.method });
 			return options.answer ?? { value: "yes" };
 		},
-		onFinish: (task) => finishes.push(task.id),
+		onFinish: (task, observations) => { finishes.push(task.id); options.onFinish?.(task, observations); },
 		onNotification: options.onNotification,
 		onSuccessfulMutation: options.onSuccessfulMutation,
 	});
@@ -72,6 +72,102 @@ function harness(options: { maxConcurrency?: number; answer?: Record<string, unk
 }
 
 const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+test("synchronous cancellation before dequeue never invokes the policy callback", async () => {
+	const h = harness(); let checks = 0;
+	const task = h.runner.run(request({ prepareResponseObservations: async () => { checks++; return true; } }));
+	h.runner.cancel(task.id);
+	await tick();
+	assert.equal(checks, 0);
+	assert.equal(h.children.length, 0);
+});
+
+test("hanging preparation never blocks spawn or queued core work; late grants are dropped", async () => {
+	const h = harness({ maxConcurrency: 1 });
+	let grant!: (value: boolean) => void;
+	let checks = 0;
+	const first = h.runner.run(request({ prepareResponseObservations: () => { checks++; return new Promise(resolve => { grant = resolve; }); } }));
+	const second = h.runner.run(request());
+	await tick();
+	assert.equal(checks, 1);
+	assert.equal(h.children.length, 1);
+	assert.equal(h.store.get(second.id)?.status, TASK_STATUS.QUEUED);
+	assert.equal(h.runner.cancel(first.id), true);
+	await tick();
+	assert.equal(h.children.length, 2);
+	grant(true);
+	await tick();
+	assert.equal(h.children.length, 2);
+	assert.equal((await h.runner.waitFor(first.id)).status, TASK_STATUS.CANCELLED);
+	h.runner.cancel(second.id);
+});
+
+for (const outcome of ["ready", "late", "reject", "throw"] as const) {
+	test(`parallel preparation ${outcome} cannot delay execution or revive dropped observations`, async () => {
+		const snapshots: Parameters<NonNullable<RunnerHooks["onFinish"]>>[1][] = [];
+		const h = harness({ onFinish: (_task, snapshot) => snapshots.push(snapshot) });
+		let grant!: (value: boolean) => void;
+		const task = h.runner.run(request({ prepareResponseObservations: () => {
+			if (outcome === "throw") throw new Error("preparation failed");
+			if (outcome === "reject") return Promise.reject(new Error("preparation failed"));
+			return new Promise(resolve => { grant = resolve; });
+		} }));
+		await tick();
+		assert.equal(h.children.length, 1);
+		if (outcome === "ready") { grant(true); await tick(); }
+		const message = { type: "message_end", message: { role: "assistant", provider: "openai", model: "gpt-4o", stopReason: "stop", content: [{ type: "text", text: "done" }] } };
+		h.children[0].emit(message);
+		if (outcome === "late") { grant(true); await tick(); }
+		h.children[0].emit(message);
+		h.children[0].emit({ type: "agent_end" });
+		h.children[0].emit({ type: "agent_settled" });
+		await h.runner.waitFor(task.id);
+		assert.equal(snapshots.length, 1);
+		assert.equal(snapshots[0]?.responses.length, outcome === "ready" ? 2 : undefined);
+	});
+}
+
+for (const checkpoint of ["launch", "stream", "finish", "throw"] as const) {
+	test(`child observation guard discards permanently at ${checkpoint} without changing task execution`, async () => {
+		let allowed = checkpoint !== "launch";
+		let calls = 0;
+		const snapshots: Parameters<NonNullable<RunnerHooks["onFinish"]>>[1][] = [];
+		const h = harness({ onFinish: (_task, snapshot) => snapshots.push(snapshot) });
+		const task = h.runner.run(request({ collectResponseObservations: true,
+			canCollectResponseObservations: () => {
+				calls++;
+				if (checkpoint === "throw") throw new Error("private policy failure");
+				return allowed;
+			} }));
+		await tick();
+		const child = h.children[0];
+		const response = { type: "message_end", message: { role: "assistant", stopReason: "stop", usage: { input: 3 } } };
+		child.emit(response);
+		if (checkpoint === "stream") {
+			allowed = false;
+			child.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "progress" } });
+			allowed = true;
+			child.emit(response);
+		}
+		if (checkpoint === "finish") allowed = false;
+		h.runner.cancel(task.id);
+		await tick();
+		assert.equal((await h.runner.waitFor(task.id)).status, TASK_STATUS.CANCELLED);
+		assert.deepEqual(snapshots, [undefined]);
+		assert.ok(calls > 0);
+	});
+}
+
+test("child observation guard is never consulted when collection is default-off", async () => {
+	let calls = 0;
+	const h = harness();
+	const task = h.runner.run(request({ canCollectResponseObservations: () => { calls++; return true; } }));
+	await tick();
+	h.children[0].emit({ type: "message_end", message: { role: "assistant", stopReason: "stop" } });
+	h.runner.cancel(task.id);
+	await tick();
+	assert.equal(calls, 0);
+});
 
 for (const ending of ["cancel", "failure", "hook-error", "hook-async-error"] as const) {
 	test(`successful child mutations require paired RPC events and survive ${ending}`, async () => {
@@ -174,6 +270,86 @@ test("runner captures resolved model and effort, retaining omitted launch values
 	assert.equal(h.store.get(task.id)?.model, "default");
 	assert.equal(h.store.get(task.id)?.thinking, undefined);
 	h.runner.cancel(task.id);
+});
+
+test("runner delivers each response combination once at finish, never attributing launch selection", async () => {
+	const snapshots: NonNullable<Parameters<NonNullable<RunnerHooks["onFinish"]>>[1]>[] = [];
+	const h = harness({ exitOnKill: false, state: { model: { provider: "anthropic", id: "launch" }, thinkingLevel: "max" },
+		onFinish: (_task, snapshot) => { assert.ok(snapshot); snapshots.push(snapshot); } });
+	const task = h.runner.run(request({ collectResponseObservations: true }));
+	await tick();
+	const child = h.children[0];
+	const responses = [
+		{ provider: "openai", model: "gpt-4o", providerThinkingLevel: "low", stopReason: "error" },
+		{ provider: "anthropic", model: "claude-sonnet-4", providerThinkingLevel: "high", stopReason: "toolUse" },
+		{ provider: "openai", model: "gpt-4o", providerThinkingLevel: "high", stopReason: "stop" },
+	];
+	for (const response of responses) {
+		const message = { role: "assistant", ...response, usage: { input: 10, totalTokens: 10, cost: { total: 0.1 } }, content: [{ type: "text", text: "private report" }] };
+		child.emit({ type: "message_start", message });
+		child.emit({ type: "message_end", message });
+		child.emit({ type: "turn_end", message });
+		child.emit({ type: "agent_end", messages: [message] });
+	}
+	assert.deepEqual(snapshots, [], "agent_end is not settlement");
+	child.emit({ type: "agent_settled" });
+	assert.deepEqual(snapshots, [], "settlement still waits for process cleanup");
+	child.exit(0);
+	await tick();
+	assert.equal(snapshots.length, 1);
+	const snapshot = snapshots[0];
+	assert.equal(snapshot.agentSettled, true);
+	assert.equal(snapshot.droppedResponses, 0);
+	assert.equal(snapshot.coverage, "final_assistant_messages_only");
+	assert.deepEqual(snapshot.responses.map((response) => [response.provider, response.model, response.providerThinkingLevel]),
+		responses.map((response) => [response.provider, response.model, response.providerThinkingLevel].map((value) => ({ state: "observed", value }))));
+	assert.ok(snapshot.responses.every((response) => Object.values(response.selected).every((field) => field.state === "unavailable")));
+	assert.equal(h.store.get(task.id)?.tokens, 30);
+	assert.equal(h.store.get(task.id)?.cost, 0.1 + 0.1 + 0.1);
+	assert.equal(h.store.get(task.id)?.model, "anthropic/launch");
+	assert.deepEqual(child.written.map((command) => command.type), ["get_state", "prompt"]);
+	assert.doesNotMatch(JSON.stringify(snapshot), /private|launch|s1|modelVersion/);
+	assert.ok(Object.isFrozen(snapshot) && Object.isFrozen(snapshot.responses) && Object.isFrozen(snapshot.responses[0].tokens.input));
+	child.emit({ type: "agent_settled" }); child.exit(0);
+	assert.equal(snapshots.length, 1);
+});
+
+for (const ending of ["cancel", "exit", "error", "timeout", "settled-error"] as const) test(`bounded response coverage survives ${ending} honestly`, async () => {
+	let snapshot: Parameters<NonNullable<RunnerHooks["onFinish"]>>[1];
+	const h = harness({ onFinish: (_task, observations) => { snapshot = observations; } });
+	const task = h.runner.run(request({ collectResponseObservations: true }));
+	await tick();
+	const child = h.children[0];
+	for (let index = 0; index < 130; index++) child.emit({ type: "message_end", message: {
+		role: "assistant", model: `model-${index}`, stopReason: "error", usage: { totalTokens: 1 } } });
+	if (ending === "cancel") h.runner.cancel(task.id);
+	else if (ending === "exit") child.exit(1);
+	else if (ending === "error") child.fail("private process error");
+	else if (ending === "timeout") h.timers.filter((timer) => !timer.cancelled && timer.ms === 10_000).at(-1)!.fn();
+	else { child.emit({ type: "agent_end", messages: [{ role: "assistant", stopReason: "error" }] }); child.emit({ type: "agent_settled" }); }
+	await h.runner.waitFor(task.id);
+	assert.ok(snapshot);
+	assert.equal(snapshot.responses.length, 128);
+	assert.equal(snapshot.droppedResponses, 2);
+	assert.equal(snapshot.agentSettled, ending === "settled-error");
+	assert.equal(h.store.get(task.id)?.tokens, 130, "buffer cap never caps existing UI totals");
+	assert.notEqual(h.store.get(task.id)?.status, TASK_STATUS.COMPLETED);
+	child.emit({ type: "message_end", message: { role: "assistant", stopReason: "stop" } });
+	assert.equal(snapshot.responses.length, 128);
+	assert.equal(h.finishes.length, 1);
+});
+
+test("response buffering is disabled by default and absent for tasks cancelled before launch", async () => {
+	const snapshots: unknown[] = [];
+	const h = harness({ maxConcurrency: 1, onFinish: (_task, snapshot) => snapshots.push(snapshot) });
+	const task = h.runner.run(request());
+	const queued = h.runner.run(request({ collectResponseObservations: true }));
+	await tick();
+	h.children[0].emit({ type: "message_end", message: { role: "assistant", stopReason: "stop", usage: { totalTokens: 7 } } });
+	h.runner.cancel(queued.id); h.runner.cancel(task.id);
+	await tick();
+	assert.deepEqual(snapshots, [undefined, undefined]);
+	assert.equal(h.store.get(task.id)?.tokens, 7);
 });
 
 test("childArguments builds an rpc launch with model, thinking, tools, session dir, and instructions", () => {
@@ -536,6 +712,7 @@ for (const lateEvents of [false, true]) test(`AgentRunner releases quarantined c
 	let launches = 0;
 	let asks = 0;
 	const finishes: string[] = [];
+	const observations: Parameters<NonNullable<RunnerHooks["onFinish"]>>[1][] = [];
 	let resolveAnswer!: (answer: { value: string }) => void;
 	const answer = new Promise<{ value: string }>((resolve) => { resolveAnswer = resolve; });
 	const child = fakeChild({ exitOnKill: false, pid: 71 });
@@ -551,11 +728,12 @@ for (const lateEvents of [false, true]) test(`AgentRunner releases quarantined c
 		process: { platform: "linux", kill: (_pid, signal) => {
 			if (signal === 0) throw Object.assign(new Error("group probe"), { code: groupGone ? "ESRCH" : "EPERM" });
 		} },
-	}, { askUser: async () => { asks += 1; return answer; }, onFinish: (task) => finishes.push(task.id) });
-	const first = runner.run(request());
+	}, { askUser: async () => { asks += 1; return answer; }, onFinish: (task, snapshot) => { finishes.push(task.id); observations.push(snapshot); } });
+	const first = runner.run(request({ collectResponseObservations: true }));
 	const second = runner.run(request({ prompt: "queued" }));
 	await tick();
 	const waiter = runner.waitFor(first.id);
+	child.emit({ type: "message_end", message: { role: "assistant", stopReason: "aborted", usage: { input: 3 } } });
 	if (lateEvents) child.emit({ type: "extension_ui_request", id: "early", method: "input", title: "Pending?" });
 	runner.cancel(first.id);
 	const grace = timers.find((timer) => timer.ms === 250);
@@ -569,6 +747,9 @@ for (const lateEvents of [false, true]) test(`AgentRunner releases quarantined c
 	assert.equal(store.get(first.id)?.status, TASK_STATUS.FAILED);
 	assert.equal((await waiter).status, TASK_STATUS.FAILED);
 	assert.match(store.get(first.id)?.error ?? "", /cleanup unconfirmed/);
+	assert.equal(observations.length, 1);
+	assert.equal(observations[0]?.agentSettled, false);
+	assert.equal(observations[0]?.responses.length, 1);
 	assert.equal(store.get(second.id)?.status, TASK_STATUS.QUEUED, "the unconfirmed group retains its capacity");
 	assert.equal(timers.filter((timer) => timer.ms === 25 && !timer.cancelled).length, 0, "confirmation polling stops at its deadline");
 	const finished = structuredClone(store.get(first.id));
@@ -598,5 +779,6 @@ for (const lateEvents of [false, true]) test(`AgentRunner releases quarantined c
 	child.exit(0);
 	await tick();
 	assert.deepEqual(finishes, [first.id], "cleanup must not finish the quarantined task twice");
+	assert.equal(observations.length, 1, "late cleanup does not redeliver observations");
 	assert.deepEqual(store.get(first.id), finished);
 });

--- a/tests/fixtures/runtime-metrics-native-batches.json
+++ b/tests/fixtures/runtime-metrics-native-batches.json
@@ -1,0 +1,6 @@
+{
+  "schema_sha256": "bf834d891028df69086ecfe5224ded8cf536959fe663e4e86c00d7d2fd8c91fb",
+  "batches": [
+    "{\"schema\":\"gentle-ai.telemetry-runtime-aggregate/v1\",\"registry\":1,\"host\":\"pi\",\"rows\":[{\"model\":{\"provider\":\"openai\",\"id\":\"gpt-5.4\"},\"model_evidence\":\"response\",\"agent_kind\":\"built_in\",\"agent_class\":\"worker\",\"selected_effort\":\"high\",\"effective_effort\":\"low\",\"launches\":null,\"responses\":1,\"input_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"output_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"cache_read_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"cache_creation_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"reasoning_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"total_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"error_category\":\"none\",\"duration\":{\"kind\":\"unavailable\",\"measured_count\":0,\"sum_ms\":null}}]}"
+  ]
+}

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -15,6 +15,8 @@ import { NativePointerScope } from "../lib/native-pointer-region.ts";
 import { PresenceCursor, PresencePublisher, listPresence, readActivity } from "../lib/orchestrator-presence.ts";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 import { fakeChild, type FakeChild } from "./agents-fake-child.ts";
+import { AgentRunner } from "../lib/agents-runner.ts";
+import { CHILD_METRICS_EVENT } from "../lib/runtime-metrics-children.ts";
 
 // Gentle Agents extension: the subagent_* tools drive isolated pi children,
 // the card above the editor follows the store, and dialogs reach the host UI.
@@ -66,9 +68,16 @@ function fakePi() {
 	const renderers = new Map<string, (message: unknown, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }>();
 	const entries: Array<{ type: string; customType: string; data: unknown }> = [];
 	const events: Array<{ name: string; data: unknown }> = [];
+	const listeners = new Map<string, Set<(data: unknown) => void>>();
 	const pi = {
 		appendEntry: (customType: string, data: unknown) => entries.push({ type: "custom", customType, data }),
-		events: { emit: (name: string, data: unknown) => events.push({ name, data }) },
+		events: {
+			emit: (name: string, data: unknown) => { events.push({ name, data }); for (const listener of listeners.get(name) ?? []) listener(data); },
+			on: (name: string, listener: (data: unknown) => void) => {
+				const set = listeners.get(name) ?? new Set(); listeners.set(name, set); set.add(listener);
+				return () => { set.delete(listener); };
+			},
+		},
 		sendMessage: (message: Record<string, unknown>, options: Record<string, unknown>) => sent.push({ message, options }),
 		registerMessageRenderer: (type: string, renderer: (message: unknown, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }) => renderers.set(type, renderer),
 		on: (event: string, handler: Handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
@@ -79,7 +88,7 @@ function fakePi() {
 	const fire = async (event: string, ctx: ExtensionContext, payload: unknown = {}) => {
 		for (const handler of handlers.get(event) ?? []) await handler(payload, ctx);
 	};
-	return { pi, tools, shortcuts, commands, fire, sent, renderers, entries, events };
+	return { pi, tools, shortcuts, commands, fire, sent, renderers, entries, events, listeners };
 }
 
 function fakeContext(tui: { requestRender(): void } = fakeTui, confirmResult: (title: string, message: string) => Promise<boolean> = async () => true, inputResult: (title: string, placeholder: string | undefined) => Promise<string | undefined> = async () => undefined, overlayTui: { terminal: { rows: number }; requestRender(): void } = { terminal: { rows: 30 }, requestRender() {} }) {
@@ -138,6 +147,7 @@ function deps(): { deps: Partial<AgentsDeps>; children: FakeChild[]; spawned: st
 		children,
 		spawned,
 		deps: {
+			runtimeMetricsPolicy: { resolve: () => { throw new Error("Policy not configured in fixture"); } },
 			spawn: (command, args) => {
 				spawned.push([command, ...args]);
 				const child = fakeChild();
@@ -332,6 +342,117 @@ test("child parent-message tooling admits notifications and the active parent pr
 	assert.deepEqual(runtime.children[0].sent, [{ id: "n1", kind: "ack", accepted: true }, { id: "n2", kind: "ack", accepted: false, error: "task parent is not the active host session" }]);
 	await parent.fire("session_shutdown", ctx);
 });
+for (const boundary of ["allowed", "env", "session", "replacement", "bus-throws", "no-spawn", "long-running"] as const) {
+	test(`local child composition through real extensions and RPC runner: ${boundary}`, async (t) => {
+		const discarded: number[] = [];
+		const discard = AgentRunner.prototype.discardResponseObservations;
+		t.mock.method(AgentRunner.prototype, "discardResponseObservations", function (this: AgentRunner, id: string) {
+			const live = Reflect.get(this, "live").get(id);
+			discarded.push(live?.observations?.responses.length ?? 0);
+			discard.call(this, id);
+			assert.equal(live?.observations, undefined, "buffer gone synchronously, without another RPC");
+		});
+		const h = fakePi();
+		const runtime = deps();
+		const context = fakeContext();
+		const spawn = runtime.deps.spawn!;
+		runtime.deps.spawn = (...args) => {
+			const child = spawn(...args);
+			const on = child.on.bind(child);
+			child.on = ((event: string, listener: (...args: any[]) => void) => {
+				if (event === "spawn" && boundary !== "no-spawn") queueMicrotask(() => listener());
+				return on(event as any, listener);
+			}) as typeof child.on;
+			return child;
+		};
+		let clock = 1;
+		const renewalTimers = new Map<number, () => void>();
+		const metricsSchedule = (fn: () => void, ms: number) => {
+			const at = clock + ms; renewalTimers.set(at, fn); return () => { renewalTimers.delete(at); };
+		};
+		let calls = 0;
+		const policy = { resolve: () => "fixture", exec: async () => {
+			calls++;
+			return { stdout: JSON.stringify({ schema: "gentle-ai.telemetry-policy/v1", operation: "policy", enabled: true,
+				source: "state", reason: "enabled" }), stderr: "", exitCode: 0, signal: null, timedOut: false, outputLimitExceeded: false };
+		} };
+		const env: NodeJS.ProcessEnv = {};
+		const profile = join(root, `metrics-${boundary}`);
+		mkdirSync(join(profile, "agents"), { recursive: true });
+		writeFileSync(join(profile, "agents", "gentle-ai-worker.md"), readFileSync(new URL("../assets/agents/gentle-ai-worker.md", import.meta.url)));
+		writeFileSync(join(profile, "subagents.json"), JSON.stringify({ model_profiles: { "gentle-ai-worker": { model: "openai/gpt-4o", effort: "high" } } }));
+		gentleAgents(h.pi, env, { ...runtime.deps, env, agentHome: profile, runtimeMetricsPolicy: policy, metricsNow: () => clock, metricsSchedule });
+		const listenerCounts = () => [...h.listeners].map(([name, set]) => [name, set.size]);
+		const initialListeners = listenerCounts();
+		await h.fire("session_start", context.ctx);
+		const result = h.tools.get("subagent_run")!.execute("call", { agent: "gentle-ai-worker", task: "private task", mode: "task" }, undefined, undefined, context.ctx);
+		await tick();
+		assert.equal(runtime.children.length, 1);
+		const child = runtime.children[0];
+		const launchedCalls = calls;
+		for (let i = 0; i < 10; i++) child.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "private streamed text" } });
+		assert.equal(calls, launchedCalls, "no per-chunk policy process");
+		if (boundary === "long-running") {
+			for (let i = 0; i < 6; i++) {
+				clock += 20_000;
+				for (const [at, fn] of [...renewalTimers]) if (at <= clock) { renewalTimers.delete(at); fn(); }
+				await tick();
+				child.emit({ type: "message_end", message: { role: "assistant", model: "gpt-4o", provider: "openai",
+					providerThinkingLevel: "low", stopReason: "stop", usage: { input: 7, output: 3 } } });
+			}
+			assert.equal(calls, launchedCalls, "no telemetry policy renewal during a two-minute child");
+			assert.equal(renewalTimers.size, 0, "child telemetry never schedules a lease timer");
+		}
+		if (boundary === "env") env.DO_NOT_TRACK = "yes";
+		if (boundary === "session" || boundary === "replacement") {
+			child.emit({ type: "message_end", message: { role: "assistant", model: "gpt-4o", provider: "openai",
+				stopReason: "stop", usage: { input: 7, output: 3 } } });
+			if (boundary === "replacement") {
+				Object.assign(context.ctx.sessionManager, { getSessionId: () => "replacement" });
+				await h.fire("session_start", context.ctx);
+			} else await h.fire("session_shutdown", context.ctx);
+			assert.deepEqual(discarded, [1], "idle buffered response discarded at lifecycle boundary");
+			assert.equal(renewalTimers.size, 0);
+			if (boundary === "session") {
+				assert.ok([...h.listeners.values()].every(set => set.size === 0), "old bus subscriptions removed");
+				const fresh = fakePi();
+				Object.assign(fresh.pi, { events: h.pi.events });
+				gentleAgents(fresh.pi, env, { ...runtime.deps, env, runtimeMetricsPolicy: policy, metricsSchedule });
+				await fresh.fire("session_start", context.ctx);
+				assert.deepEqual(listenerCounts(), initialListeners, "fresh instance installs one subscription set");
+				await fresh.fire("session_shutdown", context.ctx);
+				assert.ok([...h.listeners.values()].every(set => set.size === 0));
+				assert.equal(renewalTimers.size, 0);
+			}
+		}
+		if (boundary === "bus-throws") h.pi.events.on(CHILD_METRICS_EVENT, () => { throw new Error("private bus error"); });
+		for (const model of ["gpt-4o", "gpt-4o-mini"]) child.emit({ type: "message_end", message: {
+			role: "assistant", model, provider: "openai", providerThinkingLevel: "low", stopReason: "stop", usage: { input: 7, output: 3 } } });
+		child.emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }] });
+		child.emit({ type: "agent_settled" });
+		assert.match((await result).content[0].text, boundary === "session" ? /cancelled/ : /done/);
+		await tick(); await tick();
+		const events = h.events.filter(event => event.name === CHILD_METRICS_EVENT);
+		const admitted = boundary === "allowed" || boundary === "bus-throws" || boundary === "long-running";
+		assert.equal(events.length, Number(admitted));
+		if (admitted) {
+			assert.ok(!JSON.stringify(events).includes("private"));
+			const event = events[0].data as import("../lib/runtime-metrics-children.ts").ChildMetricsEvent;
+			assert.equal(event.launch.agentClass, "worker");
+			assert.equal(event.launch.selectedEffort, "high");
+			assert.equal(event.responses.length, boundary === "long-running" ? 8 : 2);
+			assert.ok(event.responses.every(row => row.agentClass === "worker" && row.effort === "unavailable"));
+			assert.equal(event.agentSettled, true);
+			child.emit({ type: "agent_settled" });
+			await tick();
+			assert.equal(h.events.filter(event => event.name === CHILD_METRICS_EVENT).length, 1, "completion consumed once, even after bus failure");
+		}
+		assert.equal(calls, 0, "child telemetry performs no launch, renewal or pending-forward policy query");
+		assert.equal(renewalTimers.size, 0, "no renewal timer after the last task finishes");
+		assert.ok(!JSON.stringify(h.entries).includes("launch_configuration"));
+		await h.fire("session_shutdown", context.ctx);
+	});
+}
 
 async function eventually(check: () => boolean, message: string): Promise<void> {
 	for (let attempt = 0; attempt < 120; attempt++) {
@@ -875,7 +996,7 @@ test("explicit child roots launch and continue in the actual cwd, persist withou
 	assert.deepEqual(h.entries, [], "queueing and returning a child handle do not register roots");
 	spawnEvents[0]();
 	assert.deepEqual(h.entries, [{ type: "custom", customType: SESSION_WORKTREE_ENTRY, data: { sessionId: "s1", root: childRoot, evidence: "subagent:spawn" } }]);
-	assert.deepEqual(h.events, [{ name: SESSION_WORKTREE_CHANGED, data: { sessionId: "s1" } }]);
+	assert.deepEqual(h.events.filter(event => event.name === SESSION_WORKTREE_CHANGED), [{ name: SESSION_WORKTREE_CHANGED, data: { sessionId: "s1" } }]);
 	const details = result.details.gentleAgents as { taskId: string; cwd: string };
 	assert.equal(details.cwd, childRoot);
 	runtime.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "mapped" }] }] });

--- a/tests/runtime-metrics-children.test.ts
+++ b/tests/runtime-metrics-children.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { stripTypeScriptTypes } from "node:module";
+import { runInNewContext } from "node:vm";
+import { AGENT_CLASSES } from "../lib/runtime-metrics.ts";
+import { parseAgentDefinition } from "../lib/agents-config.ts";
+import { normalizeRpcEvent, TASK_EVENT } from "../lib/agents-protocol.ts";
+import { lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
+import { ChildComposition, childEvent, classifyBuiltinAgent, launchSelection } from "../lib/runtime-metrics-children.ts";
+
+await lookupPiCatalogName({ provider: "openai", modelId: "gpt-4o" });
+const asset = new URL("../assets/agents/gentle-ai-worker.md", import.meta.url);
+const definition = parseAgentDefinition(readFileSync(asset, "utf8"), asset.pathname, "global");
+assert.ok("instructions" in definition);
+const response = (model = "gpt-4o", native = "low") => {
+	const events = normalizeRpcEvent({ type: "message_end", message: { role: "assistant", provider: "openai",
+		model, responseModel: model, providerThinkingLevel: native, stopReason: "stop", usage: { input: 3, output: 2, reasoning: 1 } } }, { observeResponses: true });
+	const event = events.find(event => event.type === TASK_EVENT.RESPONSE_OBSERVATION);
+	assert.ok(event?.type === TASK_EVENT.RESPONSE_OBSERVATION);
+	return event.observation;
+};
+const launch = () => launchSelection(definition, { provider: "openai", id: "gpt-4o" }, "high");
+const event = (taskId = "local-task") => childEvent("local-session", taskId, launch(), "completed", {
+	coverage: "final_assistant_messages_only", agentSettled: true, responses: [response(), response("gpt-4o-mini", "high")], droppedResponses: 2,
+});
+
+test("installed package definitions retain classification after the actual routing transform", () => {
+	// installSddAssets/copyDirectoryFiles copies assets verbatim on first install.
+	// Isolate the real pure routing writer; do not run an installer or read user agents.
+	const source = readFileSync(new URL("../extensions/gentle-ai.ts", import.meta.url), "utf8");
+	const transform = source.match(/function updateFrontmatterRouting\([\s\S]*?\n\}/)?.[0];
+	assert.ok(transform);
+	const route = runInNewContext(`(${stripTypeScriptTypes(transform)})`);
+	for (const kind of AGENT_CLASSES.filter(kind => kind !== "orchestrator" && kind !== "unknown")) {
+		const file = ["worker", "explore", "verify"].includes(kind) ? `gentle-ai-${kind}` : kind;
+		const asset = new URL(`../assets/agents/${file}.md`, import.meta.url);
+		const content = readFileSync(asset, "utf8");
+		const copied = parseAgentDefinition(content, asset.pathname, "global");
+		assert.ok("instructions" in copied);
+		assert.equal(classifyBuiltinAgent(copied), kind, "verbatim first install");
+		for (const entry of [undefined, { model: "openai/gpt-4o", thinking: "high" }]) {
+			const parsed = parseAgentDefinition(route(content, entry), asset.pathname, "global");
+			assert.ok("instructions" in parsed);
+			assert.equal(classifyBuiltinAgent(parsed), kind, `${kind}: installed routing`);
+			assert.equal(classifyBuiltinAgent({ ...parsed, instructions: `${parsed.instructions}\nOverride` }), "unknown");
+			assert.equal(classifyBuiltinAgent({ ...parsed, tools: ["different-tool"] }), "unknown");
+			assert.equal(classifyBuiltinAgent({ ...parsed, description: "different description" }), "unknown");
+			assert.equal(classifyBuiltinAgent({ ...parsed, mode: parsed.mode === "task" ? "background" : "task" }), "unknown");
+		}
+	}
+});
+
+test("built-in classification requires the runtime definition, not a public-looking override name", () => {
+	assert.equal(classifyBuiltinAgent(definition), "worker");
+	assert.equal(classifyBuiltinAgent({ ...definition, instructions: "private override" }), "unknown");
+	assert.equal(classifyBuiltinAgent({ ...definition, tools: ["private tool"] }), "unknown");
+	assert.equal(classifyBuiltinAgent({ ...definition, name: "private-agent" }), "unknown");
+});
+
+test("launch distribution and each observed combination remain independent and privacy-filtered", () => {
+	const composition = new ChildComposition();
+	const value = event();
+	assert.ok(value);
+	assert.equal(composition.reserve(value, "local-session"), true);
+	composition.record(value);
+	const view = composition.snapshot();
+	assert.equal(view.launches[0].launches, 1);
+	assert.equal(view.launches[0].selectedEffort, "high");
+	assert.equal(view.launches[0].agentClass, "worker");
+	assert.equal(view.responses.length, 2);
+	assert.deepEqual(view.responses.map(row => row.observedModelId), ["gpt-4o", "gpt-4o-mini"]);
+	assert.ok(view.responses.every(row => row.effort === "unavailable" && row.selectedProvider === "unknown"));
+	assert.equal(view.responses[0].providerThinkingLevel, "low");
+	assert.equal(view.responses[0].tokens.reasoning.sum, 1);
+	assert.equal(view.droppedResponses, 2);
+	assert.equal(view.settled, 1);
+	assert.equal(view.statuses.completed, 1);
+	assert.ok(!JSON.stringify(view).includes("local-"));
+	const privateLaunch = launchSelection({ ...definition, instructions: "private" }, { provider: "private", id: "private-model" }, "private-effort");
+	const filtered = childEvent("local-session", "other", privateLaunch, "failed", {
+		coverage: "final_assistant_messages_only", agentSettled: false, responses: [response("private-model", "private-native")], droppedResponses: 0,
+	});
+	assert.ok(!JSON.stringify(filtered).includes("private"));
+});
+
+test("dedupe reserves before async policy, rejects old sessions, and survives aggregate clearing", () => {
+	const c = new ChildComposition();
+	const e = event()!;
+	assert.equal(c.reserve(e, "other-session"), false);
+	assert.equal(c.reserve(e, "local-session"), true);
+	assert.equal(c.reserve(structuredClone(e), "local-session"), false);
+	c.record(e);
+	c.clear();
+	assert.equal(c.reserve(e, "local-session"), false);
+	assert.deepEqual(c.snapshot().responses, []);
+	for (let i = 0; i < 255; i++) assert.equal(c.reserve(event(String(i))!, "local-session"), true);
+	assert.equal(c.reserve(event("overflow")!, "local-session"), false);
+	assert.equal(c.snapshot().saturated, true);
+});
+
+test("response capacity retains launch ranking and reports excluded responses without eviction", () => {
+	const c = new ChildComposition();
+	for (let i = 0; i < 9; i++) {
+		const e = childEvent("local-session", String(i), launch(), "completed", {
+			coverage: "final_assistant_messages_only", agentSettled: true, responses: Array(128).fill(response()), droppedResponses: 0,
+		})!;
+		assert.equal(c.reserve(e, "local-session"), true);
+		c.record(e);
+		c.record(e);
+	}
+	const view = c.snapshot();
+	assert.equal(view.responses[0].responses, 1024);
+	assert.equal(view.launches[0].launches, 9);
+	assert.equal(view.droppedResponses, 128);
+	assert.equal(view.saturated, true);
+	assert.equal(view.statuses.completed, 9);
+});
+
+test("malformed and oversized events are rejected without reserving IDs", () => {
+	const c = new ChildComposition();
+	const e = event()!;
+	for (const patch of [{ schema: "old" }, { responses: Array(129).fill(e.responses[0]) }, { taskId: "x".repeat(129) },
+		{ droppedResponses: -1 }, { status: "native_success" }, { launch: { ...e.launch, agentClass: "private" } }]) {
+		assert.equal(c.reserve({ ...e, ...patch }, "local-session"), false);
+	}
+	assert.equal(c.reserve(e, "local-session"), true);
+});

--- a/tests/runtime-metrics-delivery.test.ts
+++ b/tests/runtime-metrics-delivery.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import * as delivery from "../lib/runtime-metrics-delivery.ts";
+
+const tick = () => new Promise<void>(resolve => setImmediate(resolve));
+
+test("callback returns before a blocked attempt; busy events are never queued", async () => {
+	const owner = new delivery.RuntimeMetricsAttempt();
+	let calls = 0;
+	let finish!: () => void;
+	assert.equal(owner.offer(() => { calls++; return new Promise<void>(resolve => { finish = resolve; }); }), true);
+	assert.equal(calls, 0, "provider callback returns before any transport work");
+	assert.equal(owner.offer(async () => { calls++; }), false);
+	await tick();
+	assert.equal(calls, 1);
+	assert.equal(new delivery.RuntimeMetricsAttempt().offer(async () => { calls++; }), false);
+	finish(); await tick(); await tick();
+	assert.equal(calls, 1, "busy events never replay");
+	owner.dispose();
+});
+
+test("failure is silent and the next fresh event may attempt without cooldown", async () => {
+	const owner = new delivery.RuntimeMetricsAttempt();
+	let calls = 0;
+	owner.offer(async () => { calls++; throw new Error("private failure"); });
+	await tick(); await tick();
+	assert.equal(calls, 1);
+	assert.equal(owner.offer(async () => { calls++; }), true);
+	await tick(); await tick();
+	assert.equal(calls, 2);
+	owner.dispose();
+});
+
+test("replacement cancels an unstarted attempt without stale execution", async () => {
+	const owner = new delivery.RuntimeMetricsAttempt();
+	let calls = 0;
+	owner.offer(async () => { calls++; });
+	owner.dispose(); owner.dispose();
+	assert.equal(owner.offer(async () => { calls++; }), false);
+	const replacement = new delivery.RuntimeMetricsAttempt();
+	assert.equal(replacement.offer(async () => { calls++; }), true);
+	await tick(); await tick();
+	assert.equal(calls, 1);
+	replacement.dispose();
+});
+
+test("shutdown aborts immediately but cannot overlap an unsettled process", async () => {
+	const owner = new delivery.RuntimeMetricsAttempt();
+	let signal!: AbortSignal;
+	let finish!: () => void;
+	owner.offer(s => { signal = s; return new Promise<void>(resolve => { finish = resolve; }); });
+	await tick();
+	assert.equal(owner.dispose(), undefined);
+	assert.equal(signal.aborted, true);
+	const replacement = new delivery.RuntimeMetricsAttempt();
+	assert.equal(replacement.offer(async () => {}), false);
+	finish(); await tick();
+	assert.equal(replacement.offer(async () => {}), true);
+	await tick(); replacement.dispose();
+});

--- a/tests/runtime-metrics-extension.test.ts
+++ b/tests/runtime-metrics-extension.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import runtimeMetrics from "../extensions/runtime-metrics.ts";
+import type { RuntimeMetricBucket } from "../lib/runtime-metrics.ts";
+import { CHILD_METRICS_EVENT, childEvent } from "../lib/runtime-metrics-children.ts";
+import { normalizeRpcEvent, TASK_EVENT } from "../lib/agents-protocol.ts";
+
+const tick = () => new Promise<void>(resolve => setImmediate(resolve));
+function harness(env: NodeJS.ProcessEnv = {}) {
+	const handlers = new Map<string, Function>();
+	const listeners = new Map<string, Function>();
+	let session = "first";
+	let finish!: () => void;
+	let signal!: AbortSignal;
+	const sent: RuntimeMetricBucket[][] = [];
+	const launches: unknown[] = [];
+	const ctx: any = { cwd: "/fixture", model: { provider: "openai", id: "gpt-4o" },
+		sessionManager: { getSessionId: () => session, getEntries: () => assert.fail("no reconstruction") } };
+	const pi: any = { on: (name: string, handler: Function) => handlers.set(name, handler),
+		getThinkingLevel: () => "high", registerCommand() {},
+		appendEntry: () => assert.fail("no metrics persistence"),
+		events: { on: (name: string, handler: Function) => { listeners.set(name, handler); return () => listeners.delete(name); } } };
+	runtimeMetrics(pi, env, { now: () => 0, send: (rows, _cwd, deps) => {
+		sent.push(structuredClone(rows)); launches.push(structuredClone(deps?.launches)); signal = deps!.signal!;
+		return new Promise(resolve => { finish = () => resolve("discarded"); });
+	} });
+	return { sent, launches, ctx, handlers,
+		emit: (name: string, event: any = {}) => handlers.get(name)?.(event, ctx),
+		bus: (event: unknown) => listeners.get(CHILD_METRICS_EVENT)?.(event),
+		replace: () => { session = "second"; }, signal: () => signal,
+		finish: async () => { finish(); await tick(); },
+	};
+}
+const final = (input = 7) => ({ role: "assistant", provider: "openai", model: "gpt-4o", responseModel: "gpt-4o",
+	providerThinkingLevel: "low", stopReason: "stop", usage: { input, output: 3, cacheRead: 0 },
+	content: [{ text: "private response" }], errorMessage: "private error", path: "/private" });
+
+test("final callback returns before blocked transport; busy and duplicate messages drop", async () => {
+	const h = harness(); await h.emit("session_start");
+	h.emit("turn_start"); h.emit("before_provider_request");
+	const message = final();
+	assert.equal(h.emit("message_end", { message }), undefined);
+	assert.equal(h.sent.length, 0);
+	h.emit("message_end", { message });
+	h.emit("message_end", { message: final(99) });
+	await tick(); assert.equal(h.sent.length, 1);
+	assert.equal(h.sent[0][0].tokens.input.sum, 7);
+	assert.equal(h.sent[0][0].effort, "high");
+	assert.equal(h.sent[0][0].providerThinkingLevel, "low");
+	assert.ok(!JSON.stringify(h.sent).includes("private"));
+	await h.finish(); await tick();
+	assert.equal(h.sent.length, 1, "no replay after failure");
+	h.emit("message_end", { message: final(2) }); await tick();
+	assert.equal(h.sent[1][0].tokens.input.sum, 2, "event usage, never cumulative totals");
+	assert.equal(h.sent[1][0].responses, 1);
+	await h.finish(); h.emit("session_shutdown");
+});
+
+test("replacement before launch cancels stale work; shutdown does not await a blocked child", async () => {
+	const h = harness(); await h.emit("session_start");
+	h.emit("message_end", { message: final() });
+	h.replace(); await h.emit("session_start"); await tick();
+	assert.equal(h.sent.length, 0);
+	h.emit("message_end", { message: final() }); await tick();
+	assert.equal(h.emit("session_shutdown"), undefined);
+	assert.equal(h.signal().aborted, true);
+	await h.finish();
+});
+
+for (const env of [{ DO_NOT_TRACK: "1" }, { GENTLE_AI_TELEMETRY: "0" }, { CI: "true" }, { GENTLE_PI_AGENTS_CHILD: "1" }]) {
+	test(`opt-out suppresses hooks and launches: ${Object.keys(env)[0]}`, async () => {
+		const h = harness(env); await h.emit("session_start");
+		h.emit("message_end", { message: final() }); await tick();
+		assert.equal(h.handlers.size, 0); assert.equal(h.sent.length, 0);
+	});
+}
+
+test("environment veto between callback and launch discards accepted event", async () => {
+	const env: NodeJS.ProcessEnv = {};
+	const h = harness(env); await h.emit("session_start");
+	h.emit("message_end", { message: final() }); env.DO_NOT_TRACK = "1";
+	await tick(); assert.equal(h.sent.length, 0); h.emit("session_shutdown");
+});
+
+test("tool and partial assistant messages are not consumed as primary usage", async () => {
+	const h = harness(); await h.emit("session_start");
+	for (const message of [{ ...final(), role: "toolResult" }, { ...final(), stopReason: "pending" }, { ...final(), stopReason: "deferred" }]) h.emit("message_end", { message });
+	await tick(); assert.equal(h.sent.length, 0); h.emit("session_shutdown");
+});
+
+test("child completion consumed once, busy children drop, and primary usage stays separate", async () => {
+	const h = harness(); await h.emit("session_start");
+	const observation = normalizeRpcEvent({ type: "message_end", message: final() }, { observeResponses: true })
+		.find(event => event.type === TASK_EVENT.RESPONSE_OBSERVATION);
+	assert.ok(observation?.type === TASK_EVENT.RESPONSE_OBSERVATION);
+	const event = (taskId: string) => childEvent("first", taskId,
+		{ agentClass: "verify", selectedProvider: "openai", selectedModelId: "gpt-4o", selectedEffort: "high" }, "completed",
+		{ coverage: "final_assistant_messages_only", agentSettled: true, droppedResponses: 0, responses: [observation.observation] }, 0)!;
+	h.bus(event("one")); h.bus(event("one")); h.bus(event("busy"));
+	await tick(); assert.equal(h.sent.length, 1);
+	assert.equal(h.sent[0][0].agentClass, "verify");
+	assert.deepEqual(h.launches[0], [{ evidence: "launch_configuration", agentClass: "verify", selectedProvider: "openai",
+		selectedModelId: "gpt-4o", selectedEffort: "high", launches: 1 }]);
+	assert.equal(h.sent[0][0].effort, "unavailable", "launch effort is not per-response selection proof");
+	assert.equal(h.sent[0][0].providerThinkingLevel, "low");
+	await h.finish(); h.bus(event("busy")); await tick();
+	assert.equal(h.sent.length, 1, "busy completion stays consumed");
+	h.emit("message_end", { message: final(2) }); await tick();
+	assert.equal(h.sent[1][0].agentClass, "orchestrator");
+	assert.equal(h.sent[1][0].tokens.input.sum, 2);
+	await h.finish(); h.emit("session_shutdown");
+});

--- a/tests/runtime-metrics-native.test.ts
+++ b/tests/runtime-metrics-native.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { test } from "node:test";
+import { readFileSync, realpathSync } from "node:fs";
+import { setGentleAiDevBinaryEnvironmentForTesting } from "../lib/gentle-ai-binary.ts";
+import * as native from "../lib/runtime-metrics-native.ts";
+import type { RuntimeMetricBucket } from "../lib/runtime-metrics.ts";
+import { createHash } from "node:crypto";
+import schema from "../contracts/telemetry/runtime-aggregate-v1.schema.json" with { type: "json" };
+import fixturePayloads from "./fixtures/runtime-metrics-native-batches.json" with { type: "json" };
+
+function source(): RuntimeMetricBucket {
+	const token = () => ({ reported: 1, unavailable: 0, unsupported: 0, sum: 7 });
+	const duration = () => ({ measured: 0, unavailable: 1, unsupported: 0, sum: 0 });
+	return { hostAgent: "pi", agentClass: "worker", executor: "worker", provider: "openai", modelFamily: "gpt",
+		selectedProvider: "openai", selectedModelId: "gpt-5.4", observedModelId: "private-alias", responseModelId: "gpt-5.4",
+		effort: "high", providerThinkingLevel: "low", error: "none", responses: 1,
+		tokens: { input: token(), output: token(), cacheRead: token(), cacheWrite: token(), reasoning: token(), totalTokens: token() },
+		responseHeadersMs: duration(), fullResponseMs: duration() };
+}
+
+test("production encoder emits exact one-shot fixture with source occurrence coverage", () => {
+	const payload = native.encodeNativeRuntimeEvent([source()]);
+	assert.equal(typeof payload, "string", "production encoder must be enabled");
+	const value = JSON.parse(payload!);
+	assert.deepEqual(Object.keys(value).sort(), [...schema.required].sort());
+	assert.deepEqual(Object.keys(value.rows[0]).sort(), [...schema.$defs.row.required].sort());
+	assert.equal(value.rows[0].launches, null);
+	assert.equal(value.rows[0].responses, 1);
+	assert.equal(value.rows[0].selected_effort, "high");
+	assert.equal(value.rows[0].effective_effort, "low");
+	assert.equal(value.rows[0].model_evidence, "response");
+	assert.deepEqual(value.rows[0].model, { provider: "openai", id: "gpt-5.4" });
+	assert.ok(!payload!.includes("private"));
+	assert.ok(!payload!.includes("batch_id") && !payload!.includes("delivery_id"));
+	assert.deepEqual(fixturePayloads.batches, [payload]);
+	assert.equal(fixturePayloads.schema_sha256, createHash("sha256").update(readFileSync(new URL("../contracts/telemetry/runtime-aggregate-v1.schema.json", import.meta.url))).digest("hex"));
+});
+
+test("child launch occurrence retains selection evidence separately from response evidence", () => {
+	const payload = native.encodeNativeRuntimeEvent([source()], [{ evidence: "launch_configuration", agentClass: "worker",
+		selectedProvider: "openai", selectedModelId: "gpt-5.4", selectedEffort: "high", launches: 1 }]);
+	const rows = JSON.parse(payload!).rows;
+	assert.equal(rows.length, 2);
+	assert.equal(rows[0].model_evidence, "response");
+	assert.equal(rows[1].model_evidence, "selected");
+	assert.equal(rows[1].launches, 1);
+	assert.equal(rows[1].responses, null);
+	assert.equal(rows[1].selected_effort, "high");
+	assert.equal(rows[1].effective_effort, "unavailable");
+	for (const field of ["input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens", "reasoning_tokens", "total_tokens"])
+		assert.deepEqual(rows[1][field], { reported: 0, unavailable: 0, unsupported: 0, sum: 0 });
+});
+
+test("encoder bounds and invalid coverage discard whole events without splitting", () => {
+	assert.equal(native.encodeNativeRuntimeEvent([]), undefined);
+	assert.equal(native.encodeNativeRuntimeEvent(Array(33).fill(source())), undefined);
+	const invalid = source(); invalid.tokens.input.reported = 0;
+	assert.equal(native.encodeNativeRuntimeEvent([invalid]), undefined);
+	invalid.tokens.input.sum = -1;
+	assert.equal(native.encodeNativeRuntimeEvent([invalid]), undefined);
+	const valid = source();
+	assert.equal(typeof native.encodeNativeRuntimeEvent([valid]), "string");
+	assert.equal(native.encodeNativeRuntimeEvent(Array(32).fill(valid)), undefined, "16 KiB bound applies even below row limit");
+	valid.fullResponseMs = { measured: 1, unavailable: 0, unsupported: 0, sum: 12.5 };
+	assert.deepEqual(JSON.parse(native.encodeNativeRuntimeEvent([valid])!).rows[0].duration,
+		{ kind: "request", measured_count: 1, sum_ms: 12.5 });
+	valid.tokens.input = { reported: 0, unavailable: 0, unsupported: 1, sum: 0 };
+	assert.deepEqual(JSON.parse(native.encodeNativeRuntimeEvent([valid])!).rows[0].input_tokens, valid.tokens.input);
+});
+
+test("encoder filters custom identities and never promotes SDK model to response proof", () => {
+	const row = source(); row.provider = "custom"; row.responseModelId = "private-model";
+	row.agentClass = "private-agent" as any; row.effort = "private-effort" as any;
+	row.error = "authentication";
+	const encoded = JSON.parse(native.encodeNativeRuntimeEvent([row])!);
+	assert.deepEqual(encoded.rows[0].model, { provider: "custom", id: "custom" });
+	assert.equal(encoded.rows[0].agent_class, "unknown");
+	assert.equal(encoded.rows[0].selected_effort, "unavailable");
+	assert.equal(encoded.rows[0].error_category, "auth");
+	assert.ok(!JSON.stringify(encoded).includes("private"));
+	row.responseModelId = "unknown";
+	const selected = JSON.parse(native.encodeNativeRuntimeEvent([row])!);
+	assert.equal(selected.rows[0].model_evidence, "selected");
+	assert.deepEqual(selected.rows[0].model, { provider: "openai", id: "gpt-5.4" });
+	row.selectedModelId = "unknown";
+	const unknown = JSON.parse(native.encodeNativeRuntimeEvent([row])!);
+	assert.equal(unknown.rows[0].model_evidence, "unknown");
+});
+
+function fixture() {
+	const child = Object.assign(new EventEmitter(), {
+		stdin: new PassThrough(), stdout: new PassThrough(), stderr: new PassThrough(),
+		kill: () => { killed++; return true; }, unref() {},
+	});
+	let killed = 0;
+	const calls: unknown[][] = [];
+	let input = "";
+	child.stdin.on("data", chunk => { input += chunk; });
+	const deps = {
+		env: {}, resolve: () => "fake-native",
+		encode: () => '{"host":"pi","rows":[]}',
+		spawn: (...args: unknown[]) => { calls.push(args); return child as any; },
+	};
+	return { deps, child, calls, input: () => input, killed: () => killed,
+		close: (decision = "stored") => {
+			child.stdout.write(JSON.stringify({ schema: native.NATIVE_SEND_ACK_SCHEMA, decision }));
+			child.emit("close", 0, null);
+		} };
+}
+
+test("one native stdin send; busy drops without another invocation or policy probe", async () => {
+	const f = fixture();
+	const first = native.sendNativeRuntimeEvent([], "/fixture", f.deps);
+	assert.equal(f.calls.length, 1);
+	assert.deepEqual(f.calls[0][1], ["telemetry", "runtime", "send", "--json"]);
+	assert.equal(f.input(), '{"host":"pi","rows":[]}');
+	assert.equal(await native.sendNativeRuntimeEvent([], "/fixture", f.deps), "discarded");
+	f.close();
+	assert.equal(await first, "stored");
+	assert.equal(f.calls.length, 1);
+});
+
+test("production encoder reaches the fake one-shot child without a test encoding override", async () => {
+	const f = fixture();
+	const { encode: _encode, ...deps } = f.deps;
+	const first = native.sendNativeRuntimeEvent([source()], "/fixture", deps);
+	assert.equal(f.calls.length, 1);
+	assert.equal(f.input(), fixturePayloads.batches[0]);
+	f.close(); assert.equal(await first, "stored");
+});
+
+test("validated dev override reaches the one-shot child through the production resolver", async () => {
+	const file = realpathSync(process.execPath);
+	setGentleAiDevBinaryEnvironmentForTesting({ env: { GENTLE_PI_GENTLE_AI_DEV_BINARY: file }, home: "/unused" });
+	try {
+		const f = fixture();
+		const { resolve: _resolve, encode: _encode, ...deps } = f.deps;
+		const pending = native.sendNativeRuntimeEvent([source()], "/fixture", deps);
+		f.close();
+		assert.equal(await pending, "stored");
+		assert.equal(f.calls.length, 1);
+		assert.equal(f.calls[0][0], file);
+		assert.deepEqual(f.calls[0][1], ["telemetry", "runtime", "send", "--json"]);
+		assert.equal(f.input(), fixturePayloads.batches[0]);
+	} finally {
+		setGentleAiDevBinaryEnvironmentForTesting(undefined);
+	}
+});
+
+test("invalid dev overrides fail closed without spawning or falling back", async () => {
+	for (const file of ["relative-binary", realpathSync(new URL(".", import.meta.url))]) {
+		setGentleAiDevBinaryEnvironmentForTesting({ env: { GENTLE_PI_GENTLE_AI_DEV_BINARY: file }, home: "/unused" });
+		try {
+			const f = fixture();
+			const { resolve: _resolve, ...deps } = f.deps;
+			assert.equal(await native.sendNativeRuntimeEvent([], "/fixture", deps), "discarded");
+			assert.equal(f.calls.length, 0);
+		} finally {
+			setGentleAiDevBinaryEnvironmentForTesting(undefined);
+		}
+	}
+});
+
+test("opt-out and pre-cancel cause zero encoding, resolution or launch", async () => {
+	const f = fixture();
+	f.deps.resolve = () => { throw new Error("must not resolve"); };
+	f.deps.encode = () => { throw new Error("must not encode"); };
+	assert.equal(await native.sendNativeRuntimeEvent([], "/fixture", { ...f.deps, env: { DO_NOT_TRACK: "1" } }), "disabled");
+	assert.equal(await native.sendNativeRuntimeEvent([], "/fixture", { ...f.deps, signal: AbortSignal.abort() }), "discarded");
+	assert.equal(f.calls.length, 0);
+});
+
+test("cancel kills once and keeps slot occupied until actual close", async () => {
+	const f = fixture();
+	const abort = new AbortController();
+	const first = native.sendNativeRuntimeEvent([], "/fixture", { ...f.deps, signal: abort.signal });
+	abort.abort(); abort.abort();
+	assert.equal(f.killed(), 1);
+	assert.equal(await native.sendNativeRuntimeEvent([], "/fixture", f.deps), "discarded");
+	f.close();
+	assert.equal(await first, "discarded");
+});
+
+for (const decision of ["discarded", "disabled", "stored", "duplicate", "sent", "private error"]) {
+	test(`native result ${decision} never triggers retry`, async () => {
+		const f = fixture();
+		const first = native.sendNativeRuntimeEvent([], "/fixture", f.deps);
+		f.close(decision);
+		assert.equal(await first, ["stored", "duplicate", "disabled"].includes(decision) ? decision : "discarded");
+		assert.equal(f.calls.length, 1);
+	});
+}
+
+test("metrics receiver, attempt gate and send transport have no filesystem persistence surface", () => {
+	for (const path of ["../extensions/runtime-metrics.ts", "../lib/runtime-metrics-delivery.ts", "../lib/runtime-metrics-native.ts"]) {
+		const source = readFileSync(new URL(path, import.meta.url), "utf8");
+		assert.doesNotMatch(source, /node:fs|appendEntry\s*\(|writeFile|mkdir|createWriteStream/);
+	}
+});
+
+test("spawn failure silently discards", async () => {
+	const f = fixture();
+	let calls = 0;
+	assert.equal(await native.sendNativeRuntimeEvent([], "/fixture", { ...f.deps,
+		spawn: () => { calls++; throw new Error("private error"); } }), "discarded");
+	assert.equal(calls, 1);
+});

--- a/tests/runtime-metrics-pi-identity.test.ts
+++ b/tests/runtime-metrics-pi-identity.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findPackageJSON } from "node:module";
+import { OPENAI_CODEX_MODELS } from "@earendil-works/pi-ai/providers/openai-codex.models";
+import { classifyPiCatalogName, lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
+import { RuntimeMetrics, type FinalResponse } from "../lib/runtime-metrics.ts";
+
+const model = Object.values(OPENAI_CODEX_MODELS)[0];
+const name = { provider: model.provider, modelId: model.id };
+
+test("uninitialized synchronous classification fails closed", () => {
+	assert.deepEqual(classifyPiCatalogName(name), { classification: "unknown", modelId: "unknown" });
+});
+
+test("missing catalog name remains unknown; no route evidence is invented", async () => {
+	for (const input of [undefined, null, {}, { provider: model.provider }, { modelId: model.id }]) {
+		assert.deepEqual(await lookupPiCatalogName(input), { classification: "unknown", modelId: "unknown" });
+	}
+});
+
+test("custom aliases never export supplied strings", async () => {
+	for (const input of [{ ...name, modelId: "private-alias" }, { ...name, provider: "private-provider" }]) {
+		const result = await lookupPiCatalogName(input);
+		assert.deepEqual(result, { classification: "custom", modelId: "custom" });
+		assert.ok(Object.isFrozen(result));
+	}
+});
+
+test("caller-created public identities cannot bypass the catalog boundary", async () => {
+	for (const input of [{ modelId: "private-model", classification: "catalog_public" },
+		{ ...name, modelId: "private-model", origin: "builtin" }]) {
+		assert.notEqual((await lookupPiCatalogName(input)).classification, "catalog_public");
+	}
+});
+
+test("malformed or oversized name metadata fails closed", async () => {
+	for (const patch of [{ modelId: "" }, { modelId: "x".repeat(129) }, { provider: 12 },
+		{ modelId: null }, { provider: "x".repeat(33) }]) {
+		assert.deepEqual(await lookupPiCatalogName({ ...name, ...patch }), { classification: "unknown", modelId: "unknown" });
+	}
+});
+
+test("actual installed ESM catalog supplies immutable public names, not route claims", async () => {
+	const pi = import.meta.resolve("@earendil-works/pi-coding-agent");
+	assert.equal(findPackageJSON("@earendil-works/pi-ai", import.meta.url), findPackageJSON("@earendil-works/pi-ai", pi));
+	assert.ok(model);
+	const result = await lookupPiCatalogName(name);
+	assert.deepEqual(result, { classification: "catalog_public", modelId: model.id });
+	assert.ok(Object.isFrozen(result));
+	assert.strictEqual(await lookupPiCatalogName(name), result);
+	// Origin/endpoint assertions do not change privacy classification of a name.
+	// Neither a real catalog entry nor matching route strings establish dispatch.
+	for (const patch of [{ origin: "builtin" }, { origin: "unknown" }, { origin: "custom" },
+		{ baseUrl: "https://private.invalid" }, { api: "custom-api" }]) {
+		assert.strictEqual(await lookupPiCatalogName({ ...name, ...patch }), result);
+	}
+	assert.deepEqual(Object.keys(result), ["classification", "modelId"]);
+	assert.ok(!("modelVersion" in result));
+});
+
+test("catalog-public selections are counted without claiming actual route identity", async () => {
+	const catalogName = await lookupPiCatalogName(name);
+	const metrics = new RuntimeMetrics();
+	const missing = { state: "unavailable" } as const;
+	for (const [index, identity] of [catalogName, { ...name, origin: "builtin", api: model.api, baseUrl: model.baseUrl }].entries()) {
+		const record = {
+			kind: "final_assistant_response", responseId: String(index), identity, selectedModelId: model.id,
+			executor: "worker", provider: model.provider, modelFamily: "gpt", effort: "high", error: "none",
+			tokens: { input: missing, output: missing, cacheRead: missing, cacheWrite: missing },
+			responseHeadersMs: missing, fullResponseMs: missing,
+		};
+		assert.equal(metrics.record(record as FinalResponse), "recorded");
+	}
+	const [bucket] = metrics.snapshot();
+	assert.equal(bucket.selectedModelId, model.id);
+	assert.ok(!("modelId" in bucket));
+	assert.ok(!("route" in bucket));
+	assert.equal(bucket.responses, 2);
+	assert.equal(bucket.hostAgent, "pi");
+});
+
+test("selection classification rejects fabricated public labels and private IDs", async () => {
+	await lookupPiCatalogName(name);
+	assert.equal(classifyPiCatalogName({ ...name, modelId: "private-id", classification: "catalog_public" }).modelId, "custom");
+	assert.equal(classifyPiCatalogName({ ...name, provider: "anthropic" }).modelId, "custom");
+});

--- a/tests/runtime-metrics-policy.test.ts
+++ b/tests/runtime-metrics-policy.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readRuntimeMetricsPolicy, runtimeMetricsEnvAllows } from "../lib/runtime-metrics-policy.ts";
+
+const grant = { schema: "gentle-ai.telemetry-policy/v1", operation: "policy", enabled: true, source: "state", reason: "enabled" };
+const result = (value: unknown) => ({ stdout: JSON.stringify(value), stderr: "", exitCode: 0,
+	signal: null, timedOut: false, outputLimitExceeded: false });
+
+test("only strict enabled policy grants; uses bounded policy invocation exclusively", async () => {
+	let calls = 0;
+	assert.equal(await readRuntimeMetricsPolicy("/workspace", {
+		resolve: () => "/fixture/gentle-ai", exec: async request => {
+			calls++;
+			assert.deepEqual(request.arguments, ["telemetry", "policy", "--json"]);
+			assert.equal(request.file, "/fixture/gentle-ai");
+			assert.equal(request.cwd, "/workspace");
+			assert.equal(request.timeoutMs, 1000);
+			assert.equal(request.maxBufferBytes, 2048);
+			return result(grant);
+		},
+	}), true);
+	assert.equal(calls, 1);
+	for (const patch of [{ schema: "wrong" }, { operation: "status" }, { enabled: "true" },
+		{ enabled: false, reason: "disabled" }, { reason: "enrollment_pending" }, { reason: "state_unavailable" },
+		{ source: "private" }, { raw: "private" }, { reason: undefined }]) {
+		assert.equal(await readRuntimeMetricsPolicy("/workspace", {
+			resolve: () => "fixture", exec: async () => result({ ...grant, ...patch }),
+		}), false);
+	}
+});
+
+test("missing, old, timed-out and malformed binary responses fail closed without fallback", async () => {
+	for (const patch of [{ exitCode: 1 }, { timedOut: true }, { outputLimitExceeded: true },
+		{ signal: "SIGTERM" }, { stderr: "private error" }, { stdout: "unsupported command" },
+		{ stdout: "x".repeat(2049) }, { stdout: "null" }, { stdout: "[]" }]) {
+		let calls = 0;
+		assert.equal(await readRuntimeMetricsPolicy("/workspace", { resolve: () => "fixture",
+			exec: async () => { calls++; return { ...result(grant), ...patch } as any; } }), false);
+		assert.equal(calls, 1);
+	}
+	assert.equal(await readRuntimeMetricsPolicy("/workspace", {
+		resolve: () => { throw new Error("missing"); }, exec: async () => assert.fail("must not spawn"),
+	}), false);
+	assert.equal(await readRuntimeMetricsPolicy("/workspace", {
+		resolve: () => "fixture", exec: async () => { throw new Error("ENOENT"); },
+	}), false);
+});
+
+test("outer deadline releases callers even when an exec adapter never settles", async () => {
+	let signal: AbortSignal | undefined;
+	assert.equal(await readRuntimeMetricsPolicy("/workspace", { resolve: () => "fixture",
+		exec: request => { signal = request.signal; return new Promise(() => {}); } }), false);
+	assert.equal(signal?.aborted, true);
+});
+
+test("native-compatible environment veto accepts broad truthy spellings", () => {
+	for (const key of ["DO_NOT_TRACK", "CI", "GITHUB_ACTIONS"]) {
+		for (const value of ["1", "true", "TRUE", " yes ", "on", "t", "unknown"]) assert.equal(runtimeMetricsEnvAllows({ [key]: value }), false);
+	}
+	assert.equal(runtimeMetricsEnvAllows({ GENTLE_AI_TELEMETRY: "0" }), false);
+	assert.equal(runtimeMetricsEnvAllows({ DO_NOT_TRACK: "false", CI: "0" }), true);
+});

--- a/tests/runtime-metrics.test.ts
+++ b/tests/runtime-metrics.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { RuntimeMetrics, type FinalResponse } from "../lib/runtime-metrics.ts";
+
+function response(responseId = "local-response"): FinalResponse {
+	return {
+		kind: "final_assistant_response", responseId,
+		executor: "worker", provider: "openai-codex", modelFamily: "gpt",
+		effort: "high", error: "none",
+		tokens: {
+			input: { state: "reported", value: 0 }, output: { state: "reported", value: 12 },
+			cacheRead: { state: "unavailable" }, cacheWrite: { state: "unsupported" },
+		},
+		responseHeadersMs: { state: "measured", value: 25.5 },
+		fullResponseMs: { state: "measured", value: 100 },
+	};
+}
+
+test("selected provider is independent from response provider without relabeling", async () => {
+	const { lookupPiCatalogName } = await import("../lib/runtime-metrics-pi-identity.ts");
+	const { OPENAI_CODEX_MODELS } = await import("@earendil-works/pi-ai/providers/openai-codex.models");
+	const model = Object.values(OPENAI_CODEX_MODELS)[0];
+	await lookupPiCatalogName({ provider: model.provider, modelId: model.id });
+	const metrics = new RuntimeMetrics();
+	assert.equal(recordRaw(metrics, { ...response(), selectedProvider: model.provider,
+		selectedModelId: model.id, provider: "anthropic" }), "recorded");
+	const [row] = metrics.snapshot();
+	assert.equal(row.selectedModelId, model.id);
+	assert.equal(row.selectedProvider, model.provider);
+	assert.equal(row.provider, "anthropic");
+	assert.equal(recordRaw(metrics, { ...response("private"), selectedProvider: "private-provider",
+		selectedModelId: model.id }), "recorded");
+	assert.equal(metrics.snapshot()[1].selectedProvider, "custom");
+	assert.equal(metrics.snapshot()[1].selectedModelId, "custom");
+});
+
+// Deliberately bypass static types to exercise the runtime boundary.
+function recordRaw(metrics: RuntimeMetrics, value: unknown) {
+	return metrics.record(value as FinalResponse);
+}
+
+test("optional native token fields preserve absence but reject explicit malformed values", () => {
+	for (const value of [null, -1, { state: "reported", value: NaN }, { state: "reported", value: 1_000_000_001 }]) {
+		assert.equal(recordRaw(new RuntimeMetrics(), { ...response(), tokens: { ...response().tokens, reasoning: value } }), "invalid");
+	}
+	const metrics = new RuntimeMetrics();
+	assert.equal(metrics.record(response()), "recorded");
+	assert.equal(metrics.snapshot()[0].tokens.reasoning.unavailable, 1);
+});
+
+test("accounts final responses with explicit zero, missing states and separate durations", () => {
+	const metrics = new RuntimeMetrics();
+	assert.equal(metrics.record(response()), "recorded");
+	assert.equal(metrics.record(response("second")), "recorded");
+	const [row] = metrics.snapshot();
+	assert.equal(row.responses, 2);
+	assert.deepEqual(row.tokens.input, { reported: 2, unavailable: 0, unsupported: 0, sum: 0 });
+	assert.equal(row.tokens.output.sum, 24);
+	assert.equal(row.tokens.cacheRead.unavailable, 2);
+	assert.equal(row.tokens.cacheWrite.unsupported, 2);
+	assert.equal(row.responseHeadersMs.sum, 51);
+	assert.equal(row.fullResponseMs.sum, 200);
+	assert.equal(row.executor, "worker");
+});
+
+test("deduplicates distinct local IDs without retaining them in snapshots", () => {
+	const metrics = new RuntimeMetrics();
+	assert.equal(metrics.record(response()), "recorded");
+	assert.equal(metrics.record({ ...response(), effort: "low" }), "duplicate");
+	assert.equal(metrics.record(response("second")), "recorded");
+	assert.equal(metrics.snapshot()[0].responses, 2);
+	assert.ok(!JSON.stringify(metrics.snapshot()).includes("local-response"));
+	const copy = metrics.snapshot();
+	copy[0].tokens.output.sum = 999;
+	assert.equal(metrics.snapshot()[0].tokens.output.sum, 24);
+});
+
+test("effort selections and absence states remain distinct", () => {
+	const metrics = new RuntimeMetrics();
+	const levels = ["off", "minimal", "low", "medium", "high", "xhigh", "max",
+		"not_selected", "unsupported", "unavailable"] as const;
+	for (const effort of levels) assert.equal(metrics.record({ ...response(effort), effort }), "recorded");
+	assert.deepEqual(metrics.snapshot().map(row => row.effort), levels);
+	assert.equal(recordRaw(metrics, { ...response("bad"), effort: "ultra" }), "invalid");
+});
+
+test("only closed dimensions survive; no prompt-based executor inference", () => {
+	const metrics = new RuntimeMetrics();
+	assert.equal(recordRaw(metrics, {
+		...response(), provider: "private-provider", modelFamily: "private-model-id",
+		executor: "SDD apply executor", systemPrompt: "reviewer", errorMessage: "private failure",
+	}), "recorded");
+	const [row] = metrics.snapshot();
+	assert.equal(row.provider, "custom");
+	assert.equal(row.modelFamily, "custom");
+	assert.equal(row.executor, "unknown");
+	assert.ok(!JSON.stringify(row).includes("private"));
+	assert.equal(recordRaw(metrics, { ...response("missing"), provider: undefined, modelFamily: null }), "recorded");
+	assert.equal(metrics.snapshot()[1].provider, "unknown");
+	assert.equal(metrics.snapshot()[1].modelFamily, "unknown");
+});
+
+test("rejects malformed numbers and ambiguous measurement states atomically", () => {
+	const metrics = new RuntimeMetrics();
+	for (const value of [-1, NaN, Infinity, "12", null, 1e20]) {
+		const base = response();
+		assert.equal(recordRaw(metrics, { ...base, tokens: { ...base.tokens, input: { state: "reported", value } } }), "invalid");
+		assert.equal(recordRaw(metrics, { ...base, fullResponseMs: { state: "measured", value } }), "invalid");
+	}
+	for (const measurement of [{ value: 0 }, { state: "reported" }, { state: "unsupported", value: 0 }]) {
+		const base = response();
+		assert.equal(recordRaw(metrics, { ...base, tokens: { ...base.tokens, input: measurement } }), "invalid");
+	}
+	assert.equal(recordRaw(metrics, { ...response(), tokens: { ...response().tokens, output: { state: "reported", value: 1.5 } } }), "invalid");
+	assert.equal(recordRaw(metrics, { ...response(), fullResponseMs: { state: "reported", value: 10 } }), "invalid");
+	assert.equal(recordRaw(metrics, { ...response(), fullResponseMs: { state: "measured", value: 10 } }), "invalid");
+	assert.deepEqual(metrics.snapshot(), []);
+	assert.equal(metrics.record(response()), "recorded", "invalid inputs do not reserve IDs");
+});
+
+test("rejects streaming, malformed records, identifiers and free-text errors", () => {
+	const metrics = new RuntimeMetrics();
+	for (const value of [null, {}, [], { ...response(), kind: "message_update" },
+		{ ...response(), responseId: "" }, { ...response(), responseId: "x".repeat(129) },
+		{ ...response(), error: "raw error text" }, { ...response(), tokens: null }]) {
+		assert.equal(recordRaw(metrics, value), "invalid");
+	}
+	for (const error of ["none", "aborted", "rate_limit", "authentication", "network", "provider", "unknown"] as const) {
+		assert.equal(metrics.record({ ...response(error), error, responseHeadersMs: { state: "unsupported" }, fullResponseMs: { state: "unavailable" } }), "recorded");
+	}
+	assert.equal(metrics.snapshot().length, 7);
+});
+
+test("host identity stays separate from role and rejects invented model dimensions", () => {
+	const metrics = new RuntimeMetrics();
+	assert.equal(recordRaw(metrics, { ...response("custom"), identity: { origin: "custom" } }), "recorded");
+	assert.equal(recordRaw(metrics, { ...response("forged"), identity: { hostAgent: "private-worker", modelId: "secret-model" } }), "recorded");
+	const rows = metrics.snapshot();
+	assert.deepEqual(rows.map(row => [row.hostAgent, row.executor, row.selectedModelId, row.effort]), [
+		["pi", "worker", "unknown", "high"],
+	]);
+	assert.ok(!JSON.stringify(rows).includes("secret-model"));
+});
+
+test("hard response and numeric ceilings keep aggregate totals bounded", () => {
+	const metrics = new RuntimeMetrics();
+	for (let i = 0; i < 1024; i++) {
+		const record = response(String(i));
+		record.tokens.input = { state: "reported", value: 1_000_000_000 };
+		record.responseHeadersMs = { state: "measured", value: 0 };
+		record.fullResponseMs = { state: "measured", value: 86_400_000 };
+		assert.equal(metrics.record(record), "recorded");
+	}
+	assert.equal(metrics.record(response("overflow")), "capacity");
+	const [row] = metrics.snapshot();
+	assert.equal(row.responses, 1024);
+	assert.equal(row.tokens.input.sum, 1_024_000_000_000);
+	assert.equal(row.fullResponseMs.sum, 88_473_600_000);
+	assert.equal(row.responseHeadersMs.measured, 1024);
+	assert.equal(row.responseHeadersMs.sum, 0);
+});
+
+test("capacity rejection keeps dedupe and accounting intact without eviction", () => {
+	const metrics = new RuntimeMetrics({ maxResponses: 2, maxBuckets: 1 });
+	assert.equal(metrics.record(response("one")), "recorded");
+	assert.equal(metrics.record({ ...response("two"), effort: "low" }), "capacity");
+	assert.equal(metrics.record(response("two")), "recorded");
+	assert.equal(metrics.record(response("three")), "capacity");
+	assert.equal(metrics.record(response("one")), "duplicate");
+	assert.equal(metrics.snapshot()[0].responses, 2);
+	for (const maxResponses of [0, -1, 1.5, Infinity, 1025]) {
+		assert.throws(() => new RuntimeMetrics({ maxResponses }), RangeError);
+	}
+	assert.throws(() => new RuntimeMetrics({ maxBuckets: 65 }), RangeError);
+});


### PR DESCRIPTION
## Linked issue

Closes #849

## PR type

- [x] `type:feature`

## Summary

Adds the mirrored contract, event-local extension, bounded aggregation, policy guard, native child delivery and tests.

## Test plan

- 2,014 tests passed with 18 skipped.\n- Runtime module, contract, package and dry-pack checks passed.\n- CI is the final merge gate.

## Contributor checklist

- [x] Linked issue has `status:approved`
- [x] Commit uses Conventional Commits
- [x] No `Co-Authored-By` trailer
- [ ] `size:exception` required where the behavior/test boundary exceeds 400 lines

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Pi runtime telemetry observations |
| Tracker PR | #851 |
| Position | 1 of 3 |
| Base | `feat/telemetry-runtime-metrics-tracker` |
| Depends on | #851 |
| Follow-up | runner child |
| Review budget | 1816 / 400; implementation and tests remain atomic |
| Starts at | feat/telemetry-runtime-metrics-tracker |
| Ends with | Adds the mirrored contract, event-local extension, bounded aggregation, policy guard, native child delivery and tests. |

### Chain Overview

```text
main
 └── #851 tracker
      └── 1
```

### Scope
- Includes: Adds the mirrored contract, event-local extension, bounded aggregation, policy guard, native child delivery and tests.
- Excludes: later child work units.
