### PR TITLE
feat(profiles): agents-style j/k line scroll in the detail pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,8 @@ Profiles are named, switchable snapshots of the global agent-model routing from 
 | `x`     | Delete the selected profile (refuses the active profile).              |
 | `e`     | Export the selected profile to `~/.pi/gentle-ai/profiles.export.json`. |
 | `i`     | Import a profile from `~/.pi/gentle-ai/profiles.export.json`.          |
-| `pgup`/`pgdn`, `ctrl+j`/`ctrl+k`, wheel | Scroll the detail pane.                                |
+| `j`/`k`, wheel | Scroll the detail pane one line at a time (agents-view style).                                |
+| `pgup`/`pgdn`, `ctrl+j`/`ctrl+k` | Scroll the detail pane by a page.                                |
 | `esc`   | Close.                                                                 |
 
 Applying a profile writes `~/.pi/gentle-ai/models.json`, then reconciles agent frontmatter and `subagents.json` the same way `/gentle:models` does. The reconciliation happens on the next subagent launch, and that launch still routes with the previous routing — expect one launch of lag after switching. The active profile is persisted so `/gentle:profiles` reopens with the applied profile marked.

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -3326,6 +3326,17 @@ class ProfilesPanel implements OverlayComponent {
 			this.scrollDetail(-this.pageRows());
 			return;
 		}
+		// Agents-view line scroll: j/k move the routing one line at a time. The
+		// arrow keys stay with the profile list, exactly as the letters below stay
+		// profile actions.
+		if (data === "j") {
+			this.scrollDetail(1);
+			return;
+		}
+		if (data === "k") {
+			this.scrollDetail(-1);
+			return;
+		}
 		if (data === "c") return this.finish({ type: "create" });
 		if (data === "i") return this.finish({ type: "import" });
 		if (!name) return this.list.handleInput(data);
@@ -3443,7 +3454,7 @@ class ProfilesPanel implements OverlayComponent {
 
 	private renderFooterRow(width: number): string {
 		const hints =
-			"enter apply · c create · s update · d duplicate · r rename · x delete · e export · i import · pgup/pgdn scroll · esc close";
+			"enter apply · c create · s update · d duplicate · r rename · x delete · e export · i import · j/k line · ctrl+j/k page · esc close";
 		return [
 			this.renderText("│", "border"),
 			" ",

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -1737,3 +1737,28 @@ test("the profiles panel fills the terminal, lists routing per agent, and scroll
 	assert.match(shortLines[0], /^╭/);
 	assert.match(shortLines.at(-1)!, /^╰/);
 });
+
+test("j and k scroll the detail pane one line at a time, like the agents view", async (t) => {
+	const { fixture, writeStore } = profilesStoreFixture(t);
+	const routing: Record<string, { model: string; thinking: string }> = {};
+	for (let index = 1; index <= 25; index += 1) {
+		routing[`agent-${String(index).padStart(2, "0")}`] = { model: "openai/alpha", thinking: "high" };
+	}
+	writeStore({ team: routing }, "team");
+	let panel: { handleInput(data: string): void; render(width: number): string[] } | undefined;
+	fixture.onInput((visited) => {
+		panel = visited;
+		visited.handleInput("\x1b");
+	});
+	await fixture.run("gentle:profiles");
+	assert.ok(panel, "the panel must open");
+	const body = () => panel!.render(120).slice(1, -2).map((line) => line.replace(/[ \t]+$/, "")).join("\n");
+	const firstAgentRow = (text: string) => text.split("\n").findIndex((line) => line.includes("agent-01"));
+	const before = body();
+	assert.ok(firstAgentRow(before) >= 0, "the first routing row must be visible before scrolling");
+	panel!.handleInput("j");
+	const afterJ = body();
+	assert.notEqual(firstAgentRow(afterJ), firstAgentRow(before), "j must scroll the detail down by one line");
+	panel!.handleInput("k");
+	assert.equal(firstAgentRow(body()), firstAgentRow(before), "k must scroll the detail back up");
+});


### PR DESCRIPTION
Closes #920

## PR Type

- [x] New feature

## Summary

- The `/gentle:profiles` detail pane now scrolls like the agents view trains: `j`/`k` one line at a time, `ctrl+j`/`ctrl+k` and `pgup`/`pgdn` by page, wheel for line scroll.
- Arrow keys keep moving the profile selection and the letters keep being profile actions; nothing existing changed behavior.
- Footer hints advertise the scroll keys (the paging keys were undiscoverable before).

## Changes Table

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | `j`/`k` bound to detail line scroll in `ProfilesPanel.handleInput` (before the profile-action letters, after the page keys); footer hints updated to `j/k line · ctrl+j/k page`. |
| `tests/gentle-ai.test.ts` | New test: with a 25-agent profile, `j` moves the first routing row off its line and `k` restores it (written red-first). |
| `README.md` | Scroll keys row split into line (`j`/`k`, wheel) and page (`pgup`/`pgdn`, `ctrl+j`/`ctrl+k`) entries. |

## Test Plan

- [x] Red-first: new test failed before the change (`j` did nothing), passes after
- [x] Full suite: 2248 tests, 2239 pass, 0 fail (9 pre-existing skips)
- [x] Type gate: 205 recorded diagnostics, no regressions
- [x] Provider contract mirror check passed
- [x] Empirical check with the real panel: `ctrl+j`/`ctrl+k` paging worked before and after; `j`/`k` only work after

## Contributor Checklist

- [x] Linked an approved issue (#920, `status:approved`)
- [x] Added exactly one `type:*` label (`type:feature`)
- [x] Ran shellcheck on modified scripts (no shell scripts modified)
- [x] Skills tested in at least one agent (exercised through the extension fixture harness)
- [x] Docs updated if behavior changed (README scroll keys)
- [x] Conventional commit format (`feat(profiles): …`)
- [x] No `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `j`/`k` keyboard controls for scrolling the profiles detail pane one line at a time.
  - Continued support for page scrolling with `Ctrl+J`/`Ctrl+K`.
  - Updated on-screen help and documentation to reflect the scrolling controls.

- **Tests**
  - Added coverage verifying single-line detail-pane scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->