### PR TITLE
fix(agents): avoid duplicate singleton elapsed time

### DIFF
--- a/lib/agents-widget.ts
+++ b/lib/agents-widget.ts
@@ -229,7 +229,7 @@ export function renderAgentsCard(tasks: readonly TaskRecord[], theme: CardTheme,
 	if (shown.length === 0) return [];
 	const cols = columns(shown, cardInnerWidth(width), now);
 	const { listed, hidden } = options.collapsed ? { listed: [shown[0]], hidden: 0 } : visibleRows(shown, options.maxRows);
-	const hint = options.collapsed && options.collapseKey ? `${options.collapseKey} expand` : batchElapsed(shown, now);
+	const hint = options.collapsed && options.collapseKey ? `${options.collapseKey} expand` : shown.length > 1 ? batchElapsed(shown, now) : undefined;
 	const body = listed.flatMap((task) => row(task, theme, cols, now, options.maxRows === undefined));
 	if (hidden > 0) body.push(overflowRow(hidden, theme, options.viewKey));
 	return renderCard(

--- a/tests/agents-widget.test.ts
+++ b/tests/agents-widget.test.ts
@@ -59,7 +59,7 @@ test("renderAgentsCard draws columns for agent, task, and model · tokens · cos
 });
 
 test("renderAgentsCard renders singleton elapsed time only on its task row", () => {
-	const lines = renderAgentsCard([task()], plainTheme, 84, 5_000, { collapsed: false }).map(stripAnsi);
+	const lines = renderAgentsCard([task({})], plainTheme, 84, 5_000, { collapsed: false }).map(stripAnsi);
 	assert.equal(lines.join("\n").match(/4s/g)?.length, 1);
 	assert.match(lines[1], /4s/);
 });

--- a/tests/agents-widget.test.ts
+++ b/tests/agents-widget.test.ts
@@ -58,6 +58,12 @@ test("renderAgentsCard draws columns for agent, task, and model · tokens · cos
 	assert.deepEqual(renderAgentsCard([], plainTheme, 60, 0, { collapsed: false }), []);
 });
 
+test("renderAgentsCard renders singleton elapsed time only on its task row", () => {
+	const lines = renderAgentsCard([task()], plainTheme, 84, 5_000, { collapsed: false }).map(stripAnsi);
+	assert.equal(lines.join("\n").match(/4s/g)?.length, 1);
+	assert.match(lines[1], /4s/);
+});
+
 test("renderAgentsCard keeps every task on one line, clipping long labels, and drops the task column when the card is narrow", () => {
 	const tasks = [task({ id: "a", label: "write the gentle shell footer and all of its tests before lunch" })];
 	const wide = renderAgentsCard(tasks, plainTheme, 84, 5_000, { collapsed: false }).map(stripAnsi);

--- a/tests/gentle-agents.test.ts
+++ b/tests/gentle-agents.test.ts
@@ -1227,7 +1227,7 @@ test("subagent_list_agents and subagent_run in task mode launch a child with the
 	assert.equal(args[args.indexOf("--tools") + 1], "read,grep,subagent_parent_message");
 	await tick();
 	assert.match(String(harness.children[0].written[1].message), /Map lib\/ and report every module\.\n\n## Context\nFocus on agents-\*\.ts/);
-	assert.match(widget()![0], /^╭─ ❀ Agents · 1 active ─+ \d+s ╮$/);
+	assert.match(widget()![0], /^╭─ ❀ Agents · 1 active ─+╮$/);
 	assert.match(widget()![1], /^│ ◐  explore  map lib modules +gpt-5\.6-terra · low · \d+s │$/);
 	harness.children[0].emit({ type: "tool_execution_start", toolCallId: "c", toolName: "grep", args: {} });
 	harness.children[0].emit({ type: "message_end", message: { role: "assistant", usage: { totalTokens: 12_000, cost: { total: 0.09 } } } });


### PR DESCRIPTION
Closes #928

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Omit the aggregate batch timer when the Agents card shows exactly one task.
- Keep the per-task timer, multi-task aggregate timer, and collapse-key hint unchanged.
- Add focused regression coverage for singleton and multi-task rendering.

## Changes

| File | Change |
|------|--------|
| `lib/agents-widget.ts` | Suppress the redundant aggregate elapsed hint for singleton cards. |
| `tests/agents-widget.test.ts` | Assert singleton elapsed time is rendered exactly once while preserving multi-task batch timing. |

## Test plan

- [x] `node --experimental-strip-types --test tests/agents-widget.test.ts` — 10 passed, 0 failed.
- [x] `pnpm run check:provider-contract` — passed.
- [x] `git diff --check` — passed.
- [x] No shell scripts changed; Shellcheck is not applicable.
- [x] No skill files changed; agent skill loading is not applicable.
- [x] Documentation impact reviewed; the README does not specify singleton timer placement.

### Local full-suite limitation

`pnpm test` did not complete locally: the writer run timed out after 600 seconds. Independent verification split the command into components; the broad Node test glob timed out after 180 seconds after reporting unrelated failures, and `test:harness` hit a Windows temporary-directory `EBUSY`. The focused affected suite and provider-contract check are green; hosted CI remains authoritative for the complete suite.

## Contributor checklist

- [x] Linked an approved issue (`#928`, `status:approved`).
- [x] Added exactly one `type:*` label (`type:bug`).
- [x] Kept tests with the behavior change.
- [x] Reviewed documentation impact.
- [x] Used a Conventional Commit message.
- [x] Added no `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved elapsed-time display for collapsed agent cards with a single task, preventing duplicate timing information.
  - Single-task cards now show elapsed time only on the task row.
  - Multi-task cards continue to show the batch elapsed-time hint.
  - Agent card headers no longer display a redundant elapsed-time suffix for singleton tasks.

- **Tests**
  - Added coverage to verify elapsed time appears exactly once for singleton tasks.
  - Updated display checks to reflect the streamlined agent card header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->