### PR TITLE
fix(review): decode approved reviewer results

### DIFF
--- a/lib/review-integration-v2.ts
+++ b/lib/review-integration-v2.ts
@@ -2539,6 +2539,28 @@ export function decodeReviewAcknowledgedV1(value: unknown, expected: ReviewAckno
 	return decoded;
 }
 
+const REVIEW_LAST_EVENT_FINDING_SEVERITIES = ["BLOCKER", "CRITICAL", "WARNING", "SUGGESTION"] as const;
+const REVIEW_LAST_EVENT_EVIDENCE_CLASSES = ["deterministic", "inferential", "insufficient"] as const;
+const REVIEW_LAST_EVENT_CAUSAL_DISPOSITIONS = ["introduced", "behavior-activated", "worsened", "pre-existing", "base-only", "unknown"] as const;
+
+export interface ReviewLastEventReviewerFindingV1 {
+	id: string;
+	lens: string;
+	location: string;
+	severity: (typeof REVIEW_LAST_EVENT_FINDING_SEVERITIES)[number];
+	claim: string;
+	proofRefs: readonly string[];
+	evidenceClass?: (typeof REVIEW_LAST_EVENT_EVIDENCE_CLASSES)[number];
+	causalDisposition?: (typeof REVIEW_LAST_EVENT_CAUSAL_DISPOSITIONS)[number];
+}
+
+export interface ReviewLastEventReviewerResultV1 {
+	lens: string;
+	findings: readonly ReviewLastEventReviewerFindingV1[];
+	evidence: readonly string[];
+	resultHash: string;
+}
+
 export interface ReviewLastEventClosureV1 {
 	schema: typeof REVIEW_LAST_EVENT_CLOSURE_SCHEMA;
 	operation: ReviewLastEventClosureOperation;
@@ -2550,6 +2572,7 @@ export interface ReviewLastEventClosureV1 {
 	requestHash?: string;
 	correctionLines?: number;
 	advisoryFindings?: ReviewAdvisoryFindingsV1;
+	reviewerResults?: readonly ReviewLastEventReviewerResultV1[];
 	statusContinuation?: ReviewStatusContinuationV1;
 	acknowledgement?: ReviewApprovedAcknowledgementV1;
 	// Set when the provider sent an acknowledgement this decoder could not
@@ -2661,8 +2684,38 @@ function decodeReviewStatusContinuationV1(value: unknown): ReviewStatusContinuat
 	};
 }
 
+function decodeReviewLastEventReviewerFindingV1(value: unknown, label: string): ReviewLastEventReviewerFindingV1 {
+	const finding = exactRecord(value, label, ["id", "lens", "location", "severity", "claim", "proof_refs"], ["evidence_class", "causal_disposition"]);
+	const evidenceClass = finding.evidence_class === undefined
+		? undefined
+		: enumeration(finding.evidence_class, REVIEW_LAST_EVENT_EVIDENCE_CLASSES, `${label}.evidence_class`);
+	const causalDisposition = finding.causal_disposition === undefined
+		? undefined
+		: enumeration(finding.causal_disposition, REVIEW_LAST_EVENT_CAUSAL_DISPOSITIONS, `${label}.causal_disposition`);
+	return {
+		id: nonempty(finding.id, `${label}.id`),
+		lens: nonempty(finding.lens, `${label}.lens`),
+		location: nonempty(finding.location, `${label}.location`),
+		severity: enumeration(finding.severity, REVIEW_LAST_EVENT_FINDING_SEVERITIES, `${label}.severity`),
+		claim: nonempty(finding.claim, `${label}.claim`),
+		proofRefs: stringArray(finding.proof_refs, `${label}.proof_refs`, { minimum: 1 }),
+		...(evidenceClass === undefined ? {} : { evidenceClass }),
+		...(causalDisposition === undefined ? {} : { causalDisposition }),
+	};
+}
+
+function decodeReviewLastEventReviewerResultV1(value: unknown, label: string): ReviewLastEventReviewerResultV1 {
+	const result = exactRecord(value, label, ["lens", "findings", "evidence", "result_hash"]);
+	return {
+		lens: nonempty(result.lens, `${label}.lens`),
+		findings: array(result.findings, `${label}.findings`, decodeReviewLastEventReviewerFindingV1),
+		evidence: stringArray(result.evidence, `${label}.evidence`),
+		resultHash: sha256(result.result_hash, `${label}.result_hash`),
+	};
+}
+
 export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventClosureV1 {
-	const body = exactRecord(value, "last_event_closure", ["schema", "operation", "lineage_id", "state", "store_revision"], ["target_identity", "request_hash", "correction_lines", "action", "advisory_findings", "status_continuation", "acknowledgement"]);
+	const body = exactRecord(value, "last_event_closure", ["schema", "operation", "lineage_id", "state", "store_revision"], ["target_identity", "request_hash", "correction_lines", "action", "advisory_findings", "reviewer_results", "status_continuation", "acknowledgement"]);
 	if (body.schema !== REVIEW_LAST_EVENT_CLOSURE_SCHEMA) throw new TypeError(`last_event_closure.schema must be ${REVIEW_LAST_EVENT_CLOSURE_SCHEMA}`);
 	const operation = enumeration(body.operation, Object.values(REVIEW_LAST_EVENT_CLOSURE_OPERATION), "last_event_closure.operation") as ReviewLastEventClosureOperation;
 	const state = enumeration(body.state, REVIEW_LAST_EVENT_TERMINAL_STATES, "last_event_closure.state") as ReviewLastEventClosureState;
@@ -2674,6 +2727,7 @@ export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventC
 		storeRevision: sha256(body.store_revision, "last_event_closure.store_revision"),
 	};
 	if (operation === REVIEW_LAST_EVENT_CLOSURE_OPERATION.CAPTURE_CORRECTION_PLAN) {
+		if (body.reviewer_results !== undefined) throw new TypeError("last_event_closure reviewer_results requires approved state");
 		if (body.action !== undefined || body.advisory_findings !== undefined || body.status_continuation !== undefined) throw new TypeError("last_event_closure correction-plan cannot carry action, advisory_findings, or status_continuation");
 		if (state !== "correction_required") throw new TypeError("last_event_closure correction-plan requires correction_required state");
 		return {
@@ -2741,10 +2795,15 @@ export function decodeReviewLastEventClosureV1(value: unknown): ReviewLastEventC
 		? undefined
 		: decodeReviewAdvisoryFindingsV1(body.advisory_findings, "last_event_closure.advisory_findings");
 	if (advisoryFindings !== undefined && state !== "approved") throw new TypeError("last_event_closure advisory_findings requires approved state");
+	const reviewerResults = body.reviewer_results === undefined
+		? undefined
+		: array(body.reviewer_results, "last_event_closure.reviewer_results", decodeReviewLastEventReviewerResultV1);
+	if (reviewerResults !== undefined && state !== "approved") throw new TypeError("last_event_closure reviewer_results requires approved state");
 	return {
 		...shared,
 		action,
 		...(advisoryFindings === undefined ? {} : { advisoryFindings }),
+		...(reviewerResults === undefined ? {} : { reviewerResults }),
 		...(statusContinuation === undefined ? {} : { statusContinuation }),
 		...(acknowledgement === undefined ? {} : { acknowledgement }),
 		...(acknowledgementUndecodable ? { acknowledgementUndecodable: true as const } : {}),

--- a/runtime/review-integration-v2.mjs
+++ b/runtime/review-integration-v2.mjs
@@ -2540,6 +2540,29 @@ export function decodeReviewAcknowledgedV1(value         , expected             
 	return decoded;
 }
 
+const REVIEW_LAST_EVENT_FINDING_SEVERITIES = ["BLOCKER", "CRITICAL", "WARNING", "SUGGESTION"]         ;
+const REVIEW_LAST_EVENT_EVIDENCE_CLASSES = ["deterministic", "inferential", "insufficient"]         ;
+const REVIEW_LAST_EVENT_CAUSAL_DISPOSITIONS = ["introduced", "behavior-activated", "worsened", "pre-existing", "base-only", "unknown"]         ;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -2662,8 +2685,38 @@ function decodeReviewStatusContinuationV1(value         )                       
 	};
 }
 
+function decodeReviewLastEventReviewerFindingV1(value         , label        )                                   {
+	const finding = exactRecord(value, label, ["id", "lens", "location", "severity", "claim", "proof_refs"], ["evidence_class", "causal_disposition"]);
+	const evidenceClass = finding.evidence_class === undefined
+		? undefined
+		: enumeration(finding.evidence_class, REVIEW_LAST_EVENT_EVIDENCE_CLASSES, `${label}.evidence_class`);
+	const causalDisposition = finding.causal_disposition === undefined
+		? undefined
+		: enumeration(finding.causal_disposition, REVIEW_LAST_EVENT_CAUSAL_DISPOSITIONS, `${label}.causal_disposition`);
+	return {
+		id: nonempty(finding.id, `${label}.id`),
+		lens: nonempty(finding.lens, `${label}.lens`),
+		location: nonempty(finding.location, `${label}.location`),
+		severity: enumeration(finding.severity, REVIEW_LAST_EVENT_FINDING_SEVERITIES, `${label}.severity`),
+		claim: nonempty(finding.claim, `${label}.claim`),
+		proofRefs: stringArray(finding.proof_refs, `${label}.proof_refs`, { minimum: 1 }),
+		...(evidenceClass === undefined ? {} : { evidenceClass }),
+		...(causalDisposition === undefined ? {} : { causalDisposition }),
+	};
+}
+
+function decodeReviewLastEventReviewerResultV1(value         , label        )                                  {
+	const result = exactRecord(value, label, ["lens", "findings", "evidence", "result_hash"]);
+	return {
+		lens: nonempty(result.lens, `${label}.lens`),
+		findings: array(result.findings, `${label}.findings`, decodeReviewLastEventReviewerFindingV1),
+		evidence: stringArray(result.evidence, `${label}.evidence`),
+		resultHash: sha256(result.result_hash, `${label}.result_hash`),
+	};
+}
+
 export function decodeReviewLastEventClosureV1(value         )                           {
-	const body = exactRecord(value, "last_event_closure", ["schema", "operation", "lineage_id", "state", "store_revision"], ["target_identity", "request_hash", "correction_lines", "action", "advisory_findings", "status_continuation", "acknowledgement"]);
+	const body = exactRecord(value, "last_event_closure", ["schema", "operation", "lineage_id", "state", "store_revision"], ["target_identity", "request_hash", "correction_lines", "action", "advisory_findings", "reviewer_results", "status_continuation", "acknowledgement"]);
 	if (body.schema !== REVIEW_LAST_EVENT_CLOSURE_SCHEMA) throw new TypeError(`last_event_closure.schema must be ${REVIEW_LAST_EVENT_CLOSURE_SCHEMA}`);
 	const operation = enumeration(body.operation, Object.values(REVIEW_LAST_EVENT_CLOSURE_OPERATION), "last_event_closure.operation")                                   ;
 	const state = enumeration(body.state, REVIEW_LAST_EVENT_TERMINAL_STATES, "last_event_closure.state")                               ;
@@ -2675,6 +2728,7 @@ export function decodeReviewLastEventClosureV1(value         )                  
 		storeRevision: sha256(body.store_revision, "last_event_closure.store_revision"),
 	};
 	if (operation === REVIEW_LAST_EVENT_CLOSURE_OPERATION.CAPTURE_CORRECTION_PLAN) {
+		if (body.reviewer_results !== undefined) throw new TypeError("last_event_closure reviewer_results requires approved state");
 		if (body.action !== undefined || body.advisory_findings !== undefined || body.status_continuation !== undefined) throw new TypeError("last_event_closure correction-plan cannot carry action, advisory_findings, or status_continuation");
 		if (state !== "correction_required") throw new TypeError("last_event_closure correction-plan requires correction_required state");
 		return {
@@ -2742,10 +2796,15 @@ export function decodeReviewLastEventClosureV1(value         )                  
 		? undefined
 		: decodeReviewAdvisoryFindingsV1(body.advisory_findings, "last_event_closure.advisory_findings");
 	if (advisoryFindings !== undefined && state !== "approved") throw new TypeError("last_event_closure advisory_findings requires approved state");
+	const reviewerResults = body.reviewer_results === undefined
+		? undefined
+		: array(body.reviewer_results, "last_event_closure.reviewer_results", decodeReviewLastEventReviewerResultV1);
+	if (reviewerResults !== undefined && state !== "approved") throw new TypeError("last_event_closure reviewer_results requires approved state");
 	return {
 		...shared,
 		action,
 		...(advisoryFindings === undefined ? {} : { advisoryFindings }),
+		...(reviewerResults === undefined ? {} : { reviewerResults }),
 		...(statusContinuation === undefined ? {} : { statusContinuation }),
 		...(acknowledgement === undefined ? {} : { acknowledgement }),
 		...(acknowledgementUndecodable ? { acknowledgementUndecodable: true          } : {}),

--- a/tests/review-last-event-closure.test.ts
+++ b/tests/review-last-event-closure.test.ts
@@ -156,6 +156,45 @@ test("strictly decodes the real zero-lens closed START and every last-event clos
 	}
 });
 
+test("approved closure preserves complete admitted reviewer results before acknowledgement", () => {
+	const approved = closure("review/capture-result", "review-results");
+	approved.reviewer_results = [{
+		lens: "review-reliability",
+		findings: [{
+			id: "R3-W01",
+			lens: "reliability",
+			location: "lib/session.ts:4",
+			severity: "SUGGESTION",
+			claim: "the complete explanatory narrative remains available",
+			proof_refs: ["the changed line was inspected"],
+			evidence_class: "insufficient",
+			causal_disposition: "pre-existing",
+		}],
+		evidence: ["inspected the complete frozen candidate"],
+		result_hash: SHA,
+	}];
+	const decoded = decodeReviewLastEventClosureV1(approved);
+	assert.deepEqual(decoded.reviewerResults, [{
+		lens: "review-reliability",
+		findings: [{
+			id: "R3-W01",
+			lens: "reliability",
+			location: "lib/session.ts:4",
+			severity: "SUGGESTION",
+			claim: "the complete explanatory narrative remains available",
+			proofRefs: ["the changed line was inspected"],
+			evidenceClass: "insufficient",
+			causalDisposition: "pre-existing",
+		}],
+		evidence: ["inspected the complete frozen candidate"],
+		resultHash: SHA,
+	}]);
+
+	const correctionPlan = closure("review.capture-correction-plan", "review-results");
+	correctionPlan.reviewer_results = approved.reviewer_results;
+	assert.throws(() => decodeReviewLastEventClosureV1(correctionPlan), /reviewer_results requires approved state/);
+});
+
 test("retired legacy client no longer exposes a FINALIZE route", () => {
 	assert.equal("NativeReviewCliV214" in nativeReviewCliModule, false);
 	assert.equal("NativeReviewCliV213" in nativeReviewCliModule, false);


### PR DESCRIPTION
Closes #868

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Accept and strictly decode Gentle AI's approved-only `reviewer_results` closure field.
- Preserve complete canonical findings and evidence for downstream triage before acknowledgement burns authority.
- Keep older v2.7.0 closures compatible and reject reviewer results on non-approved terminal states.

## Changes

| File | Change |
|------|--------|
| `lib/review-integration-v2.ts` | Adds strict reviewer result types, decoding, and approved-state enforcement. |
| `runtime/review-integration-v2.mjs` | Regenerates the published runtime decoder. |
| `tests/review-last-event-closure.test.ts` | Covers complete readback and non-approved rejection. |

## Test Plan

- [x] Genuine RED reproduced: decoder rejected `reviewer_results` as unknown.
- [x] Focused closure suite: `node --experimental-strip-types --test tests/review-last-event-closure.test.ts`
- [x] Full suite: `pnpm test` (2,099 passed, 18 skipped, 0 failed)
- [x] Runtime generation and provider contract checks passed.
- [x] Package resource/hash verification passed.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] No skills changed; agent skill loading is not applicable.

## Contributor Checklist

- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Ran all applicable checks for modified files.
- [x] Updated generated runtime output with source.
- [x] Docs updated if behavior changed (not required; this is additive wire compatibility).
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approved review closures can now include detailed reviewer results, including findings, evidence, hashes, and disposition information.
  * Reviewer result data is validated against supported severity, evidence, and causal disposition values.

* **Bug Fixes**
  * Reviewer results are rejected when attached to correction-required closures, ensuring they are only accepted for approved reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->