### PR TITLE
feat(models): configure provider-owned review roles

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -2337,6 +2337,30 @@ function isValidJsonObjectFileOrMissing(path: string): boolean {
 	}
 }
 
+const PROVIDER_REVIEW_ROLES = ["review-refuter", "review-validator"] as const;
+
+function isProviderReviewRole(name: string): boolean {
+	return PROVIDER_REVIEW_ROLES.some((role) => role === name);
+}
+
+function modelAssignmentNames(cwd: string): string[] {
+	return [...new Set([
+		...PROVIDER_REVIEW_ROLES,
+		...listDiscoverableAgents(cwd).map((agent) => agent.name),
+	])];
+}
+
+const PROVIDER_ROUTING_DEFAULT_LABELS = {
+	model: "Pi persisted default model",
+	effort: "Pi persisted default effort",
+} as const;
+
+type RoutingDefaultField = keyof typeof PROVIDER_ROUTING_DEFAULT_LABELS;
+
+function routingDefaultLabel(name: string, field: RoutingDefaultField): string {
+	return isProviderReviewRole(name) ? PROVIDER_ROUTING_DEFAULT_LABELS[field] : "inherit";
+}
+
 function migrateLegacyProjectModelOverrides(cwd: string): number {
 	const settingsPath = projectSettingsPath(cwd);
 	if (!existsSync(settingsPath)) return 0;
@@ -2355,6 +2379,7 @@ function migrateLegacyProjectModelOverrides(cwd: string): number {
 	if (!agentOverrides) return 0;
 	const agentsByName = new Map(listDiscoverableAgents(cwd).map((agent) => [agent.name, agent]));
 	const migratableEntries = Object.entries(agentOverrides)
+		.filter(([name]) => !isProviderReviewRole(name))
 		.map(([name, value]) => ({ name, entry: normalizeRoutingEntry(value) }))
 		.filter((item): item is { name: string; entry: AgentRoutingEntry } =>
 			item.entry !== undefined && !isClearRoutingEntry(item.entry),
@@ -2397,6 +2422,7 @@ export function applyModelConfig(
 	let skipped = 0;
 	const seenAgents = new Set<string>();
 	for (const agent of listDiscoverableAgents(cwd)) {
+		if (isProviderReviewRole(agent.name)) continue;
 		seenAgents.add(agent.name);
 		const entry = config[agent.name];
 		if (entry === undefined) {
@@ -2426,6 +2452,7 @@ export function applyModelConfig(
 		else skipped += 1;
 	}
 	for (const [name, entry] of Object.entries(config)) {
+		if (isProviderReviewRole(name)) continue;
 		if (!seenAgents.has(name) && isClearRoutingEntry(entry)) {
 			if (updateSubagentModelProfile(cwd, "user", name, entry)) updated += 1;
 			else skipped += 1;
@@ -2442,6 +2469,7 @@ export async function applyModelConfigAsync(
 	let skipped = 0;
 	const seenAgents = new Set<string>();
 	for (const agent of await listDiscoverableAgentsAsync(cwd)) {
+		if (isProviderReviewRole(agent.name)) continue;
 		seenAgents.add(agent.name);
 		const entry = config[agent.name];
 		if (entry === undefined) {
@@ -2473,6 +2501,7 @@ export async function applyModelConfigAsync(
 		else skipped += 1;
 	}
 	for (const [name, entry] of Object.entries(config)) {
+		if (isProviderReviewRole(name)) continue;
 		if (!seenAgents.has(name) && isClearRoutingEntry(entry)) {
 			if (await updateSubagentModelProfileAsync(cwd, "user", name, entry))
 				updated += 1;
@@ -2500,11 +2529,11 @@ export async function applySavedModelConfig(
 }
 
 function describeModelConfig(cwd: string, config: AgentModelConfig): string[] {
-	return listDiscoverableAgents(cwd).map((agent) => {
-		const entry = config[agent.name];
-		const model = entry?.model ?? "inherit";
-		const thinking = entry?.thinking ?? "inherit";
-		return `${sanitizeTerminalText(agent.name)}: model=${sanitizeTerminalText(model)}, effort=${sanitizeTerminalText(thinking)}`;
+	return modelAssignmentNames(cwd).map((name) => {
+		const entry = config[name];
+		const model = entry?.model ?? routingDefaultLabel(name, "model");
+		const thinking = entry?.thinking ?? routingDefaultLabel(name, "effort");
+		return `${sanitizeTerminalText(name)}: model=${sanitizeTerminalText(model)}, effort=${sanitizeTerminalText(thinking)}`;
 	});
 }
 
@@ -2872,7 +2901,7 @@ class SddModelPanel implements OverlayComponent {
 		lines.push("");
 		lines.push(
 			line(
-				"j/k scroll • enter model/save • e effort • i inherit • c custom • x export • r restore • ctrl+s save • esc back",
+				`j/k scroll • enter model/save • e effort • i ${isProviderReviewRole(this.rows[this.cursor] ?? "") ? "Pi persisted defaults" : "inherit"} • c custom • x export • r restore • ctrl+s save • esc back`,
 				"muted",
 			),
 		);
@@ -2904,7 +2933,9 @@ class SddModelPanel implements OverlayComponent {
 			const focused = i === this.modelCursor;
 			lines.push(
 				`${this.renderCursor(focused)} ${this.renderText(
-					options[i] ?? "",
+					options[i] === INHERIT_MODEL && isProviderReviewRole(this.selectedRow)
+						? routingDefaultLabel(this.selectedRow, "model")
+						: (options[i] ?? ""),
 					focused ? "status" : "text",
 				)}`,
 			);
@@ -2956,7 +2987,9 @@ class SddModelPanel implements OverlayComponent {
 			const focused = i === this.effortCursor;
 			lines.push(
 				`${this.renderCursor(focused)} ${this.renderText(
-					THINKING_OPTIONS[i] ?? "",
+					THINKING_OPTIONS[i] === INHERIT_THINKING && isProviderReviewRole(this.selectedRow)
+						? routingDefaultLabel(this.selectedRow, "effort")
+						: (THINKING_OPTIONS[i] ?? ""),
 					focused ? "status" : "text",
 				)}`,
 			);
@@ -2969,10 +3002,10 @@ class SddModelPanel implements OverlayComponent {
 	private renderSetAllLabel(row: string): string {
 		const models = this.rows
 			.slice(1)
-			.map((name) => this.draft[name]?.model ?? "inherit");
+			.map((name) => this.draft[name]?.model ?? routingDefaultLabel(name, "model"));
 		const efforts = this.rows
 			.slice(1)
-			.map((name) => this.draft[name]?.thinking ?? "inherit");
+			.map((name) => this.draft[name]?.thinking ?? routingDefaultLabel(name, "effort"));
 		const firstModel = models[0] ?? "inherit";
 		const firstEffort = efforts[0] ?? "inherit";
 		const modelLabel = models.every((value) => value === firstModel)
@@ -2988,8 +3021,8 @@ class SddModelPanel implements OverlayComponent {
 	}
 
 	private renderAgentLabel(row: string): string {
-		const model = this.draft[row]?.model ?? "inherit";
-		const effort = this.draft[row]?.thinking ?? "inherit";
+		const model = this.draft[row]?.model ?? routingDefaultLabel(row, "model");
+		const effort = this.draft[row]?.thinking ?? routingDefaultLabel(row, "effort");
 		return `${this.renderText(sanitizeTerminalText(row).padEnd(20), "text")} ${this.renderText("model=", "muted")}${this.renderText(model, "status")}${this.renderText(
 			", effort=",
 			"muted",
@@ -3014,7 +3047,7 @@ async function showSddModelPanel(
 	config: AgentModelConfig,
 ): Promise<ModelPanelResult> {
 	const modelOptions = await getPiModelOptions(ctx);
-	const agents = listDiscoverableAgents(ctx.cwd).map((agent) => agent.name);
+	const agents = modelAssignmentNames(ctx.cwd);
 	return ctx.ui.custom<ModelPanelResult>(
 		(_tui, theme, _keybindings, done) =>
 			new SddModelPanel(config, modelOptions, agents, done, theme),
@@ -3115,9 +3148,9 @@ async function handleModelsCommand(ctx: ExtensionContext): Promise<void> {
 			}
 			if (result.agent === "all") {
 				const next: AgentModelConfig = { ...config };
-				for (const agent of listDiscoverableAgents(ctx.cwd)) {
-					next[agent.name] = {
-						...(next[agent.name] ?? {}),
+				for (const name of modelAssignmentNames(ctx.cwd)) {
+					next[name] = {
+						...(next[name] ?? {}),
 						model,
 					};
 				}

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -12,7 +12,7 @@ import type {
 	Theme,
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
-import { __testing, applyModelConfig, createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import { __testing, applyModelConfig, applyModelConfigAsync, createGentleAiExtension } from "../extensions/gentle-ai.ts";
 import { NATIVE_REVIEW_ERROR_CODE, NativeReviewCliError, type NativeReviewCli } from "../lib/native-review-cli.ts";
 import { CandidateViewError, type CandidateViewRegistry } from "../lib/review-candidate-view.ts";
 import { installPackageAssets } from "../lib/sdd-preflight.ts";
@@ -204,7 +204,12 @@ test("registered Gentle Review tools preserve result envelopes and redact collap
 	}
 });
 
-function routingConsumerFixture(t: test.TestContext) {
+interface RoutingConsumerPanel {
+	render(width: number): string[];
+	handleInput(data: string): void;
+}
+
+function routingConsumerFixture(t: test.TestContext, agents = ["worker"]) {
 	const root = mkdtempSync(join(tmpdir(), "gentle-pi-routing-consumers-"));
 	const configHome = join(root, "global");
 	const agentHome = join(root, "agent-home");
@@ -214,9 +219,19 @@ function routingConsumerFixture(t: test.TestContext) {
 	for (const dir of [dirname(projectPath), join(root, "agents"), join(agentHome, "agents"), join(agentHome, "subagents")]) {
 		mkdirSync(dir, { recursive: true });
 	}
-	writeMarkdown(join(root, ".pi", "agents", "worker.md"), "---\nname: worker\ndescription: Worker\n---\nbody\n");
+	for (const name of agents) {
+		writeMarkdown(join(root, ".pi", "agents", `${name}.md`), `---\nname: ${name}\ndescription: Worker\n---\nbody\n`);
+	}
 	const previousConfigHome = process.env.GENTLE_PI_CONFIG_HOME;
 	const previousAgentHome = process.env.GENTLE_PI_AGENT_HOME;
+	const previousHome = process.env.HOME;
+	const previousUserProfile = process.env.USERPROFILE;
+	const isolatedHome = join(root, "home");
+	mkdirSync(isolatedHome, { recursive: true });
+	// Isolate homedir-based discovery on POSIX and Windows.
+	// Package-sibling legacy agents remain subject to discovery assertions.
+	process.env.HOME = isolatedHome;
+	process.env.USERPROFILE = isolatedHome;
 	process.env.GENTLE_PI_CONFIG_HOME = configHome;
 	process.env.GENTLE_PI_AGENT_HOME = agentHome;
 	t.after(() => {
@@ -224,6 +239,10 @@ function routingConsumerFixture(t: test.TestContext) {
 		else process.env.GENTLE_PI_CONFIG_HOME = previousConfigHome;
 		if (previousAgentHome === undefined) delete process.env.GENTLE_PI_AGENT_HOME;
 		else process.env.GENTLE_PI_AGENT_HOME = previousAgentHome;
+		if (previousHome === undefined) delete process.env.HOME;
+		else process.env.HOME = previousHome;
+		if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = previousUserProfile;
 		rmSync(root, { recursive: true, force: true });
 	});
 	const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
@@ -236,26 +255,158 @@ function routingConsumerFixture(t: test.TestContext) {
 	let panelVisits = 0;
 	const panels: string[] = [];
 	let onPanel = () => ({ type: "cancel", config: {} });
+	let onInput: ((panel: RoutingConsumerPanel) => void) | undefined;
 	const ctx = {
 		cwd: root,
 		hasUI: true,
-		modelRegistry: { getAvailable: async () => [] },
+		modelRegistry: { getAvailable: async () => [
+			{ provider: "openai", id: "alpha" },
+			{ provider: "openai", id: "beta" },
+		] },
 		ui: {
 			notify(message: string, severity: string) { notifications.push({ message, severity }); },
-			custom: async (factory: (tui: unknown, theme: Theme, keybindings: unknown, done: () => void) => { render(width: number): string[] }) => {
-				panels.push(stripAnsi(renderComponent(factory(undefined, { fg: (_color: string, text: string) => text } as unknown as Theme, undefined, () => {}))));
+			custom: async (factory: (tui: unknown, theme: Theme, keybindings: unknown, done: (result: unknown) => void) => RoutingConsumerPanel) => {
+				let result: unknown;
+				const panel = factory(undefined, { fg: (_color: string, text: string) => text } as unknown as Theme, undefined, (value) => { result = value; });
+				panels.push(stripAnsi(renderComponent(panel)));
 				panelVisits += 1;
+				if (onInput) {
+					onInput(panel);
+					assert.notEqual(result, undefined, "panel input must finish the interaction");
+					return result;
+				}
 				return onPanel();
 			},
 		},
 	} as unknown as Parameters<Parameters<ExtensionAPI["registerCommand"]>[1]["handler"]>[1];
 	return {
-		configHome, projectPath, globalPath, exportPath, notifications, panels,
+		root, agentHome, configHome, projectPath, globalPath, exportPath, notifications, panels,
 		panelVisits: () => panelVisits,
 		onPanel(action: typeof onPanel) { onPanel = action; },
+		onInput(action: (panel: RoutingConsumerPanel) => void) { onInput = action; },
 		run: (name: string) => commands.get(name)!.handler("", ctx),
 	};
 }
+
+test("models saves and clears independent provider review roles without local artifacts", async (t) => {
+	const fixture = routingConsumerFixture(t, []);
+	const roles = ["review-refuter", "review-validator"];
+	assert.deepEqual(
+		__testing.listDiscoverableAgents(fixture.root).map((agent) => agent.name),
+		[],
+		"requires zero discovered agents; check package-sibling legacy agent directories",
+	);
+
+	const assertNoLocalArtifacts = () => {
+		for (const base of [join(fixture.root, ".pi"), fixture.agentHome]) {
+			assert.equal(existsSync(join(base, "subagents.json")), false);
+			for (const dir of ["agents", "subagents"]) {
+				for (const role of roles) {
+					assert.equal(existsSync(join(base, dir, `${role}.md`)), false);
+				}
+			}
+		}
+	};
+	fixture.onInput((panel) => {
+		const initial = renderComponent(panel);
+		for (const role of roles) {
+			assert.equal(initial.split(role).length - 1, 1);
+		}
+		assert.match(initial, /Pi persisted default model/);
+		assert.match(initial, /Pi persisted default effort/);
+		for (const [index, model] of ["alpha", "beta"].entries()) {
+			panel.handleInput("j");
+			panel.handleInput("\r");
+			assert.match(renderComponent(panel), /Pi persisted default model/);
+			assert.doesNotMatch(renderComponent(panel), /Inherit active\/default model/);
+			for (const character of model) panel.handleInput(character);
+			panel.handleInput("\r");
+			panel.handleInput("e");
+			assert.match(renderComponent(panel), /Pi persisted default effort/);
+			assert.doesNotMatch(renderComponent(panel), /Inherit effort/);
+			for (let step = 0; step <= index; step++) panel.handleInput("j");
+			panel.handleInput("\r");
+		}
+		panel.handleInput("\x13");
+	});
+	await fixture.run("gentle:models");
+	assert.deepEqual(JSON.parse(readFileSync(fixture.globalPath, "utf8")), {
+		"review-refuter": { model: "openai/alpha", thinking: "off" },
+		"review-validator": { model: "openai/beta", thinking: "minimal" },
+	});
+	assertNoLocalArtifacts();
+
+	fixture.onInput((panel) => {
+		panel.handleInput("j");
+		panel.handleInput("i");
+		panel.handleInput("\x13");
+	});
+	await fixture.run("gentle:models");
+	assert.deepEqual(JSON.parse(readFileSync(fixture.globalPath, "utf8")), {
+		"review-refuter": {},
+		"review-validator": { model: "openai/beta", thinking: "minimal" },
+	});
+	assertNoLocalArtifacts();
+
+	fixture.onInput((panel) => {
+		panel.handleInput("j");
+		panel.handleInput("j");
+		panel.handleInput("i");
+		panel.handleInput("\x13");
+	});
+	await fixture.run("gentle:models");
+	assert.deepEqual(JSON.parse(readFileSync(fixture.globalPath, "utf8")), {
+		"review-refuter": {},
+		"review-validator": {},
+	});
+	assertNoLocalArtifacts();
+});
+
+test("provider review roles skip migration and both projection paths even when discoverable", async (t) => {
+	const roles = ["review-refuter", "review-validator"];
+	const fixture = routingConsumerFixture(t, [...roles, "worker"]);
+	assert.deepEqual(
+		__testing.listDiscoverableAgents(fixture.root).map((agent) => agent.name).sort(),
+		[...roles, "worker"].sort(),
+		"requires only seeded agents; check package-sibling legacy agent directories",
+	);
+
+	const rolePaths = roles.map((role) => join(fixture.root, ".pi", "agents", `${role}.md`));
+	const originals = rolePaths.map((path) => readFileSync(path, "utf8"));
+	const profilePaths = [
+		join(fixture.root, ".pi", "subagents.json"),
+		join(fixture.agentHome, "subagents.json"),
+	];
+	const profile = `${JSON.stringify({ model_profiles: {
+		"review-refuter": "existing-refuter",
+		"review-validator": "existing-validator",
+	} }, null, 2)}\n`;
+	for (const path of profilePaths) writeMarkdown(path, profile);
+	const assignments = {
+		"review-refuter": { model: "openai/alpha", thinking: "off" as const },
+		"review-validator": { model: "openai/beta", thinking: "minimal" as const },
+	};
+	writeMarkdown(join(fixture.root, ".pi", "settings.json"), JSON.stringify({
+		subagents: { agentOverrides: assignments },
+	}));
+	const assertReservedUnchanged = () => {
+		rolePaths.forEach((path, index) => assert.equal(readFileSync(path, "utf8"), originals[index]));
+		for (const path of profilePaths) assert.equal(readFileSync(path, "utf8"), profile);
+	};
+	await fixture.run("gentle:models");
+	assertReservedUnchanged();
+	for (const role of roles) assert.equal(fixture.panels[0].split(role).length - 1, 1);
+	assert.match(fixture.panels[0], /worker\s+model=inherit, effort=inherit/);
+	for (const apply of [applyModelConfig, applyModelConfigAsync]) {
+		await apply(fixture.root, assignments);
+		assertReservedUnchanged();
+		await apply(fixture.root, { "review-refuter": {}, "review-validator": {} });
+		assertReservedUnchanged();
+	}
+	await applyModelConfigAsync(fixture.root, { worker: { model: "openai/alpha" } });
+	assert.match(readFileSync(join(fixture.root, ".pi", "agents", "worker.md"), "utf8"), /model: openai\/alpha/);
+	assert.ok(JSON.parse(readFileSync(profilePaths[0], "utf8")).model_profiles.worker);
+});
 
 test("models rejects invalid project routing with its selected source path", async (t) => {
 	const fixture = routingConsumerFixture(t);


### PR DESCRIPTION
## Linked Issue

Closes #890

Companion UI for https://github.com/Gentleman-Programming/gentle-ai/pull/4486. This PR is delivered first.

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Expose independent model and thinking controls for provider-owned `review-refuter` and `review-validator` in `/gentle:models`.
- Persist through the existing canonical `models.json`; clearing these roles means Pi persisted defaults, not active-session inheritance.
- Exclude reserved roles from local agent/profile projection and legacy migration, including undiscovered clear entries. Preserve ordinary-agent behavior.

## Changes

| File | Change |
|---|---|
| `extensions/gentle-ai.ts` | Reserved rows, role-specific default labels, projection/migration exclusions. |
| `tests/gentle-ai.test.ts` | Real panel input/serialization tests, independent clearing, preserved local artifacts, explicit discovery preconditions. |

Review size: **230 added/deleted lines across two files**.

## Test Plan

- [x] RED before implementation: two assertion failures for absent rows and unwanted legacy profile mutation.
- [x] Focused tests: 2 passed; expanded routing tests: 39 passed.
- [x] Full unit suite: 2,136 passed, 0 failed, 9 skipped.
- [x] Provider contract, runtime harness, syntax, and whitespace checks passed.
- [x] Native four-lens review approved and acknowledged for the exact committed tree.

Commands ran directly with Node, not through package-manager lifecycle execution:

```sh
node --experimental-strip-types --test tests/*.test.ts
node scripts/check-provider-contract.mjs
node --experimental-strip-types tests/runtime-harness.mjs
node --experimental-strip-types --check extensions/gentle-ai.ts
git diff --check
```

Organic interactive Pi/model execution was **not** performed. A first full-suite attempt had a dependency-layout incident and is excluded from successful evidence; final results above were reproduced with fresh, independently isolated dependencies. Home discovery is isolated in fixtures; unexpected package-sibling legacy agents fail an explicit precondition rather than silently contaminating the tests.

## Contributor Checklist

- [x] Linked approved issue; exactly one matching `type:*` label.
- [x] Conventional commit without co-author trailers.
- [x] No shell scripts or skills changed; shellcheck and skill-runtime testing are not applicable.
- [x] Updated in-panel help/default wording with the behavior change.
- [x] Automated UI coverage and unexecuted organic testing distinguished above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Provider review roles are now available as first-class model-routing targets.
  - These roles appear in the model settings panel and support bulk or custom model assignments.
  - Model settings now clearly indicate when provider review roles use the persisted default model and effort configuration.

- **Bug Fixes**
  - Saving or clearing provider review role settings now works without creating unintended local configuration artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->