### PR TITLE
fix(agents): record why a subagent run ended when its tool call is aborted

### DIFF
--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -11,7 +11,7 @@ import { sidebarPart } from "../lib/shell-sidebar.ts";
 import { invalidateSidebar } from "../lib/shell-sidebar-layout.ts";
 import { AGENT_MODE, discoverAgents, loadAgentsConfig, resolveAgentProfile, type AgentDefinition, type AgentMode } from "../lib/agents-config.ts";
 import { isFinished, TASK_STATUS, TaskStore, type AskRequest, type TaskRecord } from "../lib/agents-protocol.ts";
-import { AgentRunner, piCommand, type AskAnswer, type RunnerDeps, type SddChangeSelection, type TaskRequest } from "../lib/agents-runner.ts";
+import { AgentRunner, piCommand, abortReasonText, type AskAnswer, type RunnerDeps, type SddChangeSelection, type TaskRequest } from "../lib/agents-runner.ts";
 import { ChildMessenger, type IpcEndpoint } from "../lib/agents-messaging.ts";
 import { hasReviewSessionPermission, resolveCanonicalGitRepositoryIdentitySync, type ReviewSessionManager } from "../lib/review-session-standing-permission.ts";
 import { historyDir, loadStoredTask, pruneHistory, saveTask } from "../lib/agents-history.ts";
@@ -685,7 +685,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		};
 	};
 
-	const launch = async (ctx: ExtensionContext, request: TaskRequest): Promise<ToolText> => {
+	const launch = async (ctx: ExtensionContext, request: TaskRequest, signal?: AbortSignal): Promise<ToolText> => {
 		// Bounded live observation only. Native send owns the fresh policy decision;
 		// child execution never starts a telemetry policy process or renewal timer.
 		const owner = metricsOwner;
@@ -709,16 +709,34 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		ownedTaskIds.add(task.id);
 		store.subscribe(task.id, () => { publishActivity(); requestRender(); });
 		if (request.mode === AGENT_MODE.BACKGROUND) return text(`Started ${task.agent} in the background as task ${task.id}. Use subagent_status or subagent_result with that id.`, taskDetails(task));
-		const query = await runner.waitForQuery(task.id);
-		if (query) {
-			const live = store.get(task.id) ?? task;
-			return text(`Subagent ${live.agent} is waiting for your reply to request ${query.requestId}.`, { gentleAgents: { taskId: live.id, agent: live.agent, status: live.status, mode: live.mode, requestId: query.requestId } }, true);
+		// A tool call aborted by the host (a human interrupting the turn, a timeout)
+		// would otherwise leave the child running and end the call with no result and
+		// no recorded reason. Cancel through the runner so the lifecycle runs and the
+		// record is persisted, and tell the user why.
+		const onAbort = (): void => {
+			if (runner.cancel(task.id)) {
+				ctx.ui.notify(
+					`Subagent ${task.agent} cancelled: the tool call was aborted${abortReasonText(signal?.reason)}. The run is recorded as cancelled.`,
+					"warning",
+				);
+			}
+		};
+		if (signal?.aborted) onAbort();
+		else signal?.addEventListener("abort", onAbort, { once: true });
+		try {
+			const query = await runner.waitForQuery(task.id);
+			if (query) {
+				const live = store.get(task.id) ?? task;
+				return text(`Subagent ${live.agent} is waiting for your reply to request ${query.requestId}.`, { gentleAgents: { taskId: live.id, agent: live.agent, status: live.status, mode: live.mode, requestId: query.requestId } }, true);
+			}
+			const finished = await runner.waitFor(task.id);
+			return text(finishedText(finished), taskDetails(finished));
+		} finally {
+			signal?.removeEventListener("abort", onAbort);
 		}
-		const finished = await runner.waitFor(task.id);
-		return text(finishedText(finished), taskDetails(finished));
 	};
 
-	const tool = (name: string, description: string, parameters: Record<string, unknown>, execute: (params: Record<string, unknown>, ctx: ExtensionContext) => Promise<ToolText>) => {
+	const tool = (name: string, description: string, parameters: Record<string, unknown>, execute: (params: Record<string, unknown>, ctx: ExtensionContext, signal?: AbortSignal) => Promise<ToolText>) => {
 		pi.registerTool({
 			name: `${TOOL_PREFIX}${name}`,
 			renderShell: "self",
@@ -733,8 +751,8 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 				const body = result.content.map((part) => (part.type === "text" ? part.text : "")).join("\n");
 				return new Text(options.expanded ? body : theme.fg("muted", body.split("\n")[0] ?? ""), 0, 0);
 			},
-			async execute(_id, params, _signal, _onUpdate, ctx) {
-				return execute(params as Record<string, unknown>, ctx);
+			async execute(_id, params, signal, _onUpdate, ctx) {
+				return execute(params as Record<string, unknown>, ctx, signal);
 			},
 		});
 	};
@@ -761,7 +779,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 				mode: { type: "string", enum: ["task", "background"], description: "task waits for the result (default); background returns immediately." },
 			},
 		},
-		async (params, ctx) => {
+		async (params, ctx, signal) => {
 			const { agents } = discoverAgents(roots(ctx));
 			const agent = agents.find((candidate) => candidate.name === params.agent);
 			if (!agent) return text(`Error: no subagent named "${String(params.agent)}". Known: ${agents.map((candidate) => candidate.name).join(", ") || "none"}`, { error: "unknown agent" });
@@ -769,7 +787,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			let sddChange: SddChangeSelection | undefined;
 			try { sddChange = parseSddChange(params.sdd_change, agent.name); }
 			catch (error) { return text(`Error: ${error instanceof Error ? error.message : String(error)}`, { error: "invalid sdd_change" }); }
-			return launch(ctx, buildRequest(ctx, agent, String(params.task ?? ""), typeof params.label === "string" ? params.label : undefined, typeof params.context === "string" ? params.context : undefined, mode, undefined, typeof params.workspace_root === "string" ? params.workspace_root : undefined, sddChange));
+			return launch(ctx, buildRequest(ctx, agent, String(params.task ?? ""), typeof params.label === "string" ? params.label : undefined, typeof params.context === "string" ? params.context : undefined, mode, undefined, typeof params.workspace_root === "string" ? params.workspace_root : undefined, sddChange), signal);
 		},
 	);
 
@@ -808,7 +826,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		"continue",
 		"Resume a finished subagent task in its own session with a follow-up prompt.",
 		{ required: ["task_id", "prompt"], properties: { task_id: { type: "string" }, prompt: { type: "string" }, label: { type: "string", description: "Three to six words naming the follow-up." }, sdd_change: { type: "object", additionalProperties: false, required: ["changeName", "workspaceRoot", "phase"], properties: { changeName: { type: "string" }, workspaceRoot: { type: "string" }, phase: { type: "string", enum: ["apply", "verify", "sync", "archive"] } }, description: "Fresh launch-local selected SDD identity, required when continuing an SDD phase agent." }, mode: { type: "string", enum: ["task", "background"] } } },
-		async (params, ctx) => {
+		async (params, ctx, signal) => {
 			const previous = await resolveTask(String(params.task_id));
 			if (!previous) return text(`Error: no task ${String(params.task_id)}`, { error: "unknown task" });
 			if (!isFinished(previous.status) || !previous.sessionPath) return text(`Error: task ${previous.id} cannot be continued yet (${previous.status}).`, { error: "not continuable" });
@@ -819,7 +837,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			try { sddChange = parseSddChange(params.sdd_change, agent.name); }
 			catch (error) { return text(`Error: ${error instanceof Error ? error.message : String(error)}`, { error: "invalid sdd_change" }); }
 			if (sddPhaseForAgent(agent.name) && !sddChange) return text("Error: continuing an SDD phase agent requires a fresh sdd_change selection.", { error: "missing sdd_change" });
-			return launch(ctx, buildRequest(ctx, agent, String(params.prompt ?? ""), typeof params.label === "string" ? params.label : undefined, undefined, mode, previous.sessionPath, sddChange?.workspaceRoot ?? previous.cwd, sddChange));
+			return launch(ctx, buildRequest(ctx, agent, String(params.prompt ?? ""), typeof params.label === "string" ? params.label : undefined, undefined, mode, previous.sessionPath, sddChange?.workspaceRoot ?? previous.cwd, sddChange), signal);
 		},
 	);
 

--- a/lib/agents-runner.ts
+++ b/lib/agents-runner.ts
@@ -858,3 +858,17 @@ export class AgentRunner {
 		queueMicrotask(() => this.pump());
 	}
 }
+
+// Human-readable suffix for an abort signal's reason, so a cancelled tool call is
+// distinguishable in the record and the notification rather than reported only as
+// "aborted". Returns an empty string when there is no usable reason.
+export function abortReasonText(reason: unknown): string {
+	if (reason === undefined) return "";
+	const message =
+		reason instanceof Error && reason.message.length > 0
+			? reason.message
+			: typeof reason === "string" && reason.length > 0
+				? reason
+				: "";
+	return message.length > 0 ? ` (${message})` : "";
+}

--- a/tests/agents-runner.test.ts
+++ b/tests/agents-runner.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { AGENT_MODE, type AgentDefinition } from "../lib/agents-config.ts";
 import { TASK_STATUS, TaskStore } from "../lib/agents-protocol.ts";
-import { AgentRunner, childArguments, JsonLines, piCommand, type RunnerDeps, type RunnerHooks, type TaskRequest } from "../lib/agents-runner.ts";
+import { AgentRunner, childArguments, JsonLines, piCommand, abortReasonText, type RunnerDeps, type RunnerHooks, type TaskRequest } from "../lib/agents-runner.ts";
 import { fakeChild, type FakeChild } from "./agents-fake-child.ts";
 
 // Gentle Agents runner: every subagent is a child `pi --mode rpc` process.
@@ -858,4 +858,12 @@ test("an unprobeable process group quarantines at its deadline and still records
 	assert.equal(finishes.length, 1, "the run is recorded exactly once");
 	assert.equal(store.get(second.id)?.status, TASK_STATUS.QUEUED, "an unconfirmed exit retains its capacity");
 	assert.equal(launches, 1, "no further launch happens while the slot is quarantined");
+});
+
+test("abortReasonText renders an Error, a string, and nothing for unknown reasons", () => {
+	assert.equal(abortReasonText(undefined), "");
+	assert.equal(abortReasonText(new Error("interrupted by user")), " (interrupted by user)");
+	assert.equal(abortReasonText("host timeout"), " (host timeout)");
+	assert.equal(abortReasonText(new Error("")), "");
+	assert.equal(abortReasonText(42), "");
 });

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -25,7 +25,7 @@ type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
 interface Registered {
 	renderShell?: string;
 	name: string;
-	execute(id: string, params: unknown, signal: undefined, onUpdate: undefined, ctx: ExtensionContext): Promise<{ content: Array<{ text: string }>; details: Record<string, unknown> }>;
+	execute(id: string, params: unknown, signal: AbortSignal | undefined, onUpdate: undefined, ctx: ExtensionContext): Promise<{ content: Array<{ text: string }>; details: Record<string, unknown> }>;
 	renderCall(args: unknown, theme: unknown): { render(width: number): string[] };
 }
 
@@ -1736,4 +1736,26 @@ test("the production overlay reads terminal rows at render time without a minimu
 	assert.equal(overlay.render(80).length, 1, "tiny terminals retain bounded controls rather than forced chrome");
 	overlay.handleInput("\x1b");
 	await opened;
+});
+
+test("aborting the caller's signal cancels the subagent, records it, and says why", async () => {
+	const { pi, tools, fire } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx, dialogs } = fakeContext();
+	await fire("session_start", ctx);
+	const controller = new AbortController();
+	const pending = tools.get("subagent_run")!.execute("abort", { agent: "explore", task: "keep working" }, controller.signal, undefined, ctx);
+	await tick();
+	controller.abort();
+	await tick();
+	const yielded = await pending;
+	const details = (yielded.details as { gentleAgents?: { taskId: string; status: string } }).gentleAgents!;
+	assert.equal(details.status, "cancelled", "the run is recorded as cancelled");
+	assert.match((yielded as { content: Array<{ text: string }> }).content[0].text, /cancelled/);
+	assert.ok(
+		dialogs.some((entry) => entry.startsWith("notify:") && /cancelled/.test(entry) && /tool call was aborted/.test(entry)),
+		"a warning names the abort and the cancellation",
+	);
+	assert.equal(harness.children[0].killed.length > 0, true, "the runner terminated the child");
 });


### PR DESCRIPTION
## What

Thread the `AbortSignal` Pi hands to a tool's `execute()` into the subagent launch path, and use it to cancel the child through the runner when the caller goes away.

Closes #911.

## Why

The subagent tools registered `execute(_id, params, _signal, _onUpdate, ctx)` and dropped the signal. A task-mode call aborted by the host (human interrupt, timeout) therefore ended **with no result**, left the child **running**, and recorded **no termination reason** — the run was unattributable after the fact.

## How

- `extensions/gentle-agents.ts` — the local `tool()` helper now forwards the signal; `launch()` accepts it. On abort it calls `runner.cancel(task.id)`, so the normal stop lifecycle runs and the record is persisted as `cancelled`, then notifies the user with the abort reason. The listener is removed in a `finally`, so a normal completion cannot trigger a second cancellation. `run` and `continue` pass their signal through.
- `lib/agents-runner.ts` — adds `abortReasonText()` to render an `Error`/string reason (empty when there is none) so the message says *why*, not just *aborted*.
- Tests — an integration test drives the registered `subagent_run` with a real `AbortController` and asserts the recorded status is `cancelled`, the tool call resolves instead of vanishing, the warning names the abort, and the child was terminated; plus unit coverage for `abortReasonText`. The test harness's `Registered.execute` widens `signal` from `undefined` to `AbortSignal | undefined`.

## Evidence

- `pnpm test`: 2204 tests, 2195 pass, 0 fail (9 pre-existing skips).
- `node scripts/check-types.mjs`: `205 recorded diagnostic(s), no regressions`.
- Diff: 4 files, +79/−17.

## Review

Reviewed under the native review gate (`review-6bc942344f9c385b`, tier high, 4 lenses; the reliability lens run failed and was reconciled by native status, which declared the candidate approved). Authority acknowledged and burned; delivery is ordinary repository policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cancellation support for running agent tasks when an abort request is received.
  - Users are notified when a task is cancelled, including the cancellation reason when available.
  - Cancelled tasks now complete their lifecycle and retain their records.

- **Bug Fixes**
  - Ensured cancelled child processes terminate cleanly instead of continuing to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->