### PR TITLE
fix(sdd): accept native planning route tokens

### DIFF
--- a/assets/sdd-orchestrator-workflow.md
+++ b/assets/sdd-orchestrator-workflow.md
@@ -45,10 +45,16 @@ For authoritative native status, route only by the bounded `nextRecommended` tok
 
 | `nextRecommended` | Planning route |
 | --- | --- |
+| `propose` | `sdd-proposal` |
+| `spec` | `sdd-spec` |
+| `design` | `sdd-design` |
+| `tasks` | `sdd-tasks` |
 | `sdd-propose` | `sdd-proposal` |
 | `sdd-spec` | `sdd-spec` |
 | `sdd-design` | `sdd-design` |
 | `sdd-tasks` | `sdd-tasks` |
+
+The unprefixed tokens come from the native Gentle AI v2 status contract; the `sdd-*` tokens come from Gentle Pi's local resolver. Both forms authorize the same bounded planning routes.
 
 These planning routes remain runnable when missing planning artifacts leave `dependencies.apply: blocked`; do not require apply readiness to produce those artifacts. This is a planning-only exception, not permission to run apply or another blocked non-planning phase.
 

--- a/assets/support/sdd-status-contract.md
+++ b/assets/support/sdd-status-contract.md
@@ -29,10 +29,16 @@ For authoritative native status, route only by the bounded `nextRecommended` tok
 
 | `nextRecommended` | Planning route |
 | --- | --- |
+| `propose` | `sdd-proposal` |
+| `spec` | `sdd-spec` |
+| `design` | `sdd-design` |
+| `tasks` | `sdd-tasks` |
 | `sdd-propose` | `sdd-proposal` |
 | `sdd-spec` | `sdd-spec` |
 | `sdd-design` | `sdd-design` |
 | `sdd-tasks` | `sdd-tasks` |
+
+The unprefixed tokens come from the native Gentle AI v2 status contract; the `sdd-*` tokens come from Gentle Pi's local resolver. Both forms authorize the same bounded planning routes.
 
 These planning routes remain runnable when missing planning artifacts leave `dependencies.apply: blocked`; do not require apply readiness to produce those artifacts. This is a planning-only exception, not permission to run apply or another blocked non-planning phase.
 

--- a/tests/sdd-planning-routing-contract.test.ts
+++ b/tests/sdd-planning-routing-contract.test.ts
@@ -29,6 +29,19 @@ for (const [index, path] of paths.entries()) {
 		assert.match(contract, /do not require apply readiness to produce those artifacts/);
 	});
 
+	test(`${path}: native Gentle AI planning tokens map to executable Pi phases`, () => {
+		const contract = routingContract(documents[index]);
+		for (const [token, phase] of [
+			["propose", "sdd-proposal"],
+			["spec", "sdd-spec"],
+			["design", "sdd-design"],
+			["tasks", "sdd-tasks"],
+		]) {
+			assert.ok(contract.includes(`| \`${token}\` | \`${phase}\` |`));
+		}
+		assert.match(contract, /unprefixed tokens come from the native Gentle AI v2 status contract/);
+	});
+
 	test(`${path}: planning does not weaken stop conditions or diagnostic ownership`, () => {
 		const contract = routingContract(documents[index]);
 		for (const guard of [


### PR DESCRIPTION
Closes #727

Related occurrence: Gentleman-Programming/gentle-ai#4372, especially issuecomment-5630028164.

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Accept the unprefixed planning tokens emitted by native `gentle-ai.sdd-status/v2`.
- Preserve the `sdd-*` planning tokens emitted by Gentle Pi's local resolver.
- Keep unknown tokens, dependency blockers, preflight, and action-context gates unchanged.

## Changes

| File | Change |
|------|--------|
| `assets/sdd-orchestrator-workflow.md` | Maps native and Pi-local planning token families to the same phase agents. |
| `assets/support/sdd-status-contract.md` | Keeps the installed support contract in exact semantic parity. |
| `tests/sdd-planning-routing-contract.test.ts` | Adds explicit regression coverage for `propose`, `spec`, `design`, and `tasks`. |

## Test plan

- [x] RED: focused contract test failed for both contract copies before alias mappings were added.
- [x] `node --experimental-strip-types --test tests/sdd-planning-routing-contract.test.ts tests/sdd-status.test.ts` (58 passed).
- [x] `pnpm test` (2,138 tests, 2,129 passed, 9 skipped, 0 failed on final rerun).
- [x] `pnpm run check:runtime-modules`.
- [x] `git diff --check`.
- [x] Independent verification found no candidate-caused blocker.
- [x] Native reliability review approved and acknowledged.
- [x] No shell scripts changed; shellcheck is not applicable.

## Contributor checklist

- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Tests cover the changed behavior.
- [x] Runtime contracts updated with the behavior.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Planning workflows now recognize both native status tokens (`propose`, `spec`, `design`, and `tasks`) and their existing prefixed equivalents.

- **Documentation**
  - Clarified that both token formats authorize the same bounded planning routes and documented their respective sources.

- **Tests**
  - Added coverage to verify routing consistency across workflow and support documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->