### PR TITLE
fix(sdd): trust native status authority

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -128,6 +128,7 @@ import {
 import {
 	createNativeReviewCli,
 	createNodeExecFileAdapter,
+	decodeNativeSddStatusV2,
 	isCanonicalProcessString,
 	nativeReviewAbandonAuthorization,
 	nativeReviewLegacyAliasRepairAuthorization,
@@ -148,6 +149,7 @@ import {
 	NATIVE_REVIEW_RECONCILE_ANOMALIES,
 	sanitizeForeignNativeReviewDiagnostics,
 	type NativeReviewCli,
+	type NativeSddStatusV2,
 	type NativeIntendedUntrackedSelectionSubmission,
 	type NativeReviewAcknowledgeApprovedOutcome,
 	type NativeReviewAcknowledgeApprovedRequest,
@@ -1492,12 +1494,7 @@ function sddPhaseFromAgentStartEvent(event: unknown): SddPhase | undefined {
 	return undefined;
 }
 
-function resolveSddChangeStartup(
-	serialized: unknown,
-	cwd: string,
-	agentName: string,
-	resolver: (options: Parameters<typeof resolveSddStatus>[0]) => ReturnType<typeof resolveSddStatus> = resolveSddStatus,
-) {
+function resolveSddChangeSelection(serialized: unknown, cwd: string, agentName: string) {
 	if (typeof serialized !== "string") throw new Error("SDD selection must be a JSON string.");
 	let value: unknown;
 	try {
@@ -1526,11 +1523,52 @@ function resolveSddChangeStartup(
 	if (canonicalCwd !== canonicalSelectionRoot || workspaceRoot !== canonicalSelectionRoot) {
 		throw new Error("SDD selection workspaceRoot does not match the canonical child root.");
 	}
-	const status = resolver({ cwd: canonicalCwd, workspaceRoot: canonicalCwd, changeName, includeInstructions: true });
-	if (status.actionContext.workspaceRoot !== canonicalCwd || status.changeName !== changeName) {
+	return { changeName, workspaceRoot: canonicalCwd, phase };
+}
+
+function resolveSddChangeStartup(
+	serialized: unknown,
+	cwd: string,
+	agentName: string,
+	resolver: (options: Parameters<typeof resolveSddStatus>[0]) => ReturnType<typeof resolveSddStatus> = resolveSddStatus,
+) {
+	const selection = resolveSddChangeSelection(serialized, cwd, agentName);
+	const status = resolver({ cwd: selection.workspaceRoot, workspaceRoot: selection.workspaceRoot, changeName: selection.changeName, includeInstructions: true });
+	if (status.actionContext.workspaceRoot !== selection.workspaceRoot || status.changeName !== selection.changeName) {
 		throw new Error("SDD selection resolver returned a mismatched status.");
 	}
-	return { selection: { changeName, workspaceRoot: canonicalCwd, phase }, status };
+	return { selection, status };
+}
+
+async function resolveSelectedNativeSddChangeStartup(
+	serialized: unknown,
+	cwd: string,
+	agentName: string,
+	native: Pick<NativeReviewCli, "sddStatus"> | null | undefined,
+	localResolver: (options: Parameters<typeof resolveSddStatus>[0]) => ReturnType<typeof resolveSddStatus> = resolveSddStatus,
+): Promise<{ selection: { changeName: string; workspaceRoot: string; phase: SddPhase }; status: NativeSddStatusV2 | ReturnType<typeof resolveSddStatus> }> {
+	const selection = resolveSddChangeSelection(serialized, cwd, agentName);
+	if (selection.phase === "sync") {
+		const status = localResolver({ cwd: selection.workspaceRoot, workspaceRoot: selection.workspaceRoot, changeName: selection.changeName, includeInstructions: true });
+		if (status.actionContext.workspaceRoot !== selection.workspaceRoot || status.changeName !== selection.changeName) {
+			throw new Error("SDD selection resolver returned a mismatched status.");
+		}
+		return { selection, status };
+	}
+	if (native?.sddStatus === undefined) throw new Error("SDD selection native status is unavailable.");
+	let status: NativeSddStatusV2;
+	try {
+		status = decodeNativeSddStatusV2(
+			await native.sddStatus({ changeName: selection.changeName, workspaceRoot: selection.workspaceRoot }),
+			{ changeName: selection.changeName, workspaceRoot: selection.workspaceRoot },
+		);
+	} catch (error) {
+		throw new Error(`SDD selection native status is blocked: ${error instanceof Error ? error.message : String(error)}`);
+	}
+	if (!(selection.phase in status.dependencies) || !(selection.phase in status.instructions)) {
+		throw new Error(`SDD selection native status cannot represent phase ${selection.phase}.`);
+	}
+	return { selection, status };
 }
 
 function readSddChangeFlag(pi: ExtensionAPI): unknown {
@@ -6461,6 +6499,7 @@ export const __testing = {
 	resolveControllerSddStatus,
 	resolveStartupControllerSddStatus,
 	resolveSddChangeStartup,
+	resolveSelectedNativeSddChangeStartup,
 	readSddChangeFlag,
 	resetTelemetryTriggerGuardForTesting,
 	createGentleAiExtension: createGentleAiExtensionForTesting,
@@ -6971,7 +7010,7 @@ function createGentleAiExtensionForTesting(
 		const phase = isSddAgent ? sddPhaseFromAgentStartEvent(event) : undefined;
 		const launchSddChange = isSddAgent ? readSddChangeFlag(pi) : undefined;
 		const nativeStatusPrompt = phase
-			? (() => {
+			? await (async () => {
 				if (launchSddChange === undefined) {
 					return `\n\n${renderNativeSddPhasePrompt(resolveStartupControllerSddStatus(
 						ctx.cwd,
@@ -6984,10 +7023,19 @@ function createGentleAiExtensionForTesting(
 					const names = readAgentStartNames(event);
 					const agentName = names.find((name) => name === `sdd-${phase}`);
 					if (!agentName) throw new Error("SDD selection requires a matching named SDD phase agent.");
-					const startup = resolveSddChangeStartup(launchSddChange, ctx.cwd, agentName, (options) =>
-						resolveControllerSddStatus(options.cwd, options.changeName, true, prefs?.artifactStore),
+					const startup = await resolveSelectedNativeSddChangeStartup(
+						launchSddChange,
+						ctx.cwd,
+						agentName,
+						nativeReviewCli,
+						(options) => resolveControllerSddStatus(
+							options.cwd,
+							options.changeName,
+							true,
+							prefs?.artifactStore,
+						),
 					);
-					return `\n\n${renderNativeSddPhasePrompt(startup.status, phase)}`;
+					return `\n\n${renderNativeSddPhasePrompt(startup.status as never, phase)}`;
 				} catch (error) {
 					return `\n\n## Native SDD Status Engine\nSDD selection blocked: ${error instanceof Error ? error.message : String(error)}\nDo not run phase work; return this blocker to the parent.`;
 				}

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -66,6 +66,7 @@ export const NATIVE_REVIEW_OPERATION = {
 	CAPTURE_CORRECTION_PLAN: "review/capture-correction-plan",
 	CAPTURE_PROVIDER_ROLE: "review/capture-provider-role",
 	ACKNOWLEDGE_APPROVED: "review/acknowledge-approved",
+	SDD_STATUS: "sdd-status",
 } as const;
 export type NativeReviewOperation = (typeof NATIVE_REVIEW_OPERATION)[keyof typeof NATIVE_REVIEW_OPERATION];
 
@@ -116,6 +117,10 @@ export interface NativeReviewCli {
 	// an older binary without the verb, or any other process/decode failure,
 	// rejects the returned promise -- callers fail closed to `high` risk.
 	assess?(request: NativeReviewAssessRequest): Promise<ReviewAssessmentV1>;
+	// Exact native SDD readiness authority for an explicitly selected phase.
+	// This is intentionally separate from review/RDD gates and carries no
+	// delivery or review-transaction authority.
+	sddStatus?(request: NativeSddStatusRequest): Promise<NativeSddStatusV2>;
 }
 
 export const NATIVE_REVIEW_MODE_OPERATION = {
@@ -151,6 +156,31 @@ export const NATIVE_REVIEW_MODE_SCOPE = {
 	BOTH: "both",
 } as const;
 export type NativeReviewModeScope = (typeof NATIVE_REVIEW_MODE_SCOPE)[keyof typeof NATIVE_REVIEW_MODE_SCOPE];
+
+export interface NativeSddStatusRequest {
+	changeName: string;
+	workspaceRoot: string;
+	signal?: AbortSignal;
+}
+
+export type NativeSddPhase = "apply" | "verify" | "archive";
+export type NativeSddDependencyState = "blocked" | "ready" | "all_done";
+
+/**
+ * The native CLI owns this complete v2 record. The decoder validates the fields
+ * Pi relies on and returns the original object without adding, omitting, or
+ * reconciling local SDD state.
+ */
+export interface NativeSddStatusV2 extends Readonly<Record<string, unknown>> {
+	schemaName: "gentle-ai.sdd-status";
+	schemaVersion: 2;
+	changeName: string;
+	actionContext: Readonly<Record<string, unknown>> & { workspaceRoot: string };
+	dependencies: Readonly<Record<NativeSddPhase, NativeSddDependencyState>>;
+	instructions: Readonly<Record<NativeSddPhase, readonly string[]>>;
+	blockedReasons: readonly string[];
+	nextRecommended: string;
+}
 
 export interface NativeReviewModeRequest {
 	cwd: string;
@@ -1299,6 +1329,29 @@ interface NativeJsonExecution {
 	process: ExecFileResult;
 }
 
+const NATIVE_SDD_PHASES = ["apply", "verify", "archive"] as const;
+const NATIVE_SDD_DEPENDENCY_STATES = ["blocked", "ready", "all_done"] as const;
+
+/** Strictly validates the native v2 contract while preserving its whole record. */
+export function decodeNativeSddStatusV2(value: unknown, request: Pick<NativeSddStatusRequest, "changeName" | "workspaceRoot">): NativeSddStatusV2 {
+	const status = object(value);
+	if (status.schemaName !== "gentle-ai.sdd-status" || status.schemaVersion !== 2) throw new Error("wrong native SDD status schema");
+	if (status.changeName !== request.changeName || !isCanonicalProcessString(status.changeName)) throw new Error("native SDD status change identity mismatch");
+	const actionContext = object(status.actionContext);
+	if (actionContext.workspaceRoot !== request.workspaceRoot || !isCanonicalProcessString(actionContext.workspaceRoot)) throw new Error("native SDD status workspace root mismatch");
+	const dependencies = object(status.dependencies);
+	const instructions = object(status.instructions);
+	for (const phase of NATIVE_SDD_PHASES) {
+		if (enumString(dependencies[phase], NATIVE_SDD_DEPENDENCY_STATES) !== dependencies[phase]) throw new Error("invalid native SDD dependency");
+		stringArray(instructions[phase]);
+	}
+	if (Object.keys(dependencies).length !== NATIVE_SDD_PHASES.length || Object.keys(dependencies).some((key) => !NATIVE_SDD_PHASES.includes(key as NativeSddPhase))) throw new Error("native SDD dependencies have an unsupported shape");
+	if (Object.keys(instructions).length !== NATIVE_SDD_PHASES.length || Object.keys(instructions).some((key) => !NATIVE_SDD_PHASES.includes(key as NativeSddPhase))) throw new Error("native SDD instructions have an unsupported shape");
+	stringArray(status.blockedReasons);
+	if (!isCanonicalProcessString(status.nextRecommended)) throw new Error("invalid native SDD next recommendation");
+	return status as NativeSddStatusV2;
+}
+
 class NativeReviewPlainCli {
 	private readonly adapter: ExecFileAdapter;
 	private readonly executable: string | (() => string);
@@ -1918,6 +1971,20 @@ export class NativeReviewCliV216 implements NativeReviewCli {
 		toleratedStderr: readonly string[] = [],
 	): Promise<NegotiatedExecution> {
 		return this.invoke(operation, cwd, arguments_, mutating, signal, this.executablePath(operation, mutating), toleratedStderr);
+	}
+
+	async sddStatus(request: NativeSddStatusRequest): Promise<NativeSddStatusV2> {
+		if (!isCanonicalProcessString(request.changeName) || !isCanonicalProcessString(request.workspaceRoot) || !isAbsolute(request.workspaceRoot)) {
+			throw new TypeError("Native SDD status requires a canonical selected change and absolute workspace root");
+		}
+		const execution = await this.negotiated(
+			NATIVE_REVIEW_OPERATION.SDD_STATUS,
+			request.workspaceRoot,
+			["sdd-status", request.changeName, "--cwd", request.workspaceRoot, "--json", "--instructions"],
+			false,
+			request.signal,
+		);
+		return decode(NATIVE_REVIEW_OPERATION.SDD_STATUS, false, () => decodeNativeSddStatusV2(execution.body, request));
 	}
 
 	async start(request: NativeStartRequest): Promise<NativeStartResult> {

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -67,6 +67,7 @@ export const NATIVE_REVIEW_OPERATION = {
 	CAPTURE_CORRECTION_PLAN: "review/capture-correction-plan",
 	CAPTURE_PROVIDER_ROLE: "review/capture-provider-role",
 	ACKNOWLEDGE_APPROVED: "review/acknowledge-approved",
+	SDD_STATUS: "sdd-status",
 }         ;
 
 
@@ -119,6 +120,10 @@ export const NATIVE_REVIEW_ERROR_CODE = {
 
 
 
+
+
+
+
 export const NATIVE_REVIEW_MODE_OPERATION = {
 	STATUS: "status",
 	ENABLE: "enable",
@@ -151,6 +156,31 @@ export const NATIVE_REVIEW_MODE_SCOPE = {
 	CLONE: "clone",
 	BOTH: "both",
 }         ;
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * The native CLI owns this complete v2 record. The decoder validates the fields
+ * Pi relies on and returns the original object without adding, omitting, or
+ * reconciling local SDD state.
+ */
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1300,6 +1330,29 @@ function nativeError(code                       , operation                     
 
 
 
+const NATIVE_SDD_PHASES = ["apply", "verify", "archive"]         ;
+const NATIVE_SDD_DEPENDENCY_STATES = ["blocked", "ready", "all_done"]         ;
+
+/** Strictly validates the native v2 contract while preserving its whole record. */
+export function decodeNativeSddStatusV2(value         , request                                                              )                    {
+	const status = object(value);
+	if (status.schemaName !== "gentle-ai.sdd-status" || status.schemaVersion !== 2) throw new Error("wrong native SDD status schema");
+	if (status.changeName !== request.changeName || !isCanonicalProcessString(status.changeName)) throw new Error("native SDD status change identity mismatch");
+	const actionContext = object(status.actionContext);
+	if (actionContext.workspaceRoot !== request.workspaceRoot || !isCanonicalProcessString(actionContext.workspaceRoot)) throw new Error("native SDD status workspace root mismatch");
+	const dependencies = object(status.dependencies);
+	const instructions = object(status.instructions);
+	for (const phase of NATIVE_SDD_PHASES) {
+		if (enumString(dependencies[phase], NATIVE_SDD_DEPENDENCY_STATES) !== dependencies[phase]) throw new Error("invalid native SDD dependency");
+		stringArray(instructions[phase]);
+	}
+	if (Object.keys(dependencies).length !== NATIVE_SDD_PHASES.length || Object.keys(dependencies).some((key) => !NATIVE_SDD_PHASES.includes(key                  ))) throw new Error("native SDD dependencies have an unsupported shape");
+	if (Object.keys(instructions).length !== NATIVE_SDD_PHASES.length || Object.keys(instructions).some((key) => !NATIVE_SDD_PHASES.includes(key                  ))) throw new Error("native SDD instructions have an unsupported shape");
+	stringArray(status.blockedReasons);
+	if (!isCanonicalProcessString(status.nextRecommended)) throw new Error("invalid native SDD next recommendation");
+	return status                     ;
+}
+
 class NativeReviewPlainCli {
 	                 adapter                 ;
 	                 executable                         ;
@@ -1919,6 +1972,20 @@ export class NativeReviewCliV216                            {
 		toleratedStderr                    = [],
 	)                               {
 		return this.invoke(operation, cwd, arguments_, mutating, signal, this.executablePath(operation, mutating), toleratedStderr);
+	}
+
+	async sddStatus(request                        )                             {
+		if (!isCanonicalProcessString(request.changeName) || !isCanonicalProcessString(request.workspaceRoot) || !isAbsolute(request.workspaceRoot)) {
+			throw new TypeError("Native SDD status requires a canonical selected change and absolute workspace root");
+		}
+		const execution = await this.negotiated(
+			NATIVE_REVIEW_OPERATION.SDD_STATUS,
+			request.workspaceRoot,
+			["sdd-status", request.changeName, "--cwd", request.workspaceRoot, "--json", "--instructions"],
+			false,
+			request.signal,
+		);
+		return decode(NATIVE_REVIEW_OPERATION.SDD_STATUS, false, () => decodeNativeSddStatusV2(execution.body, request));
 	}
 
 	async start(request                    )                             {

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -56,6 +56,74 @@ function client(adapter: ExecFileAdapter): NativeReviewCliV216 {
 	return new NativeReviewCliV216(adapter, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024);
 }
 
+function nativeSddStatus(changeName = "complete-native-review-lifecycle", workspaceRoot = "/repo"): Record<string, unknown> {
+	return {
+		schemaName: "gentle-ai.sdd-status",
+		schemaVersion: 2,
+		changeName,
+		actionContext: { workspaceRoot },
+		dependencies: { apply: "all_done", verify: "all_done", archive: "ready" },
+		instructions: {
+			apply: ["Apply is complete."],
+			verify: ["Verification is complete."],
+			archive: ["Archive the selected change."],
+		},
+		blockedReasons: [],
+		nextRecommended: "archive",
+	};
+}
+
+test("native SDD status executes its exact selected-root argv and returns only a validated v2 authority", async () => {
+	const body = nativeSddStatus();
+	const queue = queuedAdapter([{ stdout: JSON.stringify(body) }]);
+	const status = await (client(queue.adapter) as unknown as {
+		sddStatus(request: { changeName: string; workspaceRoot: string }): Promise<Record<string, unknown>>;
+	}).sddStatus({ changeName: "complete-native-review-lifecycle", workspaceRoot: "/repo" });
+
+	assert.deepEqual(status, body);
+	assert.deepEqual(queue.calls, [{
+		file: "/package/.gentle-ai/gentle-ai",
+		arguments: ["sdd-status", "complete-native-review-lifecycle", "--cwd", "/repo", "--json", "--instructions"],
+		cwd: "/repo",
+		timeoutMs: 30_000,
+	}]);
+});
+
+test("native SDD status rejects malformed v2 identities, dependencies, instructions, and blockers", async () => {
+	const malformed = [
+		{ ...nativeSddStatus(), schemaName: "gentle-pi.sdd-status" },
+		{ ...nativeSddStatus(), schemaVersion: 1 },
+		{ ...nativeSddStatus(), changeName: "other-change" },
+		{ ...nativeSddStatus(), actionContext: { workspaceRoot: "/other" } },
+		{ ...nativeSddStatus(), dependencies: { apply: "all_done", verify: "all_done", archive: "future" } },
+		{ ...nativeSddStatus(), instructions: { apply: ["ok"], verify: ["ok"], archive: [42] } },
+		{ ...nativeSddStatus(), blockedReasons: "not-an-array" },
+	];
+	for (const body of malformed) {
+		await assert.rejects(
+			() => (client(queuedAdapter([{ stdout: JSON.stringify(body) }]).adapter) as unknown as {
+				sddStatus(request: { changeName: string; workspaceRoot: string }): Promise<Record<string, unknown>>;
+			}).sddStatus({ changeName: "complete-native-review-lifecycle", workspaceRoot: "/repo" }),
+			(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE,
+		);
+	}
+});
+
+test("native SDD status keeps malformed JSON, timeout, and nonzero execution fail-closed", async () => {
+	for (const [result, code] of [
+		[{ stdout: "not-json" }, NATIVE_REVIEW_ERROR_CODE.MALFORMED_JSON],
+		[{ stdout: "", timedOut: true }, NATIVE_REVIEW_ERROR_CODE.TIMEOUT],
+		[{ stdout: "{}", exitCode: 1 }, NATIVE_REVIEW_ERROR_CODE.NON_ZERO],
+	] as const) {
+		await assert.rejects(
+			() => (client(queuedAdapter([result]).adapter) as unknown as {
+				sddStatus(request: { changeName: string; workspaceRoot: string }): Promise<Record<string, unknown>>;
+			}).sddStatus({ changeName: "complete-native-review-lifecycle", workspaceRoot: "/repo" }),
+			(error: unknown) => error instanceof NativeReviewCliError && error.code === code && error.mutationOutcome === "none",
+		);
+	}
+});
+
 test("negotiated STATUS accepts the pinned v5 receipt before routing its transition", async () => {
 	const status = fixture("status-v5.captured.json");
 	const queue = queuedAdapter([{ stdout: JSON.stringify(status) }]);
@@ -568,8 +636,8 @@ test("capture-result receives the controller AbortSignal without an automatic mu
 	assert.equal(receivedTimeout, undefined);
 });
 
-test("native review client leaves SDD status resolution to the local SDD engine", () => {
-	assert.equal("sddStatus" in client(queuedAdapter([]).adapter), false);
+test("native review client exposes native v2 SDD status without adding review lifecycle behavior", () => {
+	assert.equal(typeof (client(queuedAdapter([]).adapter) as unknown as { sddStatus?: unknown }).sddStatus, "function");
 });
 
 test("read-only authority inventory rejects a repository identity mismatch after decoding", async () => {

--- a/tests/sdd-selection-transport.test.ts
+++ b/tests/sdd-selection-transport.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import { AGENT_MODE, type AgentDefinition } from "../lib/agents-config.ts";
 import { AgentRunner, type TaskRequest } from "../lib/agents-runner.ts";
 import { TaskStore } from "../lib/agents-protocol.ts";
+import { NATIVE_REVIEW_ERROR_CODE, NativeReviewCliError } from "../lib/native-review-cli.ts";
 import { __testing } from "../extensions/gentle-ai.ts";
 import { fakeChild } from "./agents-fake-child.ts";
 
@@ -74,6 +75,121 @@ test("selected SDD change snapshots at task construction and reaches child start
 	const startup = __testing.resolveSddChangeStartup(serialized, root, "sdd-apply");
 	assert.equal(startup.status.changeName, "alpha");
 	assert.equal(startup.status.nextRecommended, "sdd-propose");
+});
+
+test("selected native v2 archive authority is injected whole and never falls back to the local resolver", async (t) => {
+	const root = workspace(t);
+	const serialized = JSON.stringify({ changeName: "alpha", workspaceRoot: root, phase: "archive" });
+	const nativeAuthority = {
+		schemaName: "gentle-ai.sdd-status",
+		schemaVersion: 2,
+		changeName: "alpha",
+		actionContext: { workspaceRoot: root },
+		dependencies: { apply: "all_done", verify: "all_done", archive: "ready" },
+		instructions: { apply: ["done"], verify: ["done"], archive: ["archive now"] },
+		blockedReasons: [],
+		nextRecommended: "archive",
+	};
+	const nativeCalls: unknown[] = [];
+	let localResolverCalls = 0;
+	const startup = await (__testing as unknown as {
+		resolveSelectedNativeSddChangeStartup(
+			serialized: unknown,
+			cwd: string,
+			agentName: string,
+			native: { sddStatus?: (request: unknown) => Promise<unknown> },
+			localResolver: () => unknown,
+		): Promise<{ selection: { changeName: string; workspaceRoot: string; phase: string }; status: unknown }>;
+	}).resolveSelectedNativeSddChangeStartup(serialized, root, "sdd-archive", {
+		sddStatus: async (request) => { nativeCalls.push(request); return nativeAuthority; },
+	}, () => {
+		localResolverCalls += 1;
+		// Simulates local v1's missing sync-report.md result: it must never
+		// overlay the native archive-ready authority.
+		return { dependencies: { verify: "all_done", sync: "blocked", archive: "blocked" } };
+	});
+
+	assert.deepEqual(startup.selection, { changeName: "alpha", workspaceRoot: root, phase: "archive" });
+	assert.equal(startup.status, nativeAuthority, "the validated native status object is injected without a local overlay");
+	assert.deepEqual(nativeCalls, [{ changeName: "alpha", workspaceRoot: root }]);
+	assert.equal(localResolverCalls, 0);
+});
+
+test("selected native v2 failures fail closed without consulting the local resolver", async (t) => {
+	const root = workspace(t);
+	const serialized = JSON.stringify({ changeName: "alpha", workspaceRoot: root, phase: "archive" });
+	const valid = {
+		schemaName: "gentle-ai.sdd-status", schemaVersion: 2, changeName: "alpha",
+		actionContext: { workspaceRoot: root },
+		dependencies: { apply: "all_done", verify: "all_done", archive: "blocked" },
+		instructions: { apply: ["done"], verify: ["done"], archive: ["blocked"] },
+		blockedReasons: ["native archive blocker"], nextRecommended: "verify",
+	};
+	const failures: Array<{ sddStatus?: () => Promise<unknown> }> = [
+		{},
+		{ sddStatus: async () => { throw new NativeReviewCliError(NATIVE_REVIEW_ERROR_CODE.TIMEOUT, "sdd-status", true, false, "native timeout"); } },
+		{ sddStatus: async () => { throw new NativeReviewCliError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, "sdd-status", true, false, "native nonzero"); } },
+		{ sddStatus: async () => { throw new Error("native command threw"); } },
+		{ sddStatus: async () => ({}) },
+		{ sddStatus: async () => ({ ...valid, schemaVersion: 1 }) },
+		{ sddStatus: async () => ({ ...valid, changeName: "other" }) },
+		{ sddStatus: async () => ({ ...valid, actionContext: { workspaceRoot: "/other" } }) },
+		{ sddStatus: async () => ({ ...valid, dependencies: { apply: "all_done", verify: "all_done" } }) },
+		{ sddStatus: async () => ({ ...valid, instructions: { apply: ["done"], verify: ["done"] } }) },
+		{ sddStatus: async () => ({ ...valid, blockedReasons: "invalid" }) },
+	];
+	for (const native of failures) {
+		let localResolverCalls = 0;
+		await assert.rejects(
+			() => (__testing as unknown as {
+				resolveSelectedNativeSddChangeStartup(
+					serialized: unknown, cwd: string, agentName: string,
+					native: { sddStatus?: () => Promise<unknown> }, localResolver: () => unknown,
+				): Promise<unknown>;
+			}).resolveSelectedNativeSddChangeStartup(serialized, root, "sdd-archive", native, () => { localResolverCalls += 1; return {}; }),
+			/SDD selection native status/i,
+		);
+		assert.equal(localResolverCalls, 0);
+	}
+
+	const blocked = await (__testing as unknown as {
+		resolveSelectedNativeSddChangeStartup(
+			serialized: unknown, cwd: string, agentName: string,
+			native: { sddStatus?: () => Promise<unknown> }, localResolver: () => unknown,
+		): Promise<{ status: typeof valid }>;
+	}).resolveSelectedNativeSddChangeStartup(serialized, root, "sdd-archive", { sddStatus: async () => valid }, () => {
+		throw new Error("local resolver must not run");
+	});
+	assert.deepEqual(blocked.status, valid, "a native archive blocker remains authoritative over a locally-ready result");
+
+	const syncSerialized = JSON.stringify({ changeName: "alpha", workspaceRoot: root, phase: "sync" });
+	const localStatus = __testing.resolveSddChangeStartup(syncSerialized, root, "sdd-sync").status;
+	const syncNativeCalls: unknown[] = [];
+	const syncLocalCalls: unknown[] = [];
+	const sync = await (__testing as unknown as {
+		resolveSelectedNativeSddChangeStartup(
+			serialized: unknown, cwd: string, agentName: string,
+			native: { sddStatus?: (request: unknown) => Promise<unknown> }, localResolver: (options: unknown) => unknown,
+		): Promise<{ status: unknown }>;
+	}).resolveSelectedNativeSddChangeStartup(syncSerialized, root, "sdd-sync", {
+		sddStatus: async (request) => { syncNativeCalls.push(request); throw new Error("native must not run"); },
+	}, (options) => {
+		syncLocalCalls.push(options);
+		return localStatus;
+	});
+	assert.equal(sync.status, localStatus, "selected sync injects the exact local status");
+	assert.deepEqual(syncLocalCalls, [{ cwd: root, workspaceRoot: root, changeName: "alpha", includeInstructions: true }]);
+	assert.deepEqual(syncNativeCalls, []);
+
+	await assert.rejects(
+		() => (__testing as unknown as {
+			resolveSelectedNativeSddChangeStartup(
+				serialized: unknown, cwd: string, agentName: string,
+				native: { sddStatus?: () => Promise<unknown> }, localResolver: () => typeof localStatus,
+			): Promise<unknown>;
+		}).resolveSelectedNativeSddChangeStartup(syncSerialized, root, "sdd-sync", undefined, () => ({ ...localStatus, changeName: "beta" })),
+		/mismatched status/i,
+	);
 });
 
 test("a throwing SDD selection flag reader fails closed without resolving an unselected status", (t) => {


### PR DESCRIPTION
## Summary
- acquire and strictly decode native `gentle-ai.sdd-status/v2` for explicitly selected apply, verify, and archive startup
- inject the complete native status as the sole authority without merging local v1 fields
- fail closed on native acquisition, schema, identity, root, or phase mismatches while preserving local v1 routing for `sdd-sync`, which native v2 does not model

## Testing
- `node --experimental-strip-types --test tests/native-review-cli.test.ts tests/sdd-selection-transport.test.ts tests/review-controller-native-routing.test.ts` (94 passed)
- `pnpm test` (1,937 passed, 18 skipped, 0 failed)
- `git diff --check`
- native 4R review approved after targeted correction validation

Closes #821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native SDD status support to the review CLI.
  * Startup status can now use authoritative native results for applicable workflow phases.
  * Added validation for native status responses and clear handling of blocked or unavailable states.

* **Bug Fixes**
  * Prevented invalid or mismatched native status responses from being used.
  * Preserved local status handling for the synchronization phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->