### PR TITLE
fix(skills): keep operational issue attestations agent-owned

### DIFF
--- a/skills/issue-creation/SKILL.md
+++ b/skills/issue-creation/SKILL.md
@@ -46,7 +46,7 @@ LABEL_ARGS+=(--label "$LABEL") # Repeat only for each permitted discovered label
    gh issue list --repo "$TARGET" --state all --search "$QUERY" --limit 1000
    ```
 
-   If results are saturated or completeness is uncertain, narrow the read-only search or stop. Comment on a confirmed duplicate instead of creating one. Before commenting on a confirmed duplicate, perform the same privacy scan/redaction on the exact comment body as for publication.
+   The agent must complete the duplicate search proactively and retain evidence of its result. If results are saturated or completeness is uncertain, narrow the read-only search or stop. Comment on a confirmed duplicate instead of creating one. Before commenting on a confirmed duplicate, perform the same privacy scan/redaction on the exact comment body as for publication.
 2. Select one repository-provided form only when its declared purpose matches. If multiple forms match and policy does not distinguish them, stop and request that decision.
 3. For a YAML form, read its schema and establish controls in declared order. Support only `input`, `textarea`, `dropdown`, and `checkboxes`. Markdown controls are non-answer guidance: honor their visible instructions when collecting and materializing adjacent answers, but do not render them as response sections. Fail closed before mutation on malformed, unsupported, missing, or ambiguous required structure or answers. A malformed schema, or missing or ambiguous required answers, fail closed: do not open a browser or mutate. A browser handoff is available only when the user explicitly requests browser completion or a syntactically valid selected form cannot safely/faithfully be represented by the automated path; otherwise report why automation is unsafe and stop.
 
@@ -54,7 +54,7 @@ LABEL_ARGS+=(--label "$LABEL") # Repeat only for each permitted discovered label
 | --- | --- |
 | `input` / `textarea` | Preserve the visible label. Require an answer when `validations.required` is true; otherwise render `_No response_`. |
 | `dropdown` | Preserve visible labels and options. Require exact selected option text; single-select has one selection, and multi-select preserves selections in declared options order. A required dropdown needs at least one valid selection; an optional dropdown with no selection renders `_No response_`. |
-| `checkboxes` | Preserve the visible label and every option as `- [x]` or `- [ ]` in declared order. Enforce individually required checkboxes and require explicit first-person affirmation for first-person option text. |
+| `checkboxes` | Preserve the visible label and every option as `- [x]` or `- [ ]` in declared order. Enforce individually required checkboxes. For agent-verifiable operational options, proactively complete the action and mark it only with retained evidence; the agent may explicitly attest only its own evidence-backed work and must not attribute its actions to the user. Personal facts, consent, legal declarations, and other first-person user assertions require explicit user affirmation; require explicit first-person affirmation for such user declarations. Do not blanket-check checkboxes: a request to publish does not affirm any checkbox. |
 
 For each answer, render `### <visible label>` followed by its materialized value. For `textarea.attributes.render`, fence the answer with the declared language and a fence long enough for its content. Never invent answers, selections, confirmations, or labels.
 
@@ -62,7 +62,7 @@ A Markdown template may be completed only from known evidence into the same priv
 
 ## Review And Publication
 
-Before the single create attempt, review the target, title, selected form or permitted fallback, exact body, and permitted labels. Perform a privacy scan immediately before publication: replace private project names, usernames, hostnames, home paths, credentials, and private network addresses with useful placeholders without removing reproduction structure.
+Before the single create attempt, review the target, title, selected form or permitted fallback, exact body, and permitted labels. The agent must complete the privacy scan/redaction of the exact body immediately before publication and retain evidence of it: replace private project names, usernames, hostnames, home paths, credentials, and private network addresses with useful placeholders without removing reproduction structure.
 
 Create one owner-only temporary directory outside the repository for both private files; restrict it to the current user and clean up both files on every exit/outcome:
 

--- a/tests/issue-creation-skill.test.ts
+++ b/tests/issue-creation-skill.test.ts
@@ -35,6 +35,28 @@ test("fails closed before publication for invalid required Issue Form data", () 
 	assert.match(skill, /Never invent answers, selections, confirmations, or labels/i);
 });
 
+function assertCheckboxAttestationContract(candidate: string) {
+	assert.match(candidate, /agent must complete.*duplicate search.*retain evidence/i);
+	assert.match(candidate, /agent must complete.*privacy scan\/redaction.*exact body.*retain evidence/i);
+	assert.match(candidate, /may explicitly attest.*own evidence-backed work.*must not attribute.*user/i);
+	assert.match(candidate, /personal facts, consent, legal declarations.*explicit user affirmation/i);
+	assert.match(candidate, /Do not blanket.*check(?:box|boxes)/i);
+	assert.match(candidate, /request to publish.*does not.*affirm/i);
+}
+
+test("attests only agent-verifiable checkbox work and preserves human declarations", () => {
+	assertCheckboxAttestationContract(skill);
+
+	const missingEvidence = skill.replace(/retain evidence/gi, "skip evidence");
+	assert.throws(() => assertCheckboxAttestationContract(missingEvidence));
+
+	const userOnlyDeclaration = skill.replace(
+		/personal facts, consent, legal declarations.*explicit user affirmation/i,
+		"personal facts, consent, legal declarations may be inferred from a request to publish",
+	);
+	assert.throws(() => assertCheckboxAttestationContract(userOnlyDeclaration));
+});
+
 test("publishes reviewed Issue Form bodies through a private body file", () => {
 	assert.match(skill, /private `BODY_FILE`/);
 	assert.match(skill, /gh issue create --repo "\$TARGET" --title "\$TITLE" --body-file "\$BODY_FILE"/);


### PR DESCRIPTION
## Linked Issue
Closes #875

## PR Type
- [x] Bug fix

## Summary
- Keep duplicate-search and privacy-review attestations with the agent that performed them.
- Preserve explicit human affirmation for personal facts, consent, and legal declarations.
- Add contract regression checks for evidence requirements and inferred human declarations.

## Changes
| File | Change |
|---|---|
| `skills/issue-creation/SKILL.md` | Clarify operational versus human attestation ownership |
| `tests/issue-creation-skill.test.ts` | Assert evidence requirements and human-declaration boundaries |

## Test Plan
- [x] Focused suite independently passed: `node --experimental-strip-types --test tests/issue-creation-skill.test.ts` (7/7).
- [x] `git diff --check` passed.
- [x] Independent verification found no blocking contract regression.
- [ ] Live agent/GitHub end-to-end behavior was not exercised; tests guard instruction wording.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Exactly one type label: `type:bug`.
- [x] Instructions updated with the behavior change.
- [x] Conventional commit; no attribution trailers.
- Shellcheck and runtime skill loading: not exercised; no shell scripts or loading metadata changed.

RDD is disabled/unmanaged. No native review approval is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved issue creation guidance to verify duplicate searches and privacy scans before publication.
  * Added support for completing agent-verifiable checklist items while retaining evidence.
  * Clarified that attestations apply only to evidence-backed agent work, while personal and legal declarations require explicit user confirmation.

* **Tests**
  * Added coverage for evidence retention, redaction checks, and preventing unsupported user declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->