### PR TITLE
fix(review): bind capture reconciliation

### DIFF
--- a/lib/review-last-event-controller.ts
+++ b/lib/review-last-event-controller.ts
@@ -26,11 +26,14 @@ export async function reconcileUnknownReviewLastEventCapture(
 		lineageId: binding.lineageId,
 		...(selector === undefined ? {} : selector),
 	});
-	if (binding.targetIdentity !== undefined && status.targetIdentity !== binding.targetIdentity) {
-		throw new TypeError("capture reconciliation returned a different target");
+	if (status.applicability !== "current_target") {
+		throw new TypeError("capture reconciliation STATUS is not current for the bound target");
 	}
-	if (status.authority?.lineageId !== undefined && status.authority.lineageId !== binding.lineageId) {
-		throw new TypeError("capture reconciliation returned a different lineage");
+	if (status.authority?.lineageId !== binding.lineageId) {
+		throw new TypeError("capture reconciliation returned missing or different lineage authority");
+	}
+	if (binding.targetIdentity === undefined || status.targetIdentity !== binding.targetIdentity) {
+		throw new TypeError("capture reconciliation returned missing or different target");
 	}
 	return status;
 }

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -11,6 +11,7 @@ import {
 	NATIVE_REVIEW_ERROR_CODE,
 	NativeReviewCliError,
 	NativeReviewCliV216,
+	NativeReviewIntegrationError,
 	createNodeExecFileAdapter,
 	type ExecFileAdapter,
 } from "../lib/native-review-cli.ts";
@@ -199,6 +200,40 @@ test("provider-owned refuter and targeted-validator vectors accept only their ma
 		() => client(queuedAdapter([]).adapter).captureProviderRole({ captureOperation: "review.capture-result", argumentTokens: ["--agent=pi"], cwd: "/repo" }),
 		/CAPTURE_PROVIDER_ROLE supports only/,
 	);
+});
+
+test("nonzero targeted-validator capture preserves its dot-form typed failure", async () => {
+	const failure = {
+		schema: "gentle-ai.review-integration.failure/v2",
+		contract: "gentle-ai.review-integration/v2",
+		operation: "review.capture-validation",
+		phase: "native_running",
+		code: "targeted_validation_failed",
+		message: "the targeted validator rejected the candidate",
+		mutation_outcome: "unknown",
+		authority_applicability: "current_target",
+		retry_safe: false,
+		replayability: "status_required",
+		required_inputs: [],
+		next_action: "review.status",
+	};
+	const queue = queuedAdapter([{ stdout: JSON.stringify(failure), exitCode: 1 }]);
+	await assert.rejects(
+		() => client(queue.adapter).captureProviderRole({
+			captureOperation: "review.capture-validation",
+			argumentTokens: ["--repository-context=rctx1_" + "a".repeat(64), "--agent=pi", "--execute=true"],
+			cwd: "/repo",
+		}),
+		(error: unknown) => {
+			if (!(error instanceof NativeReviewIntegrationError)) return false;
+			assert.equal(error.failureEnvelope.operation, "review.capture-validation");
+			assert.equal(error.mutationOutcome, "unknown");
+			assert.equal(error.nextAction, "review.status");
+			assert.deepEqual(error.failureEnvelope.raw, failure);
+			return true;
+		},
+	);
+	assert.deepEqual(queue.calls[0]?.arguments, ["review", "capture-validation", "--repository-context=rctx1_" + "a".repeat(64), "--agent=pi", "--execute=true"]);
 });
 
 test("malformed closure output remains a typed schema failure and never authorizes a retry", async () => {

--- a/tests/review-last-event-closure.test.ts
+++ b/tests/review-last-event-closure.test.ts
@@ -337,7 +337,7 @@ test("unknown-capture reconciliation preserves agentless legacy callers and forw
 		targetStatus: async (request: Record<string, unknown>) => {
 			calls.push(request);
 			assert.equal(request.lineageId, "reconcile-lineage");
-			return { targetIdentity: SHA, authority: { lineageId: "reconcile-lineage" } } as ReviewStatusV3;
+			return { applicability: "current_target", targetIdentity: SHA, authority: { lineageId: "reconcile-lineage" } } as ReviewStatusV3;
 		},
 	} as unknown as NativeReviewCli;
 	const result = await reconcileUnknownReviewLastEventCapture(native, "/repo", { lineageId: "reconcile-lineage", targetIdentity: SHA });
@@ -353,6 +353,71 @@ test("unknown-capture reconciliation preserves agentless legacy callers and forw
 	const strictNative = new nativeReviewCliModule.NativeReviewCliV216(async () => { launches += 1; throw new Error("must not launch"); }, "/package/.gentle-ai/gentle-ai");
 	for (const selector of [{ committedOnly: true }, { baseRef: "refs/heads/main" }, { baseRef: "refs/heads/main", committedOnly: false }] as unknown as readonly Parameters<typeof reconcileUnknownReviewLastEventCapture>[3][]) await assert.rejects(() => reconcileUnknownReviewLastEventCapture(strictNative, "/repo", { lineageId: "reconcile-lineage", targetIdentity: SHA }, selector));
 	assert.equal(launches, 0);
+});
+
+test("unknown targeted-validator capture reconciliation requires current exact authority and target", async () => {
+	const lineageId = "targeted-validator-reconciliation";
+	const input = roleInput(lineageId, "review.capture-validation");
+	const expected = status(lineageId, [input]);
+	const cases = [
+		["current matching STATUS", expected, true],
+		["unrelated STATUS", { ...expected, applicability: "unrelated" }, false],
+		["STATUS without authority", { ...expected, authority: undefined }, false],
+		["STATUS for another lineage", { ...expected, authority: { ...expected.authority!, lineageId: "other-lineage" } }, false],
+		["STATUS for another target", { ...expected, targetIdentity: `sha256:${"d".repeat(64)}` }, false],
+	] as const;
+
+	for (const [_name, reconciliationStatus, trusted] of cases) {
+		let statusCalls = 0;
+		let captureCalls = 0;
+		let startCalls = 0;
+		const native = {
+			targetStatus: async () => {
+				statusCalls += 1;
+				return statusCalls === 1 ? expected : reconciliationStatus;
+			},
+			captureProviderRole: async () => {
+				captureCalls += 1;
+				throw Object.assign(new Error("targeted-validator response lost"), {
+					mutationOutcome: "unknown",
+					nextAction: "review.status",
+					failureEnvelope: { raw: { code: "targeted-validator-response-lost" }, mutationOutcome: "unknown" },
+				});
+			},
+			start: async () => { startCalls += 1; },
+		} as unknown as NativeReviewCli;
+
+		const result = await capture(lineageId, input, native);
+		assert.equal(result.outcome, trusted ? "native-capture-outcome-unknown" : "native-capture-status-reconciliation-failed");
+		assert.equal(captureCalls, 1, "an ambiguous capture is never replayed");
+		assert.equal(statusCalls, 2, "an ambiguous capture gets one reconciliation STATUS");
+		assert.equal(startCalls, 0, "reconciliation never invokes START");
+		if (trusted) {
+			assert.equal(result.status, "reconciled");
+			assert.deepEqual((result.native_failure as { native_failure: unknown }).native_failure, { code: "targeted-validator-response-lost" });
+		} else {
+			assert.deepEqual(result.native_failure, { code: "targeted-validator-response-lost" }, "the original capture failure is preserved");
+			assert.ok(result.reconciliation_failure, "the rejected STATUS diagnostic remains nested");
+		}
+	}
+});
+
+test("unknown-capture reconciliation rejects a binding without a target identity", async () => {
+	const lineageId = "missing-reconciliation-target";
+	const input = roleInput(lineageId, "review.capture-validation");
+	let statusCalls = 0;
+	const native = {
+		targetStatus: async () => {
+			statusCalls += 1;
+			return status(lineageId, [input]);
+		},
+	} as unknown as NativeReviewCli;
+
+	await assert.rejects(
+		() => reconcileUnknownReviewLastEventCapture(native, process.cwd(), { lineageId }),
+		/capture reconciliation returned missing or different target/,
+	);
+	assert.equal(statusCalls, 1, "the missing binding is rejected after one reconciliation STATUS");
 });
 
 // One approved terminal closure carrying the exact continuation the provider


### PR DESCRIPTION
## Summary
- require unknown-capture reconciliation STATUS to prove `current_target` applicability
- require exact non-missing lineage authority and the exact bound target before accepting reconciliation
- preserve slash-form successful validator closures and dot-form typed validator failures while preventing capture replay or fresh START

## Testing
- `node --experimental-strip-types --test tests/review-last-event-closure.test.ts tests/native-review-cli.test.ts` (53 passed)
- `pnpm test` (2,027 passed, 18 skipped, 0 failed)
- `git diff --check`
- independent verifier passed
- native 4R review approved

Closes #614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened review-event reconciliation by requiring matching applicability, authority, and target identity before accepting a returned status.
  - Preserved the original capture failure when reconciliation data is incomplete or inconsistent, with additional diagnostic context.
  - Prevented unnecessary retries or replayed operations during failed reconciliation.
  - Improved targeted-validator failures with structured error details, including the operation, outcome, recommended next action, and underlying failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->