### PR TITLE
refactor(models): enforce canonical routing authority

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -23,7 +23,7 @@ import {
 	writeFile,
 } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { dirname, isAbsolute, join, posix, relative, resolve, sep, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
 	ExtensionAPI,
@@ -51,6 +51,7 @@ import {
 } from "../lib/sdd-preflight.ts";
 import {
 	THINKING_LEVELS,
+	normalizeAgentName,
 	normalizeModelConfig,
 	normalizeModelId,
 	normalizeRoutingEntry,
@@ -1791,6 +1792,71 @@ function legacyProjectModelConfigPath(cwd: string): string {
 	return join(cwd, ".pi", "gentle-ai", "models.json");
 }
 
+type ModelRoutingPathPlatform = "posix" | "win32";
+
+interface ModelRoutingTarget {
+	label: string;
+	path: string;
+}
+
+interface ModelRoutingTargets {
+	globalConfigPath: string;
+	projectConfigPath: string;
+	globalProfilePath: string;
+	projectProfilePath: string;
+}
+
+class ModelRoutingTargetAuthorityError extends Error {
+	readonly path: string;
+	readonly aliasPath: string;
+
+	constructor(path: string, aliasPath: string) {
+		super(`Model routing targets alias: ${path} and ${aliasPath}`);
+		this.path = path;
+		this.aliasPath = aliasPath;
+	}
+}
+
+function sameModelRoutingPath(
+	left: string,
+	right: string,
+	platform: ModelRoutingPathPlatform = process.platform === "win32" ? "win32" : "posix",
+): boolean {
+	const pathApi = platform === "win32" ? win32 : posix;
+	const normalizePath = (path: string) => pathApi.normalize(pathApi.resolve(path));
+	const normalizedLeft = normalizePath(left);
+	const normalizedRight = normalizePath(right);
+	return platform === "win32"
+		? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+		: normalizedLeft === normalizedRight;
+}
+
+function resolveModelRoutingTargetAuthority(
+	cwd: string,
+	platform?: ModelRoutingPathPlatform,
+): ModelRoutingTargets {
+	const targets: ModelRoutingTargets = {
+		globalConfigPath: modelConfigPath(cwd),
+		projectConfigPath: legacyProjectModelConfigPath(cwd),
+		globalProfilePath: agentModelProfileConfigPath(cwd, "builtin"),
+		projectProfilePath: agentModelProfileConfigPath(cwd, "project"),
+	};
+	const namedTargets: ModelRoutingTarget[] = [
+		{ label: "global model config", path: targets.globalConfigPath },
+		{ label: "project model config", path: targets.projectConfigPath },
+		{ label: "global model profile", path: targets.globalProfilePath },
+		{ label: "project model profile", path: targets.projectProfilePath },
+	];
+	for (const [index, target] of namedTargets.entries()) {
+		for (const candidate of namedTargets.slice(index + 1)) {
+			if (sameModelRoutingPath(target.path, candidate.path, platform)) {
+				throw new ModelRoutingTargetAuthorityError(target.path, candidate.path);
+			}
+		}
+	}
+	return targets;
+}
+
 function projectPersonaConfigPath(cwd: string): string {
 	return join(cwd, ".pi", "gentle-ai", "persona.json");
 }
@@ -1830,9 +1896,9 @@ function writePersonaMode(cwd: string, mode: PersonaMode): string[] {
 }
 
 function readSavedModelConfig(cwd: string): ModelConfigFileResult {
-	const projectPath = legacyProjectModelConfigPath(cwd);
-	const result = readModelRoutingAuthority(modelConfigPath(cwd), projectPath);
-	return result.status === "invalid" && result.path === projectPath
+	const targets = resolveModelRoutingTargetAuthority(cwd);
+	const result = readModelRoutingAuthority(targets.globalConfigPath, targets.projectConfigPath);
+	return result.status === "invalid" && result.path === targets.projectConfigPath
 		? { status: "valid", config: {} }
 		: result;
 }
@@ -1840,9 +1906,9 @@ function readSavedModelConfig(cwd: string): ModelConfigFileResult {
 async function readSavedModelConfigAsync(
 	cwd: string,
 ): Promise<ModelConfigFileResult> {
-	const projectPath = legacyProjectModelConfigPath(cwd);
-	const result = await readModelRoutingAuthorityAsync(modelConfigPath(cwd), projectPath);
-	return result.status === "invalid" && result.path === projectPath
+	const targets = resolveModelRoutingTargetAuthority(cwd);
+	const result = await readModelRoutingAuthorityAsync(targets.globalConfigPath, targets.projectConfigPath);
+	return result.status === "invalid" && result.path === targets.projectConfigPath
 		? { status: "valid", config: {} }
 		: result;
 }
@@ -1860,14 +1926,14 @@ export async function readModelConfigAsync(
 }
 
 function writeModelConfig(cwd: string, config: AgentModelConfig): void {
-	const path = modelConfigPath(cwd);
+	const path = resolveModelRoutingTargetAuthority(cwd).globalConfigPath;
 	mkdirSync(dirname(path), { recursive: true });
 	const cleaned = normalizeModelConfig(config) ?? {};
 	writeFileSync(path, `${JSON.stringify(cleaned, null, 2)}\n`);
 }
 
 async function writeModelConfigAsync(cwd: string, config: AgentModelConfig): Promise<void> {
-	const path = modelConfigPath(cwd);
+	const path = resolveModelRoutingTargetAuthority(cwd).globalConfigPath;
 	await mkdir(dirname(path), { recursive: true });
 	const cleaned = normalizeModelConfig(config) ?? {};
 	await writeFile(path, `${JSON.stringify(cleaned, null, 2)}\n`);
@@ -1880,9 +1946,10 @@ function parseModelExport(value: unknown): AgentModelConfig | undefined {
 }
 
 async function exportSavedModelConfig(ctx: ExtensionContext): Promise<number> {
+	const targets = resolveModelRoutingTargetAuthority(ctx.cwd);
 	const saved = await readModelRoutingAuthorityAsync(
-		modelConfigPath(ctx.cwd),
-		legacyProjectModelConfigPath(ctx.cwd),
+		targets.globalConfigPath,
+		targets.projectConfigPath,
 	);
 	if (saved.status === "invalid") throw new Error(`Invalid model config: ${saved.path}`);
 	const agents = saved.status === "valid" ? saved.config : {};
@@ -1944,12 +2011,14 @@ function parseAgentName(filePath: string): string | undefined {
 	} catch {
 		return undefined;
 	}
-	const name = content.match(/^name:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1]?.trim();
+	const name = normalizeAgentName(
+		content.match(/^name:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1],
+	);
 	if (!name) return undefined;
-	const packageName = content
-		.match(/^package:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1]
-		?.trim();
-	return packageName ? `${packageName}.${name}` : name;
+	const rawPackageName = content.match(/^package:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1];
+	const packageName = normalizeAgentName(rawPackageName);
+	if (rawPackageName !== undefined && !packageName) return undefined;
+	return normalizeAgentName(packageName ? `${packageName}.${name}` : name);
 }
 
 async function parseAgentNameAsync(
@@ -1961,12 +2030,14 @@ async function parseAgentNameAsync(
 	} catch {
 		return undefined;
 	}
-	const name = content.match(/^name:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1]?.trim();
+	const name = normalizeAgentName(
+		content.match(/^name:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1],
+	);
 	if (!name) return undefined;
-	const packageName = content
-		.match(/^package:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1]
-		?.trim();
-	return packageName ? `${packageName}.${name}` : name;
+	const rawPackageName = content.match(/^package:\s*["']?([^"'\n]+)["']?\s*$/m)?.[1];
+	const packageName = normalizeAgentName(rawPackageName);
+	if (rawPackageName !== undefined && !packageName) return undefined;
+	return normalizeAgentName(packageName ? `${packageName}.${name}` : name);
 }
 
 function listAgentFilesRecursive(dir: string): string[] {
@@ -2267,6 +2338,7 @@ function isValidJsonObjectFileOrMissing(path: string): boolean {
 }
 
 function migrateLegacyProjectModelOverrides(cwd: string): number {
+	resolveModelRoutingTargetAuthority(cwd);
 	const settingsPath = projectSettingsPath(cwd);
 	if (!existsSync(settingsPath)) return 0;
 	let settings: Record<string, unknown>;
@@ -2322,6 +2394,7 @@ export function applyModelConfig(
 	cwd: string,
 	config: AgentModelConfig,
 ): { updated: number; skipped: number } {
+	resolveModelRoutingTargetAuthority(cwd);
 	let updated = 0;
 	let skipped = 0;
 	const seenAgents = new Set<string>();
@@ -2367,6 +2440,7 @@ export async function applyModelConfigAsync(
 	cwd: string,
 	config: AgentModelConfig,
 ): Promise<{ updated: number; skipped: number }> {
+	resolveModelRoutingTargetAuthority(cwd);
 	let updated = 0;
 	let skipped = 0;
 	const seenAgents = new Set<string>();
@@ -2415,9 +2489,10 @@ export async function applySavedModelConfig(
 	ctx: ExtensionContext,
 	applyConfig: typeof applyModelConfigAsync = applyModelConfigAsync,
 ): Promise<{ updated: number; skipped: number; invalidPath?: string }> {
+	const targets = resolveModelRoutingTargetAuthority(ctx.cwd);
 	const result = await readModelRoutingAuthorityAsync(
-		modelConfigPath(ctx.cwd),
-		legacyProjectModelConfigPath(ctx.cwd),
+		targets.globalConfigPath,
+		targets.projectConfigPath,
 	);
 	if (result.status === "invalid") {
 		return { updated: 0, skipped: 0, invalidPath: result.path };
@@ -2960,10 +3035,17 @@ async function showSddModelPanel(
 }
 
 async function handleModelsCommand(ctx: ExtensionContext): Promise<void> {
+	let targets: ModelRoutingTargets;
+	try {
+		targets = resolveModelRoutingTargetAuthority(ctx.cwd);
+	} catch (error) {
+		ctx.ui.notify(`el Gentleman cannot open model config: ${error instanceof Error ? error.message : String(error)}`, "warning");
+		return;
+	}
 	migrateLegacyProjectModelOverrides(ctx.cwd);
 	const savedConfig = await readModelRoutingAuthorityAsync(
-		modelConfigPath(ctx.cwd),
-		legacyProjectModelConfigPath(ctx.cwd),
+		targets.globalConfigPath,
+		targets.projectConfigPath,
 	);
 	if (savedConfig.status === "invalid") {
 		ctx.ui.notify(
@@ -6856,6 +6938,8 @@ export const __testing = {
 	listAgentsFromDir,
 	listAgentsFromDirAsync,
 	listDiscoverableAgents,
+	sameModelRoutingPath,
+	resolveModelRoutingTargetAuthority,
 	orderDiscoverableAgents,
 	classifyGuardedCommand,
 	loadRuntimeGuardrailsConfig,
@@ -7870,9 +7954,10 @@ function createGentleAiExtensionForTesting(
 			const openspecConfigured = existsSync(
 				join(ctx.cwd, "openspec", "config.yaml"),
 			);
+			const targets = resolveModelRoutingTargetAuthority(ctx.cwd);
 			const savedConfig = await readModelRoutingAuthorityAsync(
-				modelConfigPath(ctx.cwd),
-				legacyProjectModelConfigPath(ctx.cwd),
+				targets.globalConfigPath,
+				targets.projectConfigPath,
 			);
 			const devBinary = await describeDevBinaryOverride();
 			ctx.ui.notify(

--- a/lib/model-routing-authority.ts
+++ b/lib/model-routing-authority.ts
@@ -26,7 +26,7 @@ export type ModelConfigFileResult =
 	| { status: "valid"; config: AgentModelConfig };
 
 const SAFE_MODEL_ID_PATTERN = /^[A-Za-z0-9._~:@/+%-]+$/;
-const SAFE_AGENT_NAME_PATTERN = /^[A-Za-z0-9._:@/+%-]+$/;
+const UNSAFE_AGENT_NAME_CHARACTERS = /["'\u0000-\u001F\u007F-\u009F]/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -56,6 +56,13 @@ export function normalizeModelId(value: unknown): string | undefined {
 	return model;
 }
 
+/** Canonical names allow unknown punctuation and internal whitespace. */
+export function normalizeAgentName(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const name = value.trim();
+	return name.length > 0 && !UNSAFE_AGENT_NAME_CHARACTERS.test(name) ? name : undefined;
+}
+
 export function normalizeRoutingEntry(value: unknown): AgentRoutingEntry | undefined {
 	if (typeof value === "string") {
 		const model = normalizeModelId(value);
@@ -74,18 +81,20 @@ export function normalizeModelConfig(value: unknown): AgentModelConfig | undefin
 	if (!isRecord(value)) return undefined;
 	const cleaned: AgentModelConfig = {};
 	for (const [name, entryValue] of Object.entries(value)) {
-		if (!SAFE_AGENT_NAME_PATTERN.test(name)) continue;
+		const canonicalName = normalizeAgentName(name);
 		const entry = normalizeRoutingEntry(entryValue);
-		if (entry) cleaned[name] = entry;
+		if (canonicalName && entry) cleaned[canonicalName] = entry;
 	}
 	return cleaned;
 }
 
-function parseModelConfigFileValue(value: Record<string, unknown>): AgentModelConfig {
+function parseModelConfigFileValue(value: Record<string, unknown>): AgentModelConfig | undefined {
 	const config: AgentModelConfig = {};
 	for (const [name, entryValue] of Object.entries(value)) {
+		const canonicalName = normalizeAgentName(name);
 		const entry = normalizeRoutingEntry(entryValue);
-		if (entry) config[name] = entry;
+		if (!canonicalName || canonicalName !== name || !entry) return undefined;
+		config[canonicalName] = entry;
 	}
 	return config;
 }
@@ -95,7 +104,8 @@ export function readModelConfigFile(path: string): ModelConfigFileResult {
 	try {
 		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
 		if (!isRecord(parsed)) return { status: "invalid", path };
-		return { status: "valid", config: parseModelConfigFileValue(parsed) };
+		const config = parseModelConfigFileValue(parsed);
+		return config === undefined ? { status: "invalid", path } : { status: "valid", config };
 	} catch {
 		return { status: "invalid", path };
 	}
@@ -108,7 +118,8 @@ export async function readModelConfigFileAsync(
 	try {
 		const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
 		if (!isRecord(parsed)) return { status: "invalid", path };
-		return { status: "valid", config: parseModelConfigFileValue(parsed) };
+		const config = parseModelConfigFileValue(parsed);
+		return config === undefined ? { status: "invalid", path } : { status: "valid", config };
 	} catch {
 		return { status: "invalid", path };
 	}

--- a/lib/model-routing-authority.ts
+++ b/lib/model-routing-authority.ts
@@ -88,11 +88,31 @@ export function normalizeModelConfig(value: unknown): AgentModelConfig | undefin
 	return cleaned;
 }
 
+function decodeSavedRoutingEntry(value: unknown): AgentRoutingEntry | undefined {
+	if (typeof value === "string") {
+		const model = normalizeModelId(value);
+		return model ? { model } : undefined;
+	}
+	if (!isRecord(value)) return undefined;
+	const entries = Object.entries(value);
+	if (entries.some(([key]) => key !== "model" && key !== "thinking")) {
+		return undefined;
+	}
+	if (entries.length === 0) return {};
+
+	const modelEntry = entries.find(([key]) => key === "model");
+	const thinkingEntry = entries.find(([key]) => key === "thinking");
+	const model = modelEntry ? normalizeModelId(modelEntry[1]) : undefined;
+	const thinking = thinkingEntry && isThinkingLevel(thinkingEntry[1]) ? thinkingEntry[1] : undefined;
+	if ((modelEntry && !model) || (thinkingEntry && !thinking)) return undefined;
+	return { model, thinking };
+}
+
 function parseModelConfigFileValue(value: Record<string, unknown>): AgentModelConfig | undefined {
 	const config: AgentModelConfig = {};
 	for (const [name, entryValue] of Object.entries(value)) {
 		const canonicalName = normalizeAgentName(name);
-		const entry = normalizeRoutingEntry(entryValue);
+		const entry = decodeSavedRoutingEntry(entryValue);
 		if (!canonicalName || canonicalName !== name || !entry) return undefined;
 		config[canonicalName] = entry;
 	}

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -257,9 +257,9 @@ function routingConsumerFixture(t: test.TestContext) {
 	};
 }
 
-test("models rejects invalid project routing with its selected source path", async (t) => {
+test("models rejects padded project routing with its selected source path", async (t) => {
 	const fixture = routingConsumerFixture(t);
-	writeFileSync(fixture.projectPath, "[]");
+	writeFileSync(fixture.projectPath, '{" worker":"openai/gpt-5"}');
 	await fixture.run("gentle:models");
 	assert.equal(fixture.notifications[0]?.severity, "warning");
 	assert.ok(fixture.notifications[0]?.message.includes(fixture.projectPath));
@@ -296,7 +296,7 @@ test("models exports missing, normalized project, and global-precedence saved ro
 	for (const source of ["missing", "project", "global"] as const) {
 		await t.test(source, async (t) => {
 			const fixture = routingConsumerFixture(t);
-			if (source !== "missing") writeFileSync(fixture.projectPath, '{"worker":" openai/gpt-5 ","ignored":null}');
+			if (source !== "missing") writeFileSync(fixture.projectPath, '{"worker":" openai/gpt-5 "}');
 			if (source === "global") writeMarkdown(fixture.globalPath, '{"worker":{"model":" anthropic/opus ","thinking":"high"}}');
 			fixture.onPanel(() => ({ type: fixture.panelVisits() === 1 ? "export" : "cancel", config: {} }));
 			await fixture.run("gentle:models");
@@ -450,6 +450,72 @@ test("agent discovery skips skills directories", async (t) => {
 		asyncAgents.map((agent) => agent.name),
 		["review-risk", "worker"],
 	);
+});
+
+test("agent metadata canonicalizes whitespace and rejects unsafe names in both readers", async (t) => {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-agent-metadata-"));
+	const agents = join(root, "agents");
+	mkdirSync(agents, { recursive: true });
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	writeMarkdown(join(agents, "valid.md"), "name:  worker helper!  \n");
+	writeMarkdown(join(agents, "quote.md"), "name: bad\"name\n");
+	writeMarkdown(join(agents, "c0.md"), "name: bad\u0000name\n");
+	writeMarkdown(join(agents, "c1.md"), "name: bad\u0080name\n");
+	writeMarkdown(join(agents, "package.md"), "name: worker\npackage: bad\u0000package\n");
+
+	assert.deepEqual(__testing.listAgentsFromDir(agents, "user").map((agent) => agent.name), ["worker helper!"]);
+	assert.deepEqual((await __testing.listAgentsFromDirAsync(agents, "user")).map((agent) => agent.name), ["worker helper!"]);
+});
+
+test("routing aliases are denied before models can migrate profiles", async (t) => {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-routing-alias-"));
+	const configDir = join(root, ".pi", "gentle-ai");
+	const profilePath = join(root, ".pi", "subagents.json");
+	const settingsPath = join(root, ".pi", "settings.json");
+	const previousConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
+	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const previousHome = process.env.HOME;
+	process.env.HOME = root;
+	delete process.env.GENTLE_PI_CONFIG_HOME;
+	process.env.GENTLE_PI_AGENT_HOME = join(root, ".pi");
+	mkdirSync(join(root, "agents"), { recursive: true });
+	mkdirSync(configDir, { recursive: true });
+	writeFileSync(join(configDir, "models.json"), '{"worker":"openai/gpt-5"}\n');
+	const profileBytes = '{"unrelated":true}\n';
+	const settingsBytes = '{"subagents":{"agentOverrides":{"worker":"openai/gpt-5"}}}\n';
+	writeFileSync(profilePath, profileBytes);
+	writeFileSync(settingsPath, settingsBytes);
+	t.after(() => {
+		if (previousConfigHome === undefined) delete process.env.GENTLE_PI_CONFIG_HOME;
+		else process.env.GENTLE_PI_CONFIG_HOME = previousConfigHome;
+		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
+		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		if (previousHome === undefined) delete process.env.HOME;
+		else process.env.HOME = previousHome;
+		rmSync(root, { recursive: true, force: true });
+	});
+	const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
+	createGentleAiExtension({ nativeReviewCli: null })({
+		on() {}, registerTool() {}, registerCommand(name, command) { commands.set(name, command); },
+	} as ExtensionAPI);
+	const notifications: string[] = [];
+	await commands.get("gentle:models")!.handler("", {
+		cwd: root,
+		hasUI: true,
+		modelRegistry: { getAvailable: async () => [] },
+		ui: {
+			notify(message: string) { notifications.push(message); },
+			custom: async () => ({ type: "cancel", config: {} }),
+		},
+	} as unknown as ExtensionContext);
+
+	assert.ok(notifications.length > 0);
+	assert.equal(readFileSync(join(configDir, "models.json"), "utf8"), '{"worker":"openai/gpt-5"}\n');
+	assert.equal(readFileSync(profilePath, "utf8"), profileBytes);
+	assert.equal(readFileSync(settingsPath, "utf8"), settingsBytes);
+	assert.equal(__testing.sameModelRoutingPath("C:\\Home\\.pi\\models.json", "c:/home/.pi/models.json", "win32"), true);
+	assert.equal(__testing.sameModelRoutingPath("/Home/.pi/models.json", "/home/.pi/models.json", "posix"), false);
+	assert.equal(__testing.sameModelRoutingPath("/home/project/../.pi/models.json/", "/home//.pi/models.json", "posix"), true);
 });
 
 test("managed routing timeout leaves its profile, agent, and manifest unchanged", (t) => {

--- a/tests/model-routing-authority.test.ts
+++ b/tests/model-routing-authority.test.ts
@@ -76,12 +76,31 @@ test("model routing authority normalizes and preserves sync/async source status"
 		["c1", { worker: "inherit", [`bad\u0080name`]: "openai/gpt-5" }],
 		["null", { valid: "inherit", worker: null }],
 		["entry", { valid: "inherit", worker: { model: "not valid" } }],
+		[
+			"partial-model",
+			{ valid: "inherit", worker: { model: "not valid", thinking: "high" } },
+		],
+		[
+			"partial-thinking",
+			{ valid: "inherit", worker: { model: "openai/gpt-5", thinking: "invalid" } },
+		],
+		[
+			"unknown-entry-field",
+			{ valid: "inherit", worker: { model: "openai/gpt-5", extra: true } },
+		],
 	] as const) {
-		const path = join(globalDir, `${label}.json`);
-		writeFileSync(path, JSON.stringify(value));
-		const expected = { status: "invalid" as const, path };
-		assert.deepEqual(authority.readModelConfigFile(path), expected, label);
-		assert.deepEqual(await authority.readModelConfigFileAsync(path), expected, label);
+		await t.test(label, async () => {
+			const path = join(globalDir, `${label}.json`);
+			writeFileSync(path, JSON.stringify(value));
+			const expected = { status: "invalid" as const, path };
+			assert.deepEqual(
+				[
+					authority.readModelConfigFile(path),
+					await authority.readModelConfigFileAsync(path),
+				],
+				[expected, expected],
+			);
+		});
 	}
 
 	const invalidGlobalPath = join(globalDir, "invalid.json");

--- a/tests/model-routing-authority.test.ts
+++ b/tests/model-routing-authority.test.ts
@@ -40,7 +40,11 @@ test("model routing authority normalizes and preserves sync/async source status"
 			"not valid": "ignored",
 			nullValue: null,
 		}),
-		{ worker: { model: "openai/gpt-5" }, clear: {} },
+		{
+			worker: { model: "openai/gpt-5" },
+			clear: {},
+			"not valid": { model: "ignored" },
+		},
 	);
 
 	const missingPath = join(globalDir, "missing.json");
@@ -50,7 +54,7 @@ test("model routing authority normalizes and preserves sync/async source status"
 	const validGlobalPath = join(globalDir, "valid.json");
 	writeFileSync(
 		validGlobalPath,
-		JSON.stringify({ worker: "openai/gpt-5", reviewer: { thinking: "medium" }, "not valid": "openai/gpt-4" }),
+		JSON.stringify({ worker: "openai/gpt-5", reviewer: { thinking: "medium" }, clear: {}, "not valid/+": "openai/gpt-4" }),
 	);
 	const validSync = authority.readModelConfigFile(validGlobalPath);
 	const validAsync = await authority.readModelConfigFileAsync(validGlobalPath);
@@ -59,10 +63,26 @@ test("model routing authority normalizes and preserves sync/async source status"
 		config: {
 			worker: { model: "openai/gpt-5" },
 			reviewer: { model: undefined, thinking: "medium" },
-			"not valid": { model: "openai/gpt-4" },
+			clear: {},
+			"not valid/+": { model: "openai/gpt-4" },
 		},
 	});
 	assert.deepEqual(validAsync, validSync);
+
+	for (const [label, value] of [
+		["padded", { worker: "inherit", " worker ": "openai/gpt-5" }],
+		["quote", { worker: "inherit", 'bad"name': "openai/gpt-5" }],
+		["c0", { worker: "inherit", [`bad\u0000name`]: "openai/gpt-5" }],
+		["c1", { worker: "inherit", [`bad\u0080name`]: "openai/gpt-5" }],
+		["null", { valid: "inherit", worker: null }],
+		["entry", { valid: "inherit", worker: { model: "not valid" } }],
+	] as const) {
+		const path = join(globalDir, `${label}.json`);
+		writeFileSync(path, JSON.stringify(value));
+		const expected = { status: "invalid" as const, path };
+		assert.deepEqual(authority.readModelConfigFile(path), expected, label);
+		assert.deepEqual(await authority.readModelConfigFileAsync(path), expected, label);
+	}
 
 	const invalidGlobalPath = join(globalDir, "invalid.json");
 	writeFileSync(invalidGlobalPath, "[]");
@@ -176,7 +196,7 @@ test("saved-routing apply fails closed for invalid project and global sources", 
 		return { updated: 0, skipped: 0 };
 	};
 
-	for (const projectValue of ["{", "[]", "null"] as const) {
+	for (const projectValue of ["{", "[]", "null", '{" worker":"openai/gpt-5"}'] as const) {
 		writeFileSync(projectPath, projectValue);
 		const before = statSync(profilePath);
 		const result = await applySavedModelConfig(context, applyConfig);
@@ -252,7 +272,7 @@ test("saved-routing apply preserves missing, valid, null, inherit, and omission 
 	const afterValid = statSync(profilePath);
 	writeFileSync(projectPath, JSON.stringify({ worker: null }));
 	const nullEntry = await applySavedModelConfig(context);
-	assert.equal(nullEntry.invalidPath, undefined);
+	assert.equal(nullEntry.invalidPath, projectPath);
 	assert.equal(readFileSync(profilePath, "utf8"), afterValidBytes);
 	assert.equal(statSync(profilePath).mtimeMs, afterValid.mtimeMs);
 	assert.doesNotMatch(readFileSync(agentPath, "utf8"), /model: null/);


### PR DESCRIPTION
## Linked issue

Closes #391

Parent trackers: #382 and #381  
Prerequisites: #389, #396, and #395

## PR type

- [x] Code refactoring

## Summary

- Enforces one canonical model-routing name boundary across saved configuration and agent metadata discovery.
- Rejects complete saved documents when any routing name or entry is invalid instead of retaining valid siblings.
- Adds explicit lexical target authority for global/project configuration and profile paths before reads, migration, apply, or writes.

## Changes

| File | Change |
|------|--------|
| `lib/model-routing-authority.ts` | Adds shared canonical-name validation and whole-document fail-closed normalization. |
| `extensions/gentle-ai.ts` | Reuses canonical validation for metadata, resolves routing targets explicitly, denies lexical aliases, and applies the same normalized configuration that is persisted. |
| `tests/model-routing-authority.test.ts` | Covers strict synchronous/asynchronous saved-document validation and preserved routing semantics. |
| `tests/gentle-ai.test.ts` | Covers metadata parity, real command flow, target collisions, platform comparison, and no-write preservation. |

## Design and dependency context

This is the canonical-boundary unit after the merged #389, #396, and #395 slices. It preserves their shared status-carrying read authority, fail-closed apply behavior, compatibility wrappers, direct export behavior, and UI/lifecycle consumers.

Target aliases are intentionally lexical: absolute normalization, dot segments, redundant/trailing separators, and platform-aware comparison. Windows comparison is case/separator-insensitive; POSIX comparison remains case-sensitive. This unit does not claim symlink, hard-link, inode, device, or `realpath` identity protection.

The guard runs before `/gentle:models` legacy migration because migration can touch profile files. Saved routing is normalized once and that same value is used for persistence and subsequent apply. Durable replacement policy and profile materialization semantics remain out of scope for their later dedicated slices.

```text
#389 shared read authority
  -> #396 fail-closed apply safety
    -> #395 direct consumer migration
      -> #391 canonical names and lexical target authority (this PR)
        -> dedicated durable-write slice
          -> dedicated materialization slice
```

This PR closes only #391. It references, but does not close, #389, #396, #395, #382, or #381.

## Test plan

- [x] `node --experimental-strip-types --test tests/model-routing-authority.test.ts` — 12 passed
- [x] `node --experimental-strip-types --test tests/gentle-ai.test.ts` — 36 passed
- [x] `pnpm test` — 2,109 passed, 18 skipped, 0 failed; provider contract passed
- [x] `pnpm run test:harness`
- [x] `pnpm run check:runtime-modules` — all 6 generated modules match
- [x] `node --experimental-strip-types --check extensions/gentle-ai.ts` — syntax check only
- [x] `git diff --check origin/main...HEAD`

The skipped native-dependent, Windows-specific, and live-research cases were not counted as passing. Windows comparison policy is covered through the production path-policy helper; no native Windows run was performed.

## Review workload

- 4 changed files
- 264 additions, 43 deletions
- 307 total changed lines
- No size exception requested

## Contributor checklist

- [x] Linked an approved issue
- [x] Kept one reviewable work unit under 400 A+D
- [x] Included tests with behavior
- [x] Used a conventional commit
- [x] Added no `Co-Authored-By` trailers
- [x] Verified no shell scripts changed; shellcheck is not applicable
- [x] Preserved intentionally out-of-scope durable-write and materialization behavior
- [x] Disclosed material AI assistance below

## AI assistance

Material AI assistance was used through Pi with delegated implementation, verification, and four-lens native review. Assistance covered repository mapping, strict TDD implementation, test design, integration with current `main`, and PR preparation. The focused suites, complete package suite, runtime harness, generated-module parity, syntax, whitespace, and changed-line checks were run after integrating current `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented model-routing conflicts when multiple configuration targets resolve to the same location.
  - Improved agent-name handling by canonicalizing valid names and rejecting unsafe or malformed values.
  - Invalid model configuration entries are now reported as invalid instead of being silently accepted.
  - Safer handling of null, padded, or malformed routing entries prevents unintended configuration changes.
- **Validation**
  - Added safeguards across model configuration reading, writing, migration, export, and application workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
