### PR TITLE
fix(agents): bound background completion delivery to the current turn

### DIFF
--- a/extensions/gentle-agents.ts
+++ b/extensions/gentle-agents.ts
@@ -9,6 +9,7 @@ import { keyHint, type ExtensionAPI, type ExtensionContext } from "@earendil-wor
 import { Text, type TUI } from "@earendil-works/pi-tui";
 import { sidebarPart } from "../lib/shell-sidebar.ts";
 import { invalidateSidebar } from "../lib/shell-sidebar-layout.ts";
+import { createCompletionQueue } from "../lib/agents-completion-delivery.ts";
 import { AGENT_MODE, discoverAgents, loadAgentsConfig, resolveAgentProfile, type AgentDefinition, type AgentMode } from "../lib/agents-config.ts";
 import { isFinished, TASK_STATUS, TaskStore, type AskRequest, type TaskRecord } from "../lib/agents-protocol.ts";
 import { AgentRunner, piCommand, type AskAnswer, type RunnerDeps, type SddChangeSelection, type TaskRequest } from "../lib/agents-runner.ts";
@@ -37,6 +38,7 @@ export const AGENTS_WIDGET_KEY = "gentle-agents";
 export const AGENTS_COMMAND_NAME = "gentle:agents";
 export const AGENTS_RESULT_TYPE = "gentle-agents.result";
 export const AGENTS_MESSAGE_TYPE = "gentle-agents.message";
+export const AGENTS_STALE_RESULT_TYPE = "gentle-agents.stale-result";
 const COLLAPSE_KEY_DEFAULT = "ctrl+shift+a";
 const VIEW_KEY_DEFAULT = "alt+a";
 const STOP_KEY_DEFAULT = "alt+s";
@@ -389,11 +391,72 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			.catch(() => {});
 	};
 
-	// A background result is delivered as a message: queued behind the current
-	// turn if the model is busy, or starting a turn right away if it is idle.
+	// A background result used to be handed straight to the host as a followUp
+	// message, but the host only drains that queue when the parent agent stops
+	// calling tools entirely, so in a long orchestrator run the notification
+	// could land nearly an hour after the parent pulled the same result (#867).
+	// Gentle Agents now owns the pending completions: they settle here, are
+	// flushed at the next turn boundary, and a stale one never re-enters the
+	// conversation.
+	const completions = createCompletionQueue<TaskRecord>();
+	let activeAgentRuns = 0;
+
 	const deliver = (task: TaskRecord) => {
-		pi.sendMessage({ customType: AGENTS_RESULT_TYPE, content: completionText(task), display: true, details: taskDetails(task) }, { deliverAs: "followUp", triggerTurn: true });
+		// Ownership is consulted at delivery time, matching onNotification and
+		// onQuery: a completion owned by another session is dropped, not delivered.
+		if (activeSessionId() !== task.parentSessionId) return;
+		// "steer" + triggerTurn keeps delivery bounded to the current turn. While
+		// the parent streams, the host polls steering each turn and injects the
+		// message before the next LLM call; "followUp" is NOT acceptable here
+		// because the host drains the follow-up queue only in the run loop's stop
+		// branch, so a parent that keeps calling tools would see the completion
+		// only when the whole run ends — the original #867 delay. When the parent
+		// is idle, triggerTurn runs the prompt immediately, preserving wake-up.
+		pi.sendMessage({ customType: AGENTS_RESULT_TYPE, content: completionText(task), display: true, details: taskDetails(task) }, { deliverAs: "steer", triggerTurn: true });
 	};
+
+	// A stale completion must not re-enter the LLM conversation, so it is
+	// delivered as durable TUI-only content and the human still sees it.
+	const deliverStale = (task: TaskRecord, settledAt: number) => {
+		if (activeSessionId() !== task.parentSessionId) return;
+		const ageSeconds = Math.max(0, Math.round((deps.now() - settledAt) / 1000));
+		pi.appendEntry(AGENTS_STALE_RESULT_TYPE, { taskId: task.id, agent: task.agent, label: task.label, status: task.status, ageSeconds });
+	};
+
+	const flushCompletions = () => {
+		for (const { task, settledAt, stale } of completions.takeDeliverable(deps.now())) {
+			try {
+				if (stale) deliverStale(task, settledAt);
+				else deliver(task);
+			} catch { /* Best-effort delivery: at most once, even if forwarding fails. */ }
+		}
+	};
+
+	// A completion settles into our queue. An idle parent flushes right away so
+	// the wake-up behavior is unchanged; a busy parent flushes at the next turn
+	// boundary, and the steer mode injects it before that turn's next LLM call
+	// instead of parking it behind the whole run.
+	const settleCompletion = (task: TaskRecord) => {
+		completions.enqueue(task, deps.now());
+		if (activeAgentRuns === 0) flushCompletions();
+	};
+
+	// `agent_start`/`agent_end` bracket a parent agent run; `turn_end` fires at
+	// every turn boundary inside one, so with steering delivery a held
+	// completion is injected before the next LLM call and never outlives the
+	// current turn. `agent_end` stays a flush trigger for runs that end without
+	// a final `turn_end` (an aborted run, or the host's early post-run return
+	// when a run produced no assistant message; the host compensates via
+	// hasQueuedMessages() + continue(), so steering there is still bounded).
+	// `agent_settled` is the final idle boundary after retries — normally a
+	// no-op safety net, since anything enqueued while idle flushes right away.
+	pi.on("agent_start", () => { activeAgentRuns += 1; });
+	pi.on("agent_end", () => {
+		activeAgentRuns = Math.max(0, activeAgentRuns - 1);
+		flushCompletions();
+	});
+	pi.on("agent_settled", () => flushCompletions());
+	pi.on("turn_end", () => flushCompletions());
 
 	const runner = new AgentRunner(store, loadAgentsConfig({ cwd: process.cwd(), home: deps.home, agentHome }), deps, {
 		askUser: (_taskId, ask, raw) => answerThroughUi(ui, ask, raw),
@@ -440,7 +503,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 				requestRender();
 				persist(task);
 				const yielded = yieldedTaskIds.delete(task.id);
-				if ((task.mode === AGENT_MODE.BACKGROUND && task.status !== TASK_STATUS.CANCELLED) || (yielded && task.status !== TASK_STATUS.CANCELLED && activeSessionId() === task.parentSessionId)) deliver(task);
+				if ((task.mode === AGENT_MODE.BACKGROUND && task.status !== TASK_STATUS.CANCELLED) || (yielded && task.status !== TASK_STATUS.CANCELLED && activeSessionId() === task.parentSessionId)) settleCompletion(task);
 			} catch { /* Best-effort completion bookkeeping cannot strand runner waiters. */ }
 		},
 	});
@@ -463,6 +526,28 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		return {
 			render(width: number) {
 				return renderCard({ title: "Agent result", subtitle: details?.agent, body, tone, glyph: AGENTS_GLYPH }, theme, width, { expanded: options.expanded, hint });
+			},
+			invalidate() {},
+		};
+	});
+
+	// A stale completion is appended as a custom entry: durable transcript
+	// content for the human that never participates in the LLM context.
+	pi.registerEntryRenderer(AGENTS_STALE_RESULT_TYPE, (entry, options, theme) => {
+		const data = (entry.data ?? {}) as { taskId?: unknown; agent?: unknown; label?: unknown; status?: unknown; ageSeconds?: unknown };
+		const taskId = typeof data.taskId === "string" ? data.taskId : "unknown";
+		const agent = typeof data.agent === "string" ? data.agent : "Subagent";
+		const label = typeof data.label === "string" ? data.label : "";
+		const status = typeof data.status === "string" ? data.status.replace("_", " ") : "unknown";
+		const ageSeconds = typeof data.ageSeconds === "number" && Number.isFinite(data.ageSeconds) ? Math.max(0, Math.round(data.ageSeconds)) : 0;
+		const age = ageSeconds < 90 ? `${ageSeconds}s` : ageSeconds < 3600 ? `${Math.round(ageSeconds / 60)}m` : `${Math.round(ageSeconds / 3600)}h`;
+		const body = [
+			`Subagent ${sanitizeTerminalText(agent)} (task ${sanitizeTerminalText(taskId)}, "${sanitizeTerminalText(label)}") ${sanitizeTerminalText(status)} about ${age} ago, while the orchestrator was still busy.`,
+			"Marked stale: the result was not replayed into the conversation. It stays available through subagent_status and subagent_result.",
+		];
+		return {
+			render(width: number) {
+				return renderCard({ title: "Stale agent result", subtitle: `${agent} · task ${taskId}`, body, tone: CARD_TONE.WARNING, glyph: AGENTS_GLYPH }, theme, width, { expanded: options.expanded, hint: expandHint(options.expanded) });
 			},
 			invalidate() {},
 		};
@@ -715,6 +800,7 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			return text(`Subagent ${live.agent} is waiting for your reply to request ${query.requestId}.`, { gentleAgents: { taskId: live.id, agent: live.agent, status: live.status, mode: live.mode, requestId: query.requestId } }, true);
 		}
 		const finished = await runner.waitFor(task.id);
+		completions.consume(finished.id);
 		return text(finishedText(finished), taskDetails(finished));
 	};
 
@@ -781,6 +867,9 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	tool("result", "Return the final answer of a finished subagent task, or its current state if it is still running.", { required: ["task_id"], properties: { task_id: { type: "string" } } }, async (params) => {
 		const task = await resolveTask(String(params.task_id));
 		if (!task) return text(`Error: no task ${String(params.task_id)}`, { error: "unknown task" });
+		// The parent just pulled a finished result; its pending completion must
+		// never be replayed on top of it.
+		if (isFinished(task.status)) completions.consume(task.id);
 		return text(isFinished(task.status) ? finishedText(task) : `Task ${task.id} is still ${task.status} (last: ${task.lastStep}).`, taskDetails(task));
 	});
 
@@ -812,6 +901,9 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 			const previous = await resolveTask(String(params.task_id));
 			if (!previous) return text(`Error: no task ${String(params.task_id)}`, { error: "unknown task" });
 			if (!isFinished(previous.status) || !previous.sessionPath) return text(`Error: task ${previous.id} cannot be continued yet (${previous.status}).`, { error: "not continuable" });
+			// Continuing acts on the previous result, so any pending completion for
+			// it is already consumed by the parent.
+			completions.consume(previous.id);
 			const agent = discoverAgents(roots(ctx)).agents.find((candidate) => candidate.name === previous.agent);
 			if (!agent) return text(`Error: subagent "${previous.agent}" is no longer defined.`, { error: "unknown agent" });
 			const mode = (params.mode as AgentMode | undefined) ?? (previous.mode as AgentMode);
@@ -852,6 +944,9 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 	}
 
 	pi.on("session_start", (_event, ctx) => {
+		// A resumed, reloaded, or replaced session starts with an empty completion
+		// queue so nothing pending from another session can replay here.
+		completions.dropAll();
 		presence?.dispose();
 		registryFor(ctx);
 		showWidget(ctx);
@@ -862,6 +957,8 @@ export default function gentleAgents(pi: ExtensionAPI, env: NodeJS.ProcessEnv = 
 		} catch { presence = undefined; }
 	});
 	pi.on("session_shutdown", () => {
+		completions.dropAll();
+		activeAgentRuns = 0;
 		presence?.dispose();
 		presence = undefined;
 		cancelClock?.();

--- a/lib/agents-completion-delivery.ts
+++ b/lib/agents-completion-delivery.ts
@@ -1,0 +1,72 @@
+// Gentle Agents completion delivery queue (issue #867).
+//
+// A background subagent completion used to be handed straight to the host as a
+// `deliverAs: "followUp"` message, but the host only flushes that queue when
+// the parent agent stops calling tools entirely. In a long orchestrator run
+// the notification could therefore land tens of minutes after the parent
+// already pulled the same result through subagent_result. This module owns the
+// pending completions instead: the extension enqueues at settle time, decides
+// freshness at flush time, and drops whatever the parent already consumed. It
+// is dependency-free and clock-agnostic: every timestamp is passed in, so the
+// behavior is unit-testable against a fake clock.
+
+/**
+ * A completion older than this at flush time is stale: the parent had many
+ * turns to pull the result with subagent_result, so replaying it into the
+ * model context would re-enter state the conversation may already have used.
+ * Ninety seconds comfortably covers one slow orchestrator turn (model latency
+ * plus a few tool calls) while staying orders of magnitude below the 50-58
+ * minute followUp delays measured in issue #867.
+ */
+export const STALE_COMPLETION_MS = 90_000;
+
+export interface DeliverableCompletion<T> {
+	/** The settled task exactly as enqueued. */
+	task: T;
+	/** Clock value passed to enqueue when the task settled. */
+	settledAt: number;
+	/** True once now - settledAt has reached STALE_COMPLETION_MS. */
+	stale: boolean;
+}
+
+export interface CompletionQueue<T extends { id: string }> {
+	/** Record a settled completion. At most one record per task id; a duplicate enqueue for a delivered, pending, or consumed id is a no-op. */
+	enqueue(task: T, settledAt: number): void;
+	/** Mark a task's result as already consumed by the parent. Idempotent; unknown ids are remembered so a later completion is suppressed. */
+	consume(taskId: string): void;
+	/** Remove and return the still-pending completions in settle order, each with its staleness decision at `now`. Consumed entries are dropped and never returned. */
+	takeDeliverable(now: number): Array<DeliverableCompletion<T>>;
+	/** Discard everything: pending completions and consumed/delivered bookkeeping. Used on session start and shutdown so nothing replays after a resume. */
+	dropAll(): void;
+}
+
+export function createCompletionQueue<T extends { id: string }>(): CompletionQueue<T> {
+	let pending: Array<{ task: T; settledAt: number }> = [];
+	const consumed = new Set<string>();
+	const delivered = new Set<string>();
+	return {
+		enqueue(task, settledAt) {
+			if (consumed.has(task.id) || delivered.has(task.id) || pending.some((entry) => entry.task.id === task.id)) return;
+			pending.push({ task, settledAt });
+		},
+		consume(taskId) {
+			consumed.add(taskId);
+		},
+		takeDeliverable(now) {
+			const taken = pending;
+			pending = [];
+			const deliverable: Array<DeliverableCompletion<T>> = [];
+			for (const entry of taken) {
+				if (consumed.has(entry.task.id)) continue;
+				delivered.add(entry.task.id);
+				deliverable.push({ task: entry.task, settledAt: entry.settledAt, stale: now - entry.settledAt >= STALE_COMPLETION_MS });
+			}
+			return deliverable;
+		},
+		dropAll() {
+			pending = [];
+			consumed.clear();
+			delivered.clear();
+		},
+	};
+}

--- a/tests/agents-completion-delivery.test.ts
+++ b/tests/agents-completion-delivery.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCompletionQueue, STALE_COMPLETION_MS } from "../lib/agents-completion-delivery.ts";
+
+// The completion queue owns Gentle Agents' pending background completions so a
+// completion is delivered at most once, promptly, and never replays state the
+// parent already consumed (issue #867).
+
+interface FakeTask {
+	id: string;
+}
+
+const task = (id: string): FakeTask => ({ id });
+
+test("STALE_COMPLETION_MS is pinned so tests can rely on the boundary", () => {
+	assert.equal(STALE_COMPLETION_MS, 90_000);
+});
+
+test("a pending completion is delivered exactly once, in settle order", () => {
+	const queue = createCompletionQueue<FakeTask>();
+	queue.enqueue(task("t1"), 1000);
+	queue.enqueue(task("t2"), 2000);
+	const first = queue.takeDeliverable(2000);
+	assert.deepEqual(first.map((entry) => entry.task.id), ["t1", "t2"]);
+	assert.equal(first[0]!.settledAt, 1000);
+	assert.equal(first[0]!.stale, false, "a completion inside the stale window is fresh");
+	assert.deepEqual(queue.takeDeliverable(2000), [], "a taken entry is never returned twice");
+});
+
+test("duplicate enqueue for a pending task id is a no-op", () => {
+	const queue = createCompletionQueue<FakeTask>();
+	queue.enqueue(task("t1"), 1000);
+	queue.enqueue(task("t1"), 5000);
+	assert.deepEqual(queue.takeDeliverable(5000).map((entry) => entry.task.id), ["t1"]);
+});
+
+test("duplicate enqueue for a delivered task id is a no-op", () => {
+	const queue = createCompletionQueue<FakeTask>();
+	queue.enqueue(task("t1"), 1000);
+	assert.equal(queue.takeDeliverable(1000).length, 1);
+	queue.enqueue(task("t1"), 5000);
+	assert.deepEqual(queue.takeDeliverable(5000), []);
+});
+
+test("duplicate enqueue for a consumed task id is a no-op", () => {
+	const queue = createCompletionQueue<FakeTask>();
+	queue.consume("t1");
+	queue.enqueue(task("t1"), 1000);
+	assert.deepEqual(queue.takeDeliverable(5000), []);
+});
+
+test("a consumed entry is dropped and never returned", () => {
+	const queue = createCompletionQueue<FakeTask>();
+	queue.enqueue(task("t1"), 1000);
+	queue.enqueue(task("t2"), 1000);
+	queue.consume("t1");
+	assert.deepEqual(queue.takeDeliverable(2000).map((entry) => entry.task.id), ["t2"]);
+});
+
+test("consume remembers unknown ids so a later completion is suppressed", () => {
+	const queue = createCompletionQueue<FakeTask>();
+	queue.consume("t9");
+	queue.enqueue(task("t9"), 1000);
+	assert.deepEqual(queue.takeDeliverable(2000), []);
+});
+
+test("consume is idempotent", () => {
+	const queue = createCompletionQueue<FakeTask>();
+	queue.consume("t1");
+	queue.consume("t1");
+	queue.enqueue(task("t1"), 1000);
+	assert.deepEqual(queue.takeDeliverable(2000), []);
+});
+
+test("an entry is stale once now - settledAt reaches STALE_COMPLETION_MS", () => {
+	const fresh = createCompletionQueue<FakeTask>();
+	fresh.enqueue(task("t1"), 1000);
+	assert.equal(fresh.takeDeliverable(1000 + STALE_COMPLETION_MS - 1)[0]!.stale, false);
+	const stale = createCompletionQueue<FakeTask>();
+	stale.enqueue(task("t1"), 1000);
+	assert.equal(stale.takeDeliverable(1000 + STALE_COMPLETION_MS)[0]!.stale, true);
+});
+
+test("dropAll discards pending, consumed, and delivered state", () => {
+	const queue = createCompletionQueue<FakeTask>();
+	queue.enqueue(task("t1"), 1000);
+	assert.equal(queue.takeDeliverable(1000).length, 1, "delivered bookkeeping exists");
+	queue.enqueue(task("t2"), 1000);
+	queue.consume("t3");
+	queue.dropAll();
+	assert.deepEqual(queue.takeDeliverable(5000), [], "nothing pending survives dropAll");
+	queue.enqueue(task("t1"), 5000);
+	assert.deepEqual(queue.takeDeliverable(5000).map((entry) => entry.task.id), ["t1"], "the queue is fresh after dropAll");
+});

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -10,6 +10,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { visibleWidth, type TuiMouseEvent } from "@earendil-works/pi-tui";
 import gentleAgents, { agentRuntimePaths, agentsCollapseKey, agentsEnabled, agentsStopKey, agentsViewKey, answerThroughUi, completionText, legacySubagentsInstalled, type AgentsDeps } from "../extensions/gentle-agents.ts";
 import { historyDir, loadHistory, saveTask } from "../lib/agents-history.ts";
+import { STALE_COMPLETION_MS } from "../lib/agents-completion-delivery.ts";
 import { emptyThread, TASK_EVENT, TASK_STATUS, TaskStore, type TaskRecord } from "../lib/agents-protocol.ts";
 import { NativePointerScope } from "../lib/native-pointer-region.ts";
 import { PresenceCursor, PresencePublisher, listPresence, readActivity } from "../lib/orchestrator-presence.ts";
@@ -66,6 +67,7 @@ function fakePi() {
 	const commands = new Map<string, { handler(args: string, ctx: ExtensionContext): Promise<void> }>();
 	const sent: Array<{ message: Record<string, unknown>; options: Record<string, unknown> }> = [];
 	const renderers = new Map<string, (message: unknown, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }>();
+	const entryRenderers = new Map<string, (entry: { type: string; customType: string; data: unknown }, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }>();
 	const entries: Array<{ type: string; customType: string; data: unknown }> = [];
 	const events: Array<{ name: string; data: unknown }> = [];
 	const listeners = new Map<string, Set<(data: unknown) => void>>();
@@ -80,6 +82,7 @@ function fakePi() {
 		},
 		sendMessage: (message: Record<string, unknown>, options: Record<string, unknown>) => sent.push({ message, options }),
 		registerMessageRenderer: (type: string, renderer: (message: unknown, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }) => renderers.set(type, renderer),
+		registerEntryRenderer: (type: string, renderer: (entry: { type: string; customType: string; data: unknown }, options: { expanded: boolean }, theme: unknown) => { render(width: number): string[] }) => entryRenderers.set(type, renderer),
 		on: (event: string, handler: Handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
 		registerTool: (tool: Registered) => tools.set(tool.name, tool),
 		registerShortcut: (key: string, registration: { description: string; handler(ctx: ExtensionContext): Promise<void> }) => shortcuts.set(key, registration),
@@ -88,7 +91,7 @@ function fakePi() {
 	const fire = async (event: string, ctx: ExtensionContext, payload: unknown = {}) => {
 		for (const handler of handlers.get(event) ?? []) await handler(payload, ctx);
 	};
-	return { pi, tools, shortcuts, commands, fire, sent, renderers, entries, events, listeners };
+	return { pi, tools, shortcuts, commands, fire, sent, renderers, entryRenderers, entries, events, listeners };
 }
 
 function fakeContext(tui: { requestRender(): void } = fakeTui, confirmResult: (title: string, message: string) => Promise<boolean> = async () => true, inputResult: (title: string, placeholder: string | undefined) => Promise<string | undefined> = async () => undefined, overlayTui: { terminal: { rows: number }; requestRender(): void } = { terminal: { rows: 30 }, requestRender() {} }) {
@@ -1269,7 +1272,11 @@ test("background runs return at once; status, result, send_message, cancel, and 
 	assert.equal(sent.length, 1, "a background result is delivered to the model once");
 	assert.equal(sent[0].message.customType, "gentle-agents.result");
 	assert.equal(sent[0].message.display, true, "completion cards remain visible");
-	assert.deepEqual(sent[0].options, { deliverAs: "followUp", triggerTurn: true });
+	// The completion path must never regress to "followUp": the host drains the
+	// follow-up queue only when the parent run stops calling tools, which is the
+	// hour-long #867 delay. "steer" keeps the idle wake-up (triggerTurn) while
+	// bounding an active parent's wait to the current turn.
+	assert.deepEqual(sent[0].options, { deliverAs: "steer", triggerTurn: true });
 	assert.match(String(sent[0].message.content), new RegExp(`^Subagent explore \\(task ${id}, "Long job"\\) finished\\.\n\nAll done\\.$`));
 	const card = renderers.get("gentle-agents.result")!(sent[0].message, { expanded: true }, plainTheme).render(70).map(stripAnsi);
 	assert.match(card[0], /^╭─ ❀ Agent result · explore ─+ collapse ╮$/);
@@ -1736,4 +1743,124 @@ test("the production overlay reads terminal rows at render time without a minimu
 	assert.equal(overlay.render(80).length, 1, "tiny terminals retain bounded controls rather than forced chrome");
 	overlay.handleInput("\x1b");
 	await opened;
+});
+
+// Issue #867: a completion settling while the parent agent run is active must
+// be held by the extension and flushed at the next turn boundary, not parked
+// in the host's followUp queue until the whole orchestrator run stops calling
+// tools.
+test("a background completion settling while the parent agent runs is delivered exactly once at the next turn end", async () => {
+	const { pi, tools, fire, sent } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx } = fakeContext();
+	await fire("session_start", ctx);
+	const started = await tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Chained turns", mode: "background" }, undefined, undefined, ctx);
+	const id = (started.details.gentleAgents as { taskId: string }).taskId;
+	await tick();
+	await fire("agent_start", ctx);
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Chained done." }] }] });
+	harness.children[0].emit({ type: "agent_settled" });
+	await tick();
+	assert.equal(sent.filter((entry) => entry.message.customType === "gentle-agents.result").length, 0, "nothing enters the conversation while the parent agent run is active");
+	await fire("turn_end", ctx);
+	const results = sent.filter((entry) => entry.message.customType === "gentle-agents.result");
+	assert.equal(results.length, 1, "the held completion is delivered exactly once at turn_end");
+	assert.match(String(results[0]!.message.content), new RegExp(`task ${id}, "Chained turns"`));
+	// Pins the delivery mode against the host's drain semantics: "followUp" is
+	// drained by the run loop only in its stop branch, so a parent that keeps
+	// calling tools would see the completion when the whole run ends. "steer" is
+	// polled every turn and injected before the next LLM call, bounding the wait
+	// to the current turn.
+	assert.deepEqual(results[0]!.options, { deliverAs: "steer", triggerTurn: true });
+	await fire("turn_end", ctx);
+	assert.equal(sent.filter((entry) => entry.message.customType === "gentle-agents.result").length, 1, "a later turn_end never replays the completion");
+	await fire("session_shutdown", ctx);
+});
+
+test("a completion held past the stale window becomes transcript-only content and never re-enters the conversation", async () => {
+	const { pi, tools, fire, sent, entries, entryRenderers } = fakePi();
+	const harness = deps();
+	let clock = 1000;
+	harness.deps.now = () => clock;
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx } = fakeContext();
+	await fire("session_start", ctx);
+	const started = await tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Slow orchestrator", mode: "background" }, undefined, undefined, ctx);
+	const id = (started.details.gentleAgents as { taskId: string }).taskId;
+	await tick();
+	await fire("agent_start", ctx);
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Late answer." }] }] });
+	harness.children[0].emit({ type: "agent_settled" });
+	await tick();
+	clock += STALE_COMPLETION_MS + 1_000;
+	await fire("turn_end", ctx);
+	assert.equal(sent.filter((entry) => entry.message.customType === "gentle-agents.result").length, 0, "a stale completion never enters the model context");
+	const stale = entries.filter((entry) => entry.customType === "gentle-agents.stale-result");
+	assert.equal(stale.length, 1, "the human still sees the stale completion as durable transcript content");
+	assert.match(JSON.stringify(stale[0]!.data), new RegExp(id), "the stale notice names the task");
+	const rendered = entryRenderers.get("gentle-agents.stale-result")!(stale[0]!, { expanded: true }, plainTheme).render(90).map(stripAnsi).join("\n");
+	assert.match(rendered, /stale/i);
+	assert.match(rendered, new RegExp(id));
+	assert.match(rendered, /explore/);
+	assert.match(rendered, /ago/);
+	await fire("session_shutdown", ctx);
+});
+
+test("a completion the parent already pulled is dropped silently at the next turn end", async () => {
+	const { pi, tools, fire, sent } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx } = fakeContext();
+	await fire("session_start", ctx);
+	const started = await tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Pulled early", mode: "background" }, undefined, undefined, ctx);
+	const id = (started.details.gentleAgents as { taskId: string }).taskId;
+	await tick();
+	await fire("agent_start", ctx);
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Pulled answer." }] }] });
+	harness.children[0].emit({ type: "agent_settled" });
+	await tick();
+	assert.equal(sent.filter((entry) => entry.message.customType === "gentle-agents.result").length, 0);
+	assert.match((await tools.get("subagent_result")!.execute("c2", { task_id: id }, undefined, undefined, ctx)).content[0].text, /Pulled answer\./);
+	await fire("turn_end", ctx);
+	assert.equal(sent.filter((entry) => entry.message.customType === "gentle-agents.result").length, 0, "a consumed completion is dropped instead of replayed");
+	await fire("session_shutdown", ctx);
+});
+
+test("a session restart never replays a completion still pending from before it", async () => {
+	const { pi, tools, fire, sent } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx } = fakeContext();
+	await fire("session_start", ctx);
+	await tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Restarted", mode: "background" }, undefined, undefined, ctx);
+	await tick();
+	await fire("agent_start", ctx);
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Unclaimed answer." }] }] });
+	harness.children[0].emit({ type: "agent_settled" });
+	await tick();
+	assert.equal(sent.filter((entry) => entry.message.customType === "gentle-agents.result").length, 0);
+	await fire("session_start", ctx, { reason: "resume" });
+	await fire("turn_end", ctx);
+	assert.equal(sent.filter((entry) => entry.message.customType === "gentle-agents.result").length, 0, "a resumed session starts with an empty completion queue");
+	await fire("session_shutdown", ctx);
+});
+
+test("a background completion owned by a prior session is dropped, never delivered into the current session", async () => {
+	const { pi, tools, fire, sent, entries } = fakePi();
+	const harness = deps();
+	gentleAgents(pi, {}, harness.deps);
+	const { ctx } = fakeContext();
+	await fire("session_start", ctx);
+	await tools.get("subagent_run")!.execute("c1", { agent: "explore", task: "Cross session", mode: "background" }, undefined, undefined, ctx);
+	await tick();
+	(ctx.sessionManager as { getSessionId(): string }).getSessionId = () => "s2";
+	await fire("session_start", ctx, { type: "session_start", reason: "new" });
+	harness.children[0].emit({ type: "agent_end", messages: [{ role: "assistant", content: [{ type: "text", text: "Cross answer." }] }] });
+	harness.children[0].emit({ type: "agent_settled" });
+	await tick();
+	await fire("turn_end", ctx);
+	assert.equal(sent.filter((entry) => entry.message.customType === "gentle-agents.result").length, 0, "the replacement session receives no completion it does not own");
+	assert.equal(entries.filter((entry) => entry.customType === "gentle-agents.stale-result").length, 0);
+	await fire("session_shutdown", ctx);
 });


### PR DESCRIPTION
## Linked Issue

Closes #867

---

## Summary

Background subagent completions were handed to the host as `deliverAs: "followUp"` messages. The host documents that mode as "waits for agent to finish, delivered only when agent has no more tool calls", so the notification's lifetime was unbounded: in an orchestrator that chains tool-calling turns, it was delivered whenever the whole run finally went idle.

Measured in a real session transcript, this is not a hypothesis:

| task | parent pulled the result | notification delivered | delay |
|---|---|---|---|
| `mtx6xx54-1-kwyn` | 17:02:39 | 18:00:52 | **58 min** |
| `mtx7lz4k-2-hnhg` | 17:19:40 | 18:09:45 | **50 min** |

There was no compaction entry anywhere in that session file, and the notification was flushed immediately after an assistant message that had no tool calls — the next idle turn boundary. The parent had already consumed both results through the `result` tool and reported both PRs before the notifications arrived.

Gentle Pi now owns completion delivery:

- **Idle parent** → delivered immediately, exactly as before, so the wake-up behaviour is unchanged.
- **Busy parent** → held and flushed at the next turn boundary, instead of whenever the host queue happens to drain.
- **Already consumed** (the parent pulled it with `result`, or resumed it with `continue`) → dropped silently; a consumed result is never announced on top of itself.
- **Stale** (settled ≥90s before the flush) → delivered as durable transcript-only content through `appendEntry` + a registered entry renderer. It never re-enters the model context, and it names the task and how long ago it settled.
- **Owned by another session** → dropped. Completion delivery was previously the only archiving path without the session gate that notifications and queries already had, so a task launched in one session could deliver its own environment into another.

The delivery mode on the flush path is `steer`, not `followUp`, and this is the crux of the fix: while the parent streams, steering is polled every turn and injected before the next LLM call, so the delay is bounded to the current turn. `followUp`'s drain point is the run loop's stop branch, which is exactly the unbounded lifetime this bug was about.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `lib/agents-completion-delivery.ts` (new) | Dependency-free, clock-injected completion queue: `enqueue` once per task id, `consume` that also remembers unknown ids, `takeDeliverable(now)` with the explicit `stale` decision, `dropAll`. Exports `STALE_COMPLETION_MS = 90_000` with the justification in-file |
| `extensions/gentle-agents.ts` | Completion queue wiring: `settleCompletion` at `onFinish` (visibility conditions untouched), `flushCompletions` on `turn_end` with `agent_end`/`agent_settled` as safety nets, immediate flush when no agent run is active, `deliver` gated on the owning session and delivered as `steer`, stale entries appended with a renderer, `consume` at the `result` tool, task-mode `waitFor`, and `continue`, and `dropAll` on `session_start`/`session_shutdown` |
| `tests/agents-completion-delivery.test.ts` (new) | 10 unit tests: settle order, duplicate-enqueue no-ops, consumed drop, unknown-id consume memory, idempotent consume, both sides of the stale boundary |
| `tests/gentle-agents.test.ts` | 5 integration tests (hold-until-turn-end and delivered exactly once, stale goes to `appendEntry` only, consumed dropped at flush, session restart never replays, cross-session drop) plus the two option pins updated to `steer`, each with a comment naming the drain behaviour it protects against. The fake-`pi` harness gained `registerEntryRenderer`/`entryRenderers` |

---

## Test Plan

```bash
node --experimental-strip-types --test tests/agents-completion-delivery.test.ts tests/gentle-agents.test.ts
pnpm test
pnpm run typecheck
pnpm run check:runtime-modules
```

Observed:

- Focused: `tests 77 / pass 77 / fail 0`
- `pnpm test`: exit 0 — `tests 2217 / pass 2208 / fail 0 / skipped 9` (all pre-existing Windows-only skips), provider contract mirror check passed, runtime harness exit 0
- `pnpm run typecheck`: `types: 205 recorded diagnostic(s), no regressions`
- `pnpm run check:runtime-modules`: `runtime matches TypeScript sources`

**RED-first evidence.** With the tests pinned to the new behaviour and the pre-change `extensions/gentle-agents.ts`, exactly 5 integration tests fail, each with `1 !== 0` on the recorded sends — for example `a background completion settling while the parent agent runs is delivered exactly once at the next turn end` → `'nothing enters the conversation while the parent agent run is active'` (`tests/gentle-agents.test.ts:1761`). Pre-change code sent the completion while the parent was mid-run: that failure *is* the defect.

**Falsification of the mode specifically.** Reverting only the one mode token to `followUp` fails exactly 2 tests with `{ + deliverAs: 'followUp', - deliverAs: 'steer', triggerTurn: true }`; restoring it returns the file to a byte-identical hash (`3528e30a…`), with final occurrence counts `steer=1` (completions) and `followUp=2` (notification/query, intentionally untouched).

An independent read-only verification pass reproduced the falsification in its own copy, re-audited at-most-once, the no-replay-after-resume paths, and the session gate, and left the worktree byte-identical (hashes captured before and after).

---

## AI Assistance

Material assistance was used. Pi coding agent (el Gentleman harness) with delegated Pi subagents:

- a read-only exploration pass that mapped the delivery path and found the missing session gate on completions;
- a bounded implementation writer that produced the change under strict TDD and reported its own falsification evidence;
- an independent read-only verifier that reproduced the falsification, re-audited the invariants, and **rejected the first implementation** on the delivery mode, with a host-source trace (`agent-session.js` / `agent.js` / `agent-loop.js`) showing that `turn_end` still runs inside an active run and that `followUp` is drained only at the run's stop branch.

The human reviewed the diff, the design forks, and the final delivery mode, and authorized the issue approval and the dependency install in the fresh worktree. Full diff reviewed by the human before committing.

---

## Notes for Reviewers

Three things worth your attention, in order of how much I would challenge them:

1. **`steer` is a deliberate behaviour change.** A fresh completion now enters the context before the parent's next LLM call rather than after the whole run. That is requirement #1 of the issue ("promptly enough to represent the current task state") and it is what makes the delay bounded, but it does mean a completion can interleave between tool calls of the orchestrating run. `onNotification` and `onQuery` keep `followUp` untouched.
2. **`STALE_COMPLETION_MS = 90_000` makes a long parent turn transcript-only.** A single turn legitimately exceeding 90s means its held completion becomes TUI-only instead of a conversation message. That is requirement #3, and the result stays reachable through `subagent_status`/`subagent_result`, but it is a real threshold decision and I would rather it be argued about than assume it.
3. **`agent_end` is kept as a flush trigger** even though the host may still auto-retry or continue after it, because a run can end without another `turn_end` (abort, or a run with no assistant message). The host compensates for an early post-run return via `hasQueuedMessages()` + `continue()` (`agent-session.js:776-778, 808-810`), and steering stays bounded there; `agent_settled` is documented in-code as a normally-no-op safety net.

Test-harness limitation to be aware of: the fake `pi` records `sendMessage`/`appendEntry` synchronously and has no `isStreaming` model, so the suite cannot observe host-side injection timing. The mode pins are therefore the regression guard — `tests/gentle-agents.test.ts:1275-1280` and `:1766-1772`. A future edit that silently restores `followUp` will fail them.

Deliberately not changed: the `onNotification`/`onQuery` paths, and the display-only `/new` + `/resume` behaviour pinned at `tests/gentle-agents.test.ts:1682-1702`.

Known residual risks, stated rather than smoothed over: a crash between enqueue and flush loses a completion (equivalent to the old behaviour, where a held `followUp` also died with the process); if the extension is registered mid-run, one completion can still take the host queue for that run and self-correct afterwards; and the stale card's live TUI rendering was verified through the renderer contract and the installed type definitions, not in a real interactive session.

Also observed while doing this work, and **not** caused by this change: `gentle_review_capture_group` reported `prepared_reviewers: 4, submitted_reviewers: 3` with `native-operation-failed` on the last lens, twice in a row across two different repositories, and bound STATUS then reconciled the lineage to `approved`. Either the engine tolerates a missing lens or the relay bookkeeping is wrong; it deserves its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Background agent completions are delivered at the next turn boundary while the parent agent is still running.
  * Completions are delivered in settlement order and only once.

* **Bug Fixes**
  * Older completions are marked as stale and shown in the transcript without being added to model context.
  * Pending completions are cleared when sessions restart or shut down, preventing results from appearing in the wrong session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->