### PR TITLE
fix(sdd): accept unnamed executors and native v2 startup status

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -1558,18 +1558,14 @@ function isNamedAgentStartEvent(event: unknown): boolean {
 }
 
 function sddPhaseFromAgentStartEvent(event: unknown): SddPhase | undefined {
-	for (const name of readAgentStartNames(event)) {
-		if (name === "sdd-apply") return "apply";
-		if (name === "sdd-verify") return "verify";
-		if (name === "sdd-sync") return "sync";
-		if (name === "sdd-archive") return "archive";
-	}
+	const phases = ["apply", "verify", "sync", "archive"] as const;
+	const names = readAgentStartNames(event);
 	const systemPrompt = readStringPath(event, ["systemPrompt"]) ?? "";
-	if (/\bSDD apply executor\b/i.test(systemPrompt)) return "apply";
-	if (/\bSDD verify executor\b/i.test(systemPrompt)) return "verify";
-	if (/\bSDD sync executor\b/i.test(systemPrompt)) return "sync";
-	if (/\bSDD archive executor\b/i.test(systemPrompt)) return "archive";
-	return undefined;
+	const promptPhases = phases.filter((phase) => new RegExp(`\\bSDD ${phase} executor\\b`, "i").test(systemPrompt));
+	if (promptPhases.length > 1) return undefined;
+	if (names.length === 0) return promptPhases[0];
+	return phases.find((phase) => names.every((name) => name === `sdd-${phase}`) &&
+		(promptPhases.length === 0 || promptPhases[0] === phase));
 }
 
 function resolveSddChangeSelection(serialized: unknown, cwd: string, agentName: string) {
@@ -1643,7 +1639,7 @@ async function resolveSelectedNativeSddChangeStartup(
 	} catch (error) {
 		throw new Error(`SDD selection native status is blocked: ${error instanceof Error ? error.message : String(error)}`);
 	}
-	if (!(selection.phase in status.dependencies) || !(selection.phase in status.instructions)) {
+	if (!(selection.phase in status.dependencies) || status.phaseInstructions === undefined || !(selection.phase in status.phaseInstructions)) {
 		throw new Error(`SDD selection native status cannot represent phase ${selection.phase}.`);
 	}
 	return { selection, status };
@@ -7477,7 +7473,7 @@ function createGentleAiExtensionForTesting(
 				? `\n\n${renderSddPreflightPrompt(prefs)}`
 				: "";
 		const phase = isSddAgent ? sddPhaseFromAgentStartEvent(event) : undefined;
-		const launchSddChange = isSddAgent ? readSddChangeFlag(pi) : undefined;
+		const launchSddChange = readSddChangeFlag(pi);
 		const nativeStatusPrompt = phase
 			? await (async () => {
 				if (launchSddChange === undefined) {
@@ -7489,9 +7485,7 @@ function createGentleAiExtensionForTesting(
 					), phase)}`;
 				}
 				try {
-					const names = readAgentStartNames(event);
-					const agentName = names.find((name) => name === `sdd-${phase}`);
-					if (!agentName) throw new Error("SDD selection requires a matching named SDD phase agent.");
+					const agentName = `sdd-${phase}`;
 					const startup = await resolveSelectedNativeSddChangeStartup(
 						launchSddChange,
 						ctx.cwd,
@@ -7504,7 +7498,7 @@ function createGentleAiExtensionForTesting(
 							prefs?.artifactStore,
 						),
 					);
-					return `\n\n${renderNativeSddPhasePrompt(startup.status as never, phase)}`;
+					return `\n\n${renderNativeSddPhasePrompt(startup.status, phase)}`;
 				} catch (error) {
 					return `\n\n## Native SDD Status Engine\nSDD selection blocked: ${error instanceof Error ? error.message : String(error)}\nDo not run phase work; return this blocker to the parent.`;
 				}

--- a/lib/native-review-cli.ts
+++ b/lib/native-review-cli.ts
@@ -179,8 +179,8 @@ export interface NativeSddStatusV2 extends Readonly<Record<string, unknown>> {
 	schemaVersion: 2;
 	changeName: string;
 	actionContext: Readonly<Record<string, unknown>> & { workspaceRoot: string };
-	dependencies: Readonly<Record<NativeSddPhase, NativeSddDependencyState>>;
-	instructions: Readonly<Record<NativeSddPhase, readonly string[]>>;
+	dependencies: Readonly<Record<(typeof NATIVE_SDD_DEPENDENCIES)[number], NativeSddDependencyState>>;
+	phaseInstructions?: Readonly<Record<(typeof NATIVE_SDD_INSTRUCTION_PHASES)[number], readonly string[]>>;
 	blockedReasons: readonly string[];
 	nextRecommended: string;
 }
@@ -1375,7 +1375,9 @@ interface NativeJsonExecution {
 	process: ExecFileResult;
 }
 
-const NATIVE_SDD_PHASES = ["apply", "verify", "archive"] as const;
+const NATIVE_SDD_DEPENDENCIES = ["proposal", "specs", "design", "tasks", "apply", "verify", "archive"] as const;
+const NATIVE_SDD_INSTRUCTION_PHASES = ["apply", "verify", "remediate", "archive"] as const;
+const NATIVE_SDD_NEXT_RECOMMENDATIONS = ["apply", "verify", "remediate", "archive", "archived", "resolve-blockers", "sdd-new", "select-change", "propose", "spec", "design", "tasks"] as const;
 const NATIVE_SDD_DEPENDENCY_STATES = ["blocked", "ready", "all_done"] as const;
 
 /** Strictly validates the native v2 contract while preserving its whole record. */
@@ -1386,15 +1388,18 @@ export function decodeNativeSddStatusV2(value: unknown, request: Pick<NativeSddS
 	const actionContext = object(status.actionContext);
 	if (actionContext.workspaceRoot !== request.workspaceRoot || !isCanonicalProcessString(actionContext.workspaceRoot)) throw new Error("native SDD status workspace root mismatch");
 	const dependencies = object(status.dependencies);
-	const instructions = object(status.instructions);
-	for (const phase of NATIVE_SDD_PHASES) {
+	for (const phase of NATIVE_SDD_DEPENDENCIES) {
 		if (enumString(dependencies[phase], NATIVE_SDD_DEPENDENCY_STATES) !== dependencies[phase]) throw new Error("invalid native SDD dependency");
-		stringArray(instructions[phase]);
 	}
-	if (Object.keys(dependencies).length !== NATIVE_SDD_PHASES.length || Object.keys(dependencies).some((key) => !NATIVE_SDD_PHASES.includes(key as NativeSddPhase))) throw new Error("native SDD dependencies have an unsupported shape");
-	if (Object.keys(instructions).length !== NATIVE_SDD_PHASES.length || Object.keys(instructions).some((key) => !NATIVE_SDD_PHASES.includes(key as NativeSddPhase))) throw new Error("native SDD instructions have an unsupported shape");
+	if (Object.keys(dependencies).length !== NATIVE_SDD_DEPENDENCIES.length) throw new Error("native SDD dependencies have an unsupported shape");
+	if (status.instructions !== undefined) throw new Error("native SDD status uses phaseInstructions, not instructions");
+	if (status.phaseInstructions !== undefined) {
+		const instructions = object(status.phaseInstructions);
+		for (const phase of NATIVE_SDD_INSTRUCTION_PHASES) stringArray(instructions[phase]);
+		if (Object.keys(instructions).length !== NATIVE_SDD_INSTRUCTION_PHASES.length) throw new Error("native SDD instructions have an unsupported shape");
+	}
 	stringArray(status.blockedReasons);
-	if (!isCanonicalProcessString(status.nextRecommended)) throw new Error("invalid native SDD next recommendation");
+	enumString(status.nextRecommended, NATIVE_SDD_NEXT_RECOMMENDATIONS);
 	return status as NativeSddStatusV2;
 }
 

--- a/lib/sdd-status.ts
+++ b/lib/sdd-status.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join, relative, resolve } from "node:path";
+import type { NativeSddStatusV2 } from "./native-review-cli.ts";
 import {
 	detectActiveDomainCollisions,
 	detectLegacyFlatSpec,
@@ -660,9 +661,15 @@ export function isNonAuthoritativeStatus(status: SddStatus): boolean {
 	return status.isNonAuthoritative;
 }
 
-export function renderNativeSddPhasePrompt(status: SddStatus, phase?: SddPhase): string {
-	const selectedInstructions = phase ? status.instructions?.[phase] : undefined;
-	const isNonAuthoritative = isNonAuthoritativeStatus(status);
+export function renderNativeSddPhasePrompt(status: SddStatus | NativeSddStatusV2, phase?: SddPhase): string {
+	const native = status.schemaName === "gentle-ai.sdd-status";
+	let selectedInstructions: readonly string[] | undefined;
+	if (phase) {
+		selectedInstructions = native
+			? phase === "sync" ? undefined : status.phaseInstructions?.[phase]
+			: status.instructions?.[phase];
+	}
+	const isNonAuthoritative = !native && isNonAuthoritativeStatus(status);
 	const authorityLine = isNonAuthoritative
 		? `This status is non-authoritative (artifact store: ${status.artifactStore}). The orchestrator must resolve readiness from Engram instead.`
 		: "The parent/orchestrator resolved this status deterministically. Treat it as authoritative over prompt inference.";

--- a/runtime/native-review-cli.mjs
+++ b/runtime/native-review-cli.mjs
@@ -1376,7 +1376,9 @@ function nativeError(code                       , operation                     
 
 
 
-const NATIVE_SDD_PHASES = ["apply", "verify", "archive"]         ;
+const NATIVE_SDD_DEPENDENCIES = ["proposal", "specs", "design", "tasks", "apply", "verify", "archive"]         ;
+const NATIVE_SDD_INSTRUCTION_PHASES = ["apply", "verify", "remediate", "archive"]         ;
+const NATIVE_SDD_NEXT_RECOMMENDATIONS = ["apply", "verify", "remediate", "archive", "archived", "resolve-blockers", "sdd-new", "select-change", "propose", "spec", "design", "tasks"]         ;
 const NATIVE_SDD_DEPENDENCY_STATES = ["blocked", "ready", "all_done"]         ;
 
 /** Strictly validates the native v2 contract while preserving its whole record. */
@@ -1387,15 +1389,18 @@ export function decodeNativeSddStatusV2(value         , request                 
 	const actionContext = object(status.actionContext);
 	if (actionContext.workspaceRoot !== request.workspaceRoot || !isCanonicalProcessString(actionContext.workspaceRoot)) throw new Error("native SDD status workspace root mismatch");
 	const dependencies = object(status.dependencies);
-	const instructions = object(status.instructions);
-	for (const phase of NATIVE_SDD_PHASES) {
+	for (const phase of NATIVE_SDD_DEPENDENCIES) {
 		if (enumString(dependencies[phase], NATIVE_SDD_DEPENDENCY_STATES) !== dependencies[phase]) throw new Error("invalid native SDD dependency");
-		stringArray(instructions[phase]);
 	}
-	if (Object.keys(dependencies).length !== NATIVE_SDD_PHASES.length || Object.keys(dependencies).some((key) => !NATIVE_SDD_PHASES.includes(key                  ))) throw new Error("native SDD dependencies have an unsupported shape");
-	if (Object.keys(instructions).length !== NATIVE_SDD_PHASES.length || Object.keys(instructions).some((key) => !NATIVE_SDD_PHASES.includes(key                  ))) throw new Error("native SDD instructions have an unsupported shape");
+	if (Object.keys(dependencies).length !== NATIVE_SDD_DEPENDENCIES.length) throw new Error("native SDD dependencies have an unsupported shape");
+	if (status.instructions !== undefined) throw new Error("native SDD status uses phaseInstructions, not instructions");
+	if (status.phaseInstructions !== undefined) {
+		const instructions = object(status.phaseInstructions);
+		for (const phase of NATIVE_SDD_INSTRUCTION_PHASES) stringArray(instructions[phase]);
+		if (Object.keys(instructions).length !== NATIVE_SDD_INSTRUCTION_PHASES.length) throw new Error("native SDD instructions have an unsupported shape");
+	}
 	stringArray(status.blockedReasons);
-	if (!isCanonicalProcessString(status.nextRecommended)) throw new Error("invalid native SDD next recommendation");
+	enumString(status.nextRecommended, NATIVE_SDD_NEXT_RECOMMENDATIONS);
 	return status                     ;
 }
 

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -7,6 +7,7 @@ import {
 	decodeReviewConsentV3,
 } from "../lib/review-integration-v2.ts";
 import {
+	decodeNativeSddStatusV2,
 	NATIVE_REVIEW_DEFAULT_MAX_BUFFER_BYTES,
 	NATIVE_REVIEW_ERROR_CODE,
 	NativeReviewCliError,
@@ -59,16 +60,19 @@ function client(adapter: ExecFileAdapter): NativeReviewCliV216 {
 	return new NativeReviewCliV216(adapter, "/package/.gentle-ai/gentle-ai", 30_000, 1024 * 1024);
 }
 
+// Structural test data follows the 2026-09-11 native 2.7.1-0.20260911070137-350f31554a4b
+// capture: seven dependencies and four phaseInstructions groups, not a legacy alias.
 function nativeSddStatus(changeName = "complete-native-review-lifecycle", workspaceRoot = "/repo"): Record<string, unknown> {
 	return {
 		schemaName: "gentle-ai.sdd-status",
 		schemaVersion: 2,
 		changeName,
 		actionContext: { workspaceRoot },
-		dependencies: { apply: "all_done", verify: "all_done", archive: "ready" },
-		instructions: {
+		dependencies: { proposal: "all_done", specs: "all_done", design: "all_done", tasks: "all_done", apply: "all_done", verify: "all_done", archive: "ready" },
+		phaseInstructions: {
 			apply: ["Apply is complete."],
 			verify: ["Verification is complete."],
+			remediate: ["Bind remediation to failed evidence."],
 			archive: ["Archive the selected change."],
 		},
 		blockedReasons: [],
@@ -99,8 +103,11 @@ test("native SDD status rejects malformed v2 identities, dependencies, instructi
 		{ ...nativeSddStatus(), changeName: "other-change" },
 		{ ...nativeSddStatus(), actionContext: { workspaceRoot: "/other" } },
 		{ ...nativeSddStatus(), dependencies: { apply: "all_done", verify: "all_done", archive: "future" } },
-		{ ...nativeSddStatus(), instructions: { apply: ["ok"], verify: ["ok"], archive: [42] } },
+		{ ...nativeSddStatus(), phaseInstructions: { apply: ["ok"], verify: ["ok"], archive: [42] } },
 		{ ...nativeSddStatus(), blockedReasons: "not-an-array" },
+		{ ...nativeSddStatus(), nextRecommended: "unknown" },
+		{ ...nativeSddStatus(), instructions: {}, phaseInstructions: undefined },
+		{ ...nativeSddStatus(), phaseInstructions: null },
 	];
 	for (const body of malformed) {
 		await assert.rejects(
@@ -110,6 +117,12 @@ test("native SDD status rejects malformed v2 identities, dependencies, instructi
 			(error: unknown) => error instanceof NativeReviewCliError && error.code === NATIVE_REVIEW_ERROR_CODE.SCHEMA_INCOMPATIBLE,
 		);
 	}
+});
+
+test("native v2 read-only decoding preserves omitted optional phaseInstructions", () => {
+	const body = nativeSddStatus();
+	delete body.phaseInstructions;
+	assert.equal(decodeNativeSddStatusV2(body, { changeName: "complete-native-review-lifecycle", workspaceRoot: "/repo" }), body);
 });
 
 test("native SDD status keeps malformed JSON, timeout, and nonzero execution fail-closed", async () => {

--- a/tests/native-review-cli.test.ts
+++ b/tests/native-review-cli.test.ts
@@ -97,13 +97,18 @@ test("native SDD status executes its exact selected-root argv and returns only a
 });
 
 test("native SDD status rejects malformed v2 identities, dependencies, instructions, and blockers", async () => {
+	const invalidInstructions = { apply: ["ok"], verify: ["ok"], remediate: ["ok"], archive: [42] };
+	assert.doesNotThrow(() => decodeNativeSddStatusV2(
+		{ ...nativeSddStatus(), phaseInstructions: { ...invalidInstructions, archive: ["ok"] } },
+		{ changeName: "complete-native-review-lifecycle", workspaceRoot: "/repo" },
+	));
 	const malformed = [
 		{ ...nativeSddStatus(), schemaName: "gentle-pi.sdd-status" },
 		{ ...nativeSddStatus(), schemaVersion: 1 },
 		{ ...nativeSddStatus(), changeName: "other-change" },
 		{ ...nativeSddStatus(), actionContext: { workspaceRoot: "/other" } },
 		{ ...nativeSddStatus(), dependencies: { apply: "all_done", verify: "all_done", archive: "future" } },
-		{ ...nativeSddStatus(), phaseInstructions: { apply: ["ok"], verify: ["ok"], archive: [42] } },
+		{ ...nativeSddStatus(), phaseInstructions: invalidInstructions },
 		{ ...nativeSddStatus(), blockedReasons: "not-an-array" },
 		{ ...nativeSddStatus(), nextRecommended: "unknown" },
 		{ ...nativeSddStatus(), instructions: {}, phaseInstructions: undefined },

--- a/tests/sdd-selection-transport.test.ts
+++ b/tests/sdd-selection-transport.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -7,7 +7,10 @@ import { AGENT_MODE, type AgentDefinition } from "../lib/agents-config.ts";
 import { AgentRunner, type TaskRequest } from "../lib/agents-runner.ts";
 import { TaskStore } from "../lib/agents-protocol.ts";
 import { NATIVE_REVIEW_ERROR_CODE, NativeReviewCliError } from "../lib/native-review-cli.ts";
-import { __testing } from "../extensions/gentle-ai.ts";
+import { createGentleAiExtension, __testing } from "../extensions/gentle-ai.ts";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { NativeReviewCli } from "../lib/native-review-cli.ts";
+import { ensureSddPreflight } from "../lib/sdd-preflight.ts";
 import { fakeChild } from "./agents-fake-child.ts";
 
 const applyAgent: AgentDefinition = {
@@ -85,8 +88,8 @@ test("selected native v2 archive authority is injected whole and never falls bac
 		schemaVersion: 2,
 		changeName: "alpha",
 		actionContext: { workspaceRoot: root },
-		dependencies: { apply: "all_done", verify: "all_done", archive: "ready" },
-		instructions: { apply: ["done"], verify: ["done"], archive: ["archive now"] },
+		dependencies: { proposal: "all_done", specs: "all_done", design: "all_done", tasks: "all_done", apply: "all_done", verify: "all_done", archive: "ready" },
+		phaseInstructions: { apply: ["done"], verify: ["done"], remediate: ["failed evidence"], archive: ["archive now"] },
 		blockedReasons: [],
 		nextRecommended: "archive",
 	};
@@ -121,8 +124,8 @@ test("selected native v2 failures fail closed without consulting the local resol
 	const valid = {
 		schemaName: "gentle-ai.sdd-status", schemaVersion: 2, changeName: "alpha",
 		actionContext: { workspaceRoot: root },
-		dependencies: { apply: "all_done", verify: "all_done", archive: "blocked" },
-		instructions: { apply: ["done"], verify: ["done"], archive: ["blocked"] },
+		dependencies: { proposal: "all_done", specs: "all_done", design: "all_done", tasks: "all_done", apply: "all_done", verify: "all_done", archive: "blocked" },
+		phaseInstructions: { apply: ["done"], verify: ["done"], remediate: ["failed evidence"], archive: ["blocked"] },
 		blockedReasons: ["native archive blocker"], nextRecommended: "verify",
 	};
 	const failures: Array<{ sddStatus?: () => Promise<unknown> }> = [
@@ -135,7 +138,7 @@ test("selected native v2 failures fail closed without consulting the local resol
 		{ sddStatus: async () => ({ ...valid, changeName: "other" }) },
 		{ sddStatus: async () => ({ ...valid, actionContext: { workspaceRoot: "/other" } }) },
 		{ sddStatus: async () => ({ ...valid, dependencies: { apply: "all_done", verify: "all_done" } }) },
-		{ sddStatus: async () => ({ ...valid, instructions: { apply: ["done"], verify: ["done"] } }) },
+		{ sddStatus: async () => ({ ...valid, phaseInstructions: { apply: ["done"], verify: ["done"] } }) },
 		{ sddStatus: async () => ({ ...valid, blockedReasons: "invalid" }) },
 	];
 	for (const native of failures) {
@@ -218,6 +221,8 @@ test("selected SDD startup fails closed for malformed identity, root, phase, sym
 	symlinkSync(outside, escaped);
 
 	for (const value of [
+		undefined,
+		null,
 		"not-json",
 		JSON.stringify({ changeName: "alpha", workspaceRoot: root, phase: "apply", extra: true }),
 		JSON.stringify({ changeName: "alpha", workspaceRoot: join(root, "wrong"), phase: "apply" }),
@@ -230,4 +235,70 @@ test("selected SDD startup fails closed for malformed identity, root, phase, sym
 		() => __testing.resolveSddChangeStartup(selected, root, "sdd-apply", () => { throw new Error("resolver failed"); }),
 		/resolver failed/i,
 	);
+});
+
+// Use the packaged executor body without an unsupported agent-name event field.
+test("before_agent_start resolves the unnamed packaged executor and renders native v2 selection", async (t) => {
+	const root = workspace(t);
+	const systemPrompt = readFileSync(new URL("../assets/agents/sdd-apply.md", import.meta.url), "utf8").replace(/^---\n[\s\S]*?\n---\n/, "");
+	const selection = { changeName: "alpha", workspaceRoot: root, phase: "apply" };
+	const status = {
+		schemaName: "gentle-ai.sdd-status", schemaVersion: 2, changeName: "alpha",
+		actionContext: { workspaceRoot: root },
+		dependencies: { proposal: "all_done", specs: "all_done", design: "all_done", tasks: "all_done", apply: "ready", verify: "blocked", archive: "blocked" },
+		phaseInstructions: { apply: ["Read proposal, specs, design, and tasks before editing."], verify: ["Verify implementation."], remediate: ["Bind failed evidence."], archive: ["Archive after verification."] },
+		blockedReasons: [], nextRecommended: "apply",
+	};
+	let serialized: unknown = JSON.stringify(selection);
+	let nativeReply: unknown = status;
+	const calls: unknown[] = [];
+	type Hook = (event: unknown, ctx: ExtensionContext) => Promise<{ systemPrompt: string }>;
+	const hooks = new Map<string, Hook>();
+	const pi = {
+		on(name: string, hook: Hook) { hooks.set(name, hook); },
+		events: { emit() {} }, registerCommand() {}, registerTool() {},
+		getFlag: () => serialized, getActiveTools: () => [],
+	} as unknown as ExtensionAPI;
+	const ctx = { cwd: root, hasUI: false, sessionManager: { getSessionId: () => root } } as unknown as ExtensionContext;
+	await ensureSddPreflight(ctx, { pi, installAssets: () => ({ agents: 0, chains: 0, support: 0, skipped: 0 }) });
+	createGentleAiExtension({
+		nativeReviewCli: { sddStatus: async (request: unknown) => { calls.push(request); return nativeReply; } } as unknown as NativeReviewCli,
+		processEnv: {},
+		resolveTelemetryTriggerBinary: () => { throw new Error("no telemetry in hook tests"); },
+	})(pi);
+	const result = await hooks.get("before_agent_start")!({ systemPrompt }, ctx);
+	assert.doesNotMatch(result.systemPrompt, /SDD selection blocked:/);
+	assert.deepEqual(calls, [{ changeName: "alpha", workspaceRoot: root }]);
+	assert.match(result.systemPrompt, /### apply instructions/);
+	assert.ok(result.systemPrompt.includes(status.phaseInstructions.apply[0]!));
+	assert.ok(result.systemPrompt.includes(JSON.stringify(status, null, 2)));
+	for (const [name, event] of [
+		["contradictory names", { systemPrompt, agentName: "sdd-apply", name: "sdd-verify" }],
+		["contradictory named phase", { systemPrompt, agentName: "sdd-verify" }],
+		["unknown explicit name", { systemPrompt, agentName: "worker" }],
+		["ambiguous executor body", { systemPrompt: `${systemPrompt}\nSDD verify executor` }],
+		["unknown executor body", { systemPrompt: "SDD unknown executor" }],
+	] as const) {
+		await t.test(name, async () => {
+			calls.length = 0;
+			assert.match((await hooks.get("before_agent_start")!(event, ctx)).systemPrompt, /SDD selection blocked:/);
+			assert.deepEqual(calls, []);
+		});
+	}
+	for (const invalid of [null, "not-json", { ...selection, phase: "verify" }, { ...selection, workspaceRoot: "/other" }]) {
+		serialized = typeof invalid === "object" && invalid !== null ? JSON.stringify(invalid) : invalid;
+		calls.length = 0;
+		assert.match((await hooks.get("before_agent_start")!({ systemPrompt }, ctx)).systemPrompt, /SDD selection blocked:/);
+		assert.deepEqual(calls, []);
+	}
+	serialized = JSON.stringify(selection);
+	for (const invalid of [{ ...status, phaseInstructions: undefined }, { ...status, nextRecommended: "unknown" }]) {
+		nativeReply = invalid;
+		assert.match((await hooks.get("before_agent_start")!({ systemPrompt }, ctx)).systemPrompt, /SDD selection blocked:/);
+	}
+	nativeReply = { ...status, dependencies: { ...status.dependencies, apply: "blocked" }, blockedReasons: ["missing native prerequisite"] };
+	const blocked = await hooks.get("before_agent_start")!({ systemPrompt }, ctx);
+	assert.match(blocked.systemPrompt, /Do not run phase work when this status marks the phase blocked/);
+	assert.ok(blocked.systemPrompt.includes(JSON.stringify(nativeReply, null, 2)));
+
 });


### PR DESCRIPTION
Closes #891

## PR type

- [x] Bug fix (`type:bug`)

## Summary

- Reuse the recognized SDD executor phase when Pi emits `before_agent_start` without an agent name. Conflicting names and ambiguous executor bodies still fail closed.
- Decode the producer's seven dependencies and four `phaseInstructions` groups, then render the native status without casting it to the local schema.
- Preserve selected-change/workspace validation, malformed-contract refusal, blocked-phase instructions, and the existing sync route. No new identity protocol or fallback router.

## Changes

| File | Change |
|---|---|
| `extensions/gentle-ai.ts` | Consistent executor resolution and selected native startup |
| `lib/native-review-cli.ts` | Validate actual v2 dependency/instruction fields and action tokens |
| `lib/sdd-status.ts` | Render native phase instructions directly |
| `runtime/native-review-cli.mjs` | Regenerated decoder mirror |
| `tests/native-review-cli.test.ts` | Complete v2 shape and malformed-input coverage |
| `tests/sdd-selection-transport.test.ts` | Unnamed hook regression and negative selection/identity cases |

168 authored additions/deletions plus 19 generated: 187 changed lines.

## Verification

Final checks used direct Node, without package-manager wrappers:

- `node --experimental-strip-types --test tests/sdd-selection-transport.test.ts tests/native-review-cli.test.ts`: 55 passed, no skips.
- `node --experimental-strip-types --test tests/*.test.ts`: 2,141 passed, nine skipped, no failures. Skips: eight Windows-only cases and one opt-in live test.
- `node scripts/build-runtime-modules.mjs --check`: six modules synchronized.
- `node scripts/verify-package-files.mjs`: 168 files and 69 byte-pinned contract artifacts validated.
- `node scripts/check-provider-contract.mjs`: passed.
- `node --experimental-strip-types tests/runtime-harness.mjs`: passed.
- `git diff --check`: passed.

Recorded RED and triangulation failures preceded GREEN. Four native review lenses completed with no findings; that inspection is separate from test evidence.

## Remaining boundary

Whole captured producer-v2 replay passed selected startup/rendering, including the actual installed executor body through the unnamed hook. This used an injected adapter, not a live native process. A real managed Pi child was **not run**. This PR does not establish deployment, live end-to-end uptake, or complete downstream AI phase startup. Delivery performs no installation, reload, or AI-worktree changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for expanded native SDD status information across proposal, specification, design, task, application, verification, remediation, and archive phases.
  - Added support for optional phase-specific instructions and recommended next actions.
  - Improved phase selection and executor coordination using consistent status signals.

- **Bug Fixes**
  - Improved rejection of malformed or outdated SDD status responses.
  - Prevented invalid phase selections and blocked phases from being launched.

- **Tests**
  - Expanded coverage for native status validation, phase selection, executor resolution, and agent-start behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->