### PR TITLE
feat(profiles): add named agent-model profiles with a live selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,9 @@ Store shape:
 }
 ```
 
-The `profiles` values use the same per-agent shape as `models.json`. Profile names are slugs of 1-64 characters (letters, numbers, `.`, `_`, `-`, starting with a letter or number). Export and import use a single-profile envelope (`kind: "gentle-pi.agent_model_profile"`, `version: 1`) at `~/.pi/gentle-ai/profiles.export.json`.
+The `profiles` values use the same per-agent shape as `models.json`. Profile names are slugs of 1-64 ASCII characters (letters, numbers, `.`, `_`, `-`, starting with a letter or number); names outside ASCII are rejected, as are the reserved object keys `__proto__`, `constructor`, and `prototype`. A rename or duplicate onto an existing name is refused, renaming the active profile keeps it active, and deleting the active profile is refused. Export and import use a single-profile envelope (`kind: "gentle-pi.agent_model_profile"`, `version: 1`) at `~/.pi/gentle-ai/profiles.export.json`.
+
+The store is replaced atomically through a sibling temp file and a rename, so an interrupted write cannot leave truncated JSON behind. Applying a profile writes `profiles.json` first and then materializes routing; if materialization fails, the previous active marker and the previous routing are restored, and anything that could not be restored is named in the warning.
 
 ## Gentle Shell
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ pi
 /gentle:sdd-preflight   Run or reuse the session SDD preflight explicitly.
 /gentle-sdd-init           Create or refresh openspec/config.yaml (openspec/both stores only).
 /gentle:models             Assign global model/effort routing to SDD/custom agents.
+/gentle:profiles           Create, switch, and manage global agent-model profiles.
 /gentle:persona            Switch between gentleman and neutral persona modes.
 /gentle:background-subagents  Show or set the managed background-subagents policy, with its deciding source.
 /gentle:review-mode          Show or set the receipt-driven development mode (status|enable|disable).
@@ -633,6 +634,59 @@ Config shape (per agent):
 
 Legacy string entries are still accepted and treated as `model`-only config.
 
+## Agent-model profiles
+
+```text
+/gentle:profiles
+```
+
+Profiles are named, switchable snapshots of the global agent-model routing from `/gentle:models`. The panel shows the profile list on the left and a detail pane comparing the selected profile's routing with the currently effective routing. Keys:
+
+| Key     | Action                                                                 |
+| ------- | ---------------------------------------------------------------------- |
+| `enter` | Apply the selected profile live (writes `models.json`, reconciles agents). |
+| `c`     | Create a new, empty profile.                                           |
+| `s`     | Update the selected profile from the current routing.                  |
+| `d`     | Duplicate the selected profile.                                        |
+| `r`     | Rename the selected profile (keeps it active if it was active).        |
+| `x`     | Delete the selected profile (refuses the active profile).              |
+| `e`     | Export the selected profile to `~/.pi/gentle-ai/profiles.export.json`. |
+| `i`     | Import a profile from `~/.pi/gentle-ai/profiles.export.json`.          |
+| `esc`   | Close.                                                                 |
+
+Applying a profile writes `~/.pi/gentle-ai/models.json`, then reconciles agent frontmatter and `subagents.json` the same way `/gentle:models` does. The reconciliation happens on the next subagent launch, and that launch still routes with the previous routing — expect one launch of lag after switching. The active profile is persisted so `/gentle:profiles` reopens with the applied profile marked.
+
+Profiles only cover per-agent routing for SDD/custom agents. The orchestrator model selected in `settings.json` is NOT part of a profile and is never changed by applying one.
+
+When `profiles.json` is missing, the command seeds one profile named `current` captured from the existing `models.json`, marked active only when `models.json` has routing entries. Profiles or routing entries dropped by normalization are named in a warning instead of being lost silently.
+
+Saved globally at:
+
+```text
+~/.pi/gentle-ai/profiles.json
+```
+
+Store shape:
+
+```json
+{
+  "kind": "gentle-pi.agent_model_profiles",
+  "version": 1,
+  "active": "deep-work",
+  "profiles": {
+    "deep-work": {
+      "sdd-design": {
+        "model": "anthropic/claude-sonnet-4",
+        "thinking": "high"
+      }
+    },
+    "current": {}
+  }
+}
+```
+
+The `profiles` values use the same per-agent shape as `models.json`. Profile names are slugs of 1-64 characters (letters, numbers, `.`, `_`, `-`, starting with a letter or number). Export and import use a single-profile envelope (`kind: "gentle-pi.agent_model_profile"`, `version: 1`) at `~/.pi/gentle-ai/profiles.export.json`.
+
 ## Gentle Shell
 
 Gentle Shell is the visual layer gentle-pi puts on top of pi. It follows the Gentle themes: one border language, champagne titles, rose for whatever is alive.
@@ -773,6 +827,7 @@ Set `GENTLE_PI_SHELL=0` to keep pi's built-in footer and editor.
 | `/gentle:doctor`              | Runs read-only diagnostics for SDD assets, model/persona config, memory tools, and safety guards. |
 | `/gentle:sdd-preflight`          | Runs or reuses the lazy SDD preflight for this Pi session.          |
 | `/gentle:models`                 | Opens global model + effort assignment UI. Press `x` to export and `r` to restore saved routing. |
+| `/gentle:profiles`               | Opens global agent-model profiles: apply live, create, update, duplicate, rename, delete, export, and import. |
 | `/gentle:persona`                | Switches global persona mode, with project override support.        |
 | `/gentle:background-subagents`   | Shows or sets the managed background-subagents policy (`status\|enable\|disable`), naming the source that decided it. |
 | `/gentle:telemetry`              | Shows or changes the local Gentle AI telemetry trigger (`status\|enable\|disable\|preview`).  |

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -32,7 +32,7 @@ import type {
 	ThemeColor,
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
-import { matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
+import { isKeyRelease, matchesKey, truncateToWidth, type KeybindingsManager, type TuiMouseEvent, type TuiMouseEventResult } from "@earendil-works/pi-tui";
 import { resolveGentlePiAgentHome } from "../lib/agent-home.ts";
 import {
 	ensureSddPreflight,
@@ -61,6 +61,30 @@ import {
 	type ModelConfigFileResult,
 	type ThinkingLevel,
 } from "../lib/model-routing-authority.ts";
+import {
+	bootstrapProfilesFile,
+	buildProfileListItems,
+	createProfile,
+	deleteProfile,
+	duplicateProfile,
+	formatProfileSummaryLines,
+	parseProfileExportTextWithDrops,
+	profileExportPath,
+	profilesFilePath,
+	readProfilesFileResult,
+	renameProfile,
+	serializeProfileExport,
+	setActiveProfile,
+	summarizeProfile,
+	updateProfile,
+	writeProfilesFileSync,
+	type AgentProfilesFile,
+	type ProfileListItem,
+	type ProfilesParseDrops,
+} from "../lib/agent-profiles.ts";
+import { measureAgentsViewLayout, type AgentsViewLayout } from "../lib/agents-view-layout.ts";
+import { NativeChoiceList } from "../lib/native-choice-list.ts";
+import { createNativeFullscreenInteraction } from "../lib/native-fullscreen-interaction.ts";
 import {
 	parseSddStatusCommandArgs,
 	renderNativeSddPhasePrompt,
@@ -3075,6 +3099,477 @@ async function handleModelsCommand(ctx: ExtensionContext): Promise<void> {
 		].join("\n"),
 		"info",
 	);
+}
+
+type ProfilesPanelResult =
+	| { type: "apply"; name: string }
+	| { type: "create" }
+	| { type: "update"; name: string }
+	| { type: "duplicate"; name: string }
+	| { type: "rename"; name: string }
+	| { type: "delete"; name: string }
+	| { type: "export"; name: string }
+	| { type: "import" }
+	| { type: "close" };
+
+const PROFILES_PANEL_MIN_BODY_ROWS = 6;
+
+type ProfilesPanelPointerLayout = AgentsViewLayout & { listTop: number };
+
+function hasOwnProfile(profiles: Record<string, unknown>, name: string): boolean {
+	return Object.prototype.hasOwnProperty.call(profiles, name);
+}
+
+function profilesErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+// Left profile list, right detail panes. Rendering and pointer routing share
+// one measured layout; the list rows keep native keyboard, hover, press,
+// click, and wheel handling through NativeChoiceList.
+class ProfilesPanel implements OverlayComponent {
+	private completed = false;
+	private pointerLayout: ProfilesPanelPointerLayout | undefined;
+	readonly list: NativeChoiceList<ProfileListItem>;
+	private readonly file: AgentProfilesFile;
+	private readonly currentConfig: AgentModelConfig;
+	private readonly done: (result: ProfilesPanelResult) => void;
+	private readonly theme: Theme | undefined;
+
+	constructor(
+		file: AgentProfilesFile,
+		currentConfig: AgentModelConfig,
+		done: (result: ProfilesPanelResult) => void,
+		keybindings: KeybindingsManager | undefined,
+		theme: Theme | undefined,
+		selectedName?: string,
+	) {
+		this.file = file;
+		this.currentConfig = currentConfig;
+		this.done = done;
+		this.theme = theme;
+		const items = buildProfileListItems(file);
+		this.list = new NativeChoiceList<ProfileListItem>(
+			items,
+			{
+				selectedPrefix: (text) => this.renderText(text, "accent"),
+				selectedText: (text) => this.renderText(text, "accent"),
+				description: (text) => this.renderText(text, "muted"),
+				hoverBackground: (text) => (this.theme ? this.theme.bg("toolPendingBg", text) : text),
+			},
+			keybindings,
+		);
+		this.list.onSelect = (item) => this.finish({ type: "apply", name: item.id });
+		this.list.onCancel = () => this.finish({ type: "close" });
+		const selected = selectedName ? items.findIndex((item) => item.id === selectedName) : -1;
+		if (selected >= 0) this.list.setSelectedIndex(selected);
+	}
+
+	invalidate(): void {
+		this.pointerLayout = undefined;
+		this.list.invalidate();
+	}
+
+	handleInput(data: string): void {
+		if (isKeyRelease(data)) return;
+		if (matchesKey(data, "ctrl+c") || matchesKey(data, "escape")) {
+			this.finish({ type: "close" });
+			return;
+		}
+		const name = this.list.getSelectedItem()?.id;
+		if (data === "c") return this.finish({ type: "create" });
+		if (data === "i") return this.finish({ type: "import" });
+		if (!name) return this.list.handleInput(data);
+		if (data === "s") return this.finish({ type: "update", name });
+		if (data === "d") return this.finish({ type: "duplicate", name });
+		if (data === "r") return this.finish({ type: "rename", name });
+		if (data === "x") return this.finish({ type: "delete", name });
+		if (data === "e") return this.finish({ type: "export", name });
+		this.list.handleInput(data);
+	}
+
+	handleMouse(event: TuiMouseEvent): TuiMouseEventResult | undefined {
+		const layout = this.pointerLayout;
+		if (!layout) return undefined;
+		if (event.y < layout.listTop || event.y >= layout.listTop + layout.bodyRows) return undefined;
+		if (event.x < layout.listX || event.x >= layout.listX + layout.listWidth) return undefined;
+		return this.list.handleMouse({
+			...event,
+			x: event.x - layout.listX,
+			y: event.y - layout.listTop,
+			width: layout.listWidth,
+			height: layout.bodyRows,
+		});
+	}
+
+	render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const listWidth = measureAgentsViewLayout(safeWidth, PROFILES_PANEL_MIN_BODY_ROWS + 3).listWidth;
+		const listLines = this.list.render(listWidth);
+		const bodyRows = Math.max(PROFILES_PANEL_MIN_BODY_ROWS, listLines.length);
+		const layout = measureAgentsViewLayout(safeWidth, bodyRows + 3);
+		if (layout.mode === "fallback" || layout.width === 0) {
+			this.pointerLayout = undefined;
+			return [];
+		}
+		this.pointerLayout = { ...layout, listTop: 1 };
+		const detailLines = this.renderDetailLines(layout.threadWidth, layout.mode === "panes");
+		const rule = "─".repeat(Math.max(0, layout.width - 2));
+		const lines: string[] = [this.renderText(`╭${rule}╮`, "border")];
+		for (let row = 0; row < layout.bodyRows; row += 1) {
+			lines.push(this.renderBodyRow(row, layout, listLines, detailLines));
+		}
+		lines.push(this.renderFooterRow(layout.width));
+		lines.push(this.renderText(`╰${rule}╯`, "border"));
+		return lines;
+	}
+
+	private finish(result: ProfilesPanelResult): void {
+		if (this.completed) return;
+		this.completed = true;
+		this.list.setDisabled(true);
+		this.done(result);
+	}
+
+	private renderBodyRow(
+		row: number,
+		layout: AgentsViewLayout,
+		listLines: string[],
+		detailLines: string[],
+	): string {
+		if (layout.mode === "panes") {
+			return [
+				this.renderText("│", "border"),
+				" ",
+				this.fitPaneLine(listLines[row] ?? "", layout.listWidth),
+				" ",
+				this.renderText("│", "border"),
+				" ",
+				this.fitPaneLine(detailLines[row] ?? "", layout.threadWidth),
+				this.renderText("│", "border"),
+			].join("");
+		}
+		return [
+			this.renderText("│", "border"),
+			" ",
+			this.fitPaneLine(listLines[row] ?? "", layout.listWidth),
+			" ",
+			this.renderText("│", "border"),
+		].join("");
+	}
+
+	private renderFooterRow(width: number): string {
+		const hints =
+			"enter apply · c create · s update · d duplicate · r rename · x delete · e export · i import · esc close";
+		return [
+			this.renderText("│", "border"),
+			" ",
+			this.fitPaneLine(this.renderText(hints, "muted"), width - 4),
+			" ",
+			this.renderText("│", "border"),
+		].join("");
+	}
+
+	private renderDetailLines(width: number, showDetail: boolean): string[] {
+		if (!showDetail) return [];
+		const name = this.list.getSelectedItem()?.id;
+		if (!name || !hasOwnProfile(this.file.profiles, name)) {
+			return [this.renderLine("No profile selected.", width, "muted")];
+		}
+		const config = this.file.profiles[name];
+		return [
+			this.renderLine(name === this.file.active ? `${name} (active)` : name, width, "title"),
+			"",
+			this.renderLine("Profile routing", width, "accent"),
+			...this.indentLines(formatProfileSummaryLines(summarizeProfile(config)), width),
+			"",
+			this.renderLine("Current routing (models.json)", width, "accent"),
+			...this.indentLines(formatProfileSummaryLines(summarizeProfile(this.currentConfig)), width),
+		];
+	}
+
+	private indentLines(lines: string[], width: number): string[] {
+		return lines.map((line) => this.renderLine(`  ${line}`, width, "text"));
+	}
+
+	private fitPaneLine(line: string, width: number): string {
+		const visible = stripAnsi(line);
+		if (visible.length > width) {
+			return truncateToWidth(visible, Math.max(1, width), "…", true);
+		}
+		return `${line}${" ".repeat(Math.max(0, width - visible.length))}`;
+	}
+
+	private renderLine(text: string, width: number, tone?: PanelTone): string {
+		const safe = truncateToWidth(
+			sanitizeTerminalText(text),
+			Math.max(1, width),
+			"…",
+			true,
+		);
+		return tone ? this.renderText(safe, tone) : safe;
+	}
+
+	private renderText(text: string, tone: PanelTone): string {
+		const safe = sanitizeTerminalText(text);
+		if (!this.theme) return safe;
+		return this.theme.fg(PANEL_TONE_COLOR[tone], safe);
+	}
+}
+
+async function showProfilesPanel(
+	ctx: ExtensionContext,
+	file: AgentProfilesFile,
+	currentConfig: AgentModelConfig,
+	selectedName?: string,
+): Promise<ProfilesPanelResult> {
+	return ctx.ui.custom<ProfilesPanelResult>(
+		(tui, theme, keybindings, done) => {
+			const panel = new ProfilesPanel(file, currentConfig, done, keybindings, theme, selectedName);
+			const container = createNativeFullscreenInteraction({
+				keyboardTarget: panel,
+				requestRender: () => tui.requestRender(),
+				mouseObserver: panel.list.createMouseObserver(() => tui.requestRender()),
+			});
+			container.addChild(panel);
+			return container;
+		},
+		{
+			overlay: true,
+			overlayOptions: {
+				anchor: "center",
+				width: "70%",
+				minWidth: 72,
+				maxHeight: "85%",
+			},
+		},
+	);
+}
+
+function reportProfilesDrops(ctx: ExtensionContext, path: string, drops: ProfilesParseDrops): void {
+	const parts: string[] = [];
+	if (drops.droppedProfiles.length > 0) parts.push(`profiles: ${drops.droppedProfiles.join(", ")}`);
+	if (drops.droppedAgents.length > 0) {
+		parts.push(
+			`routing entries: ${drops.droppedAgents.map(({ profile, agent }) => `${profile}/${agent}`).join(", ")}`,
+		);
+	}
+	if (parts.length > 0) {
+		ctx.ui.notify(
+			`el Gentleman dropped invalid entries while loading ${path} — ${parts.join("; ")}.`,
+			"warning",
+		);
+	}
+}
+
+async function runProfilesPanelAction(
+	ctx: ExtensionContext,
+	path: string,
+	file: AgentProfilesFile,
+	result: Exclude<ProfilesPanelResult, { type: "close" }>,
+): Promise<AgentProfilesFile> {
+	switch (result.type) {
+		case "apply": {
+			if (!hasOwnProfile(file.profiles, result.name)) return file;
+			const normalized = normalizeModelConfig(file.profiles[result.name]) ?? {};
+			try {
+				await writeModelConfigAsync(ctx.cwd, normalized);
+			} catch (error) {
+				ctx.ui.notify(
+					`el Gentleman could not write ${modelConfigPath(ctx.cwd)}: ${profilesErrorMessage(error)}`,
+					"warning",
+				);
+				return file;
+			}
+			const applyResult = await applySavedModelConfig(ctx);
+			if (applyResult.invalidPath) {
+				ctx.ui.notify(
+					`el Gentleman applied profile "${result.name}" to ${modelConfigPath(ctx.cwd)}, but agent reconciliation failed because ${applyResult.invalidPath} is invalid.`,
+					"warning",
+				);
+				return file;
+			}
+			const next = setActiveProfile(file, result.name);
+			try {
+				writeProfilesFileSync(path, next);
+			} catch (error) {
+				ctx.ui.notify(
+					`el Gentleman applied profile "${result.name}", but could not update ${path}: ${profilesErrorMessage(error)}`,
+					"warning",
+				);
+				return next;
+			}
+			ctx.ui.notify(
+				[
+					`el Gentleman applied profile "${result.name}" — ${applyResult.updated} agent${applyResult.updated === 1 ? "" : "s"} updated.`,
+					"New routing takes effect on the next subagent launch.",
+				].join("\n"),
+				"info",
+			);
+			return next;
+		}
+		case "create": {
+			const name = await ctx.ui.input("New profile name", "e.g. deep-work");
+			if (name === undefined) return file;
+			try {
+				const next = createProfile(file, name.trim(), {});
+				writeProfilesFileSync(path, next);
+				return next;
+			} catch (error) {
+				ctx.ui.notify(`Profile not created: ${profilesErrorMessage(error)}`, "warning");
+				return file;
+			}
+		}
+		case "update": {
+			const current = await readModelConfigAsync(ctx.cwd);
+			try {
+				const next = updateProfile(file, result.name, cloneModelConfig(current));
+				writeProfilesFileSync(path, next);
+				ctx.ui.notify(
+					`el Gentleman updated profile "${result.name}" from the current routing in ${modelConfigPath(ctx.cwd)}.`,
+					"info",
+				);
+				return next;
+			} catch (error) {
+				ctx.ui.notify(`Profile not updated: ${profilesErrorMessage(error)}`, "warning");
+				return file;
+			}
+		}
+		case "duplicate": {
+			const name = await ctx.ui.input(`Duplicate profile "${result.name}" as`, `${result.name}-copy`);
+			if (name === undefined) return file;
+			try {
+				const next = duplicateProfile(file, result.name, name.trim());
+				writeProfilesFileSync(path, next);
+				return next;
+			} catch (error) {
+				ctx.ui.notify(`Profile not duplicated: ${profilesErrorMessage(error)}`, "warning");
+				return file;
+			}
+		}
+		case "rename": {
+			const name = await ctx.ui.input(`Rename profile "${result.name}" to`, result.name);
+			if (name === undefined) return file;
+			try {
+				const next = renameProfile(file, result.name, name.trim());
+				writeProfilesFileSync(path, next);
+				return next;
+			} catch (error) {
+				ctx.ui.notify(`Profile not renamed: ${profilesErrorMessage(error)}`, "warning");
+				return file;
+			}
+		}
+		case "delete": {
+			const approved = await ctx.ui.confirm(
+				"Delete profile?",
+				`Delete profile "${result.name}" from ${path}? The routing in ${modelConfigPath(ctx.cwd)} is not changed.`,
+			);
+			if (!approved) return file;
+			try {
+				const next = deleteProfile(file, result.name);
+				writeProfilesFileSync(path, next);
+				return next;
+			} catch (error) {
+				ctx.ui.notify(`Profile not deleted: ${profilesErrorMessage(error)}`, "warning");
+				return file;
+			}
+		}
+		case "export": {
+			if (!hasOwnProfile(file.profiles, result.name)) return file;
+			const exportPath = profileExportPath(gentleAiConfigHome());
+			try {
+				const text = serializeProfileExport(result.name, file.profiles[result.name]);
+				await mkdir(dirname(exportPath), { recursive: true });
+				await writeFile(exportPath, text);
+				ctx.ui.notify(`el Gentleman exported profile "${result.name}" to ${exportPath}.`, "info");
+			} catch (error) {
+				ctx.ui.notify(`Profile export failed: ${profilesErrorMessage(error)}`, "warning");
+			}
+			return file;
+		}
+		case "import": {
+			const importPath = profileExportPath(gentleAiConfigHome());
+			let text: string;
+			try {
+				text = await readFile(importPath, "utf8");
+			} catch {
+				ctx.ui.notify(`Profile import failed: ${importPath} is missing or unreadable.`, "warning");
+				return file;
+			}
+			const parsed = parseProfileExportTextWithDrops(text);
+			if (!parsed) {
+				ctx.ui.notify(
+					`Profile import failed: ${importPath} is not a valid agent-model profile export.`,
+					"warning",
+				);
+				return file;
+			}
+			if (parsed.droppedAgents.length > 0) {
+				ctx.ui.notify(
+					`el Gentleman dropped invalid routing entries while importing profile "${parsed.name}": ${parsed.droppedAgents.join(", ")}.`,
+					"warning",
+				);
+			}
+			if (hasOwnProfile(file.profiles, parsed.name)) {
+				const approved = await ctx.ui.confirm(
+					"Replace existing profile?",
+					`Profile "${parsed.name}" already exists in ${path}. Replace its routing with the import?`,
+				);
+				if (!approved) return file;
+			}
+			try {
+				const next = hasOwnProfile(file.profiles, parsed.name)
+					? updateProfile(file, parsed.name, parsed.config)
+					: createProfile(file, parsed.name, parsed.config);
+				writeProfilesFileSync(path, next);
+				const entries = Object.keys(parsed.config).length;
+				ctx.ui.notify(
+					`el Gentleman imported profile "${parsed.name}" (${entries} routing ${entries === 1 ? "entry" : "entries"}) from ${importPath}.`,
+					"info",
+				);
+				return next;
+			} catch (error) {
+				ctx.ui.notify(`Profile import failed: ${profilesErrorMessage(error)}`, "warning");
+				return file;
+			}
+		}
+	}
+}
+
+async function handleProfilesCommand(ctx: ExtensionContext): Promise<void> {
+	const path = profilesFilePath(gentleAiConfigHome());
+	const read = readProfilesFileResult(path);
+	if (read.status === "invalid") {
+		ctx.ui.notify(
+			`el Gentleman cannot open agent profiles because ${path} is invalid JSON or not a profiles file. Fix or remove the file, then run /gentle:profiles again.`,
+			"warning",
+		);
+		return;
+	}
+	let file: AgentProfilesFile;
+	if (read.status === "missing") {
+		file = bootstrapProfilesFile(await readModelConfigAsync(ctx.cwd));
+		try {
+			writeProfilesFileSync(path, file);
+		} catch (error) {
+			ctx.ui.notify(
+				`el Gentleman could not create ${path}: ${profilesErrorMessage(error)}`,
+				"warning",
+			);
+			return;
+		}
+		ctx.ui.notify(`el Gentleman seeded the "current" profile in ${path} from the saved model routing.`, "info");
+	} else {
+		file = read.file;
+		reportProfilesDrops(ctx, path, read.drops);
+	}
+	let selectedName: string | undefined;
+	let result = await showProfilesPanel(ctx, file, await readModelConfigAsync(ctx.cwd), selectedName);
+	while (result.type !== "close") {
+		selectedName = "name" in result ? result.name : undefined;
+		file = await runProfilesPanelAction(ctx, path, file, result);
+		result = await showProfilesPanel(ctx, file, await readModelConfigAsync(ctx.cwd), selectedName);
+	}
 }
 
 async function handlePersonaCommand(ctx: ExtensionContext): Promise<void> {
@@ -7615,6 +8110,13 @@ function createGentleAiExtensionForTesting(
 		description: "Configure global per-agent models for el Gentleman.",
 		handler: async (_args, ctx) => {
 			await handleModelsCommand(ctx);
+		},
+	});
+
+	pi.registerCommand("gentle:profiles", {
+		description: "Create, switch, and manage global agent-model profiles for el Gentleman.",
+		handler: async (_args, ctx) => {
+			await handleProfilesCommand(ctx);
 		},
 	});
 

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3447,16 +3447,24 @@ async function showProfilesPanel(
 }
 
 function reportProfilesDrops(ctx: ExtensionContext, path: string, drops: ProfilesParseDrops): void {
+	// Dropped names are by definition the ones that failed validation, so they are
+	// untrusted input reaching the terminal and must be sanitized like any other
+	// externally supplied text.
 	const parts: string[] = [];
-	if (drops.droppedProfiles.length > 0) parts.push(`profiles: ${drops.droppedProfiles.join(", ")}`);
+	if (drops.droppedProfiles.length > 0) {
+		parts.push(`profiles: ${drops.droppedProfiles.map((name) => sanitizeTerminalText(name)).join(", ")}`);
+	}
 	if (drops.droppedAgents.length > 0) {
 		parts.push(
-			`routing entries: ${drops.droppedAgents.map(({ profile, agent }) => `${profile}/${agent}`).join(", ")}`,
+			`routing entries: ${drops.droppedAgents.map(({ profile, agent }) => `${sanitizeTerminalText(profile)}/${sanitizeTerminalText(agent)}`).join(", ")}`,
 		);
+	}
+	if (drops.droppedActive !== undefined) {
+		parts.push(`active marker: ${sanitizeTerminalText(drops.droppedActive)}`);
 	}
 	if (parts.length > 0) {
 		ctx.ui.notify(
-			`el Gentleman dropped invalid entries while loading ${path} — ${parts.join("; ")}.`,
+			`el Gentleman dropped invalid entries while loading ${sanitizeTerminalText(path)} — ${parts.join("; ")}.`,
 			"warning",
 		);
 	}
@@ -3472,32 +3480,63 @@ async function runProfilesPanelAction(
 		case "apply": {
 			if (!hasOwnProfile(file.profiles, result.name)) return file;
 			const normalized = normalizeModelConfig(file.profiles[result.name]) ?? {};
+			// Applying spans two files and there is no cross-file rename, so order the
+			// writes to keep the store truthful and compensate on failure: claim the
+			// profile in the store first, then materialise routing. A claim that fails
+			// leaves routing untouched; anything that fails after the claim restores the
+			// previous claim and, when the previously active profile is known, the
+			// routing that profile implies.
+			const claimed = setActiveProfile(file, result.name);
+			try {
+				writeProfilesFileSync(path, claimed);
+			} catch (error) {
+				ctx.ui.notify(
+					`el Gentleman could not update ${sanitizeTerminalText(path)}: ${profilesErrorMessage(error)}`,
+					"warning",
+				);
+				return file;
+			}
+			const previousActiveConfig =
+				file.active !== undefined && hasOwnProfile(file.profiles, file.active)
+					? normalizeModelConfig(file.profiles[file.active]) ?? {}
+					: undefined;
+			const revertClaim = async (routingWritten: boolean): Promise<AgentProfilesFile> => {
+				let restored = previousActiveConfig === undefined ? "" : "routing";
+				if (routingWritten && previousActiveConfig !== undefined) {
+					try {
+						await writeModelConfigAsync(ctx.cwd, previousActiveConfig);
+					} catch {
+						restored = "";
+					}
+				}
+				try {
+					writeProfilesFileSync(path, file);
+					restored = restored === "" ? "active marker" : `${restored} and active marker`;
+				} catch {
+					restored = restored === "" ? "nothing" : restored;
+				}
+				const unresolved =
+					routingWritten && previousActiveConfig === undefined
+						? ` ${sanitizeTerminalText(modelConfigPath(ctx.cwd))} still holds this profile's routing because no previously active profile was recorded to restore.`
+						: "";
+				ctx.ui.notify(
+					`el Gentleman could not apply profile "${result.name}". Restored: ${restored}.${unresolved}`,
+					"warning",
+				);
+				return file;
+			};
 			try {
 				await writeModelConfigAsync(ctx.cwd, normalized);
 			} catch (error) {
 				ctx.ui.notify(
-					`el Gentleman could not write ${modelConfigPath(ctx.cwd)}: ${profilesErrorMessage(error)}`,
+					`el Gentleman could not write ${sanitizeTerminalText(modelConfigPath(ctx.cwd))}: ${profilesErrorMessage(error)}`,
 					"warning",
 				);
-				return file;
+				return revertClaim(false);
 			}
 			const applyResult = await applySavedModelConfig(ctx);
 			if (applyResult.invalidPath) {
-				ctx.ui.notify(
-					`el Gentleman applied profile "${result.name}" to ${modelConfigPath(ctx.cwd)}, but agent reconciliation failed because ${applyResult.invalidPath} is invalid.`,
-					"warning",
-				);
-				return file;
-			}
-			const next = setActiveProfile(file, result.name);
-			try {
-				writeProfilesFileSync(path, next);
-			} catch (error) {
-				ctx.ui.notify(
-					`el Gentleman applied profile "${result.name}", but could not update ${path}: ${profilesErrorMessage(error)}`,
-					"warning",
-				);
-				return next;
+				return revertClaim(true);
 			}
 			ctx.ui.notify(
 				[
@@ -3506,7 +3545,7 @@ async function runProfilesPanelAction(
 				].join("\n"),
 				"info",
 			);
-			return next;
+			return claimed;
 		}
 		case "create": {
 			const name = await ctx.ui.input("New profile name", "e.g. deep-work");

--- a/lib/agent-profiles.ts
+++ b/lib/agent-profiles.ts
@@ -5,8 +5,9 @@
 // path helpers and the thin read/write wrappers at the bottom; the extension
 // panel owns all TUI and orchestration concerns.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { closeSync, constants, existsSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import {
 	normalizeModelConfig,
 	type AgentModelConfig,
@@ -64,6 +65,8 @@ export function emptyProfilesFile(): AgentProfilesFile {
 export interface ProfilesParseDrops {
 	droppedProfiles: string[];
 	droppedAgents: Array<{ profile: string; agent: string }>;
+	/** An `active` marker that did not name a normalized profile, when present. */
+	droppedActive?: string;
 }
 
 export interface NormalizedProfilesFile {
@@ -112,12 +115,19 @@ export function normalizeProfilesFile(value: unknown): NormalizedProfilesFile | 
 		profiles[name] = config;
 	}
 	let active: string | undefined;
-	if (
-		typeof value.active === "string" &&
-		isValidProfileName(value.active) &&
-		hasOwn(profiles, value.active)
-	) {
-		active = value.active;
+	if (value.active !== undefined) {
+		if (
+			typeof value.active === "string" &&
+			isValidProfileName(value.active) &&
+			hasOwn(profiles, value.active)
+		) {
+			active = value.active;
+		} else {
+			// Never clear the marker silently: a stale `active` is exactly the state
+			// an operator needs to see, not have disappear.
+			drops.droppedActive =
+				typeof value.active === "string" ? value.active : JSON.stringify(value.active);
+		}
 	}
 	return { file: { kind: PROFILES_KIND, version: PROFILES_VERSION, active, profiles }, drops };
 }
@@ -375,7 +385,7 @@ export function parseProfileExportText(text: string): ProfileExport | undefined 
 	return result ? { name: result.name, config: result.config } : undefined;
 }
 
-// ---- Thin path and file wrappers (untested by contract; pure delegation) ----
+// ---- Path helpers and file wrappers ----
 
 export type ProfilesFileReadResult =
 	| { status: "missing" }
@@ -405,7 +415,32 @@ export function readProfilesFileResult(path: string): ProfilesFileReadResult {
 	return { status: "valid", file: normalized.file, drops: normalized.drops };
 }
 
+/**
+ * Replace the store through a sibling temp file and a rename. A direct write that
+ * is interrupted leaves truncated JSON, which `readProfilesFileResult` must then
+ * reject as unreadable, so the destination is only ever swapped for a complete
+ * file and the temp file is removed on every failure path.
+ */
 export function writeProfilesFileSync(path: string, file: AgentProfilesFile): void {
 	mkdirSync(dirname(path), { recursive: true });
-	writeFileSync(path, serializeProfilesFile(file));
+	const temporary = join(dirname(path), `.${basename(path)}.${randomUUID()}.tmp`);
+	const descriptor = openSync(
+		temporary,
+		constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+		0o600,
+	);
+	try {
+		try {
+			writeFileSync(descriptor, serializeProfilesFile(file));
+		} finally {
+			closeSync(descriptor);
+		}
+		renameSync(temporary, path);
+	} finally {
+		try {
+			unlinkSync(temporary);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	}
 }

--- a/lib/agent-profiles.ts
+++ b/lib/agent-profiles.ts
@@ -1,0 +1,411 @@
+// Agent-model profiles: named, switchable snapshots of the global
+// `models.json` routing behind `/gentle:profiles`. The store lives at
+// `<configHome>/profiles.json` and single-profile exports at
+// `<configHome>/profiles.export.json`. Everything here is pure except the two
+// path helpers and the thin read/write wrappers at the bottom; the extension
+// panel owns all TUI and orchestration concerns.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+	normalizeModelConfig,
+	type AgentModelConfig,
+} from "./model-routing-authority.ts";
+
+export const PROFILES_KIND = "gentle-pi.agent_model_profiles";
+export const PROFILES_VERSION = 1;
+export const PROFILE_EXPORT_KIND = "gentle-pi.agent_model_profile";
+export const PROFILE_EXPORT_VERSION = 1;
+
+export interface AgentProfilesFile {
+	kind: typeof PROFILES_KIND;
+	version: typeof PROFILES_VERSION;
+	active?: string;
+	profiles: Record<string, AgentModelConfig>;
+}
+
+export type AgentProfileErrorCode =
+	| "invalid_name"
+	| "duplicate_name"
+	| "missing_profile"
+	| "active_profile";
+
+export class AgentProfileError extends Error {
+	readonly code: AgentProfileErrorCode;
+
+	constructor(code: AgentProfileErrorCode, message: string) {
+		super(message);
+		this.name = "AgentProfileError";
+		this.code = code;
+	}
+}
+
+const PROFILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+// Names that pass the slug pattern would still collide with object prototype
+// members when used as record keys, so they are rejected explicitly.
+const RESERVED_PROFILE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
+const INHERIT_MODEL_LABEL = "inherit";
+
+export function isValidProfileName(value: unknown): value is string {
+	return (
+		typeof value === "string" &&
+		PROFILE_NAME_PATTERN.test(value) &&
+		!RESERVED_PROFILE_NAMES.has(value)
+	);
+}
+
+export function emptyProfilesFile(): AgentProfilesFile {
+	return { kind: PROFILES_KIND, version: PROFILES_VERSION, active: undefined, profiles: {} };
+}
+
+// ---- Parse and normalize ----
+
+export interface ProfilesParseDrops {
+	droppedProfiles: string[];
+	droppedAgents: Array<{ profile: string; agent: string }>;
+}
+
+export interface NormalizedProfilesFile {
+	file: AgentProfilesFile;
+	drops: ProfilesParseDrops;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+	return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function requireValidName(name: string): string {
+	if (!isValidProfileName(name)) {
+		throw new AgentProfileError(
+			"invalid_name",
+			`Invalid profile name: ${JSON.stringify(name)}. Use 1-64 characters (letters, numbers, '.', '_', '-') starting with a letter or number.`,
+		);
+	}
+	return name;
+}
+
+export function normalizeProfilesFile(value: unknown): NormalizedProfilesFile | undefined {
+	if (!isRecord(value)) return undefined;
+	if (value.kind !== PROFILES_KIND || value.version !== PROFILES_VERSION) return undefined;
+	const rawProfiles = value.profiles;
+	if (!isRecord(rawProfiles)) return undefined;
+	const profiles: Record<string, AgentModelConfig> = {};
+	const drops: ProfilesParseDrops = { droppedProfiles: [], droppedAgents: [] };
+	for (const [name, rawConfig] of Object.entries(rawProfiles)) {
+		if (!isValidProfileName(name)) {
+			drops.droppedProfiles.push(name);
+			continue;
+		}
+		const config = normalizeModelConfig(rawConfig);
+		if (!config) {
+			drops.droppedProfiles.push(name);
+			continue;
+		}
+		for (const agent of Object.keys(isRecord(rawConfig) ? rawConfig : {})) {
+			if (!hasOwn(config, agent)) drops.droppedAgents.push({ profile: name, agent });
+		}
+		profiles[name] = config;
+	}
+	let active: string | undefined;
+	if (
+		typeof value.active === "string" &&
+		isValidProfileName(value.active) &&
+		hasOwn(profiles, value.active)
+	) {
+		active = value.active;
+	}
+	return { file: { kind: PROFILES_KIND, version: PROFILES_VERSION, active, profiles }, drops };
+}
+
+export type ProfilesFileParseResult =
+	| { status: "invalid" }
+	| { status: "valid"; file: AgentProfilesFile };
+
+export function parseProfilesFileText(text: string): ProfilesFileParseResult {
+	let value: unknown;
+	try {
+		value = JSON.parse(text);
+	} catch {
+		return { status: "invalid" };
+	}
+	const file = normalizeProfilesFile(value)?.file;
+	return file ? { status: "valid", file } : { status: "invalid" };
+}
+
+function cloneProfileConfig(config: AgentModelConfig): AgentModelConfig {
+	return Object.fromEntries(
+		Object.entries(config).map(([agent, entry]) => [agent, { ...entry }]),
+	);
+}
+
+function cloneProfiles(
+	profiles: Record<string, AgentModelConfig>,
+): Record<string, AgentModelConfig> {
+	return Object.fromEntries(
+		Object.entries(profiles).map(([name, config]) => [name, cloneProfileConfig(config)]),
+	);
+}
+
+export function serializeProfilesFile(file: AgentProfilesFile): string {
+	const payload: Record<string, unknown> = {
+		kind: file.kind,
+		version: file.version,
+		profiles: cloneProfiles(file.profiles),
+	};
+	if (file.active !== undefined) payload.active = file.active;
+	return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+// ---- Store mutations (each returns a new file and never mutates the input) ----
+
+export function createProfile(
+	file: AgentProfilesFile,
+	name: string,
+	config: AgentModelConfig,
+): AgentProfilesFile {
+	requireValidName(name);
+	if (hasOwn(file.profiles, name)) {
+		throw new AgentProfileError("duplicate_name", `Profile already exists: ${name}.`);
+	}
+	return { ...file, profiles: { ...file.profiles, [name]: cloneProfileConfig(config) } };
+}
+
+export function updateProfile(
+	file: AgentProfilesFile,
+	name: string,
+	config: AgentModelConfig,
+): AgentProfilesFile {
+	requireValidName(name);
+	if (!hasOwn(file.profiles, name)) {
+		throw new AgentProfileError("missing_profile", `Profile does not exist: ${name}.`);
+	}
+	return { ...file, profiles: { ...file.profiles, [name]: cloneProfileConfig(config) } };
+}
+
+export function duplicateProfile(
+	file: AgentProfilesFile,
+	from: string,
+	to: string,
+): AgentProfilesFile {
+	requireValidName(from);
+	if (!hasOwn(file.profiles, from)) {
+		throw new AgentProfileError("missing_profile", `Profile does not exist: ${from}.`);
+	}
+	requireValidName(to);
+	if (hasOwn(file.profiles, to)) {
+		throw new AgentProfileError("duplicate_name", `Profile already exists: ${to}.`);
+	}
+	return createProfile(file, to, file.profiles[from]);
+}
+
+export function renameProfile(
+	file: AgentProfilesFile,
+	from: string,
+	to: string,
+): AgentProfilesFile {
+	requireValidName(from);
+	if (!hasOwn(file.profiles, from)) {
+		throw new AgentProfileError("missing_profile", `Profile does not exist: ${from}.`);
+	}
+	requireValidName(to);
+	if (hasOwn(file.profiles, to)) {
+		throw new AgentProfileError("duplicate_name", `Profile already exists: ${to}.`);
+	}
+	const profiles = Object.fromEntries(
+		Object.entries(file.profiles).map(([name, config]) => [
+			name === from ? to : name,
+			cloneProfileConfig(config),
+		]),
+	);
+	return {
+		...file,
+		active: file.active === from ? to : file.active,
+		profiles,
+	};
+}
+
+export function deleteProfile(file: AgentProfilesFile, name: string): AgentProfilesFile {
+	requireValidName(name);
+	if (!hasOwn(file.profiles, name)) {
+		throw new AgentProfileError("missing_profile", `Profile does not exist: ${name}.`);
+	}
+	if (file.active === name) {
+		throw new AgentProfileError(
+			"active_profile",
+			`Profile ${name} is active. Apply another profile before deleting it.`,
+		);
+	}
+	return {
+		...file,
+		profiles: Object.fromEntries(
+			Object.entries(file.profiles).filter(([profileName]) => profileName !== name),
+		),
+	};
+}
+
+export function setActiveProfile(file: AgentProfilesFile, name: string): AgentProfilesFile {
+	requireValidName(name);
+	if (!hasOwn(file.profiles, name)) {
+		throw new AgentProfileError("missing_profile", `Profile does not exist: ${name}.`);
+	}
+	return { ...file, active: name };
+}
+
+// ---- Summaries and panel decision helpers ----
+
+export interface ProfileModelSummary {
+	model: string;
+	count: number;
+	roles: string[];
+}
+
+export interface ProfileSummary {
+	models: ProfileModelSummary[];
+	total: number;
+}
+
+export function summarizeProfile(config: AgentModelConfig): ProfileSummary {
+	const byModel = new Map<string, string[]>();
+	for (const [agent, entry] of Object.entries(config)) {
+		const model = entry?.model ?? INHERIT_MODEL_LABEL;
+		const roles = byModel.get(model);
+		if (roles) roles.push(agent);
+		else byModel.set(model, [agent]);
+	}
+	const models = [...byModel.entries()]
+		.map(([model, roles]) => ({
+			model,
+			count: roles.length,
+			roles: [...roles].sort((left, right) => left.localeCompare(right)),
+		}))
+		.sort(
+			(left, right) =>
+				right.count - left.count || left.model.localeCompare(right.model),
+		);
+	return { models, total: models.reduce((sum, model) => sum + model.count, 0) };
+}
+
+export function formatProfileSummaryLines(summary: ProfileSummary): string[] {
+	if (summary.total === 0) {
+		return ["No routing entries — every agent inherits its default model."];
+	}
+	return summary.models.map(
+		(model) =>
+			`${model.count} ${model.count === 1 ? "agent" : "agents"} → ${model.model}: ${model.roles.join(", ")}`,
+	);
+}
+
+export interface ProfileListItem {
+	id: string;
+	label: string;
+	description: string;
+}
+
+export function buildProfileListItems(file: AgentProfilesFile): ProfileListItem[] {
+	return Object.entries(file.profiles).map(([name, config]) => {
+		const roles = Object.keys(config).length;
+		return {
+			id: name,
+			label: name === file.active ? `${name} (active)` : name,
+			description: `${roles} ${roles === 1 ? "role" : "roles"}`,
+		};
+	});
+}
+
+export function bootstrapProfilesFile(currentConfig: AgentModelConfig): AgentProfilesFile {
+	const config = normalizeModelConfig(currentConfig) ?? {};
+	const file = createProfile(emptyProfilesFile(), "current", config);
+	return Object.keys(config).length > 0 ? setActiveProfile(file, "current") : file;
+}
+
+// ---- Single-profile export ----
+
+export interface ProfileExport {
+	name: string;
+	config: AgentModelConfig;
+}
+
+export interface ProfileExportParseResult extends ProfileExport {
+	droppedAgents: string[];
+}
+
+export function serializeProfileExport(name: string, config: AgentModelConfig): string {
+	requireValidName(name);
+	return `${JSON.stringify(
+		{
+			kind: PROFILE_EXPORT_KIND,
+			version: PROFILE_EXPORT_VERSION,
+			name,
+			config: cloneProfileConfig(config),
+		},
+		null,
+		2,
+	)}\n`;
+}
+
+export function parseProfileExportTextWithDrops(
+	text: string,
+): ProfileExportParseResult | undefined {
+	let value: unknown;
+	try {
+		value = JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+	if (!isRecord(value)) return undefined;
+	if (value.kind !== PROFILE_EXPORT_KIND || value.version !== PROFILE_EXPORT_VERSION) {
+		return undefined;
+	}
+	if (!isValidProfileName(value.name) || !isRecord(value.config)) return undefined;
+	const config = normalizeModelConfig(value.config);
+	if (!config) return undefined;
+	const droppedAgents = Object.keys(value.config).filter(
+		(agent) => !hasOwn(config, agent),
+	);
+	return { name: value.name, config, droppedAgents };
+}
+
+export function parseProfileExportText(text: string): ProfileExport | undefined {
+	const result = parseProfileExportTextWithDrops(text);
+	return result ? { name: result.name, config: result.config } : undefined;
+}
+
+// ---- Thin path and file wrappers (untested by contract; pure delegation) ----
+
+export type ProfilesFileReadResult =
+	| { status: "missing" }
+	| { status: "invalid" }
+	| { status: "valid"; file: AgentProfilesFile; drops: ProfilesParseDrops };
+
+export function profilesFilePath(configHome: string): string {
+	return join(configHome, "profiles.json");
+}
+
+export function profileExportPath(configHome: string): string {
+	return join(configHome, "profiles.export.json");
+}
+
+export function readProfilesFileResult(path: string): ProfilesFileReadResult {
+	if (!existsSync(path)) return { status: "missing" };
+	let value: unknown;
+	try {
+		value = JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		return { status: "invalid" };
+	}
+	// Parse through normalizeProfilesFile so the caller can name every entry
+	// dropped by normalization instead of losing it silently.
+	const normalized = normalizeProfilesFile(value);
+	if (!normalized) return { status: "invalid" };
+	return { status: "valid", file: normalized.file, drops: normalized.drops };
+}
+
+export function writeProfilesFileSync(path: string, file: AgentProfilesFile): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, serializeProfilesFile(file));
+}

--- a/tests/agent-profiles.test.ts
+++ b/tests/agent-profiles.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
 import {
 	AgentProfileError,
 	bootstrapProfilesFile,
@@ -18,12 +21,16 @@ import {
 	PROFILE_EXPORT_VERSION,
 	PROFILES_KIND,
 	PROFILES_VERSION,
+	profileExportPath,
+	profilesFilePath,
+	readProfilesFileResult,
 	renameProfile,
 	serializeProfileExport,
 	serializeProfilesFile,
 	setActiveProfile,
 	summarizeProfile,
 	updateProfile,
+	writeProfilesFileSync,
 } from "../lib/agent-profiles.ts";
 import type { AgentModelConfig } from "../lib/model-routing-authority.ts";
 
@@ -544,4 +551,84 @@ test("an empty profile exports and imports cleanly", () => {
 		config: {},
 		droppedAgents: [],
 	});
+});
+
+test("normalizeProfilesFile reports an active marker that names no profile", () => {
+	const normalized = normalizeProfilesFile({
+		kind: PROFILES_KIND,
+		version: PROFILES_VERSION,
+		active: "gone",
+		profiles: { team: CONFIG },
+	});
+	assert.equal(normalized?.file.active, undefined);
+	assert.equal(normalized?.drops.droppedActive, "gone");
+});
+
+// ---- Filesystem wrappers ----
+//
+// These two wrappers are the only part of the module that touches disk, so they
+// run against a real temporary directory instead of a mock: the atomic replace
+// cannot be proven without a filesystem, and the failure modes that matter here
+// (absent file, unreadable JSON, dropped entries, missing parent directories) are
+// exactly the ones a mock would hide.
+
+const root = mkdtempSync(join(tmpdir(), "gentle-agent-profiles-"));
+after(() => rmSync(root, { recursive: true, force: true }));
+
+test("readProfilesFileResult reports a missing store without throwing", () => {
+	assert.deepEqual(readProfilesFileResult(join(root, "absent.json")), { status: "missing" });
+});
+
+test("readProfilesFileResult reports malformed JSON as invalid", () => {
+	const path = join(root, "malformed.json");
+	writeFileSync(path, "{ not json");
+	assert.deepEqual(readProfilesFileResult(path), { status: "invalid" });
+});
+
+test("readProfilesFileResult rejects a foreign kind or version", () => {
+	const path = join(root, "foreign.json");
+	writeFileSync(path, JSON.stringify({ kind: "other", version: 1, profiles: {} }));
+	assert.deepEqual(readProfilesFileResult(path), { status: "invalid" });
+});
+
+test("readProfilesFileResult returns normalized profiles together with their drops", () => {
+	const path = join(root, "drops.json");
+	writeFileSync(
+		path,
+		JSON.stringify({
+			kind: PROFILES_KIND,
+			version: PROFILES_VERSION,
+			active: "missing-profile",
+			profiles: { team: CONFIG, "bad name": CONFIG },
+		}),
+	);
+	const result = readProfilesFileResult(path);
+	if (result.status !== "valid") throw new Error(`expected valid, got ${result.status}`);
+	assert.deepEqual(Object.keys(result.file.profiles), ["team"]);
+	assert.equal(result.file.active, undefined);
+	assert.deepEqual(result.drops.droppedProfiles, ["bad name"]);
+	assert.equal(result.drops.droppedActive, "missing-profile");
+});
+
+test("writeProfilesFileSync creates missing parent directories", () => {
+	const path = join(root, "nested", "deeper", "profiles.json");
+	writeProfilesFileSync(path, createProfile(emptyProfilesFile(), "team", CONFIG));
+	assert.equal(readProfilesFileResult(path).status, "valid");
+});
+
+test("writeProfilesFileSync replaces the store and leaves no temp file behind", () => {
+	const path = join(root, "atomic.json");
+	const first = createProfile(emptyProfilesFile(), "alpha", CONFIG);
+	writeProfilesFileSync(path, first);
+	writeProfilesFileSync(path, createProfile(first, "beta", CONFIG));
+	const round = readProfilesFileResult(path);
+	if (round.status !== "valid") throw new Error(`expected valid, got ${round.status}`);
+	assert.deepEqual(Object.keys(round.file.profiles), ["alpha", "beta"]);
+	assert.deepEqual(readdirSync(root).filter((entry) => entry.includes(".tmp")), []);
+});
+
+test("the path helpers resolve both stores inside the config home", () => {
+	const home = join(root, "config-home");
+	assert.equal(profilesFilePath(home), join(home, "profiles.json"));
+	assert.equal(profileExportPath(home), join(home, "profiles.export.json"));
 });

--- a/tests/agent-profiles.test.ts
+++ b/tests/agent-profiles.test.ts
@@ -1,0 +1,547 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	AgentProfileError,
+	bootstrapProfilesFile,
+	buildProfileListItems,
+	createProfile,
+	deleteProfile,
+	duplicateProfile,
+	emptyProfilesFile,
+	formatProfileSummaryLines,
+	isValidProfileName,
+	normalizeProfilesFile,
+	parseProfileExportText,
+	parseProfileExportTextWithDrops,
+	parseProfilesFileText,
+	PROFILE_EXPORT_KIND,
+	PROFILE_EXPORT_VERSION,
+	PROFILES_KIND,
+	PROFILES_VERSION,
+	renameProfile,
+	serializeProfileExport,
+	serializeProfilesFile,
+	setActiveProfile,
+	summarizeProfile,
+	updateProfile,
+} from "../lib/agent-profiles.ts";
+import type { AgentModelConfig } from "../lib/model-routing-authority.ts";
+
+// Agent-model profiles: pure store, summary, and export logic for the
+// /gentle:profiles panel. These tests perform zero filesystem access — every
+// tested function operates on strings and plain objects.
+
+const CONFIG: AgentModelConfig = {
+	explore: { model: "openai-codex/gpt-5.6-terra", thinking: "low" },
+	design: { model: "anthropic/claude-sonnet-4", thinking: "high" },
+};
+
+function profilesText(profiles: unknown, overrides: Record<string, unknown> = {}): string {
+	return JSON.stringify({
+		kind: PROFILES_KIND,
+		version: PROFILES_VERSION,
+		profiles,
+		...overrides,
+	});
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+	return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+
+test("isValidProfileName accepts slug names and rejects reserved and malformed names", () => {
+	assert.equal(isValidProfileName("current"), true);
+	assert.equal(isValidProfileName("deep-work"), true);
+	assert.equal(isValidProfileName("Team.Prod_2"), true);
+	assert.equal(isValidProfileName("a"), true);
+	assert.equal(isValidProfileName("x".repeat(64)), true);
+	assert.equal(isValidProfileName(""), false);
+	assert.equal(isValidProfileName("-leading"), false);
+	assert.equal(isValidProfileName(".hidden"), false);
+	assert.equal(isValidProfileName("has space"), false);
+	assert.equal(isValidProfileName("bad/name"), false);
+	assert.equal(isValidProfileName("x".repeat(65)), false);
+	assert.equal(isValidProfileName(42), false);
+	assert.equal(isValidProfileName(undefined), false);
+	assert.equal(isValidProfileName("__proto__"), false);
+	assert.equal(isValidProfileName("constructor"), false);
+	assert.equal(isValidProfileName("prototype"), false);
+});
+
+test("emptyProfilesFile returns a versioned empty store", () => {
+	assert.deepEqual(emptyProfilesFile(), {
+		kind: PROFILES_KIND,
+		version: PROFILES_VERSION,
+		active: undefined,
+		profiles: {},
+	});
+});
+
+test("parseProfilesFileText rejects malformed JSON without throwing", () => {
+	assert.deepEqual(parseProfilesFileText("{not json"), { status: "invalid" });
+	assert.deepEqual(parseProfilesFileText(""), { status: "invalid" });
+	assert.deepEqual(parseProfilesFileText("[1, 2]"), { status: "invalid" });
+	assert.deepEqual(parseProfilesFileText('"profiles"'), { status: "invalid" });
+});
+
+test("parseProfilesFileText never accepts a wrong kind or version", () => {
+	assert.deepEqual(
+		parseProfilesFileText(profilesText({ team: CONFIG }, { kind: "other.kind" })),
+		{ status: "invalid" },
+	);
+	assert.deepEqual(
+		parseProfilesFileText(profilesText({ team: CONFIG }, { version: 2 })),
+		{ status: "invalid" },
+	);
+	assert.deepEqual(
+		parseProfilesFileText(profilesText({ team: CONFIG }, { version: "1" })),
+		{ status: "invalid" },
+	);
+});
+
+test("parseProfilesFileText rejects a file whose profiles are not a record", () => {
+	assert.deepEqual(parseProfilesFileText(profilesText([CONFIG])), { status: "invalid" });
+});
+
+test("parseProfilesFileText accepts a valid store and drops profiles with invalid names", () => {
+	const parsed = parseProfilesFileText(
+		profilesText(
+			{
+				"has space": CONFIG,
+				"__proto__": { explore: { model: "m/x" } },
+				constructor: { explore: { model: "m/x" } },
+				team: CONFIG,
+			},
+			{ active: "has space" },
+		),
+	);
+	assert.deepEqual(parsed, {
+		status: "valid",
+		file: {
+			kind: PROFILES_KIND,
+			version: PROFILES_VERSION,
+			active: undefined,
+			profiles: { team: CONFIG },
+		},
+	});
+});
+
+test("parseProfilesFileText accepts legacy string routing entries and drops broken agents", () => {
+	const parsed = parseProfilesFileText(
+		profilesText({
+			team: {
+				explore: "openai-codex/gpt-5.6-terra",
+				"bad agent": { model: "m/x" },
+				empty: {},
+			},
+		}),
+	);
+	assert.deepEqual(parsed, {
+		status: "valid",
+		file: {
+			kind: PROFILES_KIND,
+			version: PROFILES_VERSION,
+			active: undefined,
+			profiles: {
+				team: {
+					explore: { model: "openai-codex/gpt-5.6-terra" },
+					empty: {},
+				},
+			},
+		},
+	});
+});
+
+test("serializeProfilesFile round-trips through parseProfilesFileText with a trailing newline", () => {
+	const file = setActiveProfile(createProfile(emptyProfilesFile(), "team", CONFIG), "team");
+	const text = serializeProfilesFile(file);
+	assert.ok(text.endsWith("}\n"));
+	assert.deepEqual(parseProfilesFileText(text), { status: "valid", file });
+});
+
+test("serializeProfilesFile omits the active field when no profile is active", () => {
+	const text = serializeProfilesFile(createProfile(emptyProfilesFile(), "team", CONFIG));
+	assert.ok(!text.includes('"active"'));
+});
+
+test("createProfile adds a profile without mutating the input", () => {
+	const file = emptyProfilesFile();
+	const before = structuredClone(file);
+	const next = createProfile(file, "team", CONFIG);
+	assert.deepEqual(file, before);
+	assert.deepEqual(next.profiles.team, CONFIG);
+	assert.equal(hasOwn(next.profiles, "team"), true);
+});
+
+test("createProfile clones the given config so later edits cannot leak", () => {
+	const config: AgentModelConfig = { explore: { model: "m/x" } };
+	const next = createProfile(emptyProfilesFile(), "team", config);
+	next.profiles.team.explore.model = "changed";
+	assert.equal(config.explore.model, "m/x");
+});
+
+test("createProfile throws typed errors on invalid and duplicate names", () => {
+	const file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	assert.throws(
+		() => createProfile(file, "bad name", CONFIG),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "invalid_name",
+	);
+	assert.throws(
+		() => createProfile(file, "constructor", CONFIG),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "invalid_name",
+	);
+	assert.throws(
+		() => createProfile(file, "team", CONFIG),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "duplicate_name",
+	);
+});
+
+test("updateProfile replaces the config without mutating the input and throws when missing", () => {
+	const file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	const before = structuredClone(file);
+	const next = updateProfile(file, "team", { explore: { model: "m/y" } });
+	assert.deepEqual(file, before);
+	assert.deepEqual(next.profiles.team, { explore: { model: "m/y" } });
+	assert.throws(
+		() => updateProfile(file, "missing", CONFIG),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "missing_profile",
+	);
+	assert.throws(
+		() => updateProfile(file, "__proto__", CONFIG),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "invalid_name",
+	);
+});
+
+test("duplicateProfile copies the config under a new name", () => {
+	const file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	const next = duplicateProfile(file, "team", "team-2");
+	assert.deepEqual(next.profiles["team-2"], CONFIG);
+	assert.deepEqual(next.profiles.team, CONFIG);
+	assert.equal(next.active, undefined);
+	assert.throws(
+		() => duplicateProfile(file, "missing", "other"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "missing_profile",
+	);
+	assert.throws(
+		() => duplicateProfile(file, "team", "team"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "duplicate_name",
+	);
+	assert.throws(
+		() => duplicateProfile(file, "team", "bad name"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "invalid_name",
+	);
+});
+
+test("renameProfile carries the active marker over and keeps the input untouched", () => {
+	let file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	file = setActiveProfile(file, "team");
+	const before = structuredClone(file);
+	const next = renameProfile(file, "team", "deep-work");
+	assert.deepEqual(file, before);
+	assert.equal(hasOwn(next.profiles, "team"), false);
+	assert.deepEqual(next.profiles["deep-work"], CONFIG);
+	assert.equal(next.active, "deep-work");
+});
+
+test("renameProfile leaves the active marker alone for other profiles", () => {
+	let file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	file = createProfile(file, "other", {});
+	file = setActiveProfile(file, "other");
+	const next = renameProfile(file, "team", "deep-work");
+	assert.equal(next.active, "other");
+});
+
+test("renameProfile throws typed errors for missing, duplicate, and invalid names", () => {
+	const file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	assert.throws(
+		() => renameProfile(file, "missing", "other"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "missing_profile",
+	);
+	assert.throws(
+		() => renameProfile(file, "team", "team"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "duplicate_name",
+	);
+	assert.throws(
+		() => renameProfile(file, "team", "bad name"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "invalid_name",
+	);
+});
+
+test("deleteProfile removes a profile but refuses to delete the active one", () => {
+	let file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	file = createProfile(file, "other", {});
+	const before = structuredClone(file);
+	const next = deleteProfile(file, "team");
+	assert.deepEqual(file, before);
+	assert.equal(hasOwn(next.profiles, "team"), false);
+	assert.deepEqual(next.profiles.other, {});
+
+	file = setActiveProfile(file, "team");
+	assert.throws(
+		() => deleteProfile(file, "team"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "active_profile",
+	);
+	assert.throws(
+		() => deleteProfile(file, "missing"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "missing_profile",
+	);
+});
+
+test("setActiveProfile marks an existing profile and throws otherwise", () => {
+	const file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	assert.equal(setActiveProfile(file, "team").active, "team");
+	assert.throws(
+		() => setActiveProfile(file, "missing"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "missing_profile",
+	);
+	assert.throws(
+		() => setActiveProfile(file, "prototype"),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "invalid_name",
+	);
+});
+
+test("summarizeProfile groups roles per model and sorts by count desc then model asc", () => {
+	const summary = summarizeProfile({
+		gamma: { model: "a/one" },
+		alpha: { model: "b/two" },
+		beta: { model: "b/two" },
+		delta: { model: "a/one" },
+		echo: { model: "a/one" },
+	});
+	assert.deepEqual(summary, {
+		models: [
+			{ model: "a/one", count: 3, roles: ["delta", "echo", "gamma"] },
+			{ model: "b/two", count: 2, roles: ["alpha", "beta"] },
+		],
+		total: 5,
+	});
+});
+
+test("summarizeProfile labels model-less entries as inherit and handles empty configs", () => {
+	assert.deepEqual(summarizeProfile({ solo: { thinking: "high" } }), {
+		models: [{ model: "inherit", count: 1, roles: ["solo"] }],
+		total: 1,
+	});
+	assert.deepEqual(summarizeProfile({}), { models: [], total: 0 });
+});
+
+test("profile export round-trips through serialize and parse", () => {
+	const text = serializeProfileExport("team", CONFIG);
+	assert.ok(text.endsWith("}\n"));
+	assert.deepEqual(parseProfileExportText(text), { name: "team", config: CONFIG });
+});
+
+test("profile export parse rejects malformed, wrong-kind, wrong-version, and invalid-name payloads", () => {
+	assert.equal(parseProfileExportText("{nope"), undefined);
+	assert.equal(
+		parseProfileExportText(JSON.stringify({ kind: "other", version: PROFILE_EXPORT_VERSION, name: "team", config: CONFIG })),
+		undefined,
+	);
+	assert.equal(
+		parseProfileExportText(JSON.stringify({ kind: PROFILE_EXPORT_KIND, version: 99, name: "team", config: CONFIG })),
+		undefined,
+	);
+	assert.equal(
+		parseProfileExportText(JSON.stringify({ kind: PROFILE_EXPORT_KIND, version: PROFILE_EXPORT_VERSION, config: CONFIG })),
+		undefined,
+	);
+	assert.equal(
+		parseProfileExportText(JSON.stringify({ kind: PROFILE_EXPORT_KIND, version: PROFILE_EXPORT_VERSION, name: "bad name", config: CONFIG })),
+		undefined,
+	);
+	assert.equal(
+		parseProfileExportText(JSON.stringify({ kind: PROFILE_EXPORT_KIND, version: PROFILE_EXPORT_VERSION, name: "team", config: "nope" })),
+		undefined,
+	);
+});
+
+test("serializeProfileExport throws on an invalid profile name", () => {
+	assert.throws(
+		() => serializeProfileExport("bad name", CONFIG),
+		(error: unknown) => error instanceof AgentProfileError && error.code === "invalid_name",
+	);
+});
+
+test("profile export parse names dropped routing entries without dropping the profile", () => {
+	const text = JSON.stringify({
+		kind: PROFILE_EXPORT_KIND,
+		version: PROFILE_EXPORT_VERSION,
+		name: "team",
+		config: {
+			explore: { model: "m/x" },
+			"bad agent": { model: "m/x" },
+			broken: "not an entry",
+		},
+	});
+	const parsed = parseProfileExportTextWithDrops(text);
+	assert.deepEqual(parsed, {
+		name: "team",
+		config: { explore: { model: "m/x", thinking: undefined } },
+		droppedAgents: ["bad agent", "broken"],
+	});
+});
+
+test("normalizeProfilesFile validates shape, drops invalid entries, and reports them", () => {
+	assert.equal(normalizeProfilesFile("nope"), undefined);
+	assert.equal(normalizeProfilesFile({ kind: PROFILES_KIND, version: PROFILES_VERSION }), undefined);
+	assert.equal(normalizeProfilesFile({ kind: "other", version: PROFILES_VERSION, profiles: {} }), undefined);
+	assert.equal(normalizeProfilesFile({ kind: PROFILES_KIND, version: 3, profiles: {} }), undefined);
+
+	const normalized = normalizeProfilesFile(
+		JSON.parse(
+			profilesText(
+				{
+					"bad name": CONFIG,
+					broken: "not a record",
+					team: { explore: { model: "m/x" }, "bad agent": { model: "m/y" } },
+				},
+				{ active: "team" },
+			),
+		),
+	);
+	assert.deepEqual(normalized, {
+		file: {
+			kind: PROFILES_KIND,
+			version: PROFILES_VERSION,
+			active: "team",
+			profiles: { team: { explore: { model: "m/x", thinking: undefined } } },
+		},
+		drops: {
+			droppedProfiles: ["bad name", "broken"],
+			droppedAgents: [{ profile: "team", agent: "bad agent" }],
+		},
+	});
+});
+
+test("normalizeProfilesFile drops an active marker that points nowhere", () => {
+	const normalized = normalizeProfilesFile(
+		JSON.parse(profilesText({ team: CONFIG }, { active: "missing" })),
+	);
+	assert.equal(normalized?.file.active, undefined);
+	assert.equal(normalized?.drops.droppedProfiles.length, 0);
+});
+
+test("bootstrapProfilesFile seeds a current profile, active only when routing is non-empty", () => {
+	const empty = bootstrapProfilesFile({});
+	assert.deepEqual(empty, {
+		kind: PROFILES_KIND,
+		version: PROFILES_VERSION,
+		active: undefined,
+		profiles: { current: {} },
+	});
+	const seeded = bootstrapProfilesFile(CONFIG);
+	assert.deepEqual(seeded, {
+		kind: PROFILES_KIND,
+		version: PROFILES_VERSION,
+		active: "current",
+		profiles: { current: CONFIG },
+	});
+	const config: AgentModelConfig = structuredClone(CONFIG);
+	bootstrapProfilesFile(config);
+	assert.deepEqual(config, CONFIG);
+});
+
+test("buildProfileListItems shows the name, active marker, and role count", () => {
+	let file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	file = createProfile(file, "idle", {});
+	file = setActiveProfile(file, "team");
+	assert.deepEqual(buildProfileListItems(file), [
+		{ id: "team", label: "team (active)", description: "2 roles" },
+		{ id: "idle", label: "idle", description: "0 roles" },
+	]);
+});
+
+test("formatProfileSummaryLines renders counts, models, and roles", () => {
+	assert.deepEqual(
+		formatProfileSummaryLines({
+			models: [
+				{ model: "a/one", count: 3, roles: ["delta", "echo", "gamma"] },
+				{ model: "b/two", count: 1, roles: ["alpha"] },
+			],
+			total: 4,
+		}),
+		[
+			"3 agents → a/one: delta, echo, gamma",
+			"1 agent → b/two: alpha",
+		],
+	);
+	assert.deepEqual(formatProfileSummaryLines({ models: [], total: 0 }), [
+		"No routing entries — every agent inherits its default model.",
+	]);
+});
+
+// ---- Triangulation: adversarial and alternate cases ----
+
+test("parseProfilesFileText drops a __proto__ profile key without polluting the object", () => {
+	const text = '{"kind":"gentle-pi.agent_model_profiles","version":1,"profiles":{"__proto__":{"explore":{"model":"m/x"}},"team":{"explore":{"model":"m/x"}}}}';
+	const parsed = parseProfilesFileText(text);
+	assert.equal(parsed.status, "valid");
+	if (parsed.status !== "valid") return;
+	assert.deepEqual(Object.keys(parsed.file.profiles), ["team"]);
+	assert.equal(({} as Record<string, unknown>).explore, undefined);
+	assert.equal(Object.getPrototypeOf(parsed.file.profiles), Object.prototype);
+});
+
+test("serialize then parse is idempotent across repeated round-trips", () => {
+	let file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	file = setActiveProfile(file, "team");
+	const first = serializeProfilesFile(file);
+	const reparsed = parseProfilesFileText(first);
+	assert.equal(reparsed.status, "valid");
+	if (reparsed.status !== "valid") return;
+	assert.equal(serializeProfilesFile(reparsed.file), first);
+});
+
+test("deleteProfile removes the last profile and leaves a valid empty store", () => {
+	const file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	const next = deleteProfile(file, "team");
+	assert.deepEqual(next.profiles, {});
+	assert.equal(next.active, undefined);
+	assert.deepEqual(parseProfilesFileText(serializeProfilesFile(next)), {
+		status: "valid",
+		file: next,
+	});
+});
+
+test("profile names accept slug punctuation but reject unicode letters", () => {
+	assert.equal(isValidProfileName("a.b-c_d"), true);
+	assert.equal(isValidProfileName("café"), false);
+	assert.equal(isValidProfileName("1up"), true);
+});
+
+test("summarizeProfile breaks count ties by model name ascending", () => {
+	const summary = summarizeProfile({
+		one: { model: "z/last" },
+		two: { model: "a/first" },
+	});
+	assert.deepEqual(
+		summary.models.map((model) => model.model),
+		["a/first", "z/last"],
+	);
+});
+
+test("duplicateProfile deep-clones so copy edits cannot leak into the source", () => {
+	const file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	const next = duplicateProfile(file, "team", "copy");
+	const copyEntry = next.profiles.copy.explore;
+	if (!copyEntry) throw new Error("copy entry missing");
+	copyEntry.model = "changed";
+	assert.equal(file.profiles.team.explore?.model, "openai-codex/gpt-5.6-terra");
+});
+
+test("renameProfile preserves the profile order in the store", () => {
+	let file = createProfile(emptyProfilesFile(), "alpha", {});
+	file = createProfile(file, "beta", CONFIG);
+	const next = renameProfile(file, "alpha", "delta");
+	assert.deepEqual(Object.keys(next.profiles), ["delta", "beta"]);
+});
+
+test("an empty profile exports and imports cleanly", () => {
+	const text = serializeProfileExport("empty", {});
+	assert.deepEqual(parseProfileExportTextWithDrops(text), {
+		name: "empty",
+		config: {},
+		droppedAgents: [],
+	});
+});


### PR DESCRIPTION
## Linked Issue

Closes #900

## PR Type

- [x] New feature (`type:feature`)

## Summary

- Add a named agent-model profile store at `<configHome>/profiles.json` — a versioned envelope plus an active marker — with pure create, update, duplicate, rename, delete, set-active, summary, and single-profile export/import operations.
- Add `/gentle:profiles`: an overlay that lists profiles with their active marker and role count, summarises the selected profile by model, and applies a profile live by writing the routing store and re-materialising agent routing, so new subagent launches pick it up without a restart.
- Reuse the native agent-management primitives (choice list, shared agents view geometry, native fullscreen interaction) and refuse destructive or lossy cases instead of discarding them silently.

## Changes

| File | Change |
|---|---|
| `lib/agent-profiles.ts` | New. Profile store shape, name and envelope validation, pure CRUD, summary, export/import, and two thin `node:fs` wrappers. |
| `tests/agent-profiles.test.ts` | New. 38 unit tests over the pure surface, with zero filesystem usage. |
| `extensions/gentle-ai.ts` | `ProfilesPanel` overlay, `handleProfilesCommand`, and the `gentle:profiles` registration. |
| `README.md` | Document the command, the store shape, and the live-switch semantics. |

Review size: **1516 added/1 deleted lines across four files**.

## Test Plan

- [x] RED before implementation: focused failures for parse, name validation, destructive refusals, and export/import round-trip before the module existed.
- [x] Focused tests: 38 passed, 0 failed (`tests/agent-profiles.test.ts`); the test file performs no filesystem writes or deletions.
- [x] Full unit suite on the merged tree: 2,181 passed, 0 failed, 9 skipped.
- [x] Provider contract check and runtime harness passed; `check:runtime-modules` reports no drift.
- [x] Native four-lens review approved and acknowledged for the candidate, after one bounded correction.
- [x] Live switch verified by hand on this machine: the routing store is re-materialised on the next subagent launch, and that launch still uses the previous routing, so a switch takes effect from the following launch.

Commands ran directly with Node, not through package-manager lifecycle execution:

```sh
node --experimental-strip-types --test tests/agent-profiles.test.ts
node --experimental-strip-types --test tests/*.test.ts
node scripts/check-provider-contract.mjs
node --experimental-strip-types tests/runtime-harness.mjs
node scripts/build-runtime-modules.mjs --check
```

The overlay was **not** exercised interactively in a TUI. Its wiring is covered by inspection plus the existing tests of the shared native primitives it reuses; the panel's own key handling and click regions remain unexecuted by this PR's evidence.

## Notes

The native review approved this candidate after one bounded correction. `lib/agent-profiles.ts` called `Object.keys` on a value typed `unknown` from `Object.entries`, which no test in this repository can catch: there is no TypeScript compiler, no `tsconfig.json`, and no `typecheck` script, and tests run through `--experimental-strip-types`, which strips types without checking them. The correction is a one-line narrowing guard.

The branch was merged with `origin/main` after the review. That merge was conflict-free, and the reviewed hunks are byte-identical afterwards; only their line offsets shifted.

## Contributor Checklist

- [x] Linked approved issue; exactly one matching `type:*` label.
- [x] Conventional commits without co-author trailers.
- [x] No shell scripts or skills changed; shellcheck and skill-runtime testing are not applicable.
- [x] Documentation updated for the new behavior.
- [x] Automated coverage and unexecuted interactive UI testing distinguished above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-model profiles for saving, switching, creating, duplicating, renaming, updating, and deleting routing configurations.
  * Added the `/gentle:profiles` command with an interactive profile management panel supporting keyboard and mouse navigation.
  * Added profile export and import support with validation and error reporting.
  * Added automatic setup of an initial profile when profiles are first used.
  * Added safeguards for invalid profile data and recovery when applying a profile fails.
* **Documentation**
  * Updated the README with profile usage, keyboard controls, storage details, and command references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->