### PR TITLE
fix(profiles): stop cleanup from masking the store write error

### DIFF
--- a/lib/agent-profiles.ts
+++ b/lib/agent-profiles.ts
@@ -429,18 +429,32 @@ export function writeProfilesFileSync(path: string, file: AgentProfilesFile): vo
 		constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
 		0o600,
 	);
+	// Every step records its own failure and cleanup never throws, so the error
+	// that actually broke the write is the one reported: a failing close or unlink
+	// must not mask a failed write or rename, and the temp file is removed on every
+	// path.
+	const failures: unknown[] = [];
 	try {
+		writeFileSync(descriptor, serializeProfilesFile(file));
+	} catch (error) {
+		failures.push(error);
+	}
+	try {
+		closeSync(descriptor);
+	} catch (error) {
+		failures.push(error);
+	}
+	if (failures.length === 0) {
 		try {
-			writeFileSync(descriptor, serializeProfilesFile(file));
-		} finally {
-			closeSync(descriptor);
-		}
-		renameSync(temporary, path);
-	} finally {
-		try {
-			unlinkSync(temporary);
+			renameSync(temporary, path);
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+			failures.push(error);
 		}
 	}
+	try {
+		unlinkSync(temporary);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") failures.push(error);
+	}
+	if (failures.length > 0) throw failures[0];
 }

--- a/tests/agent-profiles.test.ts
+++ b/tests/agent-profiles.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
@@ -624,6 +624,17 @@ test("writeProfilesFileSync replaces the store and leaves no temp file behind", 
 	const round = readProfilesFileResult(path);
 	if (round.status !== "valid") throw new Error(`expected valid, got ${round.status}`);
 	assert.deepEqual(Object.keys(round.file.profiles), ["alpha", "beta"]);
+	assert.deepEqual(readdirSync(root).filter((entry) => entry.includes(".tmp")), []);
+});
+
+test("writeProfilesFileSync reports the operation error and still removes the temp file", () => {
+	// Renaming over a directory fails, so this reaches the failure path with a
+	// real operation error rather than a stubbed one.
+	const occupied = join(root, "occupied");
+	mkdirSync(occupied, { recursive: true });
+	assert.throws(() =>
+		writeProfilesFileSync(occupied, createProfile(emptyProfilesFile(), "team", CONFIG)),
+	);
 	assert.deepEqual(readdirSync(root).filter((entry) => entry.includes(".tmp")), []);
 });
 

--- a/tests/agent-profiles.test.ts
+++ b/tests/agent-profiles.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { after } from "node:test";
@@ -628,13 +628,25 @@ test("writeProfilesFileSync replaces the store and leaves no temp file behind", 
 });
 
 test("writeProfilesFileSync reports the operation error and still removes the temp file", () => {
-	// Renaming over a directory fails, so this reaches the failure path with a
-	// real operation error rather than a stubbed one.
 	const occupied = join(root, "occupied");
 	mkdirSync(occupied, { recursive: true });
 	assert.throws(() =>
 		writeProfilesFileSync(occupied, createProfile(emptyProfilesFile(), "team", CONFIG)),
 	);
+	assert.deepEqual(readdirSync(root).filter((entry) => entry.includes(".tmp")), []);
+});
+
+test("writeProfilesFileSync reports a serialization failure, skips the rename, and cleans up", () => {
+	// The write path fails before the rename, so this proves the reported error is
+	// the operation's, that the destination is never touched once a failure is
+	// recorded, and that cleanup still runs.
+	const path = join(root, "serialize.json");
+	const file = createProfile(emptyProfilesFile(), "team", CONFIG);
+	const circular: Record<string, unknown> = {};
+	circular.self = circular;
+	(file.profiles.team as Record<string, unknown>).explore = circular;
+	assert.throws(() => writeProfilesFileSync(path, file), /circular/i);
+	assert.equal(existsSync(path), false);
 	assert.deepEqual(readdirSync(root).filter((entry) => entry.includes(".tmp")), []);
 });
 


### PR DESCRIPTION
## Linked Issue

Closes #903

## PR Type

- [x] Bug fix (`type:bug`)

## Summary

- `writeProfilesFileSync` no longer lets a cleanup failure replace the error that actually broke the store write. Each step records its own failure, no cleanup path throws, and the first recorded failure is reported.
- This also covers a case a single `finally` hid: when the write and the close both fail, the write error is reported instead of the close error.
- The temp file is still removed on every path, and `throw` no longer sits inside a `finally`, clearing the Biome `lint/correctness/noUnsafeFinally` diagnostic.

## Changes

| File | Change |
|---|---|
| `lib/agent-profiles.ts` | Per-step failure recording; the rename is skipped once a failure is recorded; the first failure is rethrown. |
| `tests/agent-profiles.test.ts` | Two failure-path tests: renaming over a directory, and a write-path failure with the rename skipped. |

Review size: **48 added/10 deleted lines across two files**.

## Test Plan

- [x] Focused tests: 48 passed, 0 failed (`tests/agent-profiles.test.ts`).
- [x] Full suite on this branch: 2,191 passed, 0 failed, 9 skipped.
- [x] `check:runtime-modules` reports no drift.
- [x] Failure paths exercised with real errors, not stubs: renaming over a directory fails, and serialization fails on a circular structure.

```sh
node --experimental-strip-types --test tests/agent-profiles.test.ts
node --experimental-strip-types --test tests/*.test.ts
node scripts/build-runtime-modules.mjs --check
```

The interactive TUI path is untouched and was not exercised.

## Notes

The same `throw`-inside-`finally` shape exists at `lib/orchestrator-presence.ts:156` and is not changed here. It is a different store with its own review surface, and folding it in would widen this fix past its finding. The repository has no Biome configuration and no lint script, so that diagnostic is advisory rather than a failing check.

One case stays uncovered, and it is recorded rather than faked: the ordering where cleanup also fails. Forcing `unlinkSync` to fail needs a directory that denies the unlink, but the temp file is created in that same directory, so the permission that allows creation also allows the unlink. Covering it end to end needs an injection seam in production code, which is a larger change than this finding warrants.

## Contributor Checklist

- [x] Linked approved issue; exactly one matching `type:*` label.
- [x] Conventional commits without co-author trailers.
- [x] No shell scripts or skills changed; shellcheck and skill-runtime testing are not applicable.
- [x] Documentation not required: observable behavior is unchanged and this is internal error reporting.
- [x] Automated coverage and unexecuted interactive testing distinguished above.
