### PR TITLE
feat(profiles): full-screen panel with per-agent routing and orchestrator in the profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,23 +640,24 @@ Legacy string entries are still accepted and treated as `model`-only config.
 /gentle:profiles
 ```
 
-Profiles are named, switchable snapshots of the global agent-model routing from `/gentle:models`. The panel shows the profile list on the left and a detail pane comparing the selected profile's routing with the currently effective routing. Keys:
+Profiles are named, switchable snapshots of the global agent-model routing from `/gentle:models`. The panel fills the terminal, shows the profile list on the left, and a detail pane comparing the selected profile's routing with the currently effective routing, one line per agent in shared columns. Keys:
 
 | Key     | Action                                                                 |
 | ------- | ---------------------------------------------------------------------- |
-| `enter` | Apply the selected profile live (writes `models.json`, reconciles agents). |
+| `enter` | Apply the selected profile live (writes `models.json`, reconciles agents, sets the orchestrator when the profile defines one). |
 | `c`     | Create a new, empty profile.                                           |
-| `s`     | Update the selected profile from the current routing.                  |
+| `s`     | Update the selected profile from the current routing (including the orchestrator currently set in `settings.json`). |
 | `d`     | Duplicate the selected profile.                                        |
 | `r`     | Rename the selected profile (keeps it active if it was active).        |
 | `x`     | Delete the selected profile (refuses the active profile).              |
 | `e`     | Export the selected profile to `~/.pi/gentle-ai/profiles.export.json`. |
 | `i`     | Import a profile from `~/.pi/gentle-ai/profiles.export.json`.          |
+| `pgup`/`pgdn`, `ctrl+j`/`ctrl+k`, wheel | Scroll the detail pane.                                |
 | `esc`   | Close.                                                                 |
 
 Applying a profile writes `~/.pi/gentle-ai/models.json`, then reconciles agent frontmatter and `subagents.json` the same way `/gentle:models` does. The reconciliation happens on the next subagent launch, and that launch still routes with the previous routing — expect one launch of lag after switching. The active profile is persisted so `/gentle:profiles` reopens with the applied profile marked.
 
-Profiles only cover per-agent routing for SDD/custom agents. The orchestrator model selected in `settings.json` is NOT part of a profile and is never changed by applying one.
+A profile also carries the orchestrator under the reserved routing key `orchestrator`. Applying a profile that defines it writes `defaultProvider`, `defaultModel`, and `defaultThinkingLevel` to Pi's global `settings.json` (preserving every other key; an unreadable `settings.json` aborts that part and is reported instead of being overwritten). Applying a profile without an `orchestrator` entry never moves the orchestrator, and `s` snapshots the currently effective orchestrator together with the routing. `orchestrator` is reserved: it is not a subagent name, is never written to `subagents.json`, and is not counted as a role.
 
 When `profiles.json` is missing, the command seeds one profile named `current` captured from the existing `models.json`, marked active only when `models.json` has routing entries. Profiles or routing entries dropped by normalization are named in a warning instead of being lost silently.
 
@@ -675,6 +676,10 @@ Store shape:
   "active": "deep-work",
   "profiles": {
     "deep-work": {
+      "orchestrator": {
+        "model": "anthropic/claude-sonnet-4",
+        "thinking": "high"
+      },
       "sdd-design": {
         "model": "anthropic/claude-sonnet-4",
         "thinking": "high"

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -32,7 +32,7 @@ import type {
 	ThemeColor,
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
-import { isKeyRelease, matchesKey, truncateToWidth, type KeybindingsManager, type TuiMouseEvent, type TuiMouseEventResult } from "@earendil-works/pi-tui";
+import { Key, isKeyRelease, matchesKey, truncateToWidth, type KeybindingsManager, type TuiMouseEvent, type TuiMouseEventResult } from "@earendil-works/pi-tui";
 import { resolveGentlePiAgentHome } from "../lib/agent-home.ts";
 import {
 	ensureSddPreflight,
@@ -67,21 +67,33 @@ import {
 	createProfile,
 	deleteProfile,
 	duplicateProfile,
-	formatProfileSummaryLines,
+	formatOrchestratorSelection,
+	formatRoutingRow,
+	isProfileOrchestratorKey,
 	parseProfileExportTextWithDrops,
+	PROFILE_ORCHESTRATOR_KEY,
 	profileExportPath,
+	profileRoutingRows,
 	profilesFilePath,
+	readProfileOrchestrator,
 	readProfilesFileResult,
 	renameProfile,
+	routingColumnWidths,
 	serializeProfileExport,
 	setActiveProfile,
-	summarizeProfile,
 	updateProfile,
 	writeProfilesFileSync,
 	type AgentProfilesFile,
 	type ProfileListItem,
+	type ProfileRoutingRow,
 	type ProfilesParseDrops,
 } from "../lib/agent-profiles.ts";
+import {
+	applyOrchestratorSettings,
+	readOrchestratorSettings,
+	restoreOrchestratorSettings,
+	type OrchestratorSettingsReadResult,
+} from "../lib/profiles-orchestrator.ts";
 import { measureAgentsViewLayout, type AgentsViewLayout } from "../lib/agents-view-layout.ts";
 import { NativeChoiceList } from "../lib/native-choice-list.ts";
 import { createNativeFullscreenInteraction } from "../lib/native-fullscreen-interaction.ts";
@@ -2333,6 +2345,15 @@ function projectSettingsPath(cwd: string): string {
 	return join(cwd, ".pi", "settings.json");
 }
 
+/**
+ * Pi's own global settings file, which is where the orchestrator model lives.
+ * Profiles own the three `default*` keys there; nothing else in this extension
+ * reads or writes that file.
+ */
+function orchestratorSettingsPath(): string {
+	return join(gentlePiAgentHome(), "settings.json");
+}
+
 function removeLegacyAgentOverridesFromSettings(
 	settingsPath: string,
 	settings: Record<string, unknown>,
@@ -2473,6 +2494,9 @@ export function applyModelConfig(
 	}
 	for (const [name, entry] of Object.entries(config)) {
 		if (isProviderReviewRole(name)) continue;
+		// The orchestrator is routing, not an agent: its model lives in Pi's global
+		// settings.json and must never reach subagents.json.
+		if (isProfileOrchestratorKey(name)) continue;
 		if (!seenAgents.has(name) && isClearRoutingEntry(entry)) {
 			if (updateSubagentModelProfile(cwd, "user", name, entry)) updated += 1;
 			else skipped += 1;
@@ -2522,6 +2546,7 @@ export async function applyModelConfigAsync(
 	}
 	for (const [name, entry] of Object.entries(config)) {
 		if (isProviderReviewRole(name)) continue;
+		if (isProfileOrchestratorKey(name)) continue;
 		if (!seenAgents.has(name) && isClearRoutingEntry(entry)) {
 			if (await updateSubagentModelProfileAsync(cwd, "user", name, entry))
 				updated += 1;
@@ -3224,17 +3249,29 @@ function profilesErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+/** Keep a detail-pane scroll offset inside the bounds of its own content. */
+function clampDetailScroll(offset: number, lineCount: number, bodyRows: number): number {
+	return Math.max(0, Math.min(offset, Math.max(0, lineCount - bodyRows)));
+}
+
 // Left profile list, right detail panes. Rendering and pointer routing share
 // one measured layout; the list rows keep native keyboard, hover, press,
-// click, and wheel handling through NativeChoiceList.
+// click, and wheel handling through NativeChoiceList. The frame takes the full
+// overlay, so its height follows the terminal rows the same way AgentsView does.
 class ProfilesPanel implements OverlayComponent {
 	private completed = false;
 	private pointerLayout: ProfilesPanelPointerLayout | undefined;
+	private detailScroll = 0;
+	private lastDetailLineCount = 0;
+	private lastDetailRows = 0;
+	private lastSelectedId: string | undefined;
 	readonly list: NativeChoiceList<ProfileListItem>;
 	private readonly file: AgentProfilesFile;
 	private readonly currentConfig: AgentModelConfig;
 	private readonly done: (result: ProfilesPanelResult) => void;
 	private readonly theme: Theme | undefined;
+	private readonly rows: () => number;
+	private readonly orchestratorSettings: OrchestratorSettingsReadResult;
 
 	constructor(
 		file: AgentProfilesFile,
@@ -3242,12 +3279,16 @@ class ProfilesPanel implements OverlayComponent {
 		done: (result: ProfilesPanelResult) => void,
 		keybindings: KeybindingsManager | undefined,
 		theme: Theme | undefined,
-		selectedName?: string,
+		selectedName: string | undefined,
+		rows: () => number,
+		orchestratorSettings: OrchestratorSettingsReadResult,
 	) {
 		this.file = file;
 		this.currentConfig = currentConfig;
 		this.done = done;
 		this.theme = theme;
+		this.rows = rows;
+		this.orchestratorSettings = orchestratorSettings;
 		const items = buildProfileListItems(file);
 		this.list = new NativeChoiceList<ProfileListItem>(
 			items,
@@ -3277,6 +3318,14 @@ class ProfilesPanel implements OverlayComponent {
 			return;
 		}
 		const name = this.list.getSelectedItem()?.id;
+		if (matchesKey(data, Key.pageDown) || matchesKey(data, Key.ctrl("j"))) {
+			this.scrollDetail(this.pageRows());
+			return;
+		}
+		if (matchesKey(data, Key.pageUp) || matchesKey(data, Key.ctrl("k"))) {
+			this.scrollDetail(-this.pageRows());
+			return;
+		}
 		if (data === "c") return this.finish({ type: "create" });
 		if (data === "i") return this.finish({ type: "import" });
 		if (!name) return this.list.handleInput(data);
@@ -3291,7 +3340,19 @@ class ProfilesPanel implements OverlayComponent {
 	handleMouse(event: TuiMouseEvent): TuiMouseEventResult | undefined {
 		const layout = this.pointerLayout;
 		if (!layout) return undefined;
-		if (event.y < layout.listTop || event.y >= layout.listTop + layout.bodyRows) return undefined;
+		const inBody = event.y >= layout.listTop && event.y < layout.listTop + layout.bodyRows;
+		if (
+			inBody &&
+			event.type === "wheel" &&
+			event.wheelDelta &&
+			layout.mode === "panes" &&
+			event.x >= layout.threadX &&
+			event.x < layout.threadX + layout.threadWidth
+		) {
+			this.scrollDetail(event.wheelDelta);
+			return { handled: true, render: true };
+		}
+		if (!inBody) return undefined;
 		if (event.x < layout.listX || event.x >= layout.listX + layout.listWidth) return undefined;
 		return this.list.handleMouse({
 			...event,
@@ -3306,14 +3367,24 @@ class ProfilesPanel implements OverlayComponent {
 		const safeWidth = Math.max(1, width);
 		const listWidth = measureAgentsViewLayout(safeWidth, PROFILES_PANEL_MIN_BODY_ROWS + 3).listWidth;
 		const listLines = this.list.render(listWidth);
-		const bodyRows = Math.max(PROFILES_PANEL_MIN_BODY_ROWS, listLines.length);
-		const layout = measureAgentsViewLayout(safeWidth, bodyRows + 3);
+		// The frame fills the overlay, and the overlay fills the terminal, so the
+		// body height comes from the terminal rows rather than from the content.
+		const rows = Math.max(PROFILES_PANEL_MIN_BODY_ROWS + 3, Math.floor(this.rows()));
+		const layout = measureAgentsViewLayout(safeWidth, rows);
 		if (layout.mode === "fallback" || layout.width === 0) {
 			this.pointerLayout = undefined;
 			return [];
 		}
-		this.pointerLayout = { ...layout, listTop: 1 };
+		const selectedId = this.list.getSelectedItem()?.id;
+		if (selectedId !== this.lastSelectedId) {
+			this.lastSelectedId = selectedId;
+			this.detailScroll = 0;
+		}
 		const detailLines = this.renderDetailLines(layout.threadWidth, layout.mode === "panes");
+		this.lastDetailLineCount = detailLines.length;
+		this.lastDetailRows = layout.bodyRows;
+		this.detailScroll = clampDetailScroll(this.detailScroll, detailLines.length, layout.bodyRows);
+		this.pointerLayout = { ...layout, listTop: 1 };
 		const rule = "─".repeat(Math.max(0, layout.width - 2));
 		const lines: string[] = [this.renderText(`╭${rule}╮`, "border")];
 		for (let row = 0; row < layout.bodyRows; row += 1) {
@@ -3322,6 +3393,18 @@ class ProfilesPanel implements OverlayComponent {
 		lines.push(this.renderFooterRow(layout.width));
 		lines.push(this.renderText(`╰${rule}╯`, "border"));
 		return lines;
+	}
+
+	private scrollDetail(delta: number): void {
+		this.detailScroll = clampDetailScroll(
+			this.detailScroll + Math.trunc(delta),
+			this.lastDetailLineCount,
+			this.lastDetailRows,
+		);
+	}
+
+	private pageRows(): number {
+		return Math.max(1, this.lastDetailRows - 1);
 	}
 
 	private finish(result: ProfilesPanelResult): void {
@@ -3345,7 +3428,7 @@ class ProfilesPanel implements OverlayComponent {
 				" ",
 				this.renderText("│", "border"),
 				" ",
-				this.fitPaneLine(detailLines[row] ?? "", layout.threadWidth),
+				this.fitPaneLine(detailLines[this.detailScroll + row] ?? "", layout.threadWidth),
 				this.renderText("│", "border"),
 			].join("");
 		}
@@ -3360,7 +3443,7 @@ class ProfilesPanel implements OverlayComponent {
 
 	private renderFooterRow(width: number): string {
 		const hints =
-			"enter apply · c create · s update · d duplicate · r rename · x delete · e export · i import · esc close";
+			"enter apply · c create · s update · d duplicate · r rename · x delete · e export · i import · pgup/pgdn scroll · esc close";
 		return [
 			this.renderText("│", "border"),
 			" ",
@@ -3377,15 +3460,44 @@ class ProfilesPanel implements OverlayComponent {
 			return [this.renderLine("No profile selected.", width, "muted")];
 		}
 		const config = this.file.profiles[name];
+		const profileRows = profileRoutingRows(config);
+		const currentRows = profileRoutingRows(this.currentConfig);
+		// One shared measurement across both tables, so the same agent sits in the
+		// same column whether it comes from the profile or from models.json.
+		const widths = routingColumnWidths(profileRows, currentRows);
 		return [
 			this.renderLine(name === this.file.active ? `${name} (active)` : name, width, "title"),
+			this.renderLine(
+				`orchestrator  ${formatOrchestratorSelection(readProfileOrchestrator(config))}`,
+				width,
+				"text",
+			),
+			this.renderLine(`now           ${this.effectiveOrchestratorLabel()}`, width, "muted"),
 			"",
 			this.renderLine("Profile routing", width, "accent"),
-			...this.indentLines(formatProfileSummaryLines(summarizeProfile(config)), width),
+			...this.indentLines(this.routingLines(profileRows, widths), width),
 			"",
 			this.renderLine("Current routing (models.json)", width, "accent"),
-			...this.indentLines(formatProfileSummaryLines(summarizeProfile(this.currentConfig)), width),
+			...this.indentLines(this.routingLines(currentRows, widths), width),
 		];
+	}
+
+	private effectiveOrchestratorLabel(): string {
+		const settings = this.orchestratorSettings;
+		if (settings.status === "invalid") {
+			return `unreadable (${sanitizeTerminalText(settings.reason)})`;
+		}
+		return formatOrchestratorSelection(settings.status === "valid" ? settings.entry : undefined);
+	}
+
+	private routingLines(
+		rows: ProfileRoutingRow[],
+		widths: { agent: number; model: number },
+	): string[] {
+		if (rows.length === 0) {
+			return ["No routing entries — every agent inherits its default model."];
+		}
+		return rows.map((row) => formatRoutingRow(row, widths));
 	}
 
 	private indentLines(lines: string[], width: number): string[] {
@@ -3423,9 +3535,21 @@ async function showProfilesPanel(
 	currentConfig: AgentModelConfig,
 	selectedName?: string,
 ): Promise<ProfilesPanelResult> {
+	// Read once, for the panel lifetime. The orchestrator shown as "now" is the
+	// state the panel opened on, not a value that changes mid-panel.
+	const orchestratorSettings = readOrchestratorSettings(orchestratorSettingsPath());
 	return ctx.ui.custom<ProfilesPanelResult>(
 		(tui, theme, keybindings, done) => {
-			const panel = new ProfilesPanel(file, currentConfig, done, keybindings, theme, selectedName);
+			const panel = new ProfilesPanel(
+				file,
+				currentConfig,
+				done,
+				keybindings,
+				theme,
+				selectedName,
+				() => Math.max(0, tui.terminal.rows),
+				orchestratorSettings,
+			);
 			const container = createNativeFullscreenInteraction({
 				keyboardTarget: panel,
 				requestRender: () => tui.requestRender(),
@@ -3438,9 +3562,9 @@ async function showProfilesPanel(
 			overlay: true,
 			overlayOptions: {
 				anchor: "center",
-				width: "70%",
-				minWidth: 72,
-				maxHeight: "85%",
+				width: "100%",
+				maxHeight: "100%",
+				margin: 0,
 			},
 		},
 	);
@@ -3480,12 +3604,14 @@ async function runProfilesPanelAction(
 		case "apply": {
 			if (!hasOwnProfile(file.profiles, result.name)) return file;
 			const normalized = normalizeModelConfig(file.profiles[result.name]) ?? {};
-			// Applying spans two files and there is no cross-file rename, so order the
-			// writes to keep the store truthful and compensate on failure: claim the
-			// profile in the store first, then materialise routing. A claim that fails
-			// leaves routing untouched; anything that fails after the claim restores the
-			// previous claim and, when the previously active profile is known, the
-			// routing that profile implies.
+			const orchestratorEntry = readProfileOrchestrator(normalized);
+			// Applying spans three files — the store, models.json, and Pi's global
+			// settings.json — and there is no cross-file rename, so order the writes to
+			// keep the store truthful and compensate on failure: claim the profile in
+			// the store first, then materialise routing, then the orchestrator. A claim
+			// that fails leaves routing untouched; anything that fails after the claim
+			// restores the previous claim and, when the previously active profile is
+			// known, the routing that profile implies.
 			const claimed = setActiveProfile(file, result.name);
 			try {
 				writeProfilesFileSync(path, claimed);
@@ -3500,6 +3626,11 @@ async function runProfilesPanelAction(
 				file.active !== undefined && hasOwnProfile(file.profiles, file.active)
 					? normalizeModelConfig(file.profiles[file.active]) ?? {}
 					: undefined;
+			// Set only when the orchestrator write succeeded, so the revert knows it has
+			// something to undo. A rollback closure (not a previous-bytes value) is used
+			// because "the file did not exist before" is a real state that must restore
+			// by removing the file, and `undefined` bytes cannot carry that distinction.
+			let orchestratorRollback: (() => void) | undefined;
 			const revertClaim = async (routingWritten: boolean): Promise<AgentProfilesFile> => {
 				let restored = previousActiveConfig === undefined ? "" : "routing";
 				if (routingWritten && previousActiveConfig !== undefined) {
@@ -3507,6 +3638,14 @@ async function runProfilesPanelAction(
 						await writeModelConfigAsync(ctx.cwd, previousActiveConfig);
 					} catch {
 						restored = "";
+					}
+				}
+				if (orchestratorRollback) {
+					try {
+						orchestratorRollback();
+						restored = restored === "" ? "settings" : `${restored} and settings`;
+					} catch {
+						restored = restored === "" ? "" : restored;
 					}
 				}
 				try {
@@ -3538,11 +3677,28 @@ async function runProfilesPanelAction(
 			if (applyResult.invalidPath) {
 				return revertClaim(true);
 			}
+			let orchestratorNote = "";
+			if (orchestratorEntry !== undefined) {
+				const settingsPath = orchestratorSettingsPath();
+				const written = applyOrchestratorSettings(settingsPath, orchestratorEntry);
+				if (written.status === "invalid") {
+					ctx.ui.notify(
+						`el Gentleman could not set the orchestrator from profile "${result.name}": ${sanitizeTerminalText(written.reason)}. ${sanitizeTerminalText(settingsPath)} was left unchanged.`,
+						"warning",
+					);
+					return revertClaim(true);
+				}
+				if (written.status === "written") {
+					const previous = written.previous;
+					orchestratorRollback = () => restoreOrchestratorSettings(settingsPath, previous);
+					orchestratorNote = `\nOrchestrator set to ${formatOrchestratorSelection(orchestratorEntry)} in ${sanitizeTerminalText(settingsPath)}.`;
+				}
+			}
 			ctx.ui.notify(
 				[
 					`el Gentleman applied profile "${result.name}" — ${applyResult.updated} agent${applyResult.updated === 1 ? "" : "s"} updated.`,
 					"New routing takes effect on the next subagent launch.",
-				].join("\n"),
+				].join("\n") + orchestratorNote,
 				"info",
 			);
 			return claimed;
@@ -3561,8 +3717,17 @@ async function runProfilesPanelAction(
 		}
 		case "update": {
 			const current = await readModelConfigAsync(ctx.cwd);
+			// A profile is a complete snapshot, so capturing the current routing also
+			// captures the orchestrator the routing is running under. A settings file
+			// that cannot be read leaves the snapshot without an orchestrator entry
+			// rather than inventing one.
+			const settings = readOrchestratorSettings(orchestratorSettingsPath());
+			const snapshot: AgentModelConfig = cloneModelConfig(current);
+			if (settings.status === "valid" && settings.entry !== undefined) {
+				snapshot[PROFILE_ORCHESTRATOR_KEY] = { ...settings.entry };
+			}
 			try {
-				const next = updateProfile(file, result.name, cloneModelConfig(current));
+				const next = updateProfile(file, result.name, snapshot);
 				writeProfilesFileSync(path, next);
 				ctx.ui.notify(
 					`el Gentleman updated profile "${result.name}" from the current routing in ${modelConfigPath(ctx.cwd)}.`,

--- a/lib/agent-profiles.ts
+++ b/lib/agent-profiles.ts
@@ -11,6 +11,7 @@ import { basename, dirname, join } from "node:path";
 import {
 	normalizeModelConfig,
 	type AgentModelConfig,
+	type AgentRoutingEntry,
 } from "./model-routing-authority.ts";
 
 export const PROFILES_KIND = "gentle-pi.agent_model_profiles";
@@ -47,6 +48,38 @@ const PROFILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 const RESERVED_PROFILE_NAMES = new Set(["__proto__", "constructor", "prototype"]);
 
 const INHERIT_MODEL_LABEL = "inherit";
+
+/**
+ * Reserved routing key for the orchestrator selection.
+ *
+ * A profile is a complete snapshot of the routing, and the orchestrator is part
+ * of it, but the orchestrator is not an agent: it is never written to
+ * `subagents.json`, never has an agent file, and its model lives in Pi's global
+ * `settings.json`. The key is reserved so the routing map can carry it while
+ * every agent-facing path skips it.
+ */
+export const PROFILE_ORCHESTRATOR_KEY = "orchestrator";
+
+export function isProfileOrchestratorKey(key: string): boolean {
+	return key === PROFILE_ORCHESTRATOR_KEY;
+}
+
+/** The profile's own orchestrator entry, when the profile defines one. */
+export function readProfileOrchestrator(
+	config: AgentModelConfig,
+): AgentRoutingEntry | undefined {
+	if (!Object.prototype.hasOwnProperty.call(config, PROFILE_ORCHESTRATOR_KEY)) return undefined;
+	const entry = config[PROFILE_ORCHESTRATOR_KEY];
+	return entry && Object.keys(entry).length > 0 ? entry : undefined;
+}
+
+/**
+ * The routing map without its reserved orchestrator key, for every caller that
+ * counts or lists roles: the orchestrator is not a role.
+ */
+export function profileRoleEntries(config: AgentModelConfig): Array<[string, AgentRoutingEntry]> {
+	return Object.entries(config).filter(([agent]) => !isProfileOrchestratorKey(agent));
+}
 
 export function isValidProfileName(value: unknown): value is string {
 	return (
@@ -281,7 +314,7 @@ export interface ProfileSummary {
 
 export function summarizeProfile(config: AgentModelConfig): ProfileSummary {
 	const byModel = new Map<string, string[]>();
-	for (const [agent, entry] of Object.entries(config)) {
+	for (const [agent, entry] of profileRoleEntries(config)) {
 		const model = entry?.model ?? INHERIT_MODEL_LABEL;
 		const roles = byModel.get(model);
 		if (roles) roles.push(agent);
@@ -310,6 +343,63 @@ export function formatProfileSummaryLines(summary: ProfileSummary): string[] {
 	);
 }
 
+export interface ProfileRoutingRow {
+	agent: string;
+	model: string;
+	thinking: string;
+}
+
+/**
+ * One row per agent, in a stable alphabetical order so the profile's routing and
+ * the effective routing can be compared line by line, and with the reserved
+ * orchestrator key excluded because it is rendered on its own line.
+ */
+export function profileRoutingRows(config: AgentModelConfig): ProfileRoutingRow[] {
+	return profileRoleEntries(config)
+		.map(([agent, entry]) => ({
+			agent,
+			model: entry?.model ?? INHERIT_MODEL_LABEL,
+			thinking: entry?.thinking ?? INHERIT_MODEL_LABEL,
+		}))
+		.sort((left, right) => left.agent.localeCompare(right.agent));
+}
+
+/**
+ * Column widths shared by every routing table in one panel, so the profile's
+ * routing and the effective routing align column for column instead of each
+ * section sizing itself.
+ */
+export function routingColumnWidths(
+	...groups: ProfileRoutingRow[][]
+): { agent: number; model: number } {
+	const rows = groups.flat();
+	return {
+		agent: rows.reduce((width, row) => Math.max(width, row.agent.length), 0),
+		model: rows.reduce((width, row) => Math.max(width, row.model.length), 0),
+	};
+}
+
+export function formatRoutingRow(
+	row: ProfileRoutingRow,
+	widths: { agent: number; model: number },
+): string {
+	return `${row.agent.padEnd(widths.agent)}  ${row.model.padEnd(widths.model)}  ${row.thinking}`;
+}
+
+/**
+ * A single line describing an orchestrator selection, for the panel header. The
+ * label distinguishes "this profile sets nothing" from "settings.json cannot be
+ * read", which are different operator states.
+ */
+export function formatOrchestratorSelection(entry: AgentRoutingEntry | undefined): string {
+	if (entry?.model === undefined) {
+		return entry?.thinking === undefined
+			? INHERIT_MODEL_LABEL
+			: `${INHERIT_MODEL_LABEL} · ${entry.thinking}`;
+	}
+	return entry.thinking === undefined ? entry.model : `${entry.model} · ${entry.thinking}`;
+}
+
 export interface ProfileListItem {
 	id: string;
 	label: string;
@@ -318,7 +408,7 @@ export interface ProfileListItem {
 
 export function buildProfileListItems(file: AgentProfilesFile): ProfileListItem[] {
 	return Object.entries(file.profiles).map(([name, config]) => {
-		const roles = Object.keys(config).length;
+		const roles = profileRoleEntries(config).length;
 		return {
 			id: name,
 			label: name === file.active ? `${name} (active)` : name,

--- a/lib/profiles-orchestrator.ts
+++ b/lib/profiles-orchestrator.ts
@@ -1,0 +1,203 @@
+// Orchestrator selection for agent-model profiles.
+//
+// A profile is a complete snapshot of the routing, and the orchestrator is part
+// of that routing. Unlike every agent, the orchestrator does not live in
+// `models.json`: Pi keeps it in its own global `settings.json` as
+// `defaultProvider` / `defaultModel` / `defaultThinkingLevel`. This module owns
+// reading and writing those three keys and nothing else.
+//
+// The write is deliberately conservative. It re-serializes the whole file so
+// every unrelated key Pi and other extensions own (`packages`, telemetry
+// settings, theme, terminal options) survives, it refuses to touch a file it
+// cannot parse instead of replacing it with a fresh object, and it swaps the
+// destination through a sibling temp file plus a rename so an interrupted write
+// can never leave truncated JSON behind.
+
+import { randomUUID } from "node:crypto";
+import { closeSync, constants, existsSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import {
+	isThinkingLevel,
+	normalizeModelId,
+	type AgentRoutingEntry,
+} from "./model-routing-authority.ts";
+
+/** The three Pi settings keys a profile's orchestrator entry owns. */
+export const ORCHESTRATOR_SETTINGS_KEYS = [
+	"defaultProvider",
+	"defaultModel",
+	"defaultThinkingLevel",
+] as const;
+
+export interface OrchestratorModelRef {
+	provider: string;
+	model: string;
+}
+
+/**
+ * Split a `provider/model` routing id. A profile entry stores one opaque model
+ * id, while Pi stores the two halves separately, so the split happens here and
+ * only here. Ids without a provider half are rejected rather than guessed: an
+ * orchestrator write is not the place to invent a provider.
+ */
+export function parseOrchestratorModelRef(modelId: unknown): OrchestratorModelRef | undefined {
+	const normalized = normalizeModelId(modelId);
+	if (normalized === undefined) return undefined;
+	const separator = normalized.indexOf("/");
+	if (separator <= 0 || separator === normalized.length - 1) return undefined;
+	return {
+		provider: normalized.slice(0, separator),
+		model: normalized.slice(separator + 1),
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export type OrchestratorSettingsReadResult =
+	| { status: "missing" }
+	| { status: "invalid"; reason: string }
+	| { status: "valid"; entry?: AgentRoutingEntry; value: Record<string, unknown> };
+
+/**
+ * Read the effective orchestrator selection from a Pi settings file. A settings
+ * file that is absent or unreadable is reported, never silently treated as
+ * "no orchestrator": the panel has to distinguish "not set" from "cannot tell".
+ */
+export function readOrchestratorSettings(settingsPath: string): OrchestratorSettingsReadResult {
+	if (!existsSync(settingsPath)) return { status: "missing" };
+	let value: unknown;
+	try {
+		value = JSON.parse(readFileSync(settingsPath, "utf8"));
+	} catch (error) {
+		return { status: "invalid", reason: describeError(error) };
+	}
+	if (!isRecord(value)) return { status: "invalid", reason: "the file is not a JSON object" };
+	const provider = value.defaultProvider;
+	const model = value.defaultModel;
+	if (typeof provider !== "string" || typeof model !== "string") {
+		return { status: "valid", entry: undefined, value };
+	}
+	if (provider.length === 0 || model.length === 0) {
+		return { status: "valid", entry: undefined, value };
+	}
+	const entry: AgentRoutingEntry = { model: `${provider}/${model}` };
+	if (isThinkingLevel(value.defaultThinkingLevel)) entry.thinking = value.defaultThinkingLevel;
+	return { status: "valid", entry, value };
+}
+
+export type OrchestratorSettingsWriteResult =
+	| { status: "invalid"; reason: string }
+	| { status: "unchanged" }
+	| { status: "written"; previous?: string };
+
+/**
+ * Persist one orchestrator routing entry into a Pi settings file.
+ *
+ * `entry` is a profile routing entry: `{ model?, thinking? }`. A missing model
+ * means the profile says nothing about the orchestrator, so the file is left
+ * exactly as it was — a profile without an orchestrator entry must never move
+ * the orchestrator, not even to "unset".
+ *
+ * `previous` carries the raw bytes that were there before a successful write so
+ * the caller can honour its own revert contract. `undefined` means the file did
+ * not exist and restoring means removing it.
+ */
+export function applyOrchestratorSettings(
+	settingsPath: string,
+	entry: AgentRoutingEntry,
+): OrchestratorSettingsWriteResult {
+	if (entry.model === undefined) return { status: "unchanged" };
+	const reference = parseOrchestratorModelRef(entry.model);
+	if (reference === undefined) {
+		return {
+			status: "invalid",
+			reason: `model id ${JSON.stringify(entry.model)} is not a provider/model pair`,
+		};
+	}
+	const read = readOrchestratorSettings(settingsPath);
+	if (read.status === "invalid") return { status: "invalid", reason: read.reason };
+	// Safe after the invalid check above: the file either parses as an object or
+	// does not exist, and a missing file means there is nothing to restore.
+	const previous = readPrevious(settingsPath);
+	const next: Record<string, unknown> = { ...(read.status === "valid" ? read.value : {}) };
+	next.defaultProvider = reference.provider;
+	next.defaultModel = reference.model;
+	if (entry.thinking === undefined) delete next.defaultThinkingLevel;
+	else next.defaultThinkingLevel = entry.thinking;
+	const text = `${JSON.stringify(next, null, 2)}\n`;
+	if (previous === text) return { status: "unchanged" };
+	writeFileAtomically(settingsPath, text);
+	return { status: "written", previous };
+}
+
+function readPrevious(settingsPath: string): string | undefined {
+	try {
+		return readFileSync(settingsPath, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Restore the bytes a successful orchestrator write replaced. `undefined` means
+ * the write created the file, so restoring removes it.
+ */
+export function restoreOrchestratorSettings(
+	settingsPath: string,
+	previous: string | undefined,
+): void {
+	if (previous === undefined) {
+		try {
+			unlinkSync(settingsPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+		return;
+	}
+	writeFileAtomically(settingsPath, previous);
+}
+
+/**
+ * Sibling temp file plus rename, with the same failure discipline as the profile
+ * store: every step records its own error, cleanup never throws, and the error
+ * that actually broke the write is the one reported.
+ */
+function writeFileAtomically(path: string, text: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const temporary = join(dirname(path), `.${basename(path)}.${randomUUID()}.tmp`);
+	const descriptor = openSync(
+		temporary,
+		constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+		0o600,
+	);
+	const failures: unknown[] = [];
+	try {
+		writeFileSync(descriptor, text);
+	} catch (error) {
+		failures.push(error);
+	}
+	try {
+		closeSync(descriptor);
+	} catch (error) {
+		failures.push(error);
+	}
+	if (failures.length === 0) {
+		try {
+			renameSync(temporary, path);
+		} catch (error) {
+			failures.push(error);
+		}
+	}
+	try {
+		unlinkSync(temporary);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") failures.push(error);
+	}
+	if (failures.length > 0) throw failures[0];
+}
+
+function describeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/tests/agent-profiles.test.ts
+++ b/tests/agent-profiles.test.ts
@@ -11,7 +11,9 @@ import {
 	deleteProfile,
 	duplicateProfile,
 	emptyProfilesFile,
+	formatOrchestratorSelection,
 	formatProfileSummaryLines,
+	formatRoutingRow,
 	isValidProfileName,
 	normalizeProfilesFile,
 	parseProfileExportText,
@@ -19,12 +21,17 @@ import {
 	parseProfilesFileText,
 	PROFILE_EXPORT_KIND,
 	PROFILE_EXPORT_VERSION,
+	PROFILE_ORCHESTRATOR_KEY,
 	PROFILES_KIND,
 	PROFILES_VERSION,
 	profileExportPath,
+	profileRoleEntries,
+	profileRoutingRows,
 	profilesFilePath,
+	readProfileOrchestrator,
 	readProfilesFileResult,
 	renameProfile,
+	routingColumnWidths,
 	serializeProfileExport,
 	serializeProfilesFile,
 	setActiveProfile,
@@ -654,4 +661,62 @@ test("the path helpers resolve both stores inside the config home", () => {
 	const home = join(root, "config-home");
 	assert.equal(profilesFilePath(home), join(home, "profiles.json"));
 	assert.equal(profileExportPath(home), join(home, "profiles.export.json"));
+});
+
+test("the orchestrator key is never counted or listed as an agent role", () => {
+	const config: AgentModelConfig = {
+		[PROFILE_ORCHESTRATOR_KEY]: { model: "nan/glm5.3", thinking: "high" },
+		alpha: { model: "a/one" },
+		beta: { model: "a/one" },
+	};
+	assert.deepEqual(summarizeProfile(config), {
+		models: [{ model: "a/one", count: 2, roles: ["alpha", "beta"] }],
+		total: 2,
+	});
+	const file = createProfile(emptyProfilesFile(), "team", config);
+	assert.deepEqual(buildProfileListItems(file).map((item) => item.description), ["2 roles"]);
+	assert.deepEqual(profileRoleEntries(config).map(([name]) => name), ["alpha", "beta"]);
+	assert.deepEqual(readProfileOrchestrator(config), { model: "nan/glm5.3", thinking: "high" });
+});
+
+test("the orchestrator helper treats an absent or empty entry as undefined", () => {
+	assert.equal(readProfileOrchestrator({}), undefined);
+	assert.equal(readProfileOrchestrator({ alpha: { model: "a/one" } }), undefined);
+	assert.equal(readProfileOrchestrator({ [PROFILE_ORCHESTRATOR_KEY]: {} }), undefined);
+});
+
+test("profileRoutingRows lists one aligned row per agent, in a stable order", () => {
+	const rows = profileRoutingRows({
+		[PROFILE_ORCHESTRATOR_KEY]: { model: "nan/glm5.3" },
+		zeta: { model: "nan/deepseek-v4-flash", thinking: "high" },
+		alpha: { thinking: "high" },
+		mid: { model: "nan/qwen3.8-flash" },
+	});
+	assert.deepEqual(rows, [
+		{ agent: "alpha", model: "inherit", thinking: "high" },
+		{ agent: "mid", model: "nan/qwen3.8-flash", thinking: "inherit" },
+		{ agent: "zeta", model: "nan/deepseek-v4-flash", thinking: "high" },
+	]);
+	assert.deepEqual(profileRoutingRows({}), []);
+
+	const widths = routingColumnWidths(rows, [{ agent: "a-much-longer-agent-name", model: "m/x", thinking: "low" }]);
+	assert.deepEqual(widths, { agent: "a-much-longer-agent-name".length, model: "nan/deepseek-v4-flash".length });
+	assert.equal(
+		formatRoutingRow(rows[0], widths),
+		`${"alpha".padEnd(widths.agent)}  ${"inherit".padEnd(widths.model)}  high`,
+	);
+	assert.equal(
+		formatRoutingRow(rows[2], widths),
+		`${"zeta".padEnd(widths.agent)}  ${"nan/deepseek-v4-flash".padEnd(widths.model)}  high`,
+	);
+});
+
+test("formatOrchestratorSelection separates set, inherit, and inherit-with-thinking", () => {
+	assert.equal(formatOrchestratorSelection(undefined), "inherit");
+	assert.equal(formatOrchestratorSelection({ thinking: "high" }), "inherit · high");
+	assert.equal(formatOrchestratorSelection({ model: "nan/glm5.3" }), "nan/glm5.3");
+	assert.equal(
+		formatOrchestratorSelection({ model: "nan/glm5.3", thinking: "max" }),
+		"nan/glm5.3 · max",
+	);
 });

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -13,6 +13,7 @@ import type {
 	ToolCallEventResult,
 } from "@earendil-works/pi-coding-agent";
 import { __testing, applyModelConfig, applyModelConfigAsync, createGentleAiExtension } from "../extensions/gentle-ai.ts";
+import { PROFILES_KIND, PROFILES_VERSION } from "../lib/agent-profiles.ts";
 import { NATIVE_REVIEW_ERROR_CODE, NativeReviewCliError, type NativeReviewCli } from "../lib/native-review-cli.ts";
 import { CandidateViewError, type CandidateViewRegistry } from "../lib/review-candidate-view.ts";
 import { installPackageAssets } from "../lib/sdd-preflight.ts";
@@ -252,6 +253,9 @@ function routingConsumerFixture(t: test.TestContext, agents = ["worker"]) {
 		registerCommand(name, command) { commands.set(name, command); },
 	} as ExtensionAPI);
 	const notifications: Array<{ message: string; severity: string }> = [];
+	// The profiles panel reads the terminal rows to size its full-screen frame, so
+	// the fake UI hands every factory a TUI-shaped stand-in with a mutable height.
+	const fixtureTui = { terminal: { rows: 24 }, requestRender() {} };
 	let panelVisits = 0;
 	const panels: string[] = [];
 	let onPanel = () => ({ type: "cancel", config: {} });
@@ -267,7 +271,7 @@ function routingConsumerFixture(t: test.TestContext, agents = ["worker"]) {
 			notify(message: string, severity: string) { notifications.push({ message, severity }); },
 			custom: async (factory: (tui: unknown, theme: Theme, keybindings: unknown, done: (result: unknown) => void) => RoutingConsumerPanel) => {
 				let result: unknown;
-				const panel = factory(undefined, { fg: (_color: string, text: string) => text } as unknown as Theme, undefined, (value) => { result = value; });
+				const panel = factory(fixtureTui, { fg: (_color: string, text: string) => text } as unknown as Theme, undefined, (value) => { result = value; });
 				panels.push(stripAnsi(renderComponent(panel)));
 				panelVisits += 1;
 				if (onInput) {
@@ -281,6 +285,7 @@ function routingConsumerFixture(t: test.TestContext, agents = ["worker"]) {
 	} as unknown as Parameters<Parameters<ExtensionAPI["registerCommand"]>[1]["handler"]>[1];
 	return {
 		root, agentHome, configHome, projectPath, globalPath, exportPath, notifications, panels,
+		tui: fixtureTui as { terminal: { rows: number } },
 		panelVisits: () => panelVisits,
 		onPanel(action: typeof onPanel) { onPanel = action; },
 		onInput(action: (panel: RoutingConsumerPanel) => void) { onInput = action; },
@@ -1592,4 +1597,143 @@ test("bash tool_call confirms every compound action and centers a long git -C pu
 	assert.equal(title, "Allow guarded actions: git push; npm publish?");
 	assert.match(preview, /push origin main && npm publish --tag beta/);
 	assert.ok(preview.startsWith("…"));
+});
+// /gentle:profiles reopens its panel after every action, so a test that applies
+// once must confirm on the first visit and close on the next, or the panel and
+// the action loop feed each other forever.
+function applyOnce(
+	fixture: { onInput(action: (panel: { handleInput(data: string): void }) => void): void },
+): void {
+	let visits = 0;
+	fixture.onInput((panel) => {
+		visits += 1;
+		panel.handleInput(visits === 1 ? "\r" : "\x1b");
+	});
+}
+
+function profilesStoreFixture(t: test.TestContext) {
+	const fixture = routingConsumerFixture(t, ["worker"]);
+	const storePath = join(fixture.configHome, "profiles.json");
+	const settingsPath = join(fixture.agentHome, "settings.json");
+	const writeStore = (profiles: Record<string, unknown>, active?: string) => {
+		mkdirSync(fixture.configHome, { recursive: true });
+		const store: Record<string, unknown> = { kind: PROFILES_KIND, version: PROFILES_VERSION, profiles };
+		if (active !== undefined) store.active = active;
+		writeFileSync(storePath, `${JSON.stringify(store, null, 2)}\n`);
+	};
+	const writeSettings = (extra: Record<string, unknown> = {}) => {
+		const settings = {
+			packages: ["npm:pi-mcp-adapter"],
+			theme: "Gentleman-Cute",
+			defaultProvider: "nan",
+			defaultModel: "deepseek-v4-flash",
+			defaultThinkingLevel: "high",
+			...extra,
+		};
+		writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+		return settings;
+	};
+	return { fixture, storePath, settingsPath, writeStore, writeSettings };
+}
+
+test("applying a profile persists its orchestrator and never leaks the key into agent routing", async (t) => {
+	const { fixture, settingsPath, writeStore, writeSettings } = profilesStoreFixture(t);
+	const before = writeSettings();
+	writeStore({
+		team: {
+			orchestrator: { model: "nan/glm5.3", thinking: "max" },
+			worker: { model: "openai/alpha" },
+		},
+	});
+	applyOnce(fixture);
+	await fixture.run("gentle:profiles");
+
+	const after = JSON.parse(readFileSync(settingsPath, "utf8"));
+	assert.equal(after.defaultProvider, "nan");
+	assert.equal(after.defaultModel, "glm5.3");
+	assert.equal(after.defaultThinkingLevel, "max");
+	assert.deepEqual(after.packages, before.packages, "unrelated settings keys survive");
+	assert.equal(after.theme, before.theme, "unrelated settings keys survive");
+
+	// The reserved key is routing, not an agent: it must never reach the
+	// subagent profile store or the agent frontmatter.
+	const projectProfiles = JSON.parse(readFileSync(join(fixture.root, ".pi", "subagents.json"), "utf8"));
+	assert.equal("orchestrator" in projectProfiles.model_profiles, false);
+	assert.equal(readFileSync(join(fixture.root, ".pi", "agents", "worker.md"), "utf8"), readFileSync(join(fixture.root, ".pi", "agents", "worker.md"), "utf8"));
+	assert.match(readFileSync(join(fixture.root, ".pi", "agents", "worker.md"), "utf8"), /model: openai\/alpha/);
+	const applied = fixture.notifications.at(-1)?.message ?? "";
+	assert.match(applied, /Orchestrator set to nan\/glm5\.3 · max/);
+});
+
+test("applying a profile without an orchestrator entry leaves settings.json untouched", async (t) => {
+	const { fixture, settingsPath, writeStore, writeSettings } = profilesStoreFixture(t);
+	writeSettings();
+	writeStore({ team: { worker: { model: "openai/alpha" } } });
+	applyOnce(fixture);
+	await fixture.run("gentle:profiles");
+
+	const after = JSON.parse(readFileSync(settingsPath, "utf8"));
+	assert.equal(after.defaultProvider, "nan");
+	assert.equal(after.defaultModel, "deepseek-v4-flash");
+	assert.equal(after.defaultThinkingLevel, "high");
+	const applied = fixture.notifications.at(-1)?.message ?? "";
+	assert.doesNotMatch(applied, /Orchestrator set to/);
+});
+
+test("a profile store entry with only the orchestrator key counts zero roles", async (t) => {
+	const { fixture, writeStore } = profilesStoreFixture(t);
+	writeStore({ team: { orchestrator: { model: "nan/glm5.3", thinking: "high" } } }, "team");
+	applyOnce(fixture);
+	await fixture.run("gentle:profiles");
+	const applied = fixture.notifications.at(-1)?.message ?? "";
+	assert.match(applied, /0 agents updated/);
+	assert.match(applied, /Orchestrator set to nan\/glm5\.3 · high/);
+});
+
+test("the profiles panel fills the terminal, lists routing per agent, and scrolls", async (t) => {
+	const { fixture, writeStore } = profilesStoreFixture(t);
+	writeStore({
+		team: {
+			orchestrator: { model: "nan/glm5.3", thinking: "high" },
+			worker: { model: "openai/alpha", thinking: "high" },
+			"sdd-design": { model: "nan/glm5.3", thinking: "high" },
+		},
+	}, "team");
+	let rendered: string | undefined;
+	let panel: { render(width: number): string[] } | undefined;
+	fixture.onInput((visited) => {
+		panel = visited;
+		rendered = renderComponent(visited);
+		visited.handleInput("\x1b");
+	});
+	await fixture.run("gentle:profiles");
+
+	assert.ok(rendered);
+	const lines = rendered.split("\n");
+	// The frame spans the terminal height the fake TUI reports.
+	assert.equal(lines.length, 24, `expected 24 rows, got ${lines.length}`);
+	assert.match(lines[0], /^╭/);
+	assert.match(lines.at(-1)!, /^╰/);
+	const text = rendered;
+	// Routing is listed one agent per line, aligned in columns, never collapsed
+	// into "N agents → model: a, b, …" summaries.
+	assert.match(text, /Profile routing/);
+	assert.match(text, /Current routing \(models\.json\)/);
+	assert.match(text, /orchestrator\s+nan\/glm5\.3 · high/);
+	assert.match(text, /worker\s+openai\/alpha\s+high/);
+	assert.match(text, /sdd-design\s+nan\/glm5\.3\s+high/);
+	assert.doesNotMatch(text, /agents? → /);
+
+	// A taller terminal renders a taller frame with the same content.
+	fixture.tui.terminal.rows = 40;
+	const taller = renderComponent(panel);
+	assert.equal(taller.split("\n").length, 40);
+
+	// A short terminal clamps instead of crashing, and keeps both borders.
+	fixture.tui.terminal.rows = 9;
+	const short = stripAnsi(panel.render(120).map((line) => line.replace(/[ \t]+$/g, "")).join("\n"));
+	const shortLines = short.split("\n");
+	assert.equal(shortLines.length, 9);
+	assert.match(shortLines[0], /^╭/);
+	assert.match(shortLines.at(-1)!, /^╰/);
 });

--- a/tests/profiles-orchestrator.test.ts
+++ b/tests/profiles-orchestrator.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	applyOrchestratorSettings,
+	parseOrchestratorModelRef,
+	readOrchestratorSettings,
+	restoreOrchestratorSettings,
+} from "../lib/profiles-orchestrator.ts";
+
+function fixture(t: test.TestContext) {
+	const root = mkdtempSync(join(tmpdir(), "gentle-pi-orchestrator-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	return { root, settingsPath: join(root, "settings.json") };
+}
+
+test("orchestrator model refs split only on a real provider boundary", () => {
+	assert.deepEqual(parseOrchestratorModelRef("nan/glm5.3"), {
+		provider: "nan",
+		model: "glm5.3",
+	});
+	assert.deepEqual(parseOrchestratorModelRef("  openai-codex/gpt-6-astra  "), {
+		provider: "openai-codex",
+		model: "gpt-6-astra",
+	});
+	// A nested slash stays with the model half.
+	assert.deepEqual(parseOrchestratorModelRef("nan/qwen3.8/flash"), {
+		provider: "nan",
+		model: "qwen3.8/flash",
+	});
+	for (const value of ["glm5.3", "/glm5.3", "nan/", "nan", "", "   ", 42, undefined, null]) {
+		assert.equal(parseOrchestratorModelRef(value), undefined, `rejects ${JSON.stringify(value)}`);
+	}
+});
+
+test("reading the orchestrator distinguishes missing, unreadable, unset and set", (t) => {
+	const { settingsPath } = fixture(t);
+	assert.deepEqual(readOrchestratorSettings(settingsPath), { status: "missing" });
+
+	writeFileSync(settingsPath, "{ not json");
+	assert.equal(readOrchestratorSettings(settingsPath).status, "invalid");
+
+	writeFileSync(settingsPath, JSON.stringify(["not", "an", "object"]));
+	assert.equal(readOrchestratorSettings(settingsPath).status, "invalid");
+
+	writeFileSync(settingsPath, JSON.stringify({ theme: "Gentleman-Cute" }));
+	const unset = readOrchestratorSettings(settingsPath);
+	assert.equal(unset.status, "valid");
+	assert.equal(unset.status === "valid" ? unset.entry : undefined, undefined);
+
+	writeFileSync(
+		settingsPath,
+		JSON.stringify({
+			defaultProvider: "nan",
+			defaultModel: "glm5.3",
+			defaultThinkingLevel: "high",
+		}),
+	);
+	const set = readOrchestratorSettings(settingsPath);
+	assert.deepEqual(set.status === "valid" ? set.entry : undefined, {
+		model: "nan/glm5.3",
+		thinking: "high",
+	});
+
+	// A half-written pair is "unset", never a fabricated provider or model.
+	writeFileSync(settingsPath, JSON.stringify({ defaultProvider: "nan" }));
+	const half = readOrchestratorSettings(settingsPath);
+	assert.equal(half.status, "valid");
+	assert.equal(half.status === "valid" ? half.entry : undefined, undefined);
+});
+
+test("an orchestrator entry without a model never touches the settings file", (t) => {
+	const { root, settingsPath } = fixture(t);
+	const before = '{\n  "packages": [\n    "npm:pi-mcp-adapter"\n  ],\n  "theme": "Gentleman-Cute"\n}\n';
+	writeFileSync(settingsPath, before);
+	assert.deepEqual(applyOrchestratorSettings(settingsPath, { thinking: "high" }), {
+		status: "unchanged",
+	});
+	assert.equal(readFileSync(settingsPath, "utf8"), before);
+
+	// Also true when there is no file at all: nothing to write, nothing created.
+	const absent = join(root, "absent-settings.json");
+	assert.deepEqual(applyOrchestratorSettings(absent, {}), { status: "unchanged" });
+	assert.equal(existsSync(absent), false);
+});
+
+test("applying the orchestrator preserves every unrelated settings key", (t) => {
+	const { settingsPath } = fixture(t);
+	const before =
+		JSON.stringify(
+			{
+				packages: ["npm:pi-mcp-adapter", "some-package"],
+				theme: "Gentleman-Cute",
+				tuiMode: "fullscreen",
+				telemetry: { enabled: true },
+				defaultProvider: "nan",
+				defaultModel: "deepseek-v4-flash",
+				defaultThinkingLevel: "high",
+				images: { autoResize: true },
+			},
+			null,
+			2,
+		) + "\n";
+	writeFileSync(settingsPath, before);
+
+	const result = applyOrchestratorSettings(settingsPath, {
+		model: "nan/glm5.3",
+		thinking: "max",
+	});
+	assert.equal(result.status, "written");
+	assert.equal(result.status === "written" ? result.previous : undefined, before);
+
+	const after = JSON.parse(readFileSync(settingsPath, "utf8"));
+	assert.equal(after.defaultProvider, "nan");
+	assert.equal(after.defaultModel, "glm5.3");
+	assert.equal(after.defaultThinkingLevel, "max");
+	assert.deepEqual(after.packages, ["npm:pi-mcp-adapter", "some-package"]);
+	assert.equal(after.theme, "Gentleman-Cute");
+	assert.equal(after.tuiMode, "fullscreen");
+	assert.deepEqual(after.telemetry, { enabled: true });
+	assert.deepEqual(after.images, { autoResize: true });
+	assert.equal(readFileSync(settingsPath, "utf8").endsWith("\n"), true);
+});
+
+test("a missing settings file is created with only the orchestrator keys", (t) => {
+	const { settingsPath } = fixture(t);
+	const result = applyOrchestratorSettings(settingsPath, { model: "nan/glm5.3" });
+	assert.equal(result.status, "written");
+	assert.equal(result.status === "written" ? result.previous : "sentinel", undefined);
+	assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), {
+		defaultProvider: "nan",
+		defaultModel: "glm5.3",
+	});
+});
+
+test("an orchestrator entry without thinking clears a stale thinking level", (t) => {
+	const { settingsPath } = fixture(t);
+	writeFileSync(
+		settingsPath,
+		JSON.stringify({
+			defaultProvider: "nan",
+			defaultModel: "glm5.3",
+			defaultThinkingLevel: "high",
+		}),
+	);
+	const result = applyOrchestratorSettings(settingsPath, { model: "nan/glm5.3-flash" });
+	assert.equal(result.status, "written");
+	const after = JSON.parse(readFileSync(settingsPath, "utf8"));
+	assert.equal(after.defaultModel, "glm5.3-flash");
+	assert.equal("defaultThinkingLevel" in after, false);
+});
+
+test("re-applying the same selection is a no-op", (t) => {
+	const { settingsPath } = fixture(t);
+	assert.equal(applyOrchestratorSettings(settingsPath, { model: "nan/glm5.3" }).status, "written");
+	const bytes = readFileSync(settingsPath, "utf8");
+	assert.deepEqual(applyOrchestratorSettings(settingsPath, { model: "nan/glm5.3" }), {
+		status: "unchanged",
+	});
+	assert.equal(readFileSync(settingsPath, "utf8"), bytes);
+});
+
+test("an unusable target is refused instead of being overwritten", (t) => {
+	const { settingsPath } = fixture(t);
+	const before = "{ this is not json\n";
+	writeFileSync(settingsPath, before);
+	const broken = applyOrchestratorSettings(settingsPath, { model: "nan/glm5.3" });
+	assert.equal(broken.status, "invalid");
+	assert.equal(readFileSync(settingsPath, "utf8"), before);
+
+	writeFileSync(settingsPath, "[]");
+	const notObject = applyOrchestratorSettings(settingsPath, { model: "nan/glm5.3" });
+	assert.equal(notObject.status, "invalid");
+	assert.equal(readFileSync(settingsPath, "utf8"), "[]");
+
+	// A model id that is not a provider/model pair is refused for the same reason:
+	// there is no provider to write, and guessing one would corrupt the selection.
+	writeFileSync(settingsPath, JSON.stringify({ theme: "Gentleman-Cute" }));
+	const noProvider = applyOrchestratorSettings(settingsPath, { model: "glm5.3" });
+	assert.equal(noProvider.status, "invalid");
+	assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf8")), { theme: "Gentleman-Cute" });
+});
+
+test("restoring returns the previous bytes, or removes a file the write created", (t) => {
+	const { root, settingsPath } = fixture(t);
+	const before = '{\n  "theme": "Gentleman-Cute"\n}\n';
+	writeFileSync(settingsPath, before);
+	const written = applyOrchestratorSettings(settingsPath, { model: "nan/glm5.3" });
+	assert.equal(written.status, "written");
+	restoreOrchestratorSettings(
+		settingsPath,
+		written.status === "written" ? written.previous : undefined,
+	);
+	assert.equal(readFileSync(settingsPath, "utf8"), before);
+
+	// A file the write created restores by disappearing, not by holding an empty object.
+	const createdPath = join(root, "created-settings.json");
+	const created = applyOrchestratorSettings(createdPath, { model: "nan/glm5.3" });
+	assert.equal(created.status, "written");
+	assert.equal(existsSync(createdPath), true);
+	restoreOrchestratorSettings(
+		createdPath,
+		created.status === "written" ? created.previous : undefined,
+	);
+	assert.equal(existsSync(createdPath), false);
+});


### PR DESCRIPTION
Closes #916

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- `/gentle:profiles` now fills the terminal (agents-view geometry) and the detail pane lists routing one line per agent in shared columns, scrollable instead of grouped and truncated.
- A profile can carry the orchestrator under the reserved `orchestrator` key; applying it persists `defaultProvider` / `defaultModel` / `defaultThinkingLevel` to Pi's global `settings.json`, safely and inside the existing apply-revert discipline.
- Profiles without the key never move the orchestrator, and `s` snapshots the effective orchestrator together with the routing.

## Changes Table

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Full-screen profiles panel (`width: "100%"`, `maxHeight: "100%"`, `margin: 0`, `rows: () => tui.terminal.rows`), per-agent detail lines with shared column widths, detail-pane scrolling (`pgup/pgdn`, `ctrl+j/k`, wheel), orchestrator display, reserved-key skip in `applyModelConfig`/`applyModelConfigAsync`, orchestrator write + revert in the apply path, orchestrator capture in `update`. |
| `lib/agent-profiles.ts` | Reserved `PROFILE_ORCHESTRATOR_KEY`, `readProfileOrchestrator`, `profileRoleEntries` (orchestrator excluded from role counts and summaries), `profileRoutingRows` / `routingColumnWidths` / `formatRoutingRow`, `formatOrchestratorSelection`. |
| `lib/profiles-orchestrator.ts` | New module: parse `provider/model` refs, read the effective orchestrator from Pi settings, write the three keys preserving every other key, refuse an unreadable settings file, atomic temp+rename write, and restore support. |
| `tests/agent-profiles.test.ts` | Orchestrator exclusion from summaries/role counts, routing row alignment, `formatOrchestratorSelection` states. |
| `tests/profiles-orchestrator.test.ts` | New: 9 tests over the settings read/write module (missing/invalid/unset/set, unknown-key preservation, atomic no-op, refused targets, restore semantics). |
| `tests/gentle-ai.test.ts` | New integration tests: apply persists the orchestrator and never leaks the key into agent routing; apply without the key leaves `settings.json` untouched; orchestrator-only store counts zero roles; the panel fills the terminal, lists routing per agent, and scrolls. |
| `README.md` | `/gentle:profiles` section: full-screen panel, scroll keys, orchestrator in profiles, reserved-key semantics, store-shape example. |

## Test Plan

- [x] Full suite: 2221 tests, 2212 pass, 0 fail (9 pre-existing skips) — `node --experimental-strip-types --test tests/*.test.ts`
- [x] Type gate: 205 recorded diagnostics, no regressions — `node scripts/check-types.mjs`
- [x] Provider contract mirror check passed
- [x] New tests: 13 (9 module + 4 integration), each written red-first
- [x] Manual render readback of the panel at multiple terminal heights (frame reaches the bottom, routing readable, no truncation)
- [x] Manually exercised apply/scroll/render paths against the real profile store

## Contributor Checklist

- [x] Linked an approved issue (#916, `status:approved`)
- [x] Added exactly one `type:*` label (`type:feature`)
- [x] Ran shellcheck on modified scripts (no shell scripts modified)
- [x] Skills tested in at least one agent (panel exercised through the extension fixture harness)
- [x] Docs updated if behavior changed (README `/gentle:profiles`)
- [x] Conventional commit format (`feat(profiles): …`)
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent-model profiles can now include and apply an orchestrator model selection.
  - Profile activation preserves unrelated settings and supports rollback if applying changes fails.
  - The profiles panel now fills the terminal and supports page navigation, keyboard shortcuts, and mouse-wheel scrolling.
  - Profile details display aligned per-agent routing and the currently effective orchestrator.

- **Documentation**
  - Updated profile documentation to describe orchestrator routing, settings behavior, snapshots, and panel controls.

- **Tests**
  - Added coverage for orchestrator settings, profile routing, panel sizing, scrolling, and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->