### PR TITLE
fix(sdd): preserve selected change in child agents

### DIFF
--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -11,7 +11,7 @@ import { sidebarPart } from "../lib/shell-sidebar.ts";
 import { invalidateSidebar } from "../lib/shell-sidebar-layout.ts";
 import { AGENT_MODE, discoverAgents, loadAgentsConfig, resolveAgentProfile, type AgentDefinition, type AgentMode } from "../lib/agents-config.ts";
 import { isFinished, TASK_STATUS, TaskStore, type AskRequest, type TaskRecord } from "../lib/agents-protocol.ts";
-import { AgentRunner, piCommand, type AskAnswer, type RunnerDeps, type TaskRequest } from "../lib/agents-runner.ts";
+import { AgentRunner, piCommand, type AskAnswer, type RunnerDeps, type SddChangeSelection, type TaskRequest } from "../lib/agents-runner.ts";
 import { ChildMessenger, type IpcEndpoint } from "../lib/agents-messaging.ts";
 import { hasReviewSessionPermission, resolveCanonicalGitRepositoryIdentitySync, type ReviewSessionManager } from "../lib/review-session-standing-permission.ts";
 import { historyDir, loadStoredTask, pruneHistory, saveTask } from "../lib/agents-history.ts";
@@ -40,6 +40,32 @@ const STOP_KEY_DEFAULT = "alt+s";
 const RENDER_COALESCE_MS = 400;
 const CLOCK_TICK_MS = 1000;
 const TOOL_PREFIX = "subagent_";
+const SDD_PHASE_BY_AGENT = {
+	"sdd-apply": "apply",
+	"sdd-verify": "verify",
+	"sdd-sync": "sync",
+	"sdd-archive": "archive",
+} as const;
+
+function sddPhaseForAgent(name: string): SddChangeSelection["phase"] | undefined {
+	return SDD_PHASE_BY_AGENT[name as keyof typeof SDD_PHASE_BY_AGENT];
+}
+
+function parseSddChange(value: unknown, agentName: string): SddChangeSelection | undefined {
+	if (value === undefined) return undefined;
+	const expectedPhase = sddPhaseForAgent(agentName);
+	if (!expectedPhase) throw new Error("sdd_change is allowed only for SDD apply, verify, sync, or archive agents.");
+	if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("sdd_change must be an object with changeName, workspaceRoot, and phase.");
+	const selection = value as Record<string, unknown>;
+	const keys = Object.keys(selection).sort();
+	if (keys.join(",") !== "changeName,phase,workspaceRoot" ||
+		typeof selection.changeName !== "string" || selection.changeName.length === 0 ||
+		typeof selection.workspaceRoot !== "string" || selection.workspaceRoot.length === 0 ||
+		selection.phase !== expectedPhase) {
+		throw new Error("sdd_change must contain only a non-empty changeName, workspaceRoot, and the agent's matching phase.");
+	}
+	return { changeName: selection.changeName, workspaceRoot: selection.workspaceRoot, phase: selection.phase };
+}
 
 export interface AgentsDeps extends RunnerDeps {
 	home: string;
@@ -557,14 +583,21 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 
 	const roots = (ctx: ExtensionContext) => ({ cwd: ctx.sessionManager.getCwd(), home: deps.home, agentHome });
 
-	const buildRequest = (ctx: ExtensionContext, agent: AgentDefinition, prompt: string, label: string | undefined, context: string | undefined, mode: AgentMode, resume?: string, workspaceRoot?: string): TaskRequest => {
+	const buildRequest = (ctx: ExtensionContext, agent: AgentDefinition, prompt: string, label: string | undefined, context: string | undefined, mode: AgentMode, resume?: string, workspaceRoot?: string, sddChange?: SddChangeSelection): TaskRequest => {
 		const registry = registryFor(ctx);
 		const parentCwd = ctx.sessionManager.getCwd();
 		// An explicit target is validated before any queue or session-dir writes.
 		const parentIdentity = deps.resolveWorktree(parentCwd, parentCwd);
+		const selectedRoot = workspaceRoot ?? sddChange?.workspaceRoot;
 		// Preserve ordinary non-Git continuation, without admitting any new root.
-		const sameNonGitContinuation = resume !== undefined && workspaceRoot === parentCwd && !parentIdentity;
-		const target = workspaceRoot !== undefined && !sameNonGitContinuation ? registry.validate(workspaceRoot) : parentIdentity?.root;
+		const sameNonGitContinuation = resume !== undefined && selectedRoot === parentCwd && !parentIdentity;
+		const target = selectedRoot !== undefined && !sameNonGitContinuation ? registry.validate(selectedRoot) : parentIdentity?.root;
+		if (sddChange && target !== sddChange.workspaceRoot && target !== resolve(sddChange.workspaceRoot)) {
+			throw new Error("sdd_change workspaceRoot must resolve to the selected child worktree.");
+		}
+		const launchSddChange = sddChange === undefined || target === undefined
+			? undefined
+			: { ...sddChange, workspaceRoot: target };
 		const config = loadAgentsConfig(roots(ctx));
 		const profile = resolveAgentProfile(agent, config);
 		const research = agent.name === "sdd-research" ? researchAgent(agent, pi) : undefined;
@@ -588,6 +621,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			sessionDir,
 			resumeSessionPath: resume,
 			env: research ? { ...deps.env, [RESEARCH_CHILD_TOOLS_ENV]: JSON.stringify(research.agent.tools) } : deps.env,
+			...(launchSddChange === undefined ? {} : { sddChange: launchSddChange }),
 			...(parentRepositoryIdentity === undefined ? {} : {
 				authorizeParentStandingReviewPermission: (repositoryIdentity: string) => {
 					try {
@@ -661,6 +695,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 				label: { type: "string", description: "Three to six words naming the work, shown on the agents card, e.g. 'map footer data sources'." },
 				context: { type: "string", description: "Optional extra context appended to the task." },
 				workspace_root: { type: "string", description: "Optional worktree in the same Git clone. Validated before queueing; the child runs at its canonical root and registers it on actual launch." },
+				sdd_change: { type: "object", additionalProperties: false, required: ["changeName", "workspaceRoot", "phase"], properties: { changeName: { type: "string" }, workspaceRoot: { type: "string" }, phase: { type: "string", enum: ["apply", "verify", "sync", "archive"] } }, description: "Launch-local selected SDD identity, accepted only by matching SDD phase agents." },
 				mode: { type: "string", enum: ["task", "background"], description: "task waits for the result (default); background returns immediately." },
 			},
 		},
@@ -669,7 +704,10 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			const agent = agents.find((candidate) => candidate.name === params.agent);
 			if (!agent) return text(`Error: no subagent named "${String(params.agent)}". Known: ${agents.map((candidate) => candidate.name).join(", ") || "none"}`, { error: "unknown agent" });
 			const mode = (params.mode as AgentMode | undefined) ?? agent.mode ?? loadAgentsConfig(roots(ctx)).defaultMode;
-			return launch(ctx, buildRequest(ctx, agent, String(params.task ?? ""), typeof params.label === "string" ? params.label : undefined, typeof params.context === "string" ? params.context : undefined, mode, undefined, typeof params.workspace_root === "string" ? params.workspace_root : undefined));
+			let sddChange: SddChangeSelection | undefined;
+			try { sddChange = parseSddChange(params.sdd_change, agent.name); }
+			catch (error) { return text(`Error: ${error instanceof Error ? error.message : String(error)}`, { error: "invalid sdd_change" }); }
+			return launch(ctx, buildRequest(ctx, agent, String(params.task ?? ""), typeof params.label === "string" ? params.label : undefined, typeof params.context === "string" ? params.context : undefined, mode, undefined, typeof params.workspace_root === "string" ? params.workspace_root : undefined, sddChange));
 		},
 	);
 
@@ -707,7 +745,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	tool(
 		"continue",
 		"Resume a finished subagent task in its own session with a follow-up prompt.",
-		{ required: ["task_id", "prompt"], properties: { task_id: { type: "string" }, prompt: { type: "string" }, label: { type: "string", description: "Three to six words naming the follow-up." }, mode: { type: "string", enum: ["task", "background"] } } },
+		{ required: ["task_id", "prompt"], properties: { task_id: { type: "string" }, prompt: { type: "string" }, label: { type: "string", description: "Three to six words naming the follow-up." }, sdd_change: { type: "object", additionalProperties: false, required: ["changeName", "workspaceRoot", "phase"], properties: { changeName: { type: "string" }, workspaceRoot: { type: "string" }, phase: { type: "string", enum: ["apply", "verify", "sync", "archive"] } }, description: "Fresh launch-local selected SDD identity, required when continuing an SDD phase agent." }, mode: { type: "string", enum: ["task", "background"] } } },
 		async (params, ctx) => {
 			const previous = await resolveTask(String(params.task_id));
 			if (!previous) return text(`Error: no task ${String(params.task_id)}`, { error: "unknown task" });
@@ -715,7 +753,11 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			const agent = discoverAgents(roots(ctx)).agents.find((candidate) => candidate.name === previous.agent);
 			if (!agent) return text(`Error: subagent "${previous.agent}" is no longer defined.`, { error: "unknown agent" });
 			const mode = (params.mode as AgentMode | undefined) ?? (previous.mode as AgentMode);
-			return launch(ctx, buildRequest(ctx, agent, String(params.prompt ?? ""), typeof params.label === "string" ? params.label : undefined, undefined, mode, previous.sessionPath, previous.cwd));
+			let sddChange: SddChangeSelection | undefined;
+			try { sddChange = parseSddChange(params.sdd_change, agent.name); }
+			catch (error) { return text(`Error: ${error instanceof Error ? error.message : String(error)}`, { error: "invalid sdd_change" }); }
+			if (sddPhaseForAgent(agent.name) && !sddChange) return text("Error: continuing an SDD phase agent requires a fresh sdd_change selection.", { error: "missing sdd_change" });
+			return launch(ctx, buildRequest(ctx, agent, String(params.prompt ?? ""), typeof params.label === "string" ? params.label : undefined, undefined, mode, previous.sessionPath, sddChange?.workspaceRoot ?? previous.cwd, sddChange));
 		},
 	);
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1399,6 +1399,8 @@ const SDD_AGENT_NAMES = [
 	"sdd-archive",
 ] as const;
 const SDD_AGENT_NAME_SET = new Set<string>(SDD_AGENT_NAMES);
+const SDD_CHANGE_FLAG = "gentle-sdd-change";
+const SDD_CHANGE_KEYS = ["changeName", "phase", "workspaceRoot"] as const;
 
 const JUDGMENT_DAY_AGENT_NAMES = [
 	"jd-judge-a",
@@ -1488,6 +1490,56 @@ function sddPhaseFromAgentStartEvent(event: unknown): SddPhase | undefined {
 	if (/\bSDD sync executor\b/i.test(systemPrompt)) return "sync";
 	if (/\bSDD archive executor\b/i.test(systemPrompt)) return "archive";
 	return undefined;
+}
+
+function resolveSddChangeStartup(
+	serialized: unknown,
+	cwd: string,
+	agentName: string,
+	resolver: (options: Parameters<typeof resolveSddStatus>[0]) => ReturnType<typeof resolveSddStatus> = resolveSddStatus,
+) {
+	if (typeof serialized !== "string") throw new Error("SDD selection must be a JSON string.");
+	let value: unknown;
+	try {
+		value = JSON.parse(serialized);
+	} catch {
+		throw new Error("SDD selection is malformed.");
+	}
+	if (!isRecord(value) || Object.keys(value).sort().join(",") !== SDD_CHANGE_KEYS.join(",")) {
+		throw new Error("SDD selection must contain only changeName, workspaceRoot, and phase.");
+	}
+	const { changeName, workspaceRoot, phase } = value;
+	if (typeof changeName !== "string" || changeName.length === 0 ||
+		typeof workspaceRoot !== "string" || workspaceRoot.length === 0 ||
+		(phase !== "apply" && phase !== "verify" && phase !== "sync" && phase !== "archive")) {
+		throw new Error("SDD selection has an invalid identity.");
+	}
+	if (agentName !== `sdd-${phase}`) throw new Error("SDD selection phase does not match the child agent.");
+	let canonicalCwd: string;
+	let canonicalSelectionRoot: string;
+	try {
+		canonicalCwd = realpathSync(cwd);
+		canonicalSelectionRoot = realpathSync(workspaceRoot);
+	} catch {
+		throw new Error("SDD selection workspaceRoot cannot be resolved.");
+	}
+	if (canonicalCwd !== canonicalSelectionRoot || workspaceRoot !== canonicalSelectionRoot) {
+		throw new Error("SDD selection workspaceRoot does not match the canonical child root.");
+	}
+	const status = resolver({ cwd: canonicalCwd, workspaceRoot: canonicalCwd, changeName, includeInstructions: true });
+	if (status.actionContext.workspaceRoot !== canonicalCwd || status.changeName !== changeName) {
+		throw new Error("SDD selection resolver returned a mismatched status.");
+	}
+	return { selection: { changeName, workspaceRoot: canonicalCwd, phase }, status };
+}
+
+function readSddChangeFlag(pi: ExtensionAPI): unknown {
+	try {
+		const value = (pi as unknown as { getFlag?: (name: string) => unknown }).getFlag?.(SDD_CHANGE_FLAG);
+		return value === false ? undefined : value;
+	} catch {
+		return null;
+	}
 }
 
 function normalizePolicyPath(value: string): string {
@@ -6408,6 +6460,8 @@ export const __testing = {
 	clearNativeReviewOutcomeMemoForTesting,
 	resolveControllerSddStatus,
 	resolveStartupControllerSddStatus,
+	resolveSddChangeStartup,
+	readSddChangeFlag,
 	resetTelemetryTriggerGuardForTesting,
 	createGentleAiExtension: createGentleAiExtensionForTesting,
 };
@@ -6478,6 +6532,11 @@ function createGentleAiExtensionForTesting(
 	const resolveTelemetryTriggerBinary = dependencies.resolveTelemetryTriggerBinary ?? resolveGentleAiBinary;
 	const telemetryExecFileAdapter = dependencies.telemetryExecFileAdapter ?? createNodeExecFileAdapter();
 	return function gentleAi(pi: ExtensionAPI): void {
+		const flags = pi as unknown as { registerFlag?: (name: string, definition: { description: string; type: "string"; default?: string }) => void };
+		flags.registerFlag?.(SDD_CHANGE_FLAG, {
+			description: "Internal launch-local selected SDD change identity for package-owned child agents.",
+			type: "string",
+		});
 	declareReviewRelayHandshake(dependencies.processEnv ?? process.env);
 	const pendingReviewConsentFallbackKey = Symbol("pending-review-consent-fallback");
 	const candidateViews = dependencies.candidateViews === undefined ? new CandidateViewRegistry() : dependencies.candidateViews;
@@ -6910,14 +6969,32 @@ function createGentleAiExtensionForTesting(
 				? `\n\n${renderSddPreflightPrompt(prefs)}`
 				: "";
 		const phase = isSddAgent ? sddPhaseFromAgentStartEvent(event) : undefined;
+		const launchSddChange = isSddAgent ? readSddChangeFlag(pi) : undefined;
 		const nativeStatusPrompt = phase
-			? `\n\n${renderNativeSddPhasePrompt(resolveStartupControllerSddStatus(
-				ctx.cwd,
-				undefined,
-				true,
-				prefs?.artifactStore,
-			), phase)}`
-			: "";
+			? (() => {
+				if (launchSddChange === undefined) {
+					return `\n\n${renderNativeSddPhasePrompt(resolveStartupControllerSddStatus(
+						ctx.cwd,
+						undefined,
+						true,
+						prefs?.artifactStore,
+					), phase)}`;
+				}
+				try {
+					const names = readAgentStartNames(event);
+					const agentName = names.find((name) => name === `sdd-${phase}`);
+					if (!agentName) throw new Error("SDD selection requires a matching named SDD phase agent.");
+					const startup = resolveSddChangeStartup(launchSddChange, ctx.cwd, agentName, (options) =>
+						resolveControllerSddStatus(options.cwd, options.changeName, true, prefs?.artifactStore),
+					);
+					return `\n\n${renderNativeSddPhasePrompt(startup.status, phase)}`;
+				} catch (error) {
+					return `\n\n## Native SDD Status Engine\nSDD selection blocked: ${error instanceof Error ? error.message : String(error)}\nDo not run phase work; return this blocker to the parent.`;
+				}
+			})()
+			: launchSddChange === undefined
+				? ""
+				: "\n\n## Native SDD Status Engine\nSDD selection blocked: the receiving agent has no recognized SDD phase.\nDo not run phase work; return this blocker to the parent.";
 		// gentle-pi#661: the RDD status line (and the rest of the gentle prompt)
 		// is built only for the primary session, mirrored on the
 		// reviewContractPrompt condition below -- named/SDD agents never reach

--- a/lib/agents-runner.ts
+++ b/lib/agents-runner.ts
@@ -77,6 +77,14 @@ export interface RunnerHooks {
 	onSuccessfulMutation?(task: TaskRecord, tool: { toolName: "write" | "edit"; toolCallId: string; path: string }): void | Promise<void>;
 }
 
+export interface SddChangeSelection {
+	changeName: string;
+	workspaceRoot: string;
+	phase: "apply" | "verify" | "sync" | "archive";
+}
+
+export const SDD_CHANGE_FLAG = "--gentle-sdd-change";
+
 export interface TaskRequest {
 	agent: AgentDefinition;
 	prompt: string;
@@ -90,6 +98,8 @@ export interface TaskRequest {
 	sessionDir: string;
 	resumeSessionPath: string | undefined;
 	env: NodeJS.ProcessEnv;
+	// A launch-local SDD identity. It is never prompt text or shared state.
+	sddChange?: SddChangeSelection;
 	// Captures the originating session; invoked only after successful OS spawn.
 	onLaunch?: () => void;
 	// This closure stays only in the parent process. Its presence creates an
@@ -174,6 +184,7 @@ const hostProcess: ProcessControl = { platform: process.platform, kill: (pid, si
 
 export function childArguments(request: TaskRequest): string[] {
 	const args = ["--mode", "rpc", "--session-dir", request.sessionDir];
+	if (request.sddChange) args.push(SDD_CHANGE_FLAG, JSON.stringify(request.sddChange));
 	if (request.resumeSessionPath) args.push("--session", request.resumeSessionPath);
 	if (request.model) args.push("--model", request.thinking ? `${formatModelRef(request.model)}:${request.thinking}` : formatModelRef(request.model));
 	else if (request.thinking) args.push("--thinking", request.thinking);
@@ -275,7 +286,12 @@ export class AgentRunner {
 			cost: 0,
 		};
 		this.store.add(task);
-		this.queue.push({ task, request });
+		// A caller can retain and mutate its request after dispatch. Preserve only
+		// the identity selected at construction for this child launch.
+		const launchRequest = request.sddChange === undefined
+			? request
+			: { ...request, sddChange: { ...request.sddChange } };
+		this.queue.push({ task, request: launchRequest });
 		queueMicrotask(() => this.pump());
 		return task;
 	}

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -894,6 +894,39 @@ test("explicit child roots launch and continue in the actual cwd, persist withou
 	await tick();
 });
 
+test("SDD phase continuation requires a fresh selection and launches only that selection", async () => {
+	const h = fakePi();
+	const runtime = deps();
+	const fixtureHome = join(root, "sdd-selection-home");
+	mkdirSync(join(fixtureHome, ".pi", "agent", "agents"), { recursive: true });
+	writeFileSync(join(fixtureHome, ".pi", "agent", "agents", "sdd-apply.md"), "---\ndescription: apply\ntools: [read]\n---\nSDD apply executor");
+	gentleAgents(h.pi, {}, { ...runtime.deps, home: fixtureHome });
+	const { ctx } = fakeContext();
+	await h.fire("session_start", ctx);
+	const run = await h.tools.get("subagent_run")!.execute("run", {
+		agent: "sdd-apply", task: "Apply alpha", mode: "background",
+		sdd_change: { changeName: "alpha", workspaceRoot: cwd, phase: "apply" },
+	}, undefined, undefined, ctx);
+	await tick();
+	const taskId = (run.details.gentleAgents as { taskId: string }).taskId;
+	const first = runtime.spawned[0]!;
+	assert.deepEqual(JSON.parse(first[first.indexOf("--gentle-sdd-change") + 1]!), { changeName: "alpha", workspaceRoot: cwd, phase: "apply" });
+	runtime.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }] });
+	runtime.children[0].emit({ type: "agent_settled" });
+	await tick();
+	const missing = await h.tools.get("subagent_continue")!.execute("missing", { task_id: taskId, prompt: "Continue", mode: "background" }, undefined, undefined, ctx);
+	assert.match(missing.content[0].text, /requires a fresh sdd_change/i);
+	assert.equal(runtime.spawned.length, 1);
+	await h.tools.get("subagent_continue")!.execute("continue", {
+		task_id: taskId, prompt: "Apply beta", mode: "background",
+		sdd_change: { changeName: "beta", workspaceRoot: cwd, phase: "apply" },
+	}, undefined, undefined, ctx);
+	await tick();
+	const second = runtime.spawned[1]!;
+	assert.deepEqual(JSON.parse(second[second.indexOf("--gentle-sdd-change") + 1]!), { changeName: "beta", workspaceRoot: cwd, phase: "apply" });
+	await h.fire("session_shutdown", ctx);
+});
+
 test("ordinary non-Git tasks still continue in their original cwd without registering a worktree", async () => {
 	const h = fakePi();
 	const runtime = deps();

--- a/tests/sdd-selection-transport.test.ts
+++ b/tests/sdd-selection-transport.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { AGENT_MODE, type AgentDefinition } from "../lib/agents-config.ts";
+import { AgentRunner, type TaskRequest } from "../lib/agents-runner.ts";
+import { TaskStore } from "../lib/agents-protocol.ts";
+import { __testing } from "../extensions/gentle-ai.ts";
+import { fakeChild } from "./agents-fake-child.ts";
+
+const applyAgent: AgentDefinition = {
+	name: "sdd-apply",
+	description: "Apply the selected change.",
+	filePath: "/agents/sdd-apply.md",
+	scope: "global",
+	instructions: "SDD apply executor",
+	model: undefined,
+	thinking: undefined,
+	mode: undefined,
+	tools: ["read"],
+};
+
+function request(sddChange: { changeName: string; workspaceRoot: string; phase: "apply" }): TaskRequest {
+	return {
+		agent: applyAgent,
+		prompt: "Apply selected change.",
+		label: undefined,
+		context: undefined,
+		mode: AGENT_MODE.BACKGROUND,
+		cwd: sddChange.workspaceRoot,
+		parentSessionId: "parent",
+		model: undefined,
+		thinking: undefined,
+		sessionDir: "/sessions",
+		resumeSessionPath: undefined,
+		env: {},
+		sddChange,
+	};
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+function workspace(t: test.TestContext): string {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-sdd-selection-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	mkdirSync(join(root, "openspec", "changes", "alpha"), { recursive: true });
+	mkdirSync(join(root, "openspec", "changes", "beta"), { recursive: true });
+	return realpathSync(root);
+}
+
+test("selected SDD change snapshots at task construction and reaches child startup in a multi-change workspace", async (t) => {
+	const root = workspace(t);
+	const selection = { changeName: "alpha", workspaceRoot: root, phase: "apply" as const };
+	const spawned: string[][] = [];
+	const runner = new AgentRunner(new TaskStore(), { maxConcurrency: 2, stallTimeoutMs: 1_000 }, {
+		spawn: (_command, args) => {
+			spawned.push(args);
+			return fakeChild().child;
+		},
+		now: () => 1,
+		schedule: () => () => {},
+		pi: { command: "pi", args: [] },
+	}, { askUser: async () => ({ cancelled: true }) });
+
+	runner.run(request(selection));
+	selection.changeName = "beta";
+	runner.run(request({ changeName: "beta", workspaceRoot: root, phase: "apply" }));
+	await tick();
+	const serialized = spawned[0]![spawned[0]!.indexOf("--gentle-sdd-change") + 1]!;
+	const concurrent = spawned[1]![spawned[1]!.indexOf("--gentle-sdd-change") + 1]!;
+	assert.deepEqual(JSON.parse(serialized), { changeName: "alpha", workspaceRoot: root, phase: "apply" });
+	assert.deepEqual(JSON.parse(concurrent), { changeName: "beta", workspaceRoot: root, phase: "apply" });
+	const startup = __testing.resolveSddChangeStartup(serialized, root, "sdd-apply");
+	assert.equal(startup.status.changeName, "alpha");
+	assert.equal(startup.status.nextRecommended, "sdd-propose");
+});
+
+test("a throwing SDD selection flag reader fails closed without resolving an unselected status", (t) => {
+	const root = workspace(t);
+	assert.equal(__testing.readSddChangeFlag({ getFlag: () => false } as never), undefined);
+	const selection = __testing.readSddChangeFlag({
+		getFlag() { throw new Error("flag reader failed"); },
+	} as never);
+	let resolverCalls = 0;
+	assert.throws(
+		() => __testing.resolveSddChangeStartup(selection, root, "sdd-apply", () => {
+			resolverCalls += 1;
+			throw new Error("status resolver must not run");
+		}),
+		/SDD selection must be a JSON string/i,
+	);
+	assert.equal(resolverCalls, 0);
+});
+
+test("selected SDD startup fails closed for malformed identity, root, phase, symlink, and resolver errors", (t) => {
+	const root = workspace(t);
+	const selected = JSON.stringify({ changeName: "alpha", workspaceRoot: root, phase: "apply" });
+	const outside = mkdtempSync(join(tmpdir(), "gentle-pi-sdd-selection-outside-"));
+	t.after(() => rmSync(outside, { recursive: true, force: true }));
+	const escaped = join(root, "escaped-root");
+	symlinkSync(outside, escaped);
+
+	for (const value of [
+		"not-json",
+		JSON.stringify({ changeName: "alpha", workspaceRoot: root, phase: "apply", extra: true }),
+		JSON.stringify({ changeName: "alpha", workspaceRoot: join(root, "wrong"), phase: "apply" }),
+		JSON.stringify({ changeName: "alpha", workspaceRoot: escaped, phase: "apply" }),
+	]) {
+		assert.throws(() => __testing.resolveSddChangeStartup(value, root, "sdd-apply"), /SDD selection/i);
+	}
+	assert.throws(() => __testing.resolveSddChangeStartup(selected, root, "sdd-verify"), /phase/i);
+	assert.throws(
+		() => __testing.resolveSddChangeStartup(selected, root, "sdd-apply", () => { throw new Error("resolver failed"); }),
+		/resolver failed/i,
+	);
+});


### PR DESCRIPTION
## Summary
- preserve the explicitly selected SDD change as immutable task metadata across `subagent_run` and `subagent_continue`
- pass the selection through child argv and validate change, canonical workspace root, and phase before startup
- fail closed on malformed transport, resolver mismatch, symlink/root mismatch, or flag-reader failure

## Testing
- `node --experimental-strip-types --test tests/gentle-agents.test.ts tests/sdd-selection-transport.test.ts` (58 passed)
- `pnpm test` (1,931 passed, 18 skipped, 0 failed)
- `git diff --check`
- native 4R review approved and acknowledged

Closes #758


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SDD change selection for launching and continuing phase agents.
  - Selected changes now include the workspace and requested phase, ensuring agents work on the intended change.
  - SDD phase prompts now reflect the selected change’s current status.

- **Bug Fixes**
  - Invalid, missing, or mismatched selections are blocked with clear errors.
  - Continuing an SDD phase now requires a fresh change selection, preventing stale work from being resumed accidentally.
  - Non-Git continuation workflows remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->