### PR TITLE
fix(sdd): treat native status notes as non-blocking

### DIFF
--- a/assets/sdd-orchestrator-workflow.md
+++ b/assets/sdd-orchestrator-workflow.md
@@ -41,7 +41,7 @@ Rules:
 
 ## Bounded Planning Routing
 
-For authoritative native status, route only by the bounded `nextRecommended` token and dependency states; never infer a route from prose. Keep human diagnostics in `blockedReasons`, not in `nextRecommended`, and report them without discarding them to enable a route.
+For authoritative native status, route only by the bounded `nextRecommended` token and dependency states; never infer a route from prose. Keep genuine blockers in `blockedReasons` and non-blocking diagnostics in `notes`, never in `nextRecommended`, and report them without discarding them to enable a route.
 
 | `nextRecommended` | Planning route |
 | --- | --- |
@@ -74,7 +74,7 @@ Execution routes accept the native Gentle AI v2 tokens and Gentle Pi's local `sd
 | `sdd-archive` | `sdd-archive` |
 | `sdd-sync` | `sdd-sync` |
 
-For non-planning phases, stop when that phase's dependency is `blocked`. When `nextRecommended` is `blocked` or `resolve-blockers`, report `blockedReasons` and stop. Unknown tokens, including native `remediate`, do not authorize a launch until Pi has an explicit typed remediation transport and executor contract. Non-empty `blockedReasons` forbid apply, sync, and archive work; `verify` or `sdd-verify` may run only when the verify dependency permits it. This alias table does not bypass preflight, selection, action-context, or runtime-attempt authority. The non-authoritative `resolve-via-engram` store carve-out remains separate and does not bypass those gates.
+For non-planning phases, stop when that phase's dependency is `blocked`. When `nextRecommended` is `blocked` or `resolve-blockers`, report `blockedReasons` and stop. Unknown tokens, including native `remediate`, do not authorize a launch until Pi has an explicit typed remediation transport and executor contract. Non-empty `blockedReasons` forbid apply, sync, and archive work; `verify` or `sdd-verify` may run only when the verify dependency permits it. This alias table does not bypass preflight, selection, action-context, or runtime-attempt authority. The non-authoritative `resolve-via-engram` store carve-out remains separate and does not bypass those gates. `notes` is separate from `blockedReasons` and never gates: a non-empty `notes` never withholds apply, sync, archive, or a terminal route, so report it as informational and proceed when the dependency and `blockedReasons` gates allow.
 
 ## SDD Status Contract
 

--- a/assets/support/sdd-status-contract.md
+++ b/assets/support/sdd-status-contract.md
@@ -20,12 +20,12 @@ Any phase that selects, continues, applies, verifies, syncs, or archives an SDD 
 - Runtime-attempt authority is different from artifact dispatch: normal runtime-bearing OpenSpec and Engram continuations MUST bracket external execution with `gentle-ai sdd-attempt acquire|settle --cwd <repo> --change <change>`. Their bounded result contains only `proceed`, `blocked`, or `complete` plus an opaque continuation token when required, and MAY carry `settle_obligation` on a `proceed`. The Git-common-dir immutable chain remains the sole authority for ordinals, cumulative attempt/line budgets, runtime evidence, and atomic bound remediation.
 - A phase actor launched BY a parent that already holds a `proceed`-state acquire for that exact work unit is a distinct call/process, not a fresh continuation: it MUST NOT `acquire` again blind. Colliding with its own parent's active attempt is not a genuine `blocked: active_attempt` (#2291). It authenticates as that SAME attempt by passing the parent's returned token on its own `acquire --token <token>` call: a token matching the ledger's live active attempt returns `proceed` with that same token and zero mutation, while a non-matching token gets the ordinary `blocked: active_attempt` naming the real active token.
 - Apply the Bounded Planning Routing contract below: a blocked apply dependency is not a blanket veto on planning. Non-planning phases must still obey their own dependency gates.
-- `nextRecommended` is a bounded machine token for routing, not human prose. Route only by `nextRecommended` and dependency states. Human-readable explanation belongs in `blockedReasons`, not `nextRecommended`.
+- `nextRecommended` is a bounded machine token for routing, not human prose. Route only by `nextRecommended` and dependency states. A genuine blocker's human-readable explanation belongs in `blockedReasons`; a non-blocking diagnostic belongs in `notes`; neither belongs in `nextRecommended`.
 - If the binary is unavailable, fall back to this prompt contract and the manual status schema below. Manual fallback status MUST stay shape-compatible with the native status JSON even when values are reconstructed manually.
 
 ## Bounded Planning Routing
 
-For authoritative native status, route only by the bounded `nextRecommended` token and dependency states; never infer a route from prose. Keep human diagnostics in `blockedReasons`, not in `nextRecommended`, and report them without discarding them to enable a route.
+For authoritative native status, route only by the bounded `nextRecommended` token and dependency states; never infer a route from prose. Keep genuine blockers in `blockedReasons` and non-blocking diagnostics in `notes`, never in `nextRecommended`, and report them without discarding them to enable a route.
 
 | `nextRecommended` | Planning route |
 | --- | --- |
@@ -58,7 +58,7 @@ Execution routes accept the native Gentle AI v2 tokens and Gentle Pi's local `sd
 | `sdd-archive` | `sdd-archive` |
 | `sdd-sync` | `sdd-sync` |
 
-For non-planning phases, stop when that phase's dependency is `blocked`. When `nextRecommended` is `blocked` or `resolve-blockers`, report `blockedReasons` and stop. Unknown tokens, including native `remediate`, do not authorize a launch until Pi has an explicit typed remediation transport and executor contract. Non-empty `blockedReasons` forbid apply, sync, and archive work; `verify` or `sdd-verify` may run only when the verify dependency permits it. This alias table does not bypass preflight, selection, action-context, or runtime-attempt authority. The non-authoritative `resolve-via-engram` store carve-out remains separate and does not bypass those gates.
+For non-planning phases, stop when that phase's dependency is `blocked`. When `nextRecommended` is `blocked` or `resolve-blockers`, report `blockedReasons` and stop. Unknown tokens, including native `remediate`, do not authorize a launch until Pi has an explicit typed remediation transport and executor contract. Non-empty `blockedReasons` forbid apply, sync, and archive work; `verify` or `sdd-verify` may run only when the verify dependency permits it. This alias table does not bypass preflight, selection, action-context, or runtime-attempt authority. The non-authoritative `resolve-via-engram` store carve-out remains separate and does not bypass those gates. `notes` is separate from `blockedReasons` and never gates: a non-empty `notes` never withholds apply, sync, archive, or a terminal route, so report it as informational and proceed when the dependency and `blockedReasons` gates allow.
 
 ## Status Schema
 

--- a/tests/sdd-execution-routing-contract.test.ts
+++ b/tests/sdd-execution-routing-contract.test.ts
@@ -37,6 +37,7 @@ for (const [index, path] of routingPaths.entries()) {
 			"When `nextRecommended` is `blocked` or `resolve-blockers`, report `blockedReasons` and stop",
 			"Unknown tokens, including native `remediate`, do not authorize a launch until Pi has an explicit typed remediation transport and executor contract",
 			"Non-empty `blockedReasons` forbid apply, sync, and archive work",
+			"`notes` is separate from `blockedReasons` and never gates",
 			"does not bypass preflight, selection, action-context, or runtime-attempt authority",
 			"store carve-out remains separate and does not bypass those gates",
 		]) {

--- a/tests/sdd-planning-routing-contract.test.ts
+++ b/tests/sdd-planning-routing-contract.test.ts
@@ -50,7 +50,7 @@ for (const [index, path] of paths.entries()) {
 			"workspace-planning without allowed edit roots remains read-only",
 			"Planning does not bypass the init guard, pre-proposal gate, or phase approval requirements",
 			"never infer a route from prose",
-			"Keep human diagnostics in `blockedReasons`, not in `nextRecommended`",
+			"Keep genuine blockers in `blockedReasons` and non-blocking diagnostics in `notes`, never in `nextRecommended`",
 			"report them without discarding them to enable a route",
 		]) {
 			assert.ok(contract.includes(guard), `missing guard: ${guard}`);


### PR DESCRIPTION
## Linked Issue

Gentle AI tracker: Gentleman-Programming/gentle-ai#4372 (consumer-side alignment of the same contract).
No separate Gentle Pi issue exists for this slice; say the word and I will split it out.

---

## Summary

Aligns Gentle Pi's SDD status contract with the native producer fix shipped in Gentleman-Programming/gentle-ai#4500.

The native `gentle-ai.sdd-status/v2` document previously reported an informational diagnostic (`note(future_edit_roots)`, for a later work unit's unauthorized edit root) inside `blockedReasons`, while still reporting `applyState: ready` and `nextRecommended: apply`. Gentle Pi's bounded routing contract reads a non-empty `blockedReasons` as a stop, so an orchestrator obeying its own documented gate refused an apply the producer had already declared ready. That is the `note`-versus-blocker occurrence reported in the tracker.

The producer now emits that diagnostic in a separate, always-present `notes` array. This PR keeps `blockedReasons` as the only stop signal and states explicitly that `notes` never gates.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `assets/sdd-orchestrator-workflow.md` | `## Bounded Planning Routing`: genuine blockers live in `blockedReasons`, non-blocking diagnostics in `notes`. `## Bounded Execution Routing`: explicit rule that a non-empty `notes` never withholds apply, sync, archive, or a terminal route. |
| `assets/support/sdd-status-contract.md` | Same two sections (the tests require both documents to agree byte-for-byte inside them) plus the `nextRecommended` diagnostic-ownership sentence |
| `tests/sdd-planning-routing-contract.test.ts` | Pinned guard updated to the new diagnostic ownership wording |
| `tests/sdd-execution-routing-contract.test.ts` | New pinned guard: `notes` is separate from `blockedReasons` and never gates |

No gate was weakened. The existing guards — dependency states, unknown-token refusal, preflight, selection, action-context, runtime-attempt authority, and the `resolve-via-engram` carve-out — are unchanged, and the "non-empty `blockedReasons` forbid apply, sync, and archive work" sentence stays exactly as it was, because the producer fix makes it accurate rather than contradictory.

## Test Plan

```bash
pnpm test
```

- Full suite: 2152 tests, 2143 pass, 0 fail, 9 skipped.
- Provider contract mirror check passed (contract 1.2.0).
- Runtime harness: exit 0.
- `pnpm run check:runtime-modules`: runtime matches TypeScript sources.
- `node scripts/verify-package-files.mjs`: passed (168 files; 69 byte-pinned contract artifacts).

End-to-end evidence on the producer side, same fixture with the old and new native binary:

```
BEFORE  applyState=ready nextRecommended=apply blockedReasons=[note(future_edit_roots): ...] notes=<absent>
AFTER   applyState=ready nextRecommended=apply blockedReasons=[]                             notes=[note(future_edit_roots): ...]
```

Note for the reviewer: these are asset/prompt changes. They reach a live session through the package install, not through a Pi `/reload` of an already-installed copy.

## AI Assistance

Material AI assistance was used (Pi coding agent, el Gentleman harness): diagnosis of the contradiction, the contract wording, and the test guards were authored with it. Verification performed: full `pnpm test`, the provider-contract and package-file checks above, a read-only independent verification pass, and the native RDD review of the producer side (lineage `review-3714b656608d3d89`, approved, authority acknowledged).

## Notes for Reviewers

- The two documents are compared byte-for-byte inside the extracted routing sections by the tests, so the edits are deliberately identical in both.
- The stale sentence "keep human diagnostics in `blockedReasons`" was the one that had become misleading after the producer split, so it was reworded rather than left alone.
- Deliberately out of scope, with the evidence an independent verification pass produced: the native-status decoder models only `blockedReasons` (`lib/native-review-cli.ts:184` type, `:1401` validator; mirrored at `runtime/native-review-cli.mjs:1402`) and accepts `notes` as `[]`, non-empty, `null`, or absent. It preserves unknown fields and never gates on them, so nothing is dropped or blocked today. Related stale fixtures that still build native v2 documents without `notes`: `tests/sdd-selection-transport.test.ts:87,125,246` and `tests/native-review-cli.test.ts:67,78`.
