### PR TITLE
fix(todo): show next pending task in collapsed card

### DIFF
--- a/extensions/gentle-todo.ts
+++ b/extensions/gentle-todo.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { Text, type TUI } from "@earendil-works/pi-tui";
+import { Text, type Component, type TUI } from "@earendil-works/pi-tui";
+import { NativePointerRegion } from "../lib/native-pointer-region.ts";
 import { sidebarPart } from "../lib/shell-sidebar.ts";
 import { invalidateSidebar } from "../lib/shell-sidebar-layout.ts";
 import {
@@ -96,6 +97,40 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 		return current;
 	};
 
+	const toggle = (current: TodoSession) => {
+		current.collapsed = !current.collapsed;
+		if (current.tui) invalidateSidebar(current.tui);
+		current.host?.requestRender();
+	};
+
+	const todoCard = (current: TodoSession, theme: Parameters<typeof renderTodoCard>[1], scrollable: boolean, spacer: boolean): Component & { dispose(): void } => {
+		const card: Component = {
+			render(width: number) {
+				const lines = renderTodoCard(current.state, theme, width, {
+					collapsed: current.collapsed,
+					staleTurns: staleTurns(current.state, current.turn),
+					collapseKey,
+					...(scrollable ? { scrollable: true } : {}),
+				});
+				return spacer && lines.length > 0 ? [...lines, ""] : lines;
+			},
+			invalidate() {},
+		};
+		const region = new NativePointerRegion(card, {
+			onClick(event) {
+				if (event.button !== "left" || event.y !== 0) return undefined;
+				toggle(current);
+				return { handled: true, render: true };
+			},
+		});
+		return {
+			render: (width) => region.render(width),
+			handleMouse: (event) => region.handleMouse(event),
+			invalidate: () => region.invalidate(),
+			dispose: () => region.dispose(),
+		};
+	};
+
 	const show = (current: TodoSession) => {
 		if (current.tui) invalidateSidebar(current.tui);
 		if (!current.ui) return;
@@ -107,16 +142,7 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 		current.ui.setWidget(WIDGET_KEY, (tui, theme) => {
 			snapshot.host = tui;
 			snapshot.tui = tui;
-			return sidebarPart(tui, "todo", {
-				render(width: number) {
-					const lines = renderTodoCard(snapshot.state, theme, width, { collapsed: snapshot.collapsed, staleTurns: staleTurns(snapshot.state, snapshot.turn), collapseKey });
-					return lines.length === 0 ? [] : [...lines, ""];
-				},
-				invalidate() {},
-			}, {
-				render: (width) => renderTodoCard(snapshot.state, theme, width, { collapsed: snapshot.collapsed, staleTurns: staleTurns(snapshot.state, snapshot.turn), collapseKey, scrollable: true }),
-				invalidate() {},
-			});
+			return sidebarPart(tui, "todo", todoCard(snapshot, theme, false, true), todoCard(snapshot, theme, true, false));
 		});
 	};
 
@@ -161,10 +187,7 @@ export default function gentleTodo(pi: ExtensionAPI, env: NodeJS.ProcessEnv = pr
 		pi.registerShortcut(collapseKey as Parameters<ExtensionAPI["registerShortcut"]>[0], {
 			description: "Collapse or expand the todo list",
 			handler: async (ctx) => {
-				const current = session(ctx);
-				current.collapsed = !current.collapsed;
-				if (current.tui) invalidateSidebar(current.tui);
-				current.host?.requestRender();
+				toggle(session(ctx));
 			},
 		});
 	}

--- a/lib/shell-sidebar-layout.ts
+++ b/lib/shell-sidebar-layout.ts
@@ -1,4 +1,4 @@
-import { ScrollView, visibleWidth, type Component, type TUI } from "@earendil-works/pi-tui";
+import { ScrollView, visibleWidth, type Component, type TUI, type TuiMouseEvent } from "@earendil-works/pi-tui";
 import { sidebarState } from "./shell-sidebar.ts";
 import type { ShellBarTheme } from "./shell-bar.ts";
 import { renderSidebarBanner } from "./shell-sidebar-banner.ts";
@@ -14,6 +14,7 @@ type LayoutNode = { type: string; entries?: unknown[]; gap?: number; align?: str
 type LayoutRoot = Component & { [NODE]?: () => LayoutNode };
 type Host = TUI & { mode?: string; layoutRoot?: LayoutRoot };
 type SidebarCache = { revision: number };
+type RailHit = { key: string; component: Component; startY: number; height: number; width: number };
 type PreparedRail = {
 	revision: number;
 	width: number;
@@ -21,8 +22,10 @@ type PreparedRail = {
 	root: LayoutRoot;
 	theme: ShellBarTheme;
 	parts: Array<[string, Component]>;
+	contentWidth: number;
 	active: boolean;
 	lines: string[];
+	hits: RailHit[];
 };
 const CACHE = Symbol.for("gentle-pi.experimental-sidebar.cache");
 
@@ -65,16 +68,35 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 		scrollbarThumbStyle: (text) => theme.fg("accent", text),
 	});
 	const nativeMouse = scroll.handleMouse.bind(scroll);
+	const dispatchPartMouse = (event: TuiMouseEvent) => {
+		const current = prepared;
+		if (!current || stopped || failed || !current.active || current.revision !== cache.revision ||
+			host.mode !== "fullscreen" || tui.terminal.columns !== current.width || host.layoutRoot !== current.root ||
+			scroll.getContentWidth(event.width) !== current.contentWidth || event.x < RAIL_PADDING ||
+			event.x >= current.contentWidth || event.y < 0 || event.y >= event.height) return undefined;
+		const contentY = scroll.scrollTop + event.y;
+		const hit = current.hits.find((candidate) => contentY >= candidate.startY && contentY < candidate.startY + candidate.height);
+		if (!hit || state.parts.get(hit.key) !== hit.component || event.x >= RAIL_PADDING + hit.width) return undefined;
+		return hit.component.handleMouse?.({
+			...event,
+			x: event.x - RAIL_PADDING,
+			y: contentY - hit.startY,
+			width: hit.width,
+			height: hit.height,
+		});
+	};
 	scroll.handleMouse = (event) => {
-		if (event.type !== "wheel") return nativeMouse(event);
-		// Consume even at the boundary or over blank rail space: Pi 0.85.1
-		// can send unconsumed delta to the primary transcript despite containment.
-		scroll.scrollBy(event.wheelDelta ?? 0);
-		return {
-			handled: true,
-			render: true,
-			target: { component: scroll, originX: event.screenX - event.x, originY: event.screenY - event.y, width: event.width, height: event.height },
-		};
+		if (event.type === "wheel") {
+			// Consume even at the boundary or over blank rail space: Pi 0.85.1
+			// can send unconsumed delta to the primary transcript despite containment.
+			scroll.scrollBy(event.wheelDelta ?? 0);
+			return {
+				handled: true,
+				render: true,
+				target: { component: scroll, originX: event.screenX - event.x, originY: event.screenY - event.y, width: event.width, height: event.height },
+			};
+		}
+		return dispatchPartMouse(event) ?? nativeMouse(event);
 	};
 	const prepare = (width: number, root: LayoutRoot): boolean => {
 		state.active = false;
@@ -94,19 +116,26 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 		try {
 			const contentWidth = scroll.getContentWidth(RAIL_WIDTH);
 			const sections = ["footer", "changes", "agents", "todo"].map((key) => {
-				const lines = [...(state.parts.get(key)?.render(contentWidth - RAIL_PADDING * 2) ?? [])];
+				const component = state.parts.get(key);
+				const lines = [...(component?.render(contentWidth - RAIL_PADDING * 2) ?? [])];
 				while (lines.length && lines[lines.length - 1]?.trim() === "") lines.pop();
-				return lines;
-			}).filter((lines) => lines.length > 0);
+				return { key, component, lines };
+			}).filter((section) => section.component !== undefined && section.lines.length > 0) as Array<{ key: string; component: Component; lines: string[] }>;
 			const branding = renderSidebarBanner(theme, contentWidth - RAIL_PADDING * 2);
-			if (sections.length && branding.length) sections.unshift(branding);
-			railLines = sections.flatMap((lines, index) => [
-				...(index === 0 ? [] : [""]),
-				...lines.map((line) => " ".repeat(RAIL_PADDING) + line + " ".repeat(RAIL_PADDING)),
-			]);
+			const hits: RailHit[] = [];
+			railLines = [];
+			if (sections.length && branding.length) {
+				railLines.push(...branding.map((line) => " ".repeat(RAIL_PADDING) + line + " ".repeat(RAIL_PADDING)));
+			}
+			for (const section of sections) {
+				if (railLines.length > 0) railLines.push("");
+				const startY = railLines.length;
+				railLines.push(...section.lines.map((line) => " ".repeat(RAIL_PADDING) + line + " ".repeat(RAIL_PADDING)));
+				hits.push({ key: section.key, component: section.component, startY, height: section.lines.length, width: contentWidth - RAIL_PADDING * 2 });
+			}
 			// Height is owned by the native ScrollView, never by the transcript.
 			const active = railLines.length > 0 && railLines.every((line) => visibleWidth(line) <= contentWidth);
-			prepared = { revision: cache.revision, width, mode: host.mode, root, theme, parts, active, lines: railLines };
+			prepared = { revision: cache.revision, width, mode: host.mode, root, theme, parts, contentWidth, active, lines: railLines, hits };
 			state.active = active;
 			return active;
 		} catch {

--- a/lib/shell-todo.ts
+++ b/lib/shell-todo.ts
@@ -282,11 +282,14 @@ export function renderTodoCard(state: TodoState, theme: TodoTheme, width: number
 	const { done, total } = todoSummary(state);
 	const stale = options.staleTurns >= STALE_AFTER_TURNS;
 	const action = options.collapsed ? "expand" : "collapse";
+	const actionLabel = action[0]!.toUpperCase() + action.slice(1);
+	const icon = options.collapsed ? "▸" : "▾";
+	const control = `${icon} ${width >= 28 ? actionLabel : ""}`.trimEnd();
 	const hint = options.collapseKey ? `${options.collapseKey} ${action}` : undefined;
 	const rows = options.collapsed ? [collapsedRow(state, theme, width)] : options.scrollable ? state.tasks.map((task) => taskRow(task, theme, width)) : bodyRows(state, theme, width);
 	const body = stale ? [theme.fg(NOTE_ROLE, `stale · ${options.staleTurns} turns`), ...rows] : rows;
 	return renderCard(
-		{ title: `Todos ${options.collapsed ? "▸" : "▾"}`, subtitle: `${done} of ${total}`, body, tone: stale ? CARD_TONE.WARNING : CARD_TONE.INFO, glyph: TODO_GLYPH },
+		{ title: `Todos ${theme.fg("accent", control)}`, subtitle: `${done} of ${total}`, body, tone: stale ? CARD_TONE.WARNING : CARD_TONE.INFO, glyph: TODO_GLYPH },
 		theme,
 		width,
 		{ expanded: true, hint },

--- a/lib/shell-todo.ts
+++ b/lib/shell-todo.ts
@@ -271,6 +271,8 @@ function bodyRows(state: TodoState, theme: TodoTheme, width: number): string[] {
 function collapsedRow(state: TodoState, theme: TodoTheme, width: number): string {
 	const active = state.tasks.find((task) => task.status === TODO_STATUS.IN_PROGRESS);
 	if (active) return taskRow(active, theme, width);
+	const pending = state.tasks.find((task) => task.status === TODO_STATUS.PENDING);
+	if (pending) return taskRow(pending, theme, width);
 	const { open } = todoSummary(state);
 	return `${theme.fg(GLYPH_ROLE[TODO_STATUS.PENDING], STATUS_GLYPH[TODO_STATUS.PENDING])} ${theme.fg(NOTE_ROLE, `${open} open`)}`;
 }

--- a/lib/shell-todo.ts
+++ b/lib/shell-todo.ts
@@ -281,11 +281,12 @@ export function renderTodoCard(state: TodoState, theme: TodoTheme, width: number
 	if (state.tasks.length === 0) return [];
 	const { done, total } = todoSummary(state);
 	const stale = options.staleTurns >= STALE_AFTER_TURNS;
-	const hint = options.collapseKey ? `${options.collapseKey} ${options.collapsed ? "expand" : "collapse"}` : undefined;
+	const action = options.collapsed ? "expand" : "collapse";
+	const hint = options.collapseKey ? `${options.collapseKey} ${action}` : undefined;
 	const rows = options.collapsed ? [collapsedRow(state, theme, width)] : options.scrollable ? state.tasks.map((task) => taskRow(task, theme, width)) : bodyRows(state, theme, width);
 	const body = stale ? [theme.fg(NOTE_ROLE, `stale · ${options.staleTurns} turns`), ...rows] : rows;
 	return renderCard(
-		{ title: "Todos", subtitle: `${done} of ${total}`, body, tone: stale ? CARD_TONE.WARNING : CARD_TONE.INFO, glyph: TODO_GLYPH },
+		{ title: `Todos ${options.collapsed ? "▸" : "▾"}`, subtitle: `${done} of ${total}`, body, tone: stale ? CARD_TONE.WARNING : CARD_TONE.INFO, glyph: TODO_GLYPH },
 		theme,
 		width,
 		{ expanded: true, hint },

--- a/tests/gentle-todo.test.ts
+++ b/tests/gentle-todo.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
 import gentleTodo, { todoCollapseKey, todoEnabled } from "../extensions/gentle-todo.ts";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 
@@ -50,22 +51,23 @@ function fakePi() {
 }
 
 function fakeContext(branch: unknown[] = [], hasUI = true) {
-	const widgets = new Map<string, (tui: unknown, theme: unknown) => { render(width: number): string[] }>();
+	const widgets = new Map<string, (tui: unknown, theme: unknown) => Component>();
 	const ctx = {
 		hasUI,
 		sessionManager: { getSessionId: () => "s1", getBranch: () => branch },
 		ui: {
-			setWidget(key: string, content: ((tui: unknown, theme: unknown) => { render(width: number): string[] }) | undefined) {
+			setWidget(key: string, content: ((tui: unknown, theme: unknown) => Component) | undefined) {
 				if (content === undefined) widgets.delete(key);
 				else widgets.set(key, content);
 			},
 		},
 	} as unknown as ExtensionContext;
-	const widget = () => {
+	const widgetComponent = () => {
 		const factory = widgets.get("gentle-todo");
-		return factory ? factory(fakeTui, plainTheme).render(70).map(stripAnsi) : undefined;
+		return factory?.(fakeTui, plainTheme);
 	};
-	return { ctx, widgets, widget };
+	const widget = () => widgetComponent()?.render(70).map(stripAnsi);
+	return { ctx, widgets, widget, widgetComponent };
 }
 
 test("todoEnabled and todoCollapseKey read their environment flags", () => {
@@ -99,7 +101,7 @@ test("the todo tool writes the list, shows the card after the call, and carries 
 	assert.equal((result.details.gentleTodo as { tasks: unknown[] }).tasks.length, 2);
 	await fire("tool_execution_end", ctx, { toolName: "todo" });
 	const lines = widget()!;
-	assert.match(lines[0], /^╭─ ❀ Todos · 0 of 2 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(lines[0], /^╭─ ❀ Todos ▾ · 0 of 2 ─+ ctrl\+shift\+t collapse ╮$/);
 	assert.match(lines[1], /◐ Write the parser · parsing/);
 	assert.match(lines[2], /○ Add tests/);
 	assert.equal(lines[lines.length - 1], "", "a blank line keeps the card off the prompt");
@@ -109,6 +111,27 @@ test("the todo tool writes the list, shows the card after the call, and carries 
 	assert.equal(bad.details.error, "no task #9");
 	assert.match(tool.renderCall({ action: "write" }, plainTheme).render(40).join(""), /❀ todo · write/);
 	assert.equal(tool.renderResult({ content: [{ type: "text", text: "a\nb" }] }, { expanded: false }, plainTheme).render(40).join("|").trimEnd(), "a");
+});
+
+test("the Todo header is a fullscreen left-click control while non-click pointer events stay inert", async () => {
+	const { pi, tools, fire } = fakePi();
+	gentleTodo(pi, {});
+	const { ctx, widgetComponent } = fakeContext();
+	await fire("session_start", ctx);
+	await tools.get("todo")!.execute("c1", { action: "write", tasks: [{ title: "A", status: "in_progress" }, { title: "B" }] }, undefined, undefined, ctx);
+	await fire("tool_execution_end", ctx, { toolName: "todo" });
+
+	const component = widgetComponent()!;
+	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▾/);
+	const event = (type: "press" | "click", button: "left" | "right", y = 0) => ({
+		type, button, x: 1, y, screenX: 1, screenY: y, width: 70, height: 5, shift: false, alt: false, ctrl: false,
+	});
+	assert.equal(component.handleMouse?.(event("press", "left")), undefined);
+	assert.equal(component.handleMouse?.(event("click", "right")), undefined);
+	assert.equal(component.handleMouse?.(event("click", "left", 1)), undefined);
+	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▾/, "only a left click on the header toggles");
+	assert.equal(component.handleMouse?.(event("click", "left"))?.handled, true);
+	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▸/);
 });
 
 test("every turn carries the open tasks in the system prompt and the card goes stale after two silent turns", async () => {
@@ -151,7 +174,7 @@ test("a finished list stays for its turn and clears at the next, and the collaps
 	await tools.get("todo")!.execute("c2", { action: "write", tasks: [{ id: 1, title: "A", status: "done" }, { id: 2, title: "B", status: "done" }] }, undefined, undefined, ctx);
 	await fire("tool_execution_end", ctx, { toolName: "todo" });
 	await fire("agent_end", ctx);
-	assert.match(widget()![0], /Todos · 2 of 2/, "the finished list is still visible at the end of its turn");
+	assert.match(widget()![0], /Todos ▾ · 2 of 2/, "the finished list is still visible at the end of its turn");
 	const next = await fire("before_agent_start", ctx, { systemPrompt: "base" });
 	assert.equal(next, undefined, "nothing open, nothing to add to the prompt");
 	assert.equal(widget(), undefined, "the card clears at the next turn");
@@ -168,7 +191,7 @@ test("session_start replays the list from the branch, rpiv-todo results included
 	const { ctx, widget } = fakeContext(branch);
 	await fire("session_start", ctx);
 	const lines = widget()!;
-	assert.match(lines[0], /Todos · 0 of 1/);
+	assert.match(lines[0], /Todos ▾ · 0 of 1/);
 	assert.match(lines[1], /◐ Old task · still going/);
 	const headless = fakeContext(branch, false);
 	await fire("session_start", headless.ctx);

--- a/tests/gentle-todo.test.ts
+++ b/tests/gentle-todo.test.ts
@@ -26,7 +26,6 @@ const plainTheme = {
 	},
 };
 const fakeTui = { requestRender() {} };
-
 function fakePi() {
 	const handlers = new Map<string, Handler[]>();
 	const tools = new Map<string, Registered>();
@@ -101,7 +100,7 @@ test("the todo tool writes the list, shows the card after the call, and carries 
 	assert.equal((result.details.gentleTodo as { tasks: unknown[] }).tasks.length, 2);
 	await fire("tool_execution_end", ctx, { toolName: "todo" });
 	const lines = widget()!;
-	assert.match(lines[0], /^╭─ ❀ Todos ▾ · 0 of 2 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(lines[0], /^╭─ ❀ Todos ▾ Collapse · 0 of 2 ─+ ctrl\+shift\+t collapse ╮$/);
 	assert.match(lines[1], /◐ Write the parser · parsing/);
 	assert.match(lines[2], /○ Add tests/);
 	assert.equal(lines[lines.length - 1], "", "a blank line keeps the card off the prompt");
@@ -122,16 +121,30 @@ test("the Todo header is a fullscreen left-click control while non-click pointer
 	await fire("tool_execution_end", ctx, { toolName: "todo" });
 
 	const component = widgetComponent()!;
-	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▾/);
+	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▾ Collapse/);
 	const event = (type: "press" | "click", button: "left" | "right", y = 0) => ({
 		type, button, x: 1, y, screenX: 1, screenY: y, width: 70, height: 5, shift: false, alt: false, ctrl: false,
 	});
 	assert.equal(component.handleMouse?.(event("press", "left")), undefined);
 	assert.equal(component.handleMouse?.(event("click", "right")), undefined);
 	assert.equal(component.handleMouse?.(event("click", "left", 1)), undefined);
-	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▾/, "only a left click on the header toggles");
+	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▾ Collapse/, "only a left click on the header toggles");
 	assert.equal(component.handleMouse?.(event("click", "left"))?.handled, true);
-	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▸/);
+	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▸ Expand/);
+});
+
+test("the Todo header remains a static visible control without hover handling", async () => {
+	const { pi, tools, fire } = fakePi();
+	gentleTodo(pi, {});
+	const { ctx, widgetComponent } = fakeContext();
+	await fire("session_start", ctx);
+	await tools.get("todo")!.execute("c1", { action: "write", tasks: [{ title: "A" }] }, undefined, undefined, ctx);
+	await fire("tool_execution_end", ctx, { toolName: "todo" });
+	const component = widgetComponent()!;
+	const move = { type: "move" as const, button: "none" as const, x: 1, y: 0, screenX: 1, screenY: 0, width: 70, height: 5, shift: false, alt: false, ctrl: false };
+	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▾ Collapse/);
+	assert.equal(component.handleMouse?.(move), undefined);
+	assert.match(stripAnsi(component.render(70)[0]!), /Todos ▾ Collapse/);
 });
 
 test("every turn carries the open tasks in the system prompt and the card goes stale after two silent turns", async () => {
@@ -174,7 +187,7 @@ test("a finished list stays for its turn and clears at the next, and the collaps
 	await tools.get("todo")!.execute("c2", { action: "write", tasks: [{ id: 1, title: "A", status: "done" }, { id: 2, title: "B", status: "done" }] }, undefined, undefined, ctx);
 	await fire("tool_execution_end", ctx, { toolName: "todo" });
 	await fire("agent_end", ctx);
-	assert.match(widget()![0], /Todos ▾ · 2 of 2/, "the finished list is still visible at the end of its turn");
+	assert.match(widget()![0], /Todos ▾ Collapse · 2 of 2/, "the finished list is still visible at the end of its turn");
 	const next = await fire("before_agent_start", ctx, { systemPrompt: "base" });
 	assert.equal(next, undefined, "nothing open, nothing to add to the prompt");
 	assert.equal(widget(), undefined, "the card clears at the next turn");
@@ -191,7 +204,7 @@ test("session_start replays the list from the branch, rpiv-todo results included
 	const { ctx, widget } = fakeContext(branch);
 	await fire("session_start", ctx);
 	const lines = widget()!;
-	assert.match(lines[0], /Todos ▾ · 0 of 1/);
+	assert.match(lines[0], /Todos ▾ Collapse · 0 of 1/);
 	assert.match(lines[1], /◐ Old task · still going/);
 	const headless = fakeContext(branch, false);
 	await fire("session_start", headless.ctx);

--- a/tests/shell-sidebar-layout.test.ts
+++ b/tests/shell-sidebar-layout.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ScrollView, visibleWidth, type TUI } from "@earendil-works/pi-tui";
+import { ScrollView, visibleWidth, type TUI, type TuiMouseEvent } from "@earendil-works/pi-tui";
 import { renderLayoutFrame } from "@earendil-works/pi-tui/dist/layout.js";
-import { installSidebar } from "../lib/shell-sidebar-layout.ts";
+import { installSidebar, invalidateSidebar } from "../lib/shell-sidebar-layout.ts";
 import { sidebarPart, sidebarState } from "../lib/shell-sidebar.ts";
 import { renderShellSidebarBar } from "../lib/shell-bar.ts";
 import { renderTodoCard, type TodoState } from "../lib/shell-todo.ts";
@@ -137,6 +137,100 @@ test("wheel scrolls the rail and is consumed at both boundaries and blank space"
 	scroll.updateLayout(1, 5, () => {});
 	assert.equal(scroll.handleMouse({ type: "wheel", wheelDelta: 1 } as Parameters<typeof scroll.handleMouse>[0])?.handled, true);
 	assert.equal(scroll.scrollTop, 0);
+});
+
+test("rail dispatches a clipped, scroll-translated left click to only the matching sidebar part", (t) => {
+	const f = fixture();
+	let clicks = 0;
+	const received: TuiMouseEvent[] = [];
+	const todo = {
+		render: () => ["Todo header", "Todo body"],
+		invalidate() {},
+		handleMouse(event: TuiMouseEvent) {
+			received.push(event);
+			if (event.type !== "click" || event.button !== "left" || event.y !== 0) return undefined;
+			clicks++;
+			return { handled: true, render: true };
+		},
+	};
+	sidebarPart(f.tui, "todo", todo);
+	const dispose = installSidebar(f.tui, theme);
+	t.after(dispose);
+	const scroll = rail(f);
+	const content = scroll.render(50);
+	scroll.updateLayout(content.length, 5, () => {});
+	scroll.scrollBy(1);
+	const headerY = content.findIndex((line) => line.includes("Todo header")) - scroll.scrollTop;
+	assert.ok(headerY >= 0);
+	const mouse = (type: TuiMouseEvent["type"], button: TuiMouseEvent["button"], y: number): TuiMouseEvent => ({
+		type, button, x: 2, y, screenX: 92, screenY: 30 + y, width: 50, height: 5, shift: false, alt: false, ctrl: false,
+	});
+
+	assert.equal(scroll.handleMouse(mouse("press", "left", headerY)), undefined);
+	assert.equal(scroll.handleMouse(mouse("click", "right", headerY)), undefined);
+	assert.equal(scroll.handleMouse(mouse("click", "left", headerY + 1)), undefined);
+	assert.equal(clicks, 0);
+	const hit = scroll.handleMouse(mouse("click", "left", headerY));
+	assert.equal(hit?.handled, true);
+	assert.equal(clicks, 1);
+	assert.deepEqual(received.at(-1) && { x: received.at(-1)!.x, y: received.at(-1)!.y, width: received.at(-1)!.width, height: received.at(-1)!.height }, { x: 1, y: 0, width: 47, height: 2 });
+
+	const gapY = headerY - 1;
+	assert.equal(scroll.handleMouse(mouse("click", "left", gapY)), undefined, "section gaps do not hit a neighbor");
+	assert.equal(scroll.handleMouse({ ...mouse("click", "left", headerY), x: 48 }), undefined, "padding outside the clipped part is inert");
+	invalidateSidebar(f.tui);
+	assert.equal(scroll.handleMouse(mouse("click", "left", headerY)), undefined, "stale geometry is inert");
+	f.host.terminal.columns = 139;
+	assert.equal(scroll.handleMouse(mouse("click", "left", headerY)), undefined, "resized-away rails are inert");
+	dispose();
+	assert.equal(scroll.handleMouse(mouse("click", "left", headerY)), undefined, "disposed rails are inert");
+});
+
+test("rail rejects removed or replaced parts before cached geometry is prepared again", (t) => {
+	const f = fixture();
+	let originalClicks = 0;
+	let replacementClicks = 0;
+	const original = {
+		render: () => ["Todo header"],
+		invalidate() {},
+		handleMouse(event: TuiMouseEvent) {
+			if (event.type !== "click" || event.button !== "left") return undefined;
+			originalClicks++;
+			return { handled: true };
+		},
+	};
+	const mounted = sidebarPart(f.tui, "todo", { render: () => ["Todo bottom"], invalidate() {} }, original);
+	const dispose = installSidebar(f.tui, theme);
+	t.after(dispose);
+	const scroll = rail(f);
+	const content = scroll.render(50);
+	scroll.updateLayout(content.length, 5, () => {});
+	const headerY = content.findIndex((line) => line.includes("Todo header"));
+	const click = (): TuiMouseEvent => ({ type: "click", button: "left", x: 2, y: headerY, screenX: 92, screenY: 30 + headerY, width: 50, height: 5, shift: false, alt: false, ctrl: false });
+	assert.equal(scroll.handleMouse(click())?.handled, true, "healthy cached geometry still dispatches");
+	assert.equal(originalClicks, 1);
+
+	mounted.dispose();
+	assert.equal(scroll.handleMouse(click()), undefined, "removed parts are inert before the next prepare");
+	assert.equal(originalClicks, 1);
+
+	const replacement = {
+		render: () => ["Todo replacement"],
+		invalidate() {},
+		handleMouse(event: TuiMouseEvent) {
+			if (event.type !== "click" || event.button !== "left") return undefined;
+			replacementClicks++;
+			return { handled: true };
+		},
+	};
+	sidebarPart(f.tui, "todo", { render: () => ["Todo bottom"], invalidate() {} }, replacement);
+	assert.equal(scroll.handleMouse(click()), undefined, "a replacement cannot receive stale cached geometry");
+	assert.equal(originalClicks, 1);
+	assert.equal(replacementClicks, 0);
+
+	rail(f);
+	assert.equal(scroll.handleMouse(click())?.handled, true, "prepared replacement dispatches normally");
+	assert.equal(replacementClicks, 1);
 });
 
 test("real layout frames reuse unchanged sidebar output and invalidate at state and breakpoint boundaries", (t) => {

--- a/tests/shell-todo.test.ts
+++ b/tests/shell-todo.test.ts
@@ -134,7 +134,7 @@ test("renderTodoCard draws the framed list with status glyphs and keeps every li
 	const lines = renderTodoCard(seeded(), plainTheme, 60, { collapsed: false, staleTurns: 0, collapseKey: "ctrl+shift+t" });
 	for (const line of lines) assert.equal(visibleWidth(line), 60, `"${stripAnsi(line)}" is not 60 wide`);
 	const plain = lines.map(stripAnsi);
-	assert.match(plain[0], /^╭─ ❀ Todos ▾ · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(plain[0], /^╭─ ❀ Todos ▾ Collapse · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
 	assert.match(plain[1], /^│ ✓ ~Add quiet tool rendering~ +│$/);
 	assert.match(plain[2], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
 	assert.match(plain[3], /^│ ○ Show git bash tails +│$/);
@@ -146,7 +146,7 @@ test("renderTodoCard folds a long list: done tasks become one row and the open o
 	const state = applyTodo(emptyTodo(), { action: "write", tasks }, 1).state;
 	const plain = renderTodoCard(state, plainTheme, 60, { collapsed: false, staleTurns: 0 }).map(stripAnsi);
 	assert.equal(plain.length, 14, "top rule, twelve rows, bottom rule");
-	assert.match(plain[0], /Todos ▾ · 25 of 40/);
+	assert.match(plain[0], /Todos ▾ Collapse · 25 of 40/);
 	assert.match(plain[1], /^│ ✓ 25 done +│$/);
 	assert.match(plain[2], /^│ ◐ Task 26 +│$/);
 	assert.match(plain[11], /^│ ○ Task 35 +│$/);
@@ -159,19 +159,19 @@ test("renderTodoCard folds a long list: done tasks become one row and the open o
 
 test("renderTodoCard keeps the configured collapse shortcut in the header while stale state remains visible", () => {
 	const freshExpanded = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
-	assert.match(freshExpanded[0], /^╭─ ❀ Todos ▾ · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(freshExpanded[0], /^╭─ ❀ Todos ▾ Collapse · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
 
 	const freshCollapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
 	assert.equal(freshCollapsed.length, 3);
-	assert.match(freshCollapsed[0], /^╭─ ❀ Todos ▸ · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
+	assert.match(freshCollapsed[0], /^╭─ ❀ Todos ▸ Expand · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
 	assert.match(freshCollapsed[1], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
 
 	const staleExpanded = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
-	assert.match(staleExpanded[0], /^╭─ ❀ Todos ▾ · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(staleExpanded[0], /^╭─ ❀ Todos ▾ Collapse · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
 	assert.match(staleExpanded[1], /^│ stale · 2 turns +│$/);
 
 	const staleCollapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
-	assert.match(staleCollapsed[0], /^╭─ ❀ Todos ▸ · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
+	assert.match(staleCollapsed[0], /^╭─ ❀ Todos ▸ Expand · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
 	assert.match(staleCollapsed[1], /^│ stale · 2 turns +│$/);
 	assert.match(staleCollapsed[2], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
 
@@ -181,6 +181,19 @@ test("renderTodoCard keeps the configured collapse shortcut in the header while 
 	const activeAfterPending = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "Pending first" }, { title: "Active second", status: "in_progress" }, { title: "Pending third" }] }, 1).state;
 	assert.match(renderTodoCard(activeAfterPending, plainTheme, 70, { collapsed: true, staleTurns: 0 }).map(stripAnsi)[1], /^│ ◐ Active second +│$/);
 	assert.deepEqual(renderTodoCard(emptyTodo(), plainTheme, 70, { collapsed: false, staleTurns: 0 }), []);
+});
+
+test("renderTodoCard keeps English controls visible and falls back to their icons at narrow widths", () => {
+	const expanded = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
+	assert.match(expanded[0], /Todos ▾ Collapse/);
+	assert.match(expanded[0], /ctrl\+shift\+t collapse/);
+	const collapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
+	assert.match(collapsed[0], /Todos ▸ Expand/);
+	for (const [collapsedState, icon] of [[false, "▾"], [true, "▸"]] as const) {
+		const line = renderTodoCard(seeded(), plainTheme, 16, { collapsed: collapsedState, staleTurns: 0, collapseKey: "ctrl+shift+t" })[0]!;
+		assert.match(stripAnsi(line), new RegExp(`Todos ${icon}`));
+		assert.equal(visibleWidth(line), 16);
+	}
 });
 
 test("completed titles strike only title cells across wrapped lines, never padding or rails", () => {
@@ -223,7 +236,7 @@ test("renderTodoCard keeps stale indicators and collapse hints in scrollable lis
 	const state = applyTodo(emptyTodo(), { action: "write", tasks }, 1).state;
 	const lines = renderTodoCard(state, plainTheme, 70, { scrollable: true, collapsed: false, staleTurns: 2, collapseKey: "alt+t" }).map(stripAnsi);
 	assert.equal(lines.length, 43, "top rule, stale row, every task, bottom rule");
-	assert.match(lines[0], /^╭─ ❀ Todos ▾ · 25 of 40 ─+ alt\+t collapse ╮$/);
+	assert.match(lines[0], /^╭─ ❀ Todos ▾ Collapse · 25 of 40 ─+ alt\+t collapse ╮$/);
 	assert.match(lines[1], /^│ stale · 2 turns +│$/);
 	assert.match(lines[2], /^│ ✓ ~Task 1~ +│$/);
 	assert.match(lines[41], /^│ ○ Task 40 +│$/);

--- a/tests/shell-todo.test.ts
+++ b/tests/shell-todo.test.ts
@@ -175,8 +175,11 @@ test("renderTodoCard keeps the configured collapse shortcut in the header while 
 	assert.match(staleCollapsed[1], /^│ stale · 2 turns +│$/);
 	assert.match(staleCollapsed[2], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
 
-	const idle = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "Only pending" }] }, 1).state;
-	assert.match(renderTodoCard(idle, plainTheme, 70, { collapsed: true, staleTurns: 0 }).map(stripAnsi)[1], /^│ ○ 1 open +│$/);
+	const fallback = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "Finished first", status: "done" }, { title: "First pending" }, { title: "Later pending" }] }, 1).state;
+	assert.match(renderTodoCard(fallback, plainTheme, 70, { collapsed: true, staleTurns: 0 }).map(stripAnsi)[1], /^│ ○ First pending +│$/);
+
+	const activeAfterPending = applyTodo(emptyTodo(), { action: "write", tasks: [{ title: "Pending first" }, { title: "Active second", status: "in_progress" }, { title: "Pending third" }] }, 1).state;
+	assert.match(renderTodoCard(activeAfterPending, plainTheme, 70, { collapsed: true, staleTurns: 0 }).map(stripAnsi)[1], /^│ ◐ Active second +│$/);
 	assert.deepEqual(renderTodoCard(emptyTodo(), plainTheme, 70, { collapsed: false, staleTurns: 0 }), []);
 });
 

--- a/tests/shell-todo.test.ts
+++ b/tests/shell-todo.test.ts
@@ -134,7 +134,7 @@ test("renderTodoCard draws the framed list with status glyphs and keeps every li
 	const lines = renderTodoCard(seeded(), plainTheme, 60, { collapsed: false, staleTurns: 0, collapseKey: "ctrl+shift+t" });
 	for (const line of lines) assert.equal(visibleWidth(line), 60, `"${stripAnsi(line)}" is not 60 wide`);
 	const plain = lines.map(stripAnsi);
-	assert.match(plain[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(plain[0], /^╭─ ❀ Todos ▾ · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
 	assert.match(plain[1], /^│ ✓ ~Add quiet tool rendering~ +│$/);
 	assert.match(plain[2], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
 	assert.match(plain[3], /^│ ○ Show git bash tails +│$/);
@@ -146,7 +146,7 @@ test("renderTodoCard folds a long list: done tasks become one row and the open o
 	const state = applyTodo(emptyTodo(), { action: "write", tasks }, 1).state;
 	const plain = renderTodoCard(state, plainTheme, 60, { collapsed: false, staleTurns: 0 }).map(stripAnsi);
 	assert.equal(plain.length, 14, "top rule, twelve rows, bottom rule");
-	assert.match(plain[0], /Todos · 25 of 40/);
+	assert.match(plain[0], /Todos ▾ · 25 of 40/);
 	assert.match(plain[1], /^│ ✓ 25 done +│$/);
 	assert.match(plain[2], /^│ ◐ Task 26 +│$/);
 	assert.match(plain[11], /^│ ○ Task 35 +│$/);
@@ -159,19 +159,19 @@ test("renderTodoCard folds a long list: done tasks become one row and the open o
 
 test("renderTodoCard keeps the configured collapse shortcut in the header while stale state remains visible", () => {
 	const freshExpanded = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
-	assert.match(freshExpanded[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(freshExpanded[0], /^╭─ ❀ Todos ▾ · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
 
 	const freshCollapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 0, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
 	assert.equal(freshCollapsed.length, 3);
-	assert.match(freshCollapsed[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
+	assert.match(freshCollapsed[0], /^╭─ ❀ Todos ▸ · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
 	assert.match(freshCollapsed[1], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
 
 	const staleExpanded = renderTodoCard(seeded(), plainTheme, 70, { collapsed: false, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
-	assert.match(staleExpanded[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
+	assert.match(staleExpanded[0], /^╭─ ❀ Todos ▾ · 1 of 3 ─+ ctrl\+shift\+t collapse ╮$/);
 	assert.match(staleExpanded[1], /^│ stale · 2 turns +│$/);
 
 	const staleCollapsed = renderTodoCard(seeded(), plainTheme, 70, { collapsed: true, staleTurns: 2, collapseKey: "ctrl+shift+t" }).map(stripAnsi);
-	assert.match(staleCollapsed[0], /^╭─ ❀ Todos · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
+	assert.match(staleCollapsed[0], /^╭─ ❀ Todos ▸ · 1 of 3 ─+ ctrl\+shift\+t expand ╮$/);
 	assert.match(staleCollapsed[1], /^│ stale · 2 turns +│$/);
 	assert.match(staleCollapsed[2], /^│ ◐ Fix quiet tools conflict · fixing conflict +│$/);
 
@@ -223,7 +223,7 @@ test("renderTodoCard keeps stale indicators and collapse hints in scrollable lis
 	const state = applyTodo(emptyTodo(), { action: "write", tasks }, 1).state;
 	const lines = renderTodoCard(state, plainTheme, 70, { scrollable: true, collapsed: false, staleTurns: 2, collapseKey: "alt+t" }).map(stripAnsi);
 	assert.equal(lines.length, 43, "top rule, stale row, every task, bottom rule");
-	assert.match(lines[0], /^╭─ ❀ Todos · 25 of 40 ─+ alt\+t collapse ╮$/);
+	assert.match(lines[0], /^╭─ ❀ Todos ▾ · 25 of 40 ─+ alt\+t collapse ╮$/);
 	assert.match(lines[1], /^│ stale · 2 turns +│$/);
 	assert.match(lines[2], /^│ ✓ ~Task 1~ +│$/);
 	assert.match(lines[41], /^│ ○ Task 40 +│$/);


### PR DESCRIPTION
## Linked Issue
Closes #878

## PR Type
- [x] Bug fix

## Summary
- Show the next pending task when the Todo card is collapsed and no task is active.
- Preserve active-task priority, task ordering, completed-task skipping, and existing collapse/expand behavior.

## Changes
| File | Change |
|---|---|
| `lib/shell-todo.ts` | Render first pending task through the existing task-row renderer when idle |
| `tests/shell-todo.test.ts` | Cover pending ordering, completed-task skipping and active priority |

## Test Plan
- [x] RED reproduced without implementation: expected pending title, received open-task counter.
- [x] `node --experimental-strip-types --test tests/shell-todo.test.ts tests/gentle-todo.test.ts`: 21/21 passing, independently verified.
- [x] `git diff --check` passed.
- [x] Independent bounded verification found no blockers.
- [ ] Full suite and interactive UI were not exercised locally.

## Contributor Checklist
- [x] Linked approved issue; exactly one `type:bug` label.
- [x] Conventional commit without attribution trailers.
- No shell scripts, skill-loading metadata or shortcuts changed. Existing Ctrl+Shift+T collapse/expand remains unchanged.

Dependencies installed using `pnpm install --frozen-lockfile --ignore-scripts`; package manifest and lockfile unchanged. RDD disabled/unmanaged; no native review approval claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Task card titles now show clear expanded or collapsed indicators.
  - Clicking a Todo header with the left mouse button toggles its collapsed state.
  - Sidebar sections respond correctly to mouse clicks, including interactions within clipped or scrolled areas.
  - Control labels remain visible at wide widths and use compact expand/collapse icons at narrow widths.

- **Bug Fixes**
  - Collapsed task cards now display the first pending task, or the first in-progress task when available, instead of only the number of open tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fullscreen pointer control

- Added a visible header collapse/expand control using left-click, with the existing keyboard fallback.
- Support ordinary fullscreen widgets and the wide sidebar through translated, clipped pointer routing.
- Reject stale, removed or replaced targets; cover header/body/button behavior, scrolling, gaps, resize and disposal.
- Four focused suites independently passed (40/40): `node --experimental-strip-types --test tests/gentle-todo.test.ts tests/shell-sidebar-layout.test.ts tests/shell-todo.test.ts tests/native-pointer-region.test.ts`. Whitespace check passed.
- A stale-disposal defect was reproduced, fixed, and independently verified.
- pi-lab loads this worktree. Interactive UI and Termius device acceptance remain pending; regular mode remains keyboard-only.

Additional changed files: `extensions/gentle-todo.ts`, `lib/shell-sidebar-layout.ts`, `tests/gentle-todo.test.ts`, and `tests/shell-sidebar-layout.test.ts`.


## Final control visibility

The control now reads `▾ Collapse` / `▸ Expand`, with icon-only fallback below 28 columns. It is static and clickable; incomplete hover behavior was removed rather than presented as working. Keyboard behavior and stale-target protections remain intact. Final independent verification: 42/42 focused tests passed, whitespace check passed. Termius device acceptance remains pending; no upstream hover issue has been published.
