### PR TITLE
feat(agents): emit anonymous subagent metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,19 +855,19 @@ Memory contract for SDD delegation:
 
 ## Telemetry
 
-`gentle-pi` does not collect anything itself. [gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) owns anonymous usage telemetry end to end — install and heartbeat events, what fields are sent, rate limiting, and every opt-out. See its README/docs for the exact contract.
+`gentle-pi` observes approved sanitized runtime usage fields in memory and asynchronously invokes `gentle-ai telemetry runtime send --json` once per accepted event. It never persists metric data, retries, or waits for delivery in provider callbacks; busy or failed attempts are silently discarded. [gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) owns native delivery and the existing opt-out policy. See [Telemetry](docs/telemetry.md) for fields and source limitations.
 
-At session start, for a primary session only (never for a named or SDD sub-agent), Gentle Pi asks the local `gentle-ai` binary to send its own telemetry: it spawns `gentle-ai telemetry trigger --json` detached, with a 3 s deadline, discards its output, and never blocks session start or surfaces an error — an older binary without the verb is silently treated as nothing to do. This runs at most once per process.
+Separately, at primary session start (never for a named or SDD sub-agent), Gentle Pi asks the local `gentle-ai` binary to handle its own install/heartbeat telemetry: it spawns `gentle-ai telemetry trigger --json` detached, with a 3 s deadline, discards its output, and never blocks session start or surfaces an error — an older binary without the verb is silently treated as nothing to do. This runs at most once per process.
 
 Install counts for `gentle-pi` and `gentle-engram` come from npm download statistics; the package itself never emits an install event.
 
 To opt out:
 
 - `/gentle:telemetry disable` — asks the local `gentle-ai` binary to disable telemetry (also `status` and `preview` to inspect it without leaving Pi).
-- `DO_NOT_TRACK=1` — Gentle Pi itself will not spawn the trigger, and `gentle-ai` also honors this standard on its own.
+- `DO_NOT_TRACK=1` — Gentle Pi suppresses runtime usage telemetry and the install/heartbeat trigger; `gentle-ai` also honors this standard independently.
 - `GENTLE_AI_TELEMETRY=0` — same effect, `gentle-ai`'s own environment switch.
 
-`CI=true` also suppresses the trigger, since automated runs are not a real usage signal.
+`CI=true` also suppresses runtime usage telemetry and the trigger, since automated runs are not a real usage signal.
 
 ## Package contents
 

--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -24,6 +24,9 @@ import { CARD_TONE, renderCard } from "../lib/shell-card.ts";
 import { openInExternalEditor } from "./gentle-shell.ts";
 import { resolveGentlePiAgentHome } from "../lib/agent-home.ts";
 import { researchAgent, resolveResearchCapabilities, renderResearchCapabilities, RESEARCH_CHILD_TOOLS_ENV } from "../lib/sdd-research-capabilities.ts";
+import { CHILD_METRICS_EVENT, CHILD_METRICS_REVOKED, childEvent, launchSelection, type LaunchSelection } from "../lib/runtime-metrics-children.ts";
+import { lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
+import { runtimeMetricsEnvAllows, type RuntimeMetricsPolicyDeps } from "../lib/runtime-metrics-policy.ts";
 
 // Gentle Agents: subagents as isolated `pi --mode rpc` children, a task
 // store that notifies per task, and a Gentle Shell card above the editor.
@@ -47,6 +50,9 @@ export interface AgentsDeps extends RunnerDeps {
 	childIpc?: IpcEndpoint;
 	env: NodeJS.ProcessEnv;
 	resolveWorktree: WorktreeResolver;
+	runtimeMetricsPolicy?: RuntimeMetricsPolicyDeps;
+	metricsNow?: () => number;
+	metricsSchedule?: RunnerDeps["schedule"];
 }
 
 export function agentRuntimePaths(home: string, agentHome = join(home, ".pi", "agent")): { sessions: string; transcripts: string } {
@@ -285,6 +291,26 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	const ownedTaskIds = new Set<string>();
 	const stoppingTaskIds = new Set<string>();
 	const yieldedTaskIds = new Set<string>();
+	const metricsNow = deps.metricsNow ?? (() => performance.now());
+	let metricsOwner = {};
+	const metricTasks = new Map<string, { selection?: LaunchSelection; started: number; launched: boolean; finished: boolean; current(): boolean; valid(): boolean }>();
+	const unsubscribeMetrics = pi.events.on(CHILD_METRICS_REVOKED, id => {
+		if (id === activeSessionId()) {
+			metricsOwner = {};
+			for (const taskId of metricTasks.keys()) runner.discardResponseObservations(taskId);
+			metricTasks.clear();
+		}
+	});
+	const clearTaskMetrics = () => {
+		metricsOwner = {};
+		for (const taskId of metricTasks.keys()) runner.discardResponseObservations(taskId);
+		metricTasks.clear();
+	};
+	pi.on("session_start", clearTaskMetrics);
+	pi.on("session_shutdown", () => {
+		clearTaskMetrics();
+		unsubscribeMetrics();
+	});
 	let stopAllConfirmation: Promise<void> | undefined;
 
 	// The card and its clock follow the session pi has open right now; a task
@@ -367,12 +393,27 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			if (!root || root !== childRoot || !worktrees.roots().includes(root)) return;
 			recordReviewMutation(pi, sessions, root, { source: "subagent", taskId: task.id, toolName: tool.toolName, toolCallId: tool.toolCallId });
 		},
-		onFinish: (task) => {
-			ownedTaskIds.delete(task.id);
-			requestRender();
-			persist(task);
-			const yielded = yieldedTaskIds.delete(task.id);
-			if ((task.mode === AGENT_MODE.BACKGROUND && task.status !== TASK_STATUS.CANCELLED) || (yielded && task.status !== TASK_STATUS.CANCELLED && activeSessionId() === task.parentSessionId)) deliver(task);
+		onFinish: (task, observations) => {
+			// Completion is the only forwarding opportunity. No pending event, policy
+			// query or promise survives this callback; the receiver drops when busy.
+			const { id, parentSessionId, status } = task;
+			const metrics = metricTasks.get(id);
+			metricTasks.delete(id); // Deliver at most once, even if forwarding fails.
+			try {
+				const authorized = metrics?.valid();
+				if (metrics) metrics.finished = true;
+				if (authorized && metrics?.launched && metrics.selection && observations) {
+					const event = childEvent(parentSessionId, id, metrics.selection, status, observations, metrics.started);
+					if (event && metrics.current()) pi.events.emit(CHILD_METRICS_EVENT, event);
+				}
+			} catch { /* Metrics must never interrupt task finalization. */ }
+			try {
+				ownedTaskIds.delete(task.id);
+				requestRender();
+				persist(task);
+				const yielded = yieldedTaskIds.delete(task.id);
+				if ((task.mode === AGENT_MODE.BACKGROUND && task.status !== TASK_STATUS.CANCELLED) || (yielded && task.status !== TASK_STATUS.CANCELLED && activeSessionId() === task.parentSessionId)) deliver(task);
+			} catch { /* Best-effort completion bookkeeping cannot strand runner waiters. */ }
 		},
 	});
 
@@ -609,7 +650,27 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	};
 
 	const launch = async (ctx: ExtensionContext, request: TaskRequest): Promise<ToolText> => {
-		const task = runner.run(request);
+		// Bounded live observation only. Native send owns the fresh policy decision;
+		// child execution never starts a telemetry policy process or renewal timer.
+		const owner = metricsOwner;
+		const metrics = { selection: undefined as LaunchSelection | undefined,
+			started: 0, launched: false, finished: false,
+			current: () => owner === metricsOwner && request.parentSessionId === activeSessionId() && runtimeMetricsEnvAllows(deps.env),
+			valid: () => !metrics.finished && metrics.current() };
+		const observe = runtimeMetricsEnvAllows(deps.env) && metricTasks.size < 256;
+		const task = runner.run({ ...request, collectResponseObservations: false,
+			onLaunch: () => { metrics.launched = true; request.onLaunch?.(); },
+			...(observe ? { canCollectResponseObservations: metrics.valid, prepareResponseObservations: async () => {
+				if (metrics.finished || owner !== metricsOwner || request.parentSessionId !== activeSessionId() || !runtimeMetricsEnvAllows(deps.env)) return false;
+				try { await lookupPiCatalogName({ provider: "openai", modelId: "gpt-4o" }); }
+				catch { return false; }
+				if (!metrics.valid()) return false;
+				metrics.selection = launchSelection(request.agent, request.model, request.thinking);
+				metrics.started = metricsNow();
+				return metrics.valid();
+			} } : {}),
+		});
+		if (observe) metricTasks.set(task.id, metrics);
 		ownedTaskIds.add(task.id);
 		store.subscribe(task.id, () => { publishActivity(); requestRender(); });
 		if (request.mode === AGENT_MODE.BACKGROUND) return text(`Started ${task.agent} in the background as task ${task.id}. Use subagent_status or subagent_result with that id.`, taskDetails(task));

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -15,6 +15,8 @@ import { NativePointerScope } from "../lib/native-pointer-region.ts";
 import { PresenceCursor, PresencePublisher, listPresence, readActivity } from "../lib/orchestrator-presence.ts";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 import { fakeChild, type FakeChild } from "./agents-fake-child.ts";
+import { AgentRunner } from "../lib/agents-runner.ts";
+import { CHILD_METRICS_EVENT } from "../lib/runtime-metrics-children.ts";
 
 // Gentle Agents extension: the subagent_* tools drive isolated pi children,
 // the card above the editor follows the store, and dialogs reach the host UI.
@@ -66,9 +68,16 @@ function fakePi() {
 	const renderers = new Map<string, (message: unknown, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }>();
 	const entries: Array<{ type: string; customType: string; data: unknown }> = [];
 	const events: Array<{ name: string; data: unknown }> = [];
+	const listeners = new Map<string, Set<(data: unknown) => void>>();
 	const pi = {
 		appendEntry: (customType: string, data: unknown) => entries.push({ type: "custom", customType, data }),
-		events: { emit: (name: string, data: unknown) => events.push({ name, data }) },
+		events: {
+			emit: (name: string, data: unknown) => { events.push({ name, data }); for (const listener of listeners.get(name) ?? []) listener(data); },
+			on: (name: string, listener: (data: unknown) => void) => {
+				const set = listeners.get(name) ?? new Set(); listeners.set(name, set); set.add(listener);
+				return () => { set.delete(listener); };
+			},
+		},
 		sendMessage: (message: Record<string, unknown>, options: Record<string, unknown>) => sent.push({ message, options }),
 		registerMessageRenderer: (type: string, renderer: (message: unknown, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }) => renderers.set(type, renderer),
 		on: (event: string, handler: Handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
@@ -79,7 +88,7 @@ function fakePi() {
 	const fire = async (event: string, ctx: ExtensionContext, payload: unknown = {}) => {
 		for (const handler of handlers.get(event) ?? []) await handler(payload, ctx);
 	};
-	return { pi, tools, shortcuts, commands, fire, sent, renderers, entries, events };
+	return { pi, tools, shortcuts, commands, fire, sent, renderers, entries, events, listeners };
 }
 
 function fakeContext(tui: { requestRender(): void } = fakeTui, confirmResult: (title: string, message: string) => Promise<boolean> = async () => true, inputResult: (title: string, placeholder: string | undefined) => Promise<string | undefined> = async () => undefined, overlayTui: { terminal: { rows: number }; requestRender(): void } = { terminal: { rows: 30 }, requestRender() {} }) {
@@ -138,6 +147,7 @@ function deps(): { deps: Partial<AgentsDeps>; children: FakeChild[]; spawned: st
 		children,
 		spawned,
 		deps: {
+			runtimeMetricsPolicy: { resolve: () => { throw new Error("Policy not configured in fixture"); } },
 			spawn: (command, args) => {
 				spawned.push([command, ...args]);
 				const child = fakeChild();
@@ -332,6 +342,117 @@ test("child parent-message tooling admits notifications and the active parent pr
 	assert.deepEqual(runtime.children[0].sent, [{ id: "n1", kind: "ack", accepted: true }, { id: "n2", kind: "ack", accepted: false, error: "task parent is not the active host session" }]);
 	await parent.fire("session_shutdown", ctx);
 });
+for (const boundary of ["allowed", "env", "session", "replacement", "bus-throws", "no-spawn", "long-running"] as const) {
+	test(`local child composition through real extensions and RPC runner: ${boundary}`, async (t) => {
+		const discarded: number[] = [];
+		const discard = AgentRunner.prototype.discardResponseObservations;
+		t.mock.method(AgentRunner.prototype, "discardResponseObservations", function (this: AgentRunner, id: string) {
+			const live = Reflect.get(this, "live").get(id);
+			discarded.push(live?.observations?.responses.length ?? 0);
+			discard.call(this, id);
+			assert.equal(live?.observations, undefined, "buffer gone synchronously, without another RPC");
+		});
+		const h = fakePi();
+		const runtime = deps();
+		const context = fakeContext();
+		const spawn = runtime.deps.spawn!;
+		runtime.deps.spawn = (...args) => {
+			const child = spawn(...args);
+			const on = child.on.bind(child);
+			child.on = ((event: string, listener: (...args: any[]) => void) => {
+				if (event === "spawn" && boundary !== "no-spawn") queueMicrotask(() => listener());
+				return on(event as any, listener);
+			}) as typeof child.on;
+			return child;
+		};
+		let clock = 1;
+		const renewalTimers = new Map<number, () => void>();
+		const metricsSchedule = (fn: () => void, ms: number) => {
+			const at = clock + ms; renewalTimers.set(at, fn); return () => { renewalTimers.delete(at); };
+		};
+		let calls = 0;
+		const policy = { resolve: () => "fixture", exec: async () => {
+			calls++;
+			return { stdout: JSON.stringify({ schema: "gentle-ai.telemetry-policy/v1", operation: "policy", enabled: true,
+				source: "state", reason: "enabled" }), stderr: "", exitCode: 0, signal: null, timedOut: false, outputLimitExceeded: false };
+		} };
+		const env: NodeJS.ProcessEnv = {};
+		const profile = join(root, `metrics-${boundary}`);
+		mkdirSync(join(profile, "agents"), { recursive: true });
+		writeFileSync(join(profile, "agents", "gentle-ai-worker.md"), readFileSync(new URL("../assets/agents/gentle-ai-worker.md", import.meta.url)));
+		writeFileSync(join(profile, "subagents.json"), JSON.stringify({ model_profiles: { "gentle-ai-worker": { model: "openai/gpt-4o", effort: "high" } } }));
+		gentleAgents(h.pi, env, { ...runtime.deps, env, agentHome: profile, runtimeMetricsPolicy: policy, metricsNow: () => clock, metricsSchedule });
+		const listenerCounts = () => [...h.listeners].map(([name, set]) => [name, set.size]);
+		const initialListeners = listenerCounts();
+		await h.fire("session_start", context.ctx);
+		const result = h.tools.get("subagent_run")!.execute("call", { agent: "gentle-ai-worker", task: "private task", mode: "task" }, undefined, undefined, context.ctx);
+		await tick();
+		assert.equal(runtime.children.length, 1);
+		const child = runtime.children[0];
+		const launchedCalls = calls;
+		for (let i = 0; i < 10; i++) child.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "private streamed text" } });
+		assert.equal(calls, launchedCalls, "no per-chunk policy process");
+		if (boundary === "long-running") {
+			for (let i = 0; i < 6; i++) {
+				clock += 20_000;
+				for (const [at, fn] of [...renewalTimers]) if (at <= clock) { renewalTimers.delete(at); fn(); }
+				await tick();
+				child.emit({ type: "message_end", message: { role: "assistant", model: "gpt-4o", provider: "openai",
+					providerThinkingLevel: "low", stopReason: "stop", usage: { input: 7, output: 3 } } });
+			}
+			assert.equal(calls, launchedCalls, "no telemetry policy renewal during a two-minute child");
+			assert.equal(renewalTimers.size, 0, "child telemetry never schedules a lease timer");
+		}
+		if (boundary === "env") env.DO_NOT_TRACK = "yes";
+		if (boundary === "session" || boundary === "replacement") {
+			child.emit({ type: "message_end", message: { role: "assistant", model: "gpt-4o", provider: "openai",
+				stopReason: "stop", usage: { input: 7, output: 3 } } });
+			if (boundary === "replacement") {
+				Object.assign(context.ctx.sessionManager, { getSessionId: () => "replacement" });
+				await h.fire("session_start", context.ctx);
+			} else await h.fire("session_shutdown", context.ctx);
+			assert.deepEqual(discarded, [1], "idle buffered response discarded at lifecycle boundary");
+			assert.equal(renewalTimers.size, 0);
+			if (boundary === "session") {
+				assert.ok([...h.listeners.values()].every(set => set.size === 0), "old bus subscriptions removed");
+				const fresh = fakePi();
+				Object.assign(fresh.pi, { events: h.pi.events });
+				gentleAgents(fresh.pi, env, { ...runtime.deps, env, runtimeMetricsPolicy: policy, metricsSchedule });
+				await fresh.fire("session_start", context.ctx);
+				assert.deepEqual(listenerCounts(), initialListeners, "fresh instance installs one subscription set");
+				await fresh.fire("session_shutdown", context.ctx);
+				assert.ok([...h.listeners.values()].every(set => set.size === 0));
+				assert.equal(renewalTimers.size, 0);
+			}
+		}
+		if (boundary === "bus-throws") h.pi.events.on(CHILD_METRICS_EVENT, () => { throw new Error("private bus error"); });
+		for (const model of ["gpt-4o", "gpt-4o-mini"]) child.emit({ type: "message_end", message: {
+			role: "assistant", model, provider: "openai", providerThinkingLevel: "low", stopReason: "stop", usage: { input: 7, output: 3 } } });
+		child.emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }] });
+		child.emit({ type: "agent_settled" });
+		assert.match((await result).content[0].text, boundary === "session" ? /cancelled/ : /done/);
+		await tick(); await tick();
+		const events = h.events.filter(event => event.name === CHILD_METRICS_EVENT);
+		const admitted = boundary === "allowed" || boundary === "bus-throws" || boundary === "long-running";
+		assert.equal(events.length, Number(admitted));
+		if (admitted) {
+			assert.ok(!JSON.stringify(events).includes("private"));
+			const event = events[0].data as import("../lib/runtime-metrics-children.ts").ChildMetricsEvent;
+			assert.equal(event.launch.agentClass, "worker");
+			assert.equal(event.launch.selectedEffort, "high");
+			assert.equal(event.responses.length, boundary === "long-running" ? 8 : 2);
+			assert.ok(event.responses.every(row => row.agentClass === "worker" && row.effort === "unavailable"));
+			assert.equal(event.agentSettled, true);
+			child.emit({ type: "agent_settled" });
+			await tick();
+			assert.equal(h.events.filter(event => event.name === CHILD_METRICS_EVENT).length, 1, "completion consumed once, even after bus failure");
+		}
+		assert.equal(calls, 0, "child telemetry performs no launch, renewal or pending-forward policy query");
+		assert.equal(renewalTimers.size, 0, "no renewal timer after the last task finishes");
+		assert.ok(!JSON.stringify(h.entries).includes("launch_configuration"));
+		await h.fire("session_shutdown", context.ctx);
+	});
+}
 
 async function eventually(check: () => boolean, message: string): Promise<void> {
 	for (let attempt = 0; attempt < 120; attempt++) {
@@ -875,7 +996,7 @@ test("explicit child roots launch and continue in the actual cwd, persist withou
 	assert.deepEqual(h.entries, [], "queueing and returning a child handle do not register roots");
 	spawnEvents[0]();
 	assert.deepEqual(h.entries, [{ type: "custom", customType: SESSION_WORKTREE_ENTRY, data: { sessionId: "s1", root: childRoot, evidence: "subagent:spawn" } }]);
-	assert.deepEqual(h.events, [{ name: SESSION_WORKTREE_CHANGED, data: { sessionId: "s1" } }]);
+	assert.deepEqual(h.events.filter(event => event.name === SESSION_WORKTREE_CHANGED), [{ name: SESSION_WORKTREE_CHANGED, data: { sessionId: "s1" } }]);
 	const details = result.details.gentleAgents as { taskId: string; cwd: string };
 	assert.equal(details.cwd, childRoot);
 	runtime.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "mapped" }] }] });


### PR DESCRIPTION
## Linked issue

Closes #849

## PR type

- [x] `type:feature`

## Summary

Connects known Pi agent/subagent model and effort observations to one-shot runtime delivery.

## Test plan

- Full Pi suite passed: 2,014 passed, 18 skipped, 0 failed.\n- CI is the final merge gate.

## Contributor checklist

- [x] Linked issue has `status:approved`
- [x] Commit uses Conventional Commits
- [x] No `Co-Authored-By` trailer
- [ ] `size:exception` required where the behavior/test boundary exceeds 400 lines

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Pi runtime telemetry observations |
| Tracker PR | #851 |
| Position | 3 of 3 |
| Base | `feat/telemetry-runtime-metrics-02-runner` |
| Depends on | previous child |
| Follow-up | None |
| Review budget | 210 / 400; implementation and tests remain atomic |
| Starts at | feat/telemetry-runtime-metrics-02-runner |
| Ends with | Connects known Pi agent/subagent model and effort observations to one-shot runtime delivery. |

### Chain Overview

```text
main
 └── #851 tracker
      └── 3
```

### Scope
- Includes: Connects known Pi agent/subagent model and effort observations to one-shot runtime delivery.
- Excludes: later child work units.
