### PR TITLE
fix(windows): hide standing permission Git processes

### DIFF
--- a/lib/review-session-standing-permission.ts
+++ b/lib/review-session-standing-permission.ts
@@ -10,6 +10,16 @@ export const REVIEW_SESSION_PERMISSION_REGISTRY_SYMBOL = Symbol.for(REVIEW_SESSI
 
 const execFileAsync = promisify(execFile);
 
+export interface GitCommandOptions {
+	encoding: "utf8";
+	timeout: number;
+	maxBuffer: number;
+	windowsHide?: boolean;
+}
+
+export type GitAsyncRunner = (command: string, args: readonly string[], options: GitCommandOptions) => Promise<{ stdout: string }>;
+export type GitSyncRunner = (command: string, args: readonly string[], options: GitCommandOptions) => string;
+
 export interface ReviewSessionManager {
 	getSessionId(): unknown;
 }
@@ -78,12 +88,16 @@ function validAbsoluteGitPath(value: string): boolean {
 	return isAbsolute(value) && value.length > 0 && !value.includes("\n") && !value.includes("\r");
 }
 
-export async function resolveCanonicalGitWorktreeRoot(cwd: string): Promise<string | undefined> {
+export async function resolveCanonicalGitWorktreeRoot(
+	cwd: string,
+	run: GitAsyncRunner = execFileAsync as unknown as GitAsyncRunner,
+): Promise<string | undefined> {
 	try {
-		const result = await execFileAsync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+		const result = await run("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
 			encoding: "utf8",
 			timeout: 5_000,
 			maxBuffer: 64 * 1024,
+			windowsHide: true,
 		});
 		const output = result.stdout.trim();
 		if (!validAbsoluteGitPath(output)) return undefined;
@@ -94,12 +108,16 @@ export async function resolveCanonicalGitWorktreeRoot(cwd: string): Promise<stri
 }
 
 /** Resolves a non-secret, clone-stable identity from Git's canonical common dir. */
-export async function resolveCanonicalGitRepositoryIdentity(cwd: string): Promise<string | undefined> {
+export async function resolveCanonicalGitRepositoryIdentity(
+	cwd: string,
+	run: GitAsyncRunner = execFileAsync as unknown as GitAsyncRunner,
+): Promise<string | undefined> {
 	try {
-		const result = await execFileAsync("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
+		const result = await run("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
 			encoding: "utf8",
 			timeout: 5_000,
 			maxBuffer: 64 * 1024,
+			windowsHide: true,
 		});
 		const output = result.stdout.trim();
 		if (output.length === 0 || output.includes("\n") || output.includes("\r")) return undefined;
@@ -110,9 +128,12 @@ export async function resolveCanonicalGitRepositoryIdentity(cwd: string): Promis
 }
 
 /** The parent AgentRunner binds a child task to this same digest at spawn time. */
-export function resolveCanonicalGitRepositoryIdentitySync(cwd: string): string | undefined {
+export function resolveCanonicalGitRepositoryIdentitySync(
+	cwd: string,
+	run: GitSyncRunner = execFileSync as unknown as GitSyncRunner,
+): string | undefined {
 	try {
-		const output = execFileSync("git", ["-C", cwd, "rev-parse", "--git-common-dir"], { encoding: "utf8", timeout: 5_000, maxBuffer: 64 * 1024 }).trim();
+		const output = run("git", ["-C", cwd, "rev-parse", "--git-common-dir"], { encoding: "utf8", timeout: 5_000, maxBuffer: 64 * 1024, windowsHide: true }).trim();
 		if (output.length === 0 || output.includes("\n") || output.includes("\r")) return undefined;
 		return canonicalRepositoryIdentity(realpathSync(resolve(cwd, output)));
 	} catch {

--- a/tests/review-session-standing-permission.test.ts
+++ b/tests/review-session-standing-permission.test.ts
@@ -9,6 +9,12 @@ import {
 	REVIEW_SESSION_PERMISSION_REGISTRY_SYMBOL,
 	captureReviewSessionIdentity,
 	grantReviewSessionPermission,
+	resolveCanonicalGitRepositoryIdentity,
+	resolveCanonicalGitRepositoryIdentitySync,
+	resolveCanonicalGitWorktreeRoot,
+	type GitAsyncRunner,
+	type GitCommandOptions,
+	type GitSyncRunner,
 	hasReviewSessionPermission,
 	reviewSessionPermissionEpoch,
 	revokeReviewSessionPermission,
@@ -68,6 +74,30 @@ test("standing permission is process-memory-only and bound to one live manager, 
 
 	assert.equal(revokeReviewSessionPermission(identity), true);
 	assert.equal(hasReviewSessionPermission(sibling), false);
+});
+
+test("review session Git identity lookups hide every Windows child process", async (t) => {
+	const root = repository(t);
+	const asyncCalls: Array<{ command: string; args: readonly string[]; options: GitCommandOptions }> = [];
+	const runAsync: GitAsyncRunner = async (command, args, options) => {
+		asyncCalls.push({ command, args, options });
+		return { stdout: `${args.at(-1) === "--show-toplevel" ? root : ".git"}\n` };
+	};
+	const syncCalls: Array<{ command: string; args: readonly string[]; options: GitCommandOptions }> = [];
+	const runSync: GitSyncRunner = (command, args, options) => {
+		syncCalls.push({ command, args, options });
+		return ".git\n";
+	};
+
+	assert.equal(await resolveCanonicalGitWorktreeRoot(root, runAsync), root);
+	assert.match(await resolveCanonicalGitRepositoryIdentity(root, runAsync) ?? "", /^sha256:/);
+	assert.match(resolveCanonicalGitRepositoryIdentitySync(root, runSync) ?? "", /^sha256:/);
+	assert.deepEqual(asyncCalls.map((call) => call.args.at(-1)), ["--show-toplevel", "--git-common-dir"]);
+	assert.deepEqual(syncCalls.map((call) => call.args.at(-1)), ["--git-common-dir"]);
+	for (const call of [...asyncCalls, ...syncCalls]) {
+		assert.equal(call.command, "git");
+		assert.equal(call.options.windowsHide, true);
+	}
 });
 
 test("headless, child, empty-session, and non-Git contexts cannot offer or consume standing permission", async (t) => {


### PR DESCRIPTION
Closes #828

## Summary

- Hide async and sync Git subprocesses used to establish review standing-permission identity on Windows.
- Preserve existing fail-closed identity behavior and one-argument public call compatibility.
- Add option-level regression coverage for all three process boundaries.

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Changes

| File | Change |
| --- | --- |
| `lib/review-session-standing-permission.ts` | Pass `windowsHide: true` to both async Git resolvers and the sync repository-identity resolver; allow narrow runner injection for testing. |
| `tests/review-session-standing-permission.test.ts` | Capture all three Git invocation option objects and assert hidden Windows children. |

## Test plan

- [x] `node --experimental-strip-types --test --test-name-pattern="review session Git identity lookups hide every Windows child process" tests/review-session-standing-permission.test.ts`
- [x] `git diff --check`
- [x] Independent read-only verification after fast-forwarding to current `origin/main`

The complete test file has one environment-specific baseline failure when the system temporary directory belongs to an ancestor Git worktree. Replaying the unmodified base reproduces the same failure; the candidate adds no related failure.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label: `type:bug`.
- [x] Shellcheck is not applicable; no shell scripts changed.
- [x] Skill testing is not applicable; no skill changed.
- [x] Documentation is not required; no user-facing API or workflow changed.
- [x] Used a Conventional Commit message.
- [x] Added no `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved Git repository and worktree resolution with configurable command execution.
  - Git operations now run without displaying command windows on Windows systems.

- **Tests**
  - Added coverage verifying Git commands use the expected arguments and Windows-specific execution settings for both asynchronous and synchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->