### PR TITLE
fix(agents): reject a boolean-like tools scalar instead of turning it into a tool name

### DIFF
--- a/lib/agents-config.ts
+++ b/lib/agents-config.ts
@@ -171,10 +171,19 @@ function parseMode(value: unknown): AgentMode | undefined | string {
 	return AGENT_MODES.includes(normalized) ? (normalized as AgentMode) : `mode "${value}" is not one of ${AGENT_MODES.join(", ")}`;
 }
 
-function parseTools(value: FrontmatterValue | undefined): string[] {
+// YAML scalars that spell a boolean or null rather than a tool name. The
+// frontmatter parser keeps them as strings, so without this check
+// `tools: false` became a subagent allowlist containing a tool named "false".
+const NON_LIST_TOOL_SCALARS = new Set(["true", "false", "yes", "no", "on", "off", "null", "none", "~"]);
+
+function parseTools(value: FrontmatterValue | undefined): string[] | string {
 	if (value === undefined) return [];
 	const items = Array.isArray(value) ? value : value.split(",");
-	return items.map((item) => item.trim()).filter((item) => item.length > 0);
+	const tools = items.map((item) => item.trim()).filter((item) => item.length > 0);
+	if (!Array.isArray(value) && tools.length === 1 && NON_LIST_TOOL_SCALARS.has(tools[0].toLowerCase())) {
+		return `tools "${value}" is not a tool list; use "tools: []" or omit the key for no tools`;
+	}
+	return tools;
 }
 
 function scalar(value: FrontmatterValue | undefined): string | undefined {
@@ -187,6 +196,8 @@ export function parseAgentDefinition(text: string, filePath: string, scope: Agen
 	if (thinking !== undefined && !THINKING_LEVELS.includes(thinking)) return { filePath, error: thinking };
 	const mode = parseMode(scalar(data.subagent_mode) ?? scalar(data.mode));
 	if (mode !== undefined && !AGENT_MODES.includes(mode)) return { filePath, error: mode };
+	const tools = parseTools(data.tools);
+	if (typeof tools === "string") return { filePath, error: tools };
 	if (body.length === 0) return { filePath, error: "no instructions after the frontmatter" };
 	const name = scalar(data.name)?.trim() || basename(filePath).replace(/\.md$/i, "");
 	return {
@@ -198,7 +209,7 @@ export function parseAgentDefinition(text: string, filePath: string, scope: Agen
 		model: parseModelRef(data.model),
 		thinking: thinking as ThinkingLevel | undefined,
 		mode: mode as AgentMode | undefined,
-		tools: parseTools(data.tools),
+		tools,
 	};
 }
 

--- a/tests/agents-config.test.ts
+++ b/tests/agents-config.test.ts
@@ -77,6 +77,22 @@ test("parseAgentDefinition rejects unknown thinking levels, modes, and empty bod
 	assert.match((parseAgentDefinition("---\nname: a\n---\n   \n", "/a.md", "global") as { error: string }).error, /no instructions/);
 });
 
+test("parseAgentDefinition rejects a boolean-like tools scalar instead of making it a tool name", () => {
+	// `tools: false` is a natural way to write "no tools" in YAML; it must not
+	// become a subagent allowlist containing a tool named "false" (#895).
+	for (const value of ["false", "true", "no", "none", "null", "~", "Off"]) {
+		const result = parseAgentDefinition(`---\nname: a\ntools: ${value}\n---\nbody`, "/a.md", "global");
+		assert.ok("error" in result, `tools: ${value} should be rejected`);
+		assert.match(result.error, new RegExp(`tools "${value.replace("~", "~")}" is not a tool list`));
+		assert.match(result.error, /tools: \[\]/);
+	}
+	// Legitimate spellings still parse: a single tool, a csv, an empty inline list, and a missing key.
+	assert.deepEqual((parseAgentDefinition("---\nname: a\ntools: read\n---\nbody", "/a.md", "global") as { tools: string[] }).tools, ["read"]);
+	assert.deepEqual((parseAgentDefinition("---\nname: a\ntools: read, bash\n---\nbody", "/a.md", "global") as { tools: string[] }).tools, ["read", "bash"]);
+	assert.deepEqual((parseAgentDefinition("---\nname: a\ntools: []\n---\nbody", "/a.md", "global") as { tools: string[] }).tools, []);
+	assert.deepEqual((parseAgentDefinition("---\nname: a\n---\nbody", "/a.md", "global") as { tools: string[] }).tools, []);
+});
+
 test("discoverAgents merges the four directories with project over global and subagents over agents", () => {
 	const home = join(root, "home");
 	const cwd = join(root, "project");


### PR DESCRIPTION
Closes #895.

## Problem

`parseFrontmatter` keeps every scalar as a string and `parseTools` split it on commas, so an agent file with `tools: false` (a natural way to write "no tools" in YAML) produced a definition whose `tools` was `["false"]`. That token reached the child's tool allowlist as a nonexistent tool name, silently.

## Change

`parseTools` now recognises the YAML scalars that spell a boolean or null (`true`, `false`, `yes`, `no`, `on`, `off`, `null`, `none`, `~`, case-insensitive) when they arrive as the whole value and reports them through the existing `AgentDefinitionError` path, the same way unknown thinking levels and modes are rejected: `tools "false" is not a tool list; use "tools: []" or omit the key for no tools`. A real single tool name, a csv (`read, bash`), an inline list (`[]`, `[read]`), a block list, and a missing key parse exactly as before. Items inside an explicit list are not second-guessed.

## Tests

New case in `tests/agents-config.test.ts` covering each rejected spelling (including `Off`) and the four legitimate forms.

```
node --experimental-strip-types --test tests/agents-config.test.ts
ℹ tests 10  ℹ pass 10  ℹ fail 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Agent configurations now reject boolean- or null-like scalar values in the tools setting with a clear validation error recommending `tools: []`.
  - Valid single-tool, comma-separated, empty-list, and missing-tool configurations continue to parse as expected.
  - Invalid tool settings now produce a consistent configuration error without affecting valid agent definitions.

- **Tests**
  - Added coverage for invalid scalar tool values and existing valid parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->