### PR TITLE
fix(shell): reuse fullscreen sidebar presentation

### DIFF
--- a/lib/shell-sidebar-layout.ts
+++ b/lib/shell-sidebar-layout.ts
@@ -14,6 +14,7 @@ type LayoutNode = { type: string; entries?: unknown[]; gap?: number; align?: str
 type LayoutRoot = Component & { [NODE]?: () => LayoutNode };
 type Host = TUI & { mode?: string; layoutRoot?: LayoutRoot };
 type SidebarCache = { revision: number };
+type SidebarPresentation = { scrollTop: number; output: LayoutNode };
 type PreparedRail = {
 	revision: number;
 	width: number;
@@ -23,6 +24,7 @@ type PreparedRail = {
 	parts: Array<[string, Component]>;
 	active: boolean;
 	lines: string[];
+	presentation?: SidebarPresentation;
 };
 const CACHE = Symbol.for("gentle-pi.experimental-sidebar.cache");
 
@@ -124,12 +126,18 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 			const original = root[NODE]!;
 			const descriptor = Object.getOwnPropertyDescriptor(root, NODE);
 			const left = { render: (width: number) => root.render(width), invalidate() {}, [NODE]: () => original.call(root) };
-			const replacement = () => prepare(tui.terminal.columns, root)
-				? { type: "hstack", gap: GAP, align: "stretch", entries: [
-					{ component: left, basis: 0, grow: 1, shrink: 1, minSize: 1 },
-					{ component: scroll, basis: RAIL_WIDTH, grow: 0, shrink: 0, minSize: RAIL_WIDTH },
-				] }
-				: original.call(root);
+			const replacement = () => {
+				if (!prepare(tui.terminal.columns, root)) return original.call(root);
+				const current = prepared!;
+				if (current.presentation?.scrollTop === scroll.scrollTop) return current.presentation.output;
+				return (current.presentation = {
+					scrollTop: scroll.scrollTop,
+					output: { type: "hstack", gap: GAP, align: "stretch", entries: [
+						{ component: left, basis: 0, grow: 1, shrink: 1, minSize: 1 },
+						{ component: scroll, basis: RAIL_WIDTH, grow: 0, shrink: 0, minSize: RAIL_WIDTH },
+					] },
+				}).output;
+			};
 			root[NODE] = replacement;
 			roots.add(root);
 			tui.requestRender();

--- a/tests/shell-sidebar-layout.test.ts
+++ b/tests/shell-sidebar-layout.test.ts
@@ -193,6 +193,34 @@ test("real layout frames reuse unchanged sidebar output and invalidate at state 
 	assert.equal(replacementRenders, 1);
 });
 
+test("reuses final sidebar presentation until a relevant invalidation", (t) => {
+	const f = fixture();
+	sidebarPart(f.tui, "todo", { render: () => Array.from({ length: 10 }, (_, index) => `Todo ${index}`), invalidate() {} });
+	t.after(installSidebar(f.tui, theme));
+
+	const first = f.root[NODE]();
+	assert.equal(f.root[NODE](), first);
+	const scroll = (first as { entries: { component: ScrollView }[] }).entries[1].component;
+	scroll.updateLayout(scroll.render(50).length, 1, () => {});
+	scroll.scrollBy(1);
+	const scrolled = f.root[NODE]();
+	assert.notEqual(scrolled, first);
+	assert.equal(f.root[NODE](), scrolled);
+
+	scroll.invalidate();
+	const invalidated = f.root[NODE]();
+	assert.notEqual(invalidated, scrolled);
+	assert.equal(f.root[NODE](), invalidated);
+
+	f.host.terminal.columns = 141;
+	const resized = f.root[NODE]();
+	assert.notEqual(resized, invalidated);
+	assert.equal(f.root[NODE](), resized);
+	f.host.mode = "regular";
+	assert.equal(f.root[NODE]().type, "vstack");
+	assert.deepEqual(f.bottom.render(80), ["Status"]);
+});
+
 test("cleanup restores the native layout and bottom paint without disposing widgets", () => {
 	const f = fixture();
 	const dispose = installSidebar(f.tui, theme);


### PR DESCRIPTION
Closes #832

## Summary

- Reuse the final fullscreen sidebar presentation when prepared rail inputs and scroll position are unchanged.
- Preserve invalidation for sidebar state, width, mode, root, theme, part identity, and scrolling.
- Add focused regression coverage for unchanged frames and relevant invalidations.

## Changes

| File | Change |
|------|--------|
| `lib/shell-sidebar-layout.ts` | Cache the final sidebar `LayoutNode` and reuse it until prepared inputs or `scrollTop` change. |
| `tests/shell-sidebar-layout.test.ts` | Cover final-node reuse plus scroll, state, resize, and regular-mode invalidation. |

## Test plan

- [x] `node --experimental-strip-types --test --test-name-pattern="reuses final sidebar presentation until a relevant invalidation" tests/shell-sidebar-layout.test.ts` — 1 passed.
- [x] `node --experimental-strip-types --test tests/shell-sidebar-layout.test.ts` — 11 passed, 0 failed.
- [x] `git diff --check`.
- [ ] Real Windows Terminal performance validation was not run.
- [ ] No broad suite was run locally; CI owns broad validation.

The existing source-level headless A/B baseline was approximately 10.55 ms/frame with the real sidebar, 0.2603 ms/frame with Gentle Shell but no sidebar, and 0.0996 ms/frame with Gentle Shell disabled. This PR does not claim that baseline as Windows Terminal I/O proof, and no persistent focused benchmark harness exists in the repository.

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Contributor checklist

- [x] Linked approved issue #832 (`status:approved`).
- [x] Added exactly one `type:*` label: `type:bug`.
- [x] Used a Conventional Commit with no `Co-Authored-By` trailer.
- [x] Shellcheck is not applicable; no shell scripts changed.
- [x] Agent/skill testing is not applicable; no skill changed.
- [x] Documentation is not required for this internal performance correction.

## Review status

Native RDD review was unavailable for this candidate: `INSPECT` repeatedly returned `managed_assets_outdated` after an authorized sync, restart, and a confirmed no-op sync; no lineage was created. The fallback candidate-bound independent verifier reported PASS with no severe findings. The verified pre-commit binary diff SHA-256 was `cef38b29e4ad021e20bb81166cbade5441123d8f240356bd3ef777b8bc2d8492`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fullscreen sidebar layout behavior by reusing the existing layout when the view has not changed.
  - Sidebar layouts now refresh correctly after scrolling, resizing, or switching display modes.
  - Restored the standard vertical layout and bottom content when returning to regular mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->