### PR TITLE
fix(telemetry): name packaged subagents with model and effort in runtime observations

### DIFF
--- a/contracts/telemetry/runtime-aggregate-v1.schema.json
+++ b/contracts/telemetry/runtime-aggregate-v1.schema.json
@@ -49,7 +49,7 @@
       "properties": {
         "reasoning_tokens": {"$ref": "#/$defs/token"},
         "total_tokens": {"$ref": "#/$defs/token"},
-        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-init", "sdd-explore", "sdd-research", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"]},
+        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-init", "sdd-explore", "sdd-research", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard", "sdd-status", "sdd-sync", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"]},
         "error_category": {"enum": ["none", "unknown", "auth", "output_length", "aborted", "api", "rate_limit", "server"]},
         "duration": {"$ref": "#/$defs/duration"},
         "model": {"$ref": "#/$defs/model"},

--- a/contracts/telemetry/runtime-aggregate-v1.schema.json
+++ b/contracts/telemetry/runtime-aggregate-v1.schema.json
@@ -49,7 +49,7 @@
       "properties": {
         "reasoning_tokens": {"$ref": "#/$defs/token"},
         "total_tokens": {"$ref": "#/$defs/token"},
-        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-apply", "sdd-archive", "sdd-design", "sdd-explore", "sdd-init", "sdd-onboard", "sdd-proposal", "sdd-research", "sdd-spec", "sdd-status", "sdd-sync", "sdd-tasks", "sdd-verify", "review-readability", "review-reliability", "review-resilience", "review-risk", "jd-fix-agent", "jd-judge-a", "jd-judge-b"]},
+        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-init", "sdd-explore", "sdd-research", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"]},
         "error_category": {"enum": ["none", "unknown", "auth", "output_length", "aborted", "api", "rate_limit", "server"]},
         "duration": {"$ref": "#/$defs/duration"},
         "model": {"$ref": "#/$defs/model"},

--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -79,6 +79,7 @@ export interface AgentsDeps extends RunnerDeps {
 	runtimeMetricsPolicy?: RuntimeMetricsPolicyDeps;
 	metricsNow?: () => number;
 	metricsSchedule?: RunnerDeps["schedule"];
+	lookupPiCatalogName?: typeof lookupPiCatalogName;
 }
 
 export function agentRuntimePaths(home: string, agentHome = join(home, ".pi", "agent")): { sessions: string; transcripts: string } {
@@ -318,6 +319,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	const stoppingTaskIds = new Set<string>();
 	const yieldedTaskIds = new Set<string>();
 	const metricsNow = deps.metricsNow ?? (() => performance.now());
+	const catalogLookup = deps.lookupPiCatalogName ?? lookupPiCatalogName;
 	let metricsOwner = {};
 	const metricTasks = new Map<string, { selection?: LaunchSelection; started: number; launched: boolean; finished: boolean; current(): boolean; valid(): boolean }>();
 	const unsubscribeMetrics = pi.events.on(CHILD_METRICS_REVOKED, id => {
@@ -696,8 +698,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			onLaunch: () => { metrics.launched = true; request.onLaunch?.(); },
 			...(observe ? { canCollectResponseObservations: metrics.valid, prepareResponseObservations: async () => {
 				if (metrics.finished || owner !== metricsOwner || request.parentSessionId !== activeSessionId() || !runtimeMetricsEnvAllows(deps.env)) return false;
-				try { await lookupPiCatalogName({ provider: "openai", modelId: "gpt-4o" }); }
-				catch { return false; }
+				void catalogLookup({ provider: "openai", modelId: "gpt-4o" }).catch(() => {});
 				if (!metrics.valid()) return false;
 				metrics.selection = launchSelection(request.agent, request.model, request.thinking);
 				metrics.started = metricsNow();

--- a/extensions/runtime-metrics.ts
+++ b/extensions/runtime-metrics.ts
@@ -7,13 +7,15 @@ import { sendNativeRuntimeEvent, type NativeRuntimeTransportDeps } from "../lib/
 import { runtimeMetricsEnvAllows } from "../lib/runtime-metrics-policy.ts";
 
 /** Available final usage -> one deferred attempt -> discard. No history reads,
- * cumulative session accounting, policy leases, delivery queue or shutdown join.
+ * cumulative session accounting, policy leases, delivery queue or retry. Print
+ * mode alone joins its accepted attempt for at most 1.5 seconds at shutdown.
  * Pi hooks lack request correlation: latency and SDK-zero presence are unknown.
  */
 export default function runtimeMetrics(pi: ExtensionAPI, env = process.env,
-	{ lookup = lookupPiCatalogName, classify = classifyPiCatalogName, native, send = sendNativeRuntimeEvent, now = () => performance.now() }:
+	{ lookup = lookupPiCatalogName, classify = classifyPiCatalogName, native, send = sendNativeRuntimeEvent,
+		now = () => performance.now(), shutdownWaitMs = 1500 }:
 	{ lookup?: typeof lookupPiCatalogName; classify?: typeof classifyPiCatalogName; native?: NativeRuntimeTransportDeps;
-		send?: typeof sendNativeRuntimeEvent; now?: () => number } = {}): void {
+		send?: typeof sendNativeRuntimeEvent; now?: () => number; shutdownWaitMs?: number } = {}): void {
 	const allows = () => env.GENTLE_PI_AGENTS_CHILD !== "1" && runtimeMetricsEnvAllows(env);
 	if (!allows()) return;
 	type Selection = Pick<FinalResponse, "selectedModelId" | "selectedProvider" | "effort">;
@@ -74,7 +76,12 @@ export default function runtimeMetrics(pi: ExtensionAPI, env = process.env,
 		live = owner;
 		refreshCatalog(owner, { provider: "openai", modelId: "gpt-4o" });
 	});
-	pi.on("session_shutdown", () => { dispose(); offChild(); offRevoke(); });
+	pi.on("session_shutdown", (_event, ctx) => {
+		const teardown = () => { dispose(); offChild(); offRevoke(); };
+		const owner = live;
+		if (ctx.mode !== "print" || !owner) { teardown(); return; }
+		return owner.attempt.waitForSettled(shutdownWaitMs).finally(teardown);
+	});
 	pi.on("turn_start", () => { ambiguous = active; active = true; requestSeen = false; selection = undefined; });
 	pi.on("turn_end", () => { active = false; invalidate(); });
 	pi.on("agent_end", () => { active = false; invalidate(); });

--- a/extensions/runtime-metrics.ts
+++ b/extensions/runtime-metrics.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { EFFORTS, RuntimeMetrics, type FinalResponse, type TokenMeasurement } from "../lib/runtime-metrics.ts";
-import { lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
+import { EFFORTS, ORCHESTRATOR_AGENT_CLASS, RuntimeMetrics, UNKNOWN_AGENT_CLASS, type FinalResponse, type TokenMeasurement } from "../lib/runtime-metrics.ts";
+import { classifyPiCatalogName, lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
 import { CHILD_METRICS_EVENT, CHILD_METRICS_REVOKED, snapshotChildEvent, type ChildLaunchBucket } from "../lib/runtime-metrics-children.ts";
 import { RuntimeMetricsAttempt } from "../lib/runtime-metrics-delivery.ts";
 import { sendNativeRuntimeEvent, type NativeRuntimeTransportDeps } from "../lib/runtime-metrics-native.ts";
@@ -11,8 +11,8 @@ import { runtimeMetricsEnvAllows } from "../lib/runtime-metrics-policy.ts";
  * Pi hooks lack request correlation: latency and SDK-zero presence are unknown.
  */
 export default function runtimeMetrics(pi: ExtensionAPI, env = process.env,
-	{ lookup = lookupPiCatalogName, native, send = sendNativeRuntimeEvent, now = () => performance.now() }:
-	{ lookup?: typeof lookupPiCatalogName; native?: NativeRuntimeTransportDeps;
+	{ lookup = lookupPiCatalogName, classify = classifyPiCatalogName, native, send = sendNativeRuntimeEvent, now = () => performance.now() }:
+	{ lookup?: typeof lookupPiCatalogName; classify?: typeof classifyPiCatalogName; native?: NativeRuntimeTransportDeps;
 		send?: typeof sendNativeRuntimeEvent; now?: () => number } = {}): void {
 	const allows = () => env.GENTLE_PI_AGENTS_CHILD !== "1" && runtimeMetricsEnvAllows(env);
 	if (!allows()) return;
@@ -30,10 +30,15 @@ export default function runtimeMetrics(pi: ExtensionAPI, env = process.env,
 		if (!allows() || live?.id !== ctx.sessionManager.getSessionId()) dispose();
 		return live;
 	}
+	function refreshCatalog(owner: NonNullable<typeof live>, input: { provider: unknown; modelId: unknown }) {
+		void lookup(input).then(result => {
+			if (live === owner && result.classification === "catalog_public") owner.catalog = true;
+		}, () => { /* A later classification callback may retry the bounded load. */ });
+	}
 	function submit(owner: NonNullable<typeof live>, responses: FinalResponse[], launches?: ChildLaunchBucket[]) {
 		if (!responses.length || live !== owner || !current(owner.ctx)) return;
 		// Ephemeral event-local accounting only; source IDs never enter these rows.
-		const metrics = new RuntimeMetrics();
+		const metrics = new RuntimeMetrics({ classifyModel: classify });
 		for (const [index, row] of responses.entries()) metrics.record({ ...row, responseId: String(index) });
 		const rows = metrics.snapshot();
 		if (!rows.length) return;
@@ -61,16 +66,13 @@ export default function runtimeMetrics(pi: ExtensionAPI, env = process.env,
 			invalidate();
 		}
 	});
-	pi.on("session_start", async (_event, ctx) => {
+	pi.on("session_start", (_event, ctx) => {
 		dispose();
 		if (!allows()) return;
 		const owner = { id: ctx.sessionManager.getSessionId(), started: now(), ctx,
 			attempt: new RuntimeMetricsAttempt(), seen: new WeakSet<object>(), children: new Set<string>(), catalog: false };
 		live = owner;
-		try {
-			await lookup({ provider: "openai", modelId: "gpt-4o" });
-			if (live === owner) owner.catalog = true;
-		} catch { /* Public catalog failure stays silent. */ }
+		refreshCatalog(owner, { provider: "openai", modelId: "gpt-4o" });
 	});
 	pi.on("session_shutdown", () => { dispose(); offChild(); offRevoke(); });
 	pi.on("turn_start", () => { ambiguous = active; active = true; requestSeen = false; selection = undefined; });
@@ -100,12 +102,13 @@ export default function runtimeMetrics(pi: ExtensionAPI, env = process.env,
 			if (!owner || message.role !== "assistant" || message.stopReason === "pending" || message.stopReason === "deferred"
 				|| owner.seen.has(message)) return;
 			owner.seen.add(message);
+			refreshCatalog(owner, { provider: "openai", modelId: "gpt-4o" });
 			const selected = active && !ambiguous ? selection : undefined;
 			submit(owner, [{ kind: "final_assistant_response", responseId: "0",
 				selectedProvider: selected?.selectedProvider ?? "unknown", selectedModelId: selected?.selectedModelId,
 				effort: selected?.effort ?? "unavailable",
 				executor: env.GENTLE_PI_AGENTS_CHILD === undefined ? "orchestrator" : "unknown",
-				agentClass: env.GENTLE_PI_AGENTS_CHILD === undefined ? "orchestrator" : "unknown",
+				agentClass: env.GENTLE_PI_AGENTS_CHILD === undefined ? ORCHESTRATOR_AGENT_CLASS : UNKNOWN_AGENT_CLASS,
 				observedModelId: message.model, responseModelId: message.responseModel,
 				providerThinkingLevel: EFFORTS.includes(message.providerThinkingLevel as FinalResponse["effort"])
 					? message.providerThinkingLevel as FinalResponse["effort"] : "unavailable",

--- a/lib/runtime-metrics-children.ts
+++ b/lib/runtime-metrics-children.ts
@@ -20,6 +20,11 @@ const tokenFields = ["input", "output", "cacheRead", "cacheWrite", "reasoning", 
  * Only the fixed package catalog is cached; runtime instructions are not retained.
  */
 let definitions: Array<{ name: string; fingerprint: string; fingerprintClass?: AgentClass }> | undefined;
+const packagedAgentClassAliases = new Map([["sdd-proposal", "sdd-propose"]] as const);
+function fingerprintAgentClassName(name: string): string {
+	const compatibilityName = name.startsWith("gentle-ai-") ? name.slice("gentle-ai-".length) : name;
+	return packagedAgentClassAliases.get(compatibilityName) ?? compatibilityName;
+}
 function fingerprint(agent: AgentDefinition): string {
 	return JSON.stringify([agent.name, agent.description, agent.instructions, agent.tools, agent.mode]);
 }
@@ -30,11 +35,10 @@ export function classifyBuiltinAgent(agent: AgentDefinition): AgentClass {
 			const path = new URL(`../assets/agents/${file}`, import.meta.url);
 			const parsed = parseAgentDefinition(readFileSync(path, "utf8"), path.pathname, "global");
 			if (!("instructions" in parsed)) throw new Error("Invalid packaged definition");
-			const compatibilityName = parsed.name.startsWith("gentle-ai-") ? parsed.name.slice("gentle-ai-".length) : parsed.name;
 			return { name: parsed.name, fingerprint: fingerprint(parsed),
-				fingerprintClass: parseAgentClass(compatibilityName) };
+				fingerprintClass: parseAgentClass(fingerprintAgentClassName(parsed.name)) };
 		});
-		const namedClass = parseAgentClass(agent.name);
+		const namedClass = parseAgentClass(packagedAgentClassAliases.get(agent.name) ?? agent.name);
 		if (namedClass && definitions.some(entry => entry.name === agent.name)) return namedClass;
 		return definitions.find(entry => entry.fingerprintClass && entry.fingerprint === fingerprint(agent))?.fingerprintClass ?? UNKNOWN_AGENT_CLASS;
 	} catch { return UNKNOWN_AGENT_CLASS; }

--- a/lib/runtime-metrics-children.ts
+++ b/lib/runtime-metrics-children.ts
@@ -1,8 +1,8 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { parseAgentDefinition, type AgentDefinition, type ModelRef } from "./agents-config.ts";
 import type { ChildObservationSnapshot } from "./agents-runner.ts";
 import { FINISHED_STATUSES, type TaskStatus } from "./agents-protocol.ts";
-import { AGENT_CLASSES, EFFORTS, RuntimeMetrics, validRuntimeResponse, type AgentClass, type FinalResponse, type RuntimeMetricBucket } from "./runtime-metrics.ts";
+import { EFFORTS, parseAgentClass, RuntimeMetrics, UNKNOWN_AGENT_CLASS, validRuntimeResponse, type AgentClass, type FinalResponse, type RuntimeMetricBucket } from "./runtime-metrics.ts";
 import { classifyPiCatalogName } from "./runtime-metrics-pi-identity.ts";
 export const CHILD_METRICS_EVENT = "gentle:runtime-metrics:child/v1";
 // Local revocation notification invalidates active observations. Contains only
@@ -11,30 +11,33 @@ export const CHILD_METRICS_REVOKED = "gentle:runtime-metrics:revoked/v1";
 const missing = { state: "unavailable" } as const;
 const providers = ["anthropic", "openai", "openai-codex", "google", "google-vertex", "amazon-bedrock", "openrouter", "custom", "unknown"];
 const tokenFields = ["input", "output", "cacheRead", "cacheWrite", "reasoning", "totalTokens"] as const;
-const builtinFiles = AGENT_CLASSES.filter(name => name !== "orchestrator" && name !== "unknown")
-	.map(name => [name, ["worker", "explore", "verify"].includes(name) ? `gentle-ai-${name}` : name] as const);
-
-/** Compare the runtime definition against this package's fixed assets, not its
- * public-looking name/path. Normalize only model/thinking routing, which the
- * package's gentle-ai.ts updateFrontmatterRouting writer changes on installation
- * and model configuration. Instructions, tools, description and mode must match.
- * No installed files are read; this class is not execution/review authority.
+/** Recognize only names from this package's fixed assets and the transport's
+ * closed agent_class enum. Customized packaged agents retain their schema name;
+ * user-defined names never enter telemetry. Exact fingerprints preserve the
+ * worker/explore/verify compatibility mapping whose packaged names are prefixed.
+ * Model/thinking routing is excluded from fingerprints because installation
+ * rewrites it. No installed files are read; this class is not execution/review authority.
  * Only the fixed package catalog is cached; runtime instructions are not retained.
  */
-let definitions: Array<{ agentClass: AgentClass; fingerprint: string }> | undefined;
+let definitions: Array<{ name: string; fingerprint: string; fingerprintClass?: AgentClass }> | undefined;
 function fingerprint(agent: AgentDefinition): string {
 	return JSON.stringify([agent.name, agent.description, agent.instructions, agent.tools, agent.mode]);
 }
 export function classifyBuiltinAgent(agent: AgentDefinition): AgentClass {
 	try {
-		definitions ??= builtinFiles.map(([agentClass, file]) => {
-			const path = new URL(`../assets/agents/${file}.md`, import.meta.url);
+		definitions ??= readdirSync(new URL("../assets/agents/", import.meta.url))
+			.filter(file => file.endsWith(".md")).map(file => {
+			const path = new URL(`../assets/agents/${file}`, import.meta.url);
 			const parsed = parseAgentDefinition(readFileSync(path, "utf8"), path.pathname, "global");
 			if (!("instructions" in parsed)) throw new Error("Invalid packaged definition");
-			return { agentClass, fingerprint: fingerprint(parsed) };
+			const compatibilityName = parsed.name.startsWith("gentle-ai-") ? parsed.name.slice("gentle-ai-".length) : parsed.name;
+			return { name: parsed.name, fingerprint: fingerprint(parsed),
+				fingerprintClass: parseAgentClass(compatibilityName) };
 		});
-		return definitions.find(entry => entry.fingerprint === fingerprint(agent))?.agentClass ?? "unknown";
-	} catch { return "unknown"; }
+		const namedClass = parseAgentClass(agent.name);
+		if (namedClass && definitions.some(entry => entry.name === agent.name)) return namedClass;
+		return definitions.find(entry => entry.fingerprintClass && entry.fingerprint === fingerprint(agent))?.fingerprintClass ?? UNKNOWN_AGENT_CLASS;
+	} catch { return UNKNOWN_AGENT_CLASS; }
 }
 function provider(value: unknown): FinalResponse["provider"] {
 	return providers.includes(value as string) ? value as FinalResponse["provider"] : value ? "custom" : "unknown";
@@ -98,7 +101,7 @@ function validEvent(value: unknown): value is ChildMetricsEvent {
 		&& Number.isFinite(e.launchedAt) && e.launchedAt >= 0
 		&& e.coverage === "final_assistant_messages_only" && typeof e.agentSettled === "boolean"
 		&& FINISHED_STATUSES.includes(e.status) && Number.isSafeInteger(e.droppedResponses) && e.droppedResponses >= 0
-		&& e.droppedResponses <= Number.MAX_SAFE_INTEGER && !!l && AGENT_CLASSES.includes(l.agentClass) && l.agentClass !== "orchestrator"
+		&& e.droppedResponses <= Number.MAX_SAFE_INTEGER && !!l && !!parseAgentClass(l.agentClass) && l.agentClass !== "orchestrator"
 		&& provider(l.selectedProvider) === l.selectedProvider && modelId(l.selectedProvider, l.selectedModelId) === l.selectedModelId
 		&& effort(l.selectedEffort) === l.selectedEffort && Array.isArray(e.responses) && e.responses.length <= 128
 		&& e.responses.every(row => validRuntimeResponse(row) && row.agentClass === l.agentClass

--- a/lib/runtime-metrics-children.ts
+++ b/lib/runtime-metrics-children.ts
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync } from "node:fs";
 import { parseAgentDefinition, type AgentDefinition, type ModelRef } from "./agents-config.ts";
 import type { ChildObservationSnapshot } from "./agents-runner.ts";
 import { FINISHED_STATUSES, type TaskStatus } from "./agents-protocol.ts";
-import { EFFORTS, parseAgentClass, RuntimeMetrics, UNKNOWN_AGENT_CLASS, validRuntimeResponse, type AgentClass, type FinalResponse, type RuntimeMetricBucket } from "./runtime-metrics.ts";
+import { classifyRuntimeModelId, EFFORTS, parseAgentClass, RuntimeMetrics, UNKNOWN_AGENT_CLASS, validRuntimeResponse, type AgentClass, type FinalResponse, type RuntimeMetricBucket } from "./runtime-metrics.ts";
 import { classifyPiCatalogName } from "./runtime-metrics-pi-identity.ts";
 export const CHILD_METRICS_EVENT = "gentle:runtime-metrics:child/v1";
 // Local revocation notification invalidates active observations. Contains only
@@ -48,7 +48,7 @@ function provider(value: unknown): FinalResponse["provider"] {
 }
 function modelId(namespace: unknown, value: unknown): string {
 	if (value === "unknown" || value === undefined) return "unknown";
-	return classifyPiCatalogName({ provider: namespace, modelId: value }).modelId;
+	return classifyRuntimeModelId(namespace, value, classifyPiCatalogName);
 }
 function effort(value: unknown): FinalResponse["effort"] {
 	return EFFORTS.includes(value as FinalResponse["effort"]) ? value as FinalResponse["effort"] : "unavailable";
@@ -90,7 +90,8 @@ export function childEvent(parentSessionId: string, taskId: string, launch: Laun
 			return { kind: "final_assistant_response", responseId: String(index), agentClass: launch.agentClass,
 				executor: "worker", provider: provider(namespace), modelFamily: "unknown", observedModelId: name(row.model),
 				responseModelId: name(row.responseModel), providerThinkingLevel: effort(row.providerThinkingLevel.state === "observed" ? row.providerThinkingLevel.value : undefined),
-				selectedProvider: "unknown", effort: "unavailable", error: row.stopReason === "error" ? "unknown" : row.stopReason === "aborted" ? "aborted" : "none",
+				selectedProvider: launch.selectedProvider, selectedModelId: launch.selectedModelId, effort: launch.selectedEffort,
+				error: row.stopReason === "error" ? "unknown" : row.stopReason === "aborted" ? "aborted" : "none",
 				tokens: Object.fromEntries(tokenFields.map(field => [field, { ...row.tokens[field] }])) as FinalResponse["tokens"],
 				responseHeadersMs: missing, fullResponseMs: missing };
 		}) };
@@ -109,7 +110,7 @@ function validEvent(value: unknown): value is ChildMetricsEvent {
 		&& provider(l.selectedProvider) === l.selectedProvider && modelId(l.selectedProvider, l.selectedModelId) === l.selectedModelId
 		&& effort(l.selectedEffort) === l.selectedEffort && Array.isArray(e.responses) && e.responses.length <= 128
 		&& e.responses.every(row => validRuntimeResponse(row) && row.agentClass === l.agentClass
-			&& row.executor === "worker" && row.effort === "unavailable" && row.selectedProvider === "unknown" && row.selectedModelId === undefined
+			&& row.executor === "worker" && row.effort === l.selectedEffort && row.selectedProvider === l.selectedProvider && row.selectedModelId === l.selectedModelId
 			&& provider(row.provider) === row.provider && effort(row.providerThinkingLevel) === row.providerThinkingLevel
 			&& (row.observedModelId === undefined || modelId(row.provider, row.observedModelId) === row.observedModelId)
 			&& (row.responseModelId === undefined || modelId(row.provider, row.responseModelId) === row.responseModelId)
@@ -127,7 +128,7 @@ export function snapshotChildEvent(value: unknown): ChildMetricsEvent | undefine
 		responses: value.responses.map((row, index) => ({ kind: "final_assistant_response", responseId: String(index),
 			agentClass: row.agentClass, executor: "worker", provider: row.provider, observedModelId: row.observedModelId,
 			responseModelId: row.responseModelId, providerThinkingLevel: row.providerThinkingLevel, modelFamily: "unknown",
-			selectedProvider: "unknown", effort: "unavailable", error: row.error,
+			selectedProvider: l.selectedProvider, selectedModelId: l.selectedModelId, effort: l.selectedEffort, error: row.error,
 			tokens: Object.fromEntries(tokenFields.map(field => {
 				const t = row.tokens[field];
 				return [field, t?.state === "reported" ? { state: "reported", value: t.value } : { state: t?.state ?? "unavailable" }];
@@ -136,7 +137,8 @@ export function snapshotChildEvent(value: unknown): ChildMetricsEvent | undefine
 
 /** Export-facing shape: no IDs, paths, task labels, or raw agent/model names.
  * Rankings are descending counts, NOT quality/success comparisons. Native
- * transport is deliberately absent. Response buckets never inherit launch effort.
+ * transport is deliberately absent. Response buckets retain selected launch
+ * identity and effort separately from effective response evidence.
  */
 export interface ChildCompositionSnapshot {
 	launches: ChildLaunchBucket[];

--- a/lib/runtime-metrics-delivery.ts
+++ b/lib/runtime-metrics-delivery.ts
@@ -3,26 +3,53 @@ let busy = false;
 
 /** One accepted attempt, never a queue. Defer resolver/process work beyond the
  * provider callback. Busy events are discarded rather than captured for later.
- * The transport must settle only after its process exits; disposal never waits.
+ * The transport must settle only after its process exits. Print-mode shutdown
+ * may join the one accepted attempt for a bounded deadline; it never queues or
+ * retries work. Every other disposal remains immediate.
  */
 export class RuntimeMetricsAttempt {
 	#closed = false;
 	#scheduled?: ReturnType<typeof setImmediate>;
 	#abort?: AbortController;
+	#settled?: Promise<void>;
+	#release?: () => void;
 	offer(work: (signal: AbortSignal) => Promise<unknown>): boolean {
 		if (this.#closed || busy) return false;
 		busy = true;
 		const abort = new AbortController();
 		this.#abort = abort;
+		let release!: () => void;
+		const settled = new Promise<void>(resolve => { release = resolve; });
+		this.#settled = settled;
+		this.#release = release;
 		this.#scheduled = setImmediate(() => {
 			this.#scheduled = undefined;
 			void (async () => {
 				try { if (!abort.signal.aborted) await work(abort.signal); }
 				catch { /* An attempt is always best effort; never retry or report. */ }
-				finally { this.#abort = undefined; busy = false; }
+				finally {
+					this.#abort = undefined;
+					busy = false;
+					if (this.#settled === settled) {
+						this.#settled = undefined;
+						this.#release = undefined;
+					}
+					release();
+				}
 			})();
 		});
 		return true;
+	}
+	/** Await only the already accepted attempt, up to the caller's deadline. */
+	async waitForSettled(timeoutMs: number): Promise<void> {
+		const settled = this.#settled;
+		if (!settled) return;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		try {
+			await Promise.race([settled, new Promise<void>(resolve => { timer = setTimeout(resolve, timeoutMs); })]);
+		} finally {
+			if (timer) clearTimeout(timer);
+		}
 	}
 	dispose(): void {
 		if (this.#closed) return;
@@ -31,6 +58,9 @@ export class RuntimeMetricsAttempt {
 			clearImmediate(this.#scheduled);
 			this.#scheduled = undefined;
 			busy = false;
+			this.#settled = undefined;
+			this.#release?.();
+			this.#release = undefined;
 		}
 		this.#abort?.abort();
 		this.#abort = undefined;

--- a/lib/runtime-metrics-pi-identity.ts
+++ b/lib/runtime-metrics-pi-identity.ts
@@ -13,6 +13,7 @@ const CUSTOM: PiCatalogName = Object.freeze({ classification: "custom", modelId:
 // additions require deliberate review. These are providers, not model-ID lists.
 const CATALOGS = ["anthropic", "openai", "openai-codex", "google", "google-vertex", "amazon-bedrock", "openrouter"] as const;
 const MAX_MODELS = 4096;
+const MAX_LOAD_ATTEMPTS = 3;
 
 function object(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -26,8 +27,6 @@ function key(provider: string, modelId: string): string {
 	return JSON.stringify([provider, modelId]);
 }
 
-let catalogPromise: Promise<ReadonlyMap<string, PiCatalogName>> | undefined;
-let loadedCatalog: ReadonlyMap<string, PiCatalogName> | undefined;
 async function loadCatalog(): Promise<ReadonlyMap<string, PiCatalogName>> {
 	// Node >=22.19 supports findPackageJSON. Verify ESM lookup from this module
 	// selects Pi's own pi-ai package; fail rather than silently use another copy.
@@ -56,6 +55,42 @@ async function loadCatalog(): Promise<ReadonlyMap<string, PiCatalogName>> {
 	return entries;
 }
 
+export function createPiCatalogNameLookup(
+	load: () => Promise<ReadonlyMap<string, PiCatalogName>> = loadCatalog,
+	maxAttempts = MAX_LOAD_ATTEMPTS,
+): { lookup(input: unknown): Promise<PiCatalogName>; classify(input: unknown): PiCatalogName } {
+	let catalogPromise: Promise<ReadonlyMap<string, PiCatalogName>> | undefined;
+	let loadedCatalog: ReadonlyMap<string, PiCatalogName> | undefined;
+	let attempts = 0;
+	const classify = (input: unknown): PiCatalogName => {
+		if (!object(input) || !text(input.provider, 32) || !text(input.modelId, 128)) return UNKNOWN;
+		if (!CATALOGS.includes(input.provider as typeof CATALOGS[number])) return CUSTOM;
+		return loadedCatalog ? loadedCatalog.get(key(input.provider, input.modelId)) ?? CUSTOM : UNKNOWN;
+	};
+	const lookup = async (input: unknown): Promise<PiCatalogName> => {
+		if (!object(input) || !text(input.provider, 32) || !text(input.modelId, 128)) return UNKNOWN;
+		if (!CATALOGS.includes(input.provider as typeof CATALOGS[number])) return CUSTOM;
+		if (!loadedCatalog) {
+			if (!catalogPromise) {
+				if (attempts >= maxAttempts) throw new Error("Pi catalog load attempts exhausted");
+				attempts++;
+				catalogPromise = load().then(catalog => {
+					loadedCatalog = catalog;
+					return catalog;
+				}, error => {
+					catalogPromise = undefined;
+					throw error;
+				});
+			}
+			await catalogPromise;
+		}
+		return classify(input);
+	};
+	return { lookup, classify };
+}
+
+const catalogLookup = createPiCatalogNameLookup();
+
 /**
  * Returns only a privacy-safe catalog name, NOT the model actually dispatched.
  * Matching a public ID remains a public-name fact even on a custom endpoint;
@@ -67,18 +102,12 @@ async function loadCatalog(): Promise<ReadonlyMap<string, PiCatalogName>> {
  * Missing/incompatible dependencies and catalog overflow reject, never skip.
  */
 export async function lookupPiCatalogName(input: unknown): Promise<PiCatalogName> {
-	if (!object(input) || !text(input.provider, 32) || !text(input.modelId, 128)) return UNKNOWN;
-	if (!CATALOGS.includes(input.provider as typeof CATALOGS[number])) return CUSTOM;
-	catalogPromise ??= loadCatalog();
-	loadedCatalog = await catalogPromise;
-	return classifyPiCatalogName(input);
+	return catalogLookup.lookup(input);
 }
 
 /** Pure lookup after async catalog loading; unknown until initialization succeeds.
  * Always recheck membership, never trust a caller's classification/public label.
  */
 export function classifyPiCatalogName(input: unknown): PiCatalogName {
-	if (!object(input) || !text(input.provider, 32) || !text(input.modelId, 128)) return UNKNOWN;
-	if (!CATALOGS.includes(input.provider as typeof CATALOGS[number])) return CUSTOM;
-	return loadedCatalog ? loadedCatalog.get(key(input.provider, input.modelId)) ?? CUSTOM : UNKNOWN;
+	return catalogLookup.classify(input);
 }

--- a/lib/runtime-metrics.ts
+++ b/lib/runtime-metrics.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { classifyPiCatalogName } from "./runtime-metrics-pi-identity.ts";
 
+const runtimeSchema = JSON.parse(readFileSync(new URL("../contracts/telemetry/runtime-aggregate-v1.schema.json", import.meta.url), "utf8"));
+
 // Pure local accounting, not a telemetry transport or Pi event adapter.
 // Callers supply finalized assistant responses and authoritative classifications.
 // Never infer executor, usage availability, or measured timings from SDK defaults.
@@ -18,8 +20,7 @@ declare const agentClassBrand: unique symbol;
 export type AgentClass = string & { readonly [agentClassBrand]: "AgentClass" };
 
 function agentClasses(): readonly AgentClass[] {
-	const schema = JSON.parse(readFileSync(new URL("../contracts/telemetry/runtime-aggregate-v1.schema.json", import.meta.url), "utf8"));
-	const values: unknown = schema?.$defs?.row?.properties?.agent_class?.enum;
+	const values: unknown = runtimeSchema?.$defs?.row?.properties?.agent_class?.enum;
 	if (!Array.isArray(values) || !values.length || values.some(value => typeof value !== "string")) {
 		throw new Error("Invalid runtime telemetry agent_class schema");
 	}
@@ -40,6 +41,40 @@ function requiredAgentClass(value: string): AgentClass {
 }
 export const UNKNOWN_AGENT_CLASS = requiredAgentClass("unknown");
 export const ORCHESTRATOR_AGENT_CLASS = requiredAgentClass("orchestrator");
+
+function registeredModels(): ReadonlySet<string> {
+	const rules: unknown = runtimeSchema?.$defs?.model?.oneOf;
+	if (!Array.isArray(rules) || !rules.length) throw new Error("Invalid runtime telemetry model schema");
+	const values = (rule: unknown, field: "provider" | "id"): string[] => {
+		if (!object(rule)) throw new Error("Invalid runtime telemetry model schema");
+		const properties = rule.properties;
+		if (!object(properties) || !object(properties[field])) throw new Error("Invalid runtime telemetry model schema");
+		const property = properties[field];
+		const candidates = typeof property.const === "string" ? [property.const] : property.enum;
+		if (!Array.isArray(candidates) || !candidates.length || candidates.some(value => typeof value !== "string")) {
+			throw new Error("Invalid runtime telemetry model schema");
+		}
+		return candidates as string[];
+	};
+	const models = new Set<string>();
+	for (const rule of rules) for (const provider of values(rule, "provider")) {
+		for (const id of values(rule, "id")) models.add(JSON.stringify([provider, id]));
+	}
+	return models;
+}
+
+const REGISTERED_MODELS = registeredModels();
+
+/** The mirrored transport registry is authoritative before the optional Pi
+ * catalog. Unknown registry pairs still pass through the existing privacy
+ * classifier, so private IDs can only become custom/unknown.
+ */
+export function classifyRuntimeModelId(provider: unknown, modelId: unknown,
+	classifyModel: typeof classifyPiCatalogName = classifyPiCatalogName): string {
+	if (typeof provider === "string" && typeof modelId === "string"
+		&& REGISTERED_MODELS.has(JSON.stringify([provider, modelId]))) return modelId;
+	return classifyModel({ provider, modelId }).modelId;
+}
 
 type Missing = { state: "unavailable" | "unsupported" };
 export type TokenMeasurement = Missing | { state: "reported"; value: number };
@@ -180,10 +215,10 @@ export class RuntimeMetrics {
 		const dimensions = {
 			hostAgent: "pi" as const,
 			agentClass: category(AGENT_CLASSES, response.agentClass, UNKNOWN_AGENT_CLASS),
-			observedModelId: this.#classifyModel({ provider: response.provider, modelId: response.observedModelId }).modelId,
-			responseModelId: this.#classifyModel({ provider: response.provider, modelId: response.responseModelId }).modelId,
+			observedModelId: classifyRuntimeModelId(response.provider, response.observedModelId, this.#classifyModel),
+			responseModelId: classifyRuntimeModelId(response.provider, response.responseModelId, this.#classifyModel),
 			providerThinkingLevel: category(EFFORTS, response.providerThinkingLevel, "unavailable"),
-			selectedModelId: this.#classifyModel({ provider: selectedProvider, modelId: response.selectedModelId }).modelId,
+			selectedModelId: classifyRuntimeModelId(selectedProvider, response.selectedModelId, this.#classifyModel),
 			selectedProvider: category(PROVIDERS, selectedProvider, typeof selectedProvider === "string" && selectedProvider ? "custom" : "unknown"),
 			executor: category(EXECUTORS, response.executor, "unknown"),
 			provider: category(PROVIDERS, response.provider, typeof response.provider === "string" && response.provider ? "custom" : "unknown"),

--- a/lib/runtime-metrics.ts
+++ b/lib/runtime-metrics.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { classifyPiCatalogName } from "./runtime-metrics-pi-identity.ts";
 
 // Pure local accounting, not a telemetry transport or Pi event adapter.
@@ -13,11 +14,32 @@ const FAMILIES = ["claude", "gpt", "o-series", "gemini", "llama", "qwen", "deeps
 export const EFFORTS = ["off", "minimal", "low", "medium", "high", "xhigh", "max", "not_selected", "unsupported", "unavailable"] as const;
 const ERRORS = ["none", "aborted", "rate_limit", "authentication", "network", "provider", "unknown"] as const;
 const TOKEN_FIELDS = ["input", "output", "cacheRead", "cacheWrite", "reasoning", "totalTokens"] as const;
-export const AGENT_CLASSES = ["orchestrator", "worker", "explore", "verify", "unknown",
-	"sdd-apply", "sdd-archive", "sdd-design", "sdd-explore", "sdd-init", "sdd-onboard", "sdd-proposal",
-	"sdd-research", "sdd-spec", "sdd-status", "sdd-sync", "sdd-tasks", "sdd-verify",
-	"review-readability", "review-reliability", "review-resilience", "review-risk", "jd-fix-agent", "jd-judge-a", "jd-judge-b"] as const;
-export type AgentClass = typeof AGENT_CLASSES[number];
+declare const agentClassBrand: unique symbol;
+export type AgentClass = string & { readonly [agentClassBrand]: "AgentClass" };
+
+function agentClasses(): readonly AgentClass[] {
+	const schema = JSON.parse(readFileSync(new URL("../contracts/telemetry/runtime-aggregate-v1.schema.json", import.meta.url), "utf8"));
+	const values: unknown = schema?.$defs?.row?.properties?.agent_class?.enum;
+	if (!Array.isArray(values) || !values.length || values.some(value => typeof value !== "string")) {
+		throw new Error("Invalid runtime telemetry agent_class schema");
+	}
+	return Object.freeze([...values]) as readonly AgentClass[];
+}
+
+// The mirrored transport contract is the runtime source of truth. Keeping this
+// data-driven lets packaged agent updates follow the closed enum without a
+// second name registry drifting in TypeScript.
+export const AGENT_CLASSES = agentClasses();
+export function parseAgentClass(value: unknown): AgentClass | undefined {
+	return typeof value === "string" && (AGENT_CLASSES as readonly string[]).includes(value) ? value as AgentClass : undefined;
+}
+function requiredAgentClass(value: string): AgentClass {
+	const parsed = parseAgentClass(value);
+	if (!parsed) throw new Error(`Runtime telemetry schema is missing required agent_class ${value}`);
+	return parsed;
+}
+export const UNKNOWN_AGENT_CLASS = requiredAgentClass("unknown");
+export const ORCHESTRATOR_AGENT_CLASS = requiredAgentClass("orchestrator");
 
 type Missing = { state: "unavailable" | "unsupported" };
 export type TokenMeasurement = Missing | { state: "reported"; value: number };
@@ -138,14 +160,17 @@ export class RuntimeMetrics {
 	#buckets = new Map<string, RuntimeMetricBucket>();
 	#maxResponses: number;
 	#maxBuckets: number;
+	#classifyModel: typeof classifyPiCatalogName;
 
-	constructor({ maxResponses = 1024, maxBuckets = 64 }: { maxResponses?: number; maxBuckets?: number } = {}) {
+	constructor({ maxResponses = 1024, maxBuckets = 64, classifyModel = classifyPiCatalogName }:
+		{ maxResponses?: number; maxBuckets?: number; classifyModel?: typeof classifyPiCatalogName } = {}) {
 		if (!Number.isInteger(maxResponses) || maxResponses < 1 || maxResponses > 1024
 			|| !Number.isInteger(maxBuckets) || maxBuckets < 1 || maxBuckets > 64) {
 			throw new RangeError("Invalid runtime metrics capacity");
 		}
 		this.#maxResponses = maxResponses;
 		this.#maxBuckets = maxBuckets;
+		this.#classifyModel = classifyModel;
 	}
 
 	record(response: FinalResponse): "recorded" | "duplicate" | "invalid" | "capacity" {
@@ -154,11 +179,11 @@ export class RuntimeMetrics {
 		const selectedProvider = response.selectedProvider ?? response.provider;
 		const dimensions = {
 			hostAgent: "pi" as const,
-			agentClass: category(AGENT_CLASSES, response.agentClass, "unknown"),
-			observedModelId: classifyPiCatalogName({ provider: response.provider, modelId: response.observedModelId }).modelId,
-			responseModelId: classifyPiCatalogName({ provider: response.provider, modelId: response.responseModelId }).modelId,
+			agentClass: category(AGENT_CLASSES, response.agentClass, UNKNOWN_AGENT_CLASS),
+			observedModelId: this.#classifyModel({ provider: response.provider, modelId: response.observedModelId }).modelId,
+			responseModelId: this.#classifyModel({ provider: response.provider, modelId: response.responseModelId }).modelId,
 			providerThinkingLevel: category(EFFORTS, response.providerThinkingLevel, "unavailable"),
-			selectedModelId: classifyPiCatalogName({ provider: selectedProvider, modelId: response.selectedModelId }).modelId,
+			selectedModelId: this.#classifyModel({ provider: selectedProvider, modelId: response.selectedModelId }).modelId,
 			selectedProvider: category(PROVIDERS, selectedProvider, typeof selectedProvider === "string" && selectedProvider ? "custom" : "unknown"),
 			executor: category(EXECUTORS, response.executor, "unknown"),
 			provider: category(PROVIDERS, response.provider, typeof response.provider === "string" && response.provider ? "custom" : "unknown"),

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -180,7 +180,7 @@ const contractHashes = {
   "contracts/review-integration/v2/schemas/repair.schema.json": "98a85fd45a8ae7f6211ffeeb3f9c478fa1dd1c17f385751f15f2111e6c3ab167",
   "contracts/review-integration/v2/schemas/start.schema.json": "2991e3fcca672d9257d61b6a336fb34e58b15a8e03f8a09a7adf892cae6a8085",
   "contracts/review-integration/v2/schemas/status.schema.json": "c4dcc736cfc6300560a3c4262d2d982368529d5c49d58d499552a3b0beef9212",
-  "contracts/telemetry/runtime-aggregate-v1.schema.json": "bf834d891028df69086ecfe5224ded8cf536959fe663e4e86c00d7d2fd8c91fb",
+  "contracts/telemetry/runtime-aggregate-v1.schema.json": "26be905d39fe8274e049e1270553695b7540a3b24571d42eb7d96c5a7deb48b5",
   "docs/review-integration.md": "95a3df92785bc4d9f3b99e702aaf817ae0440bd16c83218d2c3f2aca67c280fb",
 };
 

--- a/tests/fixtures/runtime-metrics-native-batches.json
+++ b/tests/fixtures/runtime-metrics-native-batches.json
@@ -1,5 +1,5 @@
 {
-  "schema_sha256": "bf834d891028df69086ecfe5224ded8cf536959fe663e4e86c00d7d2fd8c91fb",
+  "schema_sha256": "26be905d39fe8274e049e1270553695b7540a3b24571d42eb7d96c5a7deb48b5",
   "batches": [
     "{\"schema\":\"gentle-ai.telemetry-runtime-aggregate/v1\",\"registry\":1,\"host\":\"pi\",\"rows\":[{\"model\":{\"provider\":\"openai\",\"id\":\"gpt-5.4\"},\"model_evidence\":\"response\",\"agent_kind\":\"built_in\",\"agent_class\":\"worker\",\"selected_effort\":\"high\",\"effective_effort\":\"low\",\"launches\":null,\"responses\":1,\"input_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"output_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"cache_read_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"cache_creation_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"reasoning_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"total_tokens\":{\"reported\":1,\"unavailable\":0,\"unsupported\":0,\"sum\":7},\"error_category\":\"none\",\"duration\":{\"kind\":\"unavailable\",\"measured_count\":0,\"sum_ms\":null}}]}"
   ]

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -447,7 +447,8 @@ for (const boundary of ["allowed", "env", "session", "replacement", "bus-throws"
 			assert.equal(event.launch.agentClass, "worker");
 			assert.equal(event.launch.selectedEffort, "high");
 			assert.equal(event.responses.length, boundary === "long-running" ? 8 : 2);
-			assert.ok(event.responses.every(row => row.agentClass === "worker" && row.effort === "unavailable"));
+			assert.ok(event.responses.every(row => row.agentClass === "worker" && row.effort === "high"
+				&& row.selectedProvider === "openai" && row.selectedModelId === "gpt-4o"));
 			assert.equal(event.agentSettled, true);
 			child.emit({ type: "agent_settled" });
 			await tick();

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -354,6 +354,11 @@ for (const boundary of ["allowed", "env", "session", "replacement", "bus-throws"
 		});
 		const h = fakePi();
 		const runtime = deps();
+		let catalogAttempts = 0;
+		if (boundary === "allowed") runtime.deps.lookupPiCatalogName = () => {
+			catalogAttempts++;
+			return new Promise(() => {});
+		};
 		const context = fakeContext();
 		const spawn = runtime.deps.spawn!;
 		runtime.deps.spawn = (...args) => {
@@ -388,6 +393,7 @@ for (const boundary of ["allowed", "env", "session", "replacement", "bus-throws"
 		const result = h.tools.get("subagent_run")!.execute("call", { agent: "gentle-ai-worker", task: "private task", mode: "task" }, undefined, undefined, context.ctx);
 		await tick();
 		assert.equal(runtime.children.length, 1);
+		if (boundary === "allowed") assert.equal(catalogAttempts, 1, "child launch does not await catalog loading");
 		const child = runtime.children[0];
 		const launchedCalls = calls;
 		for (let i = 0; i < 10; i++) child.emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "private streamed text" } });

--- a/tests/runtime-metrics-children.test.ts
+++ b/tests/runtime-metrics-children.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { readFileSync } from "node:fs";
 import { stripTypeScriptTypes } from "node:module";
 import { runInNewContext } from "node:vm";
-import { AGENT_CLASSES } from "../lib/runtime-metrics.ts";
+import { AGENT_CLASSES, parseAgentClass } from "../lib/runtime-metrics.ts";
 import { parseAgentDefinition } from "../lib/agents-config.ts";
 import { normalizeRpcEvent, TASK_EVENT } from "../lib/agents-protocol.ts";
 import { lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
@@ -43,16 +43,24 @@ test("installed package definitions retain classification after the actual routi
 			const parsed = parseAgentDefinition(route(content, entry), asset.pathname, "global");
 			assert.ok("instructions" in parsed);
 			assert.equal(classifyBuiltinAgent(parsed), kind, `${kind}: installed routing`);
-			assert.equal(classifyBuiltinAgent({ ...parsed, instructions: `${parsed.instructions}\nOverride` }), "unknown");
-			assert.equal(classifyBuiltinAgent({ ...parsed, tools: ["different-tool"] }), "unknown");
-			assert.equal(classifyBuiltinAgent({ ...parsed, description: "different description" }), "unknown");
-			assert.equal(classifyBuiltinAgent({ ...parsed, mode: parsed.mode === "task" ? "background" : "task" }), "unknown");
+			const customizedClass = parseAgentClass(parsed.name) ?? "unknown";
+			assert.equal(classifyBuiltinAgent({ ...parsed, instructions: `${parsed.instructions}\nOverride` }), customizedClass);
+			assert.equal(classifyBuiltinAgent({ ...parsed, tools: ["different-tool"] }), customizedClass);
+			assert.equal(classifyBuiltinAgent({ ...parsed, description: "different description" }), customizedClass);
+			assert.equal(classifyBuiltinAgent({ ...parsed, mode: parsed.mode === "task" ? "background" : "task" }), customizedClass);
 		}
 	}
 });
 
-test("built-in classification requires the runtime definition, not a public-looking override name", () => {
+test("schema-approved packaged names survive customization without exposing private names", () => {
+	const path = new URL("../assets/agents/sdd-apply.md", import.meta.url);
+	const packaged = parseAgentDefinition(readFileSync(path, "utf8"), path.pathname, "global");
+	assert.ok("instructions" in packaged);
+	assert.equal(classifyBuiltinAgent({ ...packaged, instructions: "customized instructions" }), "sdd-apply");
+
 	assert.equal(classifyBuiltinAgent(definition), "worker");
+	// This is a packaged frontmatter name, but it is absent from the telemetry
+	// enum. Its exact fingerprint retains the compatibility mapping only.
 	assert.equal(classifyBuiltinAgent({ ...definition, instructions: "private override" }), "unknown");
 	assert.equal(classifyBuiltinAgent({ ...definition, tools: ["private tool"] }), "unknown");
 	assert.equal(classifyBuiltinAgent({ ...definition, name: "private-agent" }), "unknown");

--- a/tests/runtime-metrics-children.test.ts
+++ b/tests/runtime-metrics-children.test.ts
@@ -1,13 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { stripTypeScriptTypes } from "node:module";
 import { runInNewContext } from "node:vm";
-import { AGENT_CLASSES, parseAgentClass } from "../lib/runtime-metrics.ts";
+import { parseAgentClass } from "../lib/runtime-metrics.ts";
 import { parseAgentDefinition } from "../lib/agents-config.ts";
 import { normalizeRpcEvent, TASK_EVENT } from "../lib/agents-protocol.ts";
 import { lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
 import { ChildComposition, childEvent, classifyBuiltinAgent, launchSelection } from "../lib/runtime-metrics-children.ts";
+import { encodeNativeRuntimeEvent } from "../lib/runtime-metrics-native.ts";
 
 await lookupPiCatalogName({ provider: "openai", modelId: "gpt-4o" });
 const asset = new URL("../assets/agents/gentle-ai-worker.md", import.meta.url);
@@ -32,8 +33,12 @@ test("installed package definitions retain classification after the actual routi
 	const transform = source.match(/function updateFrontmatterRouting\([\s\S]*?\n\}/)?.[0];
 	assert.ok(transform);
 	const route = runInNewContext(`(${stripTypeScriptTypes(transform)})`);
-	for (const kind of AGENT_CLASSES.filter(kind => kind !== "orchestrator" && kind !== "unknown")) {
-		const file = ["worker", "explore", "verify"].includes(kind) ? `gentle-ai-${kind}` : kind;
+	for (const entry of readdirSync(new URL("../assets/agents/", import.meta.url)).filter(file => file.endsWith(".md"))) {
+		const file = entry.slice(0, -3);
+		const className = file === "sdd-proposal" ? "sdd-propose"
+			: file.startsWith("gentle-ai-") ? file.slice("gentle-ai-".length) : file;
+		const kind = parseAgentClass(className);
+		assert.ok(kind, `${file}: telemetry class`);
 		const asset = new URL(`../assets/agents/${file}.md`, import.meta.url);
 		const content = readFileSync(asset, "utf8");
 		const copied = parseAgentDefinition(content, asset.pathname, "global");
@@ -43,13 +48,33 @@ test("installed package definitions retain classification after the actual routi
 			const parsed = parseAgentDefinition(route(content, entry), asset.pathname, "global");
 			assert.ok("instructions" in parsed);
 			assert.equal(classifyBuiltinAgent(parsed), kind, `${kind}: installed routing`);
-			const customizedClass = parseAgentClass(parsed.name) ?? "unknown";
+			const customizedClass = parsed.name === "sdd-proposal" ? "sdd-propose" : parseAgentClass(parsed.name) ?? "unknown";
 			assert.equal(classifyBuiltinAgent({ ...parsed, instructions: `${parsed.instructions}\nOverride` }), customizedClass);
 			assert.equal(classifyBuiltinAgent({ ...parsed, tools: ["different-tool"] }), customizedClass);
 			assert.equal(classifyBuiltinAgent({ ...parsed, description: "different description" }), customizedClass);
 			assert.equal(classifyBuiltinAgent({ ...parsed, mode: parsed.mode === "task" ? "background" : "task" }), customizedClass);
 		}
 	}
+});
+
+test("packaged sdd-proposal is encoded only as canonical sdd-propose", () => {
+	const path = new URL("../assets/agents/sdd-proposal.md", import.meta.url);
+	const packaged = parseAgentDefinition(readFileSync(path, "utf8"), path.pathname, "global");
+	assert.ok("instructions" in packaged);
+	const selection = launchSelection(packaged, { provider: "openai", id: "gpt-4o" }, "high");
+	assert.equal(selection.agentClass, "sdd-propose");
+	const completed = childEvent("local-session", "sdd-propose-task", selection, "completed", {
+		coverage: "final_assistant_messages_only", agentSettled: true, responses: [response()], droppedResponses: 0,
+	});
+	assert.ok(completed);
+	const composition = new ChildComposition();
+	assert.equal(composition.reserve(completed, "local-session"), true);
+	composition.record(completed);
+	const snapshot = composition.snapshot();
+	const payload = encodeNativeRuntimeEvent(snapshot.responses, snapshot.launches);
+	assert.ok(payload);
+	assert.equal(JSON.parse(payload).rows[0].agent_class, "sdd-propose");
+	assert.ok(!payload.includes("sdd-proposal"));
 });
 
 test("schema-approved packaged names survive customization without exposing private names", () => {

--- a/tests/runtime-metrics-children.test.ts
+++ b/tests/runtime-metrics-children.test.ts
@@ -103,9 +103,14 @@ test("launch distribution and each observed combination remain independent and p
 	assert.equal(view.launches[0].agentClass, "worker");
 	assert.equal(view.responses.length, 2);
 	assert.deepEqual(view.responses.map(row => row.observedModelId), ["gpt-4o", "gpt-4o-mini"]);
-	assert.ok(view.responses.every(row => row.effort === "unavailable" && row.selectedProvider === "unknown"));
+	assert.ok(view.responses.every(row => row.effort === "high" && row.selectedProvider === "openai"
+		&& row.selectedModelId === "gpt-4o"));
 	assert.equal(view.responses[0].providerThinkingLevel, "low");
 	assert.equal(view.responses[0].tokens.reasoning.sum, 1);
+	const encoded = encodeNativeRuntimeEvent(view.responses, view.launches);
+	assert.ok(encoded);
+	assert.ok(JSON.parse(encoded).rows.filter((row: { responses: number | null }) => row.responses !== null)
+		.every((row: { model_evidence: string; selected_effort: string }) => row.model_evidence === "response" && row.selected_effort === "high"));
 	assert.equal(view.droppedResponses, 2);
 	assert.equal(view.settled, 1);
 	assert.equal(view.statuses.completed, 1);
@@ -115,6 +120,38 @@ test("launch distribution and each observed combination remain independent and p
 		coverage: "final_assistant_messages_only", agentSettled: false, responses: [response("private-model", "private-native")], droppedResponses: 0,
 	});
 	assert.ok(!JSON.stringify(filtered).includes("private"));
+});
+
+test("registered child launch identity survives catalog state and missing response evidence inherits selection", () => {
+	const path = new URL("../assets/agents/sdd-explore.md", import.meta.url);
+	const agent = parseAgentDefinition(readFileSync(path, "utf8"), path.pathname, "global");
+	assert.ok("instructions" in agent);
+	const selection = launchSelection(agent, { provider: "openai-codex", id: "gpt-5.6-terra" }, "high");
+	const [observation] = normalizeRpcEvent({ type: "message_end", message: { role: "assistant", stopReason: "stop",
+		usage: { input: 3, output: 2 } } }, { observeResponses: true })
+		.filter(event => event.type === TASK_EVENT.RESPONSE_OBSERVATION);
+	assert.ok(observation?.type === TASK_EVENT.RESPONSE_OBSERVATION);
+	const completed = childEvent("local-session", "sdd-explore-task", selection, "completed", {
+		coverage: "final_assistant_messages_only", agentSettled: true,
+		responses: Array(5).fill(observation.observation), droppedResponses: 0,
+	});
+	assert.ok(completed);
+	const composition = new ChildComposition();
+	assert.equal(composition.reserve(completed, "local-session"), true);
+	composition.record(completed);
+	const snapshot = composition.snapshot();
+	const payload = encodeNativeRuntimeEvent(snapshot.responses, snapshot.launches);
+	assert.ok(payload);
+	const rows = JSON.parse(payload).rows;
+	const launchRow = rows.find((row: { launches: number | null }) => row.launches === 1);
+	const responseRow = rows.find((row: { responses: number | null }) => row.responses === 5);
+	assert.deepEqual(launchRow.model, { provider: "openai-codex", id: "gpt-5.6-terra" });
+	assert.equal(launchRow.model_evidence, "selected");
+	assert.equal(launchRow.selected_effort, "high");
+	assert.deepEqual(responseRow.model, { provider: "openai-codex", id: "gpt-5.6-terra" });
+	assert.equal(responseRow.model_evidence, "selected");
+	assert.equal(responseRow.selected_effort, "high");
+	assert.equal(responseRow.responses, 5);
 });
 
 test("dedupe reserves before async policy, rejects old sessions, and survives aggregate clearing", () => {

--- a/tests/runtime-metrics-delivery.test.ts
+++ b/tests/runtime-metrics-delivery.test.ts
@@ -58,3 +58,28 @@ test("shutdown aborts immediately but cannot overlap an unsettled process", asyn
 	assert.equal(replacement.offer(async () => {}), true);
 	await tick(); replacement.dispose();
 });
+
+test("bounded shutdown join waits for the accepted attempt without replaying busy work", async () => {
+	const owner = new delivery.RuntimeMetricsAttempt();
+	let calls = 0;
+	let finish!: () => void;
+	owner.offer(() => { calls++; return new Promise<void>(resolve => { finish = resolve; }); });
+	assert.equal(owner.offer(async () => { calls++; }), false);
+	await tick();
+	let joined = false;
+	const joining = owner.waitForSettled(50).then(() => { joined = true; });
+	await tick();
+	assert.equal(joined, false);
+	finish();
+	await joining;
+	assert.equal(calls, 1, "joining never queues or retries discarded work");
+	owner.dispose();
+});
+
+test("bounded shutdown join returns after its deadline", async () => {
+	const owner = new delivery.RuntimeMetricsAttempt();
+	owner.offer(() => new Promise<void>(() => {}));
+	await tick();
+	await owner.waitForSettled(5);
+	owner.dispose();
+});

--- a/tests/runtime-metrics-extension.test.ts
+++ b/tests/runtime-metrics-extension.test.ts
@@ -9,7 +9,7 @@ import { normalizeRpcEvent, TASK_EVENT } from "../lib/agents-protocol.ts";
 const tick = () => new Promise<void>(resolve => setImmediate(resolve));
 type CatalogLookup = NonNullable<NonNullable<Parameters<typeof runtimeMetrics>[2]>["lookup"]>;
 function harness(env: NodeJS.ProcessEnv = {}, lookup?: CatalogLookup,
-	classify?: (input: unknown) => PiCatalogName) {
+	classify?: (input: unknown) => PiCatalogName, mode: "tui" | "print" = "tui", shutdownWaitMs = 1500) {
 	const handlers = new Map<string, Function>();
 	const listeners = new Map<string, Function>();
 	let session = "first";
@@ -17,13 +17,13 @@ function harness(env: NodeJS.ProcessEnv = {}, lookup?: CatalogLookup,
 	let signal!: AbortSignal;
 	const sent: RuntimeMetricBucket[][] = [];
 	const launches: unknown[] = [];
-	const ctx: any = { cwd: "/fixture", model: { provider: "openai", id: "gpt-4o" },
+	const ctx: any = { cwd: "/fixture", mode, model: { provider: "openai", id: "gpt-4o" },
 		sessionManager: { getSessionId: () => session, getEntries: () => assert.fail("no reconstruction") } };
 	const pi: any = { on: (name: string, handler: Function) => handlers.set(name, handler),
 		getThinkingLevel: () => "high", registerCommand() {},
 		appendEntry: () => assert.fail("no metrics persistence"),
 		events: { on: (name: string, handler: Function) => { listeners.set(name, handler); return () => listeners.delete(name); } } };
-	runtimeMetrics(pi, env, { lookup, classify, now: () => 0, send: (rows, _cwd, deps) => {
+	runtimeMetrics(pi, env, { lookup, classify, now: () => 0, shutdownWaitMs, send: (rows, _cwd, deps) => {
 		sent.push(structuredClone(rows)); launches.push(structuredClone(deps?.launches)); signal = deps!.signal!;
 		return new Promise(resolve => { finish = () => resolve("discarded"); });
 	} });
@@ -90,6 +90,52 @@ test("replacement before launch cancels stale work; shutdown does not await a bl
 	h.emit("message_end", { message: final() });
 	h.replace(); await h.emit("session_start"); await tick();
 	assert.equal(h.sent.length, 0);
+	h.emit("message_end", { message: final() }); await tick();
+	assert.equal(h.emit("session_shutdown"), undefined);
+	assert.equal(h.signal().aborted, true);
+	await h.finish();
+});
+
+test("print shutdown joins an accepted orchestrator delivery before disposing", async () => {
+	const h = harness({}, undefined, undefined, "print", 50); await h.emit("session_start");
+	h.emit("message_end", { message: final() }); await tick();
+	let stopped = false;
+	const shutdown = h.emit("session_shutdown").then(() => { stopped = true; });
+	await tick();
+	assert.equal(stopped, false);
+	assert.equal(h.signal().aborted, false);
+	await h.finish(); await shutdown;
+	assert.equal(stopped, true);
+});
+
+test("print shutdown joins an accepted child launch and response delivery", async () => {
+	const h = harness({}, undefined, undefined, "print", 50); await h.emit("session_start");
+	const observation = normalizeRpcEvent({ type: "message_end", message: final() }, { observeResponses: true })
+		.find(event => event.type === TASK_EVENT.RESPONSE_OBSERVATION);
+	assert.ok(observation?.type === TASK_EVENT.RESPONSE_OBSERVATION);
+	h.bus(childEvent("first", "child", {
+		agentClass: parseAgentClass("sdd-explore")!, selectedProvider: "openai", selectedModelId: "gpt-4o", selectedEffort: "high",
+	}, "completed", { coverage: "final_assistant_messages_only", agentSettled: true, droppedResponses: 0,
+		responses: [observation.observation] }, 0)!);
+	await tick();
+	const shutdown = h.emit("session_shutdown");
+	assert.equal(h.sent[0][0].agentClass, "sdd-explore");
+	assert.deepEqual(h.launches[0], [{ evidence: "launch_configuration", agentClass: "sdd-explore", selectedProvider: "openai",
+		selectedModelId: "gpt-4o", selectedEffort: "high", launches: 1 }]);
+	assert.equal(h.signal().aborted, false);
+	await h.finish(); await shutdown;
+});
+
+test("print shutdown aborts a delivery after the bounded join deadline", async () => {
+	const h = harness({}, undefined, undefined, "print", 5); await h.emit("session_start");
+	h.emit("message_end", { message: final() }); await tick();
+	await h.emit("session_shutdown");
+	assert.equal(h.signal().aborted, true);
+	await h.finish();
+});
+
+test("interactive shutdown never joins a blocked delivery", async () => {
+	const h = harness({}, undefined, undefined, "tui", 50); await h.emit("session_start");
 	h.emit("message_end", { message: final() }); await tick();
 	assert.equal(h.emit("session_shutdown"), undefined);
 	assert.equal(h.signal().aborted, true);

--- a/tests/runtime-metrics-extension.test.ts
+++ b/tests/runtime-metrics-extension.test.ts
@@ -176,7 +176,7 @@ test("child completion consumed once, busy children drop, and primary usage stay
 	assert.equal(h.sent[0][0].agentClass, "verify");
 	assert.deepEqual(h.launches[0], [{ evidence: "launch_configuration", agentClass: "verify", selectedProvider: "openai",
 		selectedModelId: "gpt-4o", selectedEffort: "high", launches: 1 }]);
-	assert.equal(h.sent[0][0].effort, "unavailable", "launch effort is not per-response selection proof");
+	assert.equal(h.sent[0][0].effort, "high", "child response retains launch selection separately from response evidence");
 	assert.equal(h.sent[0][0].providerThinkingLevel, "low");
 	await h.finish(); h.bus(event("busy")); await tick();
 	assert.equal(h.sent.length, 1, "busy completion stays consumed");

--- a/tests/runtime-metrics-extension.test.ts
+++ b/tests/runtime-metrics-extension.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import runtimeMetrics from "../extensions/runtime-metrics.ts";
-import type { RuntimeMetricBucket } from "../lib/runtime-metrics.ts";
+import { parseAgentClass, type RuntimeMetricBucket } from "../lib/runtime-metrics.ts";
+import { createPiCatalogNameLookup, type PiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
 import { CHILD_METRICS_EVENT, childEvent } from "../lib/runtime-metrics-children.ts";
 import { normalizeRpcEvent, TASK_EVENT } from "../lib/agents-protocol.ts";
 
 const tick = () => new Promise<void>(resolve => setImmediate(resolve));
-function harness(env: NodeJS.ProcessEnv = {}) {
+type CatalogLookup = NonNullable<NonNullable<Parameters<typeof runtimeMetrics>[2]>["lookup"]>;
+function harness(env: NodeJS.ProcessEnv = {}, lookup?: CatalogLookup,
+	classify?: (input: unknown) => PiCatalogName) {
 	const handlers = new Map<string, Function>();
 	const listeners = new Map<string, Function>();
 	let session = "first";
@@ -20,7 +23,7 @@ function harness(env: NodeJS.ProcessEnv = {}) {
 		getThinkingLevel: () => "high", registerCommand() {},
 		appendEntry: () => assert.fail("no metrics persistence"),
 		events: { on: (name: string, handler: Function) => { listeners.set(name, handler); return () => listeners.delete(name); } } };
-	runtimeMetrics(pi, env, { now: () => 0, send: (rows, _cwd, deps) => {
+	runtimeMetrics(pi, env, { lookup, classify, now: () => 0, send: (rows, _cwd, deps) => {
 		sent.push(structuredClone(rows)); launches.push(structuredClone(deps?.launches)); signal = deps!.signal!;
 		return new Promise(resolve => { finish = () => resolve("discarded"); });
 	} });
@@ -34,6 +37,32 @@ function harness(env: NodeJS.ProcessEnv = {}) {
 const final = (input = 7) => ({ role: "assistant", provider: "openai", model: "gpt-4o", responseModel: "gpt-4o",
 	providerThinkingLevel: "low", stopReason: "stop", usage: { input, output: 3, cacheRead: 0 },
 	content: [{ text: "private response" }], errorMessage: "private error", path: "/private" });
+
+test("message classification retries a failed catalog load without awaiting it", async () => {
+	let calls = 0;
+	const publicName = Object.freeze({ classification: "catalog_public", modelId: "gpt-4o" }) satisfies PiCatalogName;
+	const catalog = new Map([[JSON.stringify(["openai", "gpt-4o"]), publicName]]);
+	const catalogLookup = createPiCatalogNameLookup(async () => {
+		calls++;
+		if (calls === 1) throw new Error("transient catalog failure");
+		return catalog;
+	});
+	const h = harness({}, catalogLookup.lookup, catalogLookup.classify);
+	h.emit("session_start");
+	await tick();
+	assert.equal(calls, 1);
+	assert.equal(h.emit("message_end", { message: final() }), undefined);
+	assert.equal(calls, 2);
+	await tick();
+	assert.equal(h.sent.length, 1);
+	assert.equal(h.sent[0][0].observedModelId, "unknown", "the racing row remains fail-closed");
+	await h.finish();
+	h.emit("message_end", { message: final(8) });
+	await tick();
+	assert.equal(h.sent[1][0].observedModelId, "gpt-4o", "a later row uses the recovered catalog");
+	await h.finish();
+	h.emit("session_shutdown");
+});
 
 test("final callback returns before blocked transport; busy and duplicate messages drop", async () => {
 	const h = harness(); await h.emit("session_start");
@@ -94,7 +123,7 @@ test("child completion consumed once, busy children drop, and primary usage stay
 		.find(event => event.type === TASK_EVENT.RESPONSE_OBSERVATION);
 	assert.ok(observation?.type === TASK_EVENT.RESPONSE_OBSERVATION);
 	const event = (taskId: string) => childEvent("first", taskId,
-		{ agentClass: "verify", selectedProvider: "openai", selectedModelId: "gpt-4o", selectedEffort: "high" }, "completed",
+		{ agentClass: parseAgentClass("verify")!, selectedProvider: "openai", selectedModelId: "gpt-4o", selectedEffort: "high" }, "completed",
 		{ coverage: "final_assistant_messages_only", agentSettled: true, droppedResponses: 0, responses: [observation.observation] }, 0)!;
 	h.bus(event("one")); h.bus(event("one")); h.bus(event("busy"));
 	await tick(); assert.equal(h.sent.length, 1);

--- a/tests/runtime-metrics-native.test.ts
+++ b/tests/runtime-metrics-native.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import { readFileSync, realpathSync } from "node:fs";
 import { setGentleAiDevBinaryEnvironmentForTesting } from "../lib/gentle-ai-binary.ts";
 import * as native from "../lib/runtime-metrics-native.ts";
-import type { RuntimeMetricBucket } from "../lib/runtime-metrics.ts";
+import { parseAgentClass, type RuntimeMetricBucket } from "../lib/runtime-metrics.ts";
 import { createHash } from "node:crypto";
 import schema from "../contracts/telemetry/runtime-aggregate-v1.schema.json" with { type: "json" };
 import fixturePayloads from "./fixtures/runtime-metrics-native-batches.json" with { type: "json" };
@@ -13,7 +13,7 @@ import fixturePayloads from "./fixtures/runtime-metrics-native-batches.json" wit
 function source(): RuntimeMetricBucket {
 	const token = () => ({ reported: 1, unavailable: 0, unsupported: 0, sum: 7 });
 	const duration = () => ({ measured: 0, unavailable: 1, unsupported: 0, sum: 0 });
-	return { hostAgent: "pi", agentClass: "worker", executor: "worker", provider: "openai", modelFamily: "gpt",
+	return { hostAgent: "pi", agentClass: parseAgentClass("worker")!, executor: "worker", provider: "openai", modelFamily: "gpt",
 		selectedProvider: "openai", selectedModelId: "gpt-5.4", observedModelId: "private-alias", responseModelId: "gpt-5.4",
 		effort: "high", providerThinkingLevel: "low", error: "none", responses: 1,
 		tokens: { input: token(), output: token(), cacheRead: token(), cacheWrite: token(), reasoning: token(), totalTokens: token() },
@@ -39,7 +39,7 @@ test("production encoder emits exact one-shot fixture with source occurrence cov
 });
 
 test("child launch occurrence retains selection evidence separately from response evidence", () => {
-	const payload = native.encodeNativeRuntimeEvent([source()], [{ evidence: "launch_configuration", agentClass: "worker",
+	const payload = native.encodeNativeRuntimeEvent([source()], [{ evidence: "launch_configuration", agentClass: parseAgentClass("worker")!,
 		selectedProvider: "openai", selectedModelId: "gpt-5.4", selectedEffort: "high", launches: 1 }]);
 	const rows = JSON.parse(payload!).rows;
 	assert.equal(rows.length, 2);

--- a/tests/runtime-metrics-pi-identity.test.ts
+++ b/tests/runtime-metrics-pi-identity.test.ts
@@ -2,11 +2,38 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { findPackageJSON } from "node:module";
 import { OPENAI_CODEX_MODELS } from "@earendil-works/pi-ai/providers/openai-codex.models";
-import { classifyPiCatalogName, lookupPiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
+import { classifyPiCatalogName, createPiCatalogNameLookup, lookupPiCatalogName, type PiCatalogName } from "../lib/runtime-metrics-pi-identity.ts";
 import { RuntimeMetrics, type FinalResponse } from "../lib/runtime-metrics.ts";
 
 const model = Object.values(OPENAI_CODEX_MODELS)[0];
 const name = { provider: model.provider, modelId: model.id };
+
+test("a failed catalog load is retried lazily and later classifications recover", async () => {
+	let attempts = 0;
+	const publicName = Object.freeze({ classification: "catalog_public", modelId: name.modelId }) satisfies PiCatalogName;
+	const catalog = new Map([[JSON.stringify([name.provider, name.modelId]), publicName]]);
+	const lookup = createPiCatalogNameLookup(async () => {
+		attempts++;
+		if (attempts === 1) throw new Error("transient catalog failure");
+		return catalog;
+	});
+	await assert.rejects(lookup.lookup(name), /transient catalog failure/);
+	assert.deepEqual(lookup.classify(name), { classification: "unknown", modelId: "unknown" });
+	assert.strictEqual(await lookup.lookup(name), publicName);
+	assert.strictEqual(lookup.classify(name), publicName);
+	assert.equal(attempts, 2);
+});
+
+test("catalog loading attempts are capped per lookup instance", async () => {
+	let attempts = 0;
+	const lookup = createPiCatalogNameLookup(async () => {
+		attempts++;
+		throw new Error(`failure ${attempts}`);
+	});
+	for (let attempt = 0; attempt < 5; attempt++) await assert.rejects(lookup.lookup(name));
+	assert.equal(attempts, 3);
+	assert.deepEqual(lookup.classify(name), { classification: "unknown", modelId: "unknown" });
+});
 
 test("uninitialized synchronous classification fails closed", () => {
 	assert.deepEqual(classifyPiCatalogName(name), { classification: "unknown", modelId: "unknown" });

--- a/tests/runtime-metrics.test.ts
+++ b/tests/runtime-metrics.test.ts
@@ -34,6 +34,15 @@ test("selected provider is independent from response provider without relabeling
 	assert.equal(metrics.snapshot()[1].selectedModelId, "custom");
 });
 
+test("mirrored registry identities survive an unavailable Pi catalog", () => {
+	const metrics = new RuntimeMetrics({ classifyModel: () => ({ classification: "unknown", modelId: "unknown" }) });
+	assert.equal(metrics.record({ ...response(), selectedProvider: "openai-codex", selectedModelId: "gpt-5.6-terra",
+		responseModelId: "gpt-5.6-sol" }), "recorded");
+	const [row] = metrics.snapshot();
+	assert.equal(row.selectedModelId, "gpt-5.6-terra");
+	assert.equal(row.responseModelId, "gpt-5.6-sol");
+});
+
 // Deliberately bypass static types to exercise the runtime boundary.
 function recordRaw(metrics: RuntimeMetrics, value: unknown) {
 	return metrics.record(value as FinalResponse);


### PR DESCRIPTION
Closes #884

## Summary

Runtime telemetry rows now name the packaged subagent that produced them, carry the configured model and effort, and are delivered in print mode too.

- Classify packaged built-in agents by name so customized instructions no longer collapse to `unknown`; the packaged `sdd-proposal` agent is sent as the canonical `sdd-propose` class; user-defined agents stay `unknown`.
- Retry the Pi model catalog lazily (at most 3 attempts per process) so later rows recover after a failed warm-up.
- Use the mirrored schema registry as the source of truth for child model identity and propagate the launch selection onto child response rows.
- Join the pending one-shot delivery for at most 1.5 s at print-mode shutdown; interactive shutdown stays immediate.
- Refresh the mirrored `runtime-aggregate-v1.schema.json` from gentle-ai and its pinned digest.

`size:exception` rationale: the runtime metrics extension, the child classification, the delivery gate and their tests form one behavior boundary and the maintainer requested a single PR per repository for this delivery.

## Test plan

- `node --experimental-strip-types --test tests/runtime-metrics*.test.ts tests/gentle-agents.test.ts`
- `pnpm run check:provider-contract`, `pnpm run check:runtime-modules`, `node scripts/verify-package-files.mjs`
- `pnpm test` (pre-existing flaky failures in `review-candidate-view` race/reaper tests are unrelated)
- Live: Pi loaded from this branch ran `pi -p` with a `subagent_run` launch of `sdd-explore`; the production collector received the orchestrator row (`gpt-5.6-sol`, `medium`) and `built_in/sdd-explore` rows with responses and tokens.

## AI assistance

Material: OpenAI Codex CLI wrote the implementation and tests under strict TDD from specifications derived from production telemetry; verification and live runs were executed by the maintainer's session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime telemetry now recognizes additional agent types and validates classifications against the telemetry contract.
  - Model and provider identities are preserved more accurately in launch and response metrics, including when catalog data is unavailable.
  - Telemetry catalog lookups retry within bounded limits and refresh in the background.
  - Print-mode shutdown waits briefly for accepted telemetry deliveries to settle.

- **Bug Fixes**
  - Improved handling of catalog failures, customized agents, effort values, and selected model details in runtime metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->