### PR TITLE
fix(shell): refresh the fullscreen sidebar from live session state

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,8 @@ Gentle Shell is the visual layer gentle-pi puts on top of pi. It follows the Gen
 
 In fullscreen at 140 columns or wider, the right sidebar scrolls **✿ Gentle-Pi ✿ → Status → Changes → Agents → TODO** together. The one-line heading is horizontally centered within the usable rail width, with pink flowers and normal white text in the Gentleman themes. Colors follow the active theme; no artwork scaling or custom fonts are used. Narrow/mobile terminals and regular mode retain bottom widgets without the sidebar heading. The original rose and text logo remain in the main chat startup intro.
 
+The rail reuses its last frame until something it paints changes, so silent frames stay cheap and live session state still lands on the next frame: a model switch, a new thinking level, context growth, session cost, session name and extension statuses all refresh the Status card without a redraw of the rest of the sidebar.
+
 The status bar replaces pi's three-line footer with a single line of segments:
 
 ```text

--- a/extensions/gentle-shell.ts
+++ b/extensions/gentle-shell.ts
@@ -554,8 +554,14 @@ export default function gentleShell(pi: ExtensionAPI, env: NodeJS.ProcessEnv = p
 		ctx.ui.setFooter((tui, theme, footerData) => {
 			renderHost = { requestRender: () => tui.requestRender(), invalidateSidebar: () => invalidateSidebar(tui) };
 			const bottom = createShellBarComponent(pi, ctx, renderHost, theme, footerData, () => tracker.model.files.length, () => usage.get(ctx.model?.provider ?? ""));
+			// The Status card paints live session state that no event re-registers a
+			// part for: model, effort, context, cost, session name and extension
+			// statuses. The digest is what keeps the fullscreen memo honest, and it
+			// rebuilds the model exactly as the narrow bottom bar does every frame.
+			const footerModel = () => buildShellBarModel(pi, ctx, footerData, { dirty: tracker.model.files.length, usage: usage.get(ctx.model?.provider ?? "") });
 			const part = sidebarPart(tui, "footer", bottom, {
-				render: (width) => renderShellSidebarBar(buildShellBarModel(pi, ctx, footerData, { dirty: tracker.model.files.length, usage: usage.get(ctx.model?.provider ?? "") }), theme, width),
+				digest: () => JSON.stringify(footerModel()),
+				render: (width) => renderShellSidebarBar(footerModel(), theme, width),
 				invalidate() {},
 			});
 			const uninstall = installSidebar(tui, theme);

--- a/lib/shell-sidebar-layout.ts
+++ b/lib/shell-sidebar-layout.ts
@@ -1,5 +1,5 @@
 import { ScrollView, visibleWidth, type Component, type TUI, type TuiMouseEvent } from "@earendil-works/pi-tui";
-import { sidebarState } from "./shell-sidebar.ts";
+import { sidebarState, type SidebarRail } from "./shell-sidebar.ts";
 import type { ShellBarTheme } from "./shell-bar.ts";
 import { renderSidebarBanner } from "./shell-sidebar-banner.ts";
 
@@ -22,7 +22,8 @@ type PreparedRail = {
 	mode: string | undefined;
 	root: LayoutRoot;
 	theme: ShellBarTheme;
-	parts: Array<[string, Component]>;
+	parts: Array<[string, SidebarRail]>;
+	digests: Array<string | undefined>;
 	contentWidth: number;
 	active: boolean;
 	lines: string[];
@@ -39,6 +40,20 @@ function sidebarCache(tui: TUI): SidebarCache {
 /** Mark terminal-owned fullscreen sidebar output stale after a part state change. */
 export function invalidateSidebar(tui: TUI): void {
 	if (tui.terminal) sidebarCache(tui).revision++;
+}
+
+// The memo keys on part identity and an explicit revision, neither of which can
+// see live session state read inside a rail's render closure: a model switch, a
+// new context percentage or an extension status change leaves the prepared lines
+// intact. A rail that paints such state declares a digest of it, so the memo can
+// notice by itself; a throwing digest degrades that rail to invalidation-only
+// rather than taking the whole sidebar down with it.
+function railDigest(rail: SidebarRail): string | undefined {
+	try {
+		return rail.digest?.();
+	} catch {
+		return undefined;
+	}
 }
 
 export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
@@ -107,9 +122,11 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 			return false;
 		}
 		const parts = [...state.parts.entries()];
+		const digests = parts.map(([, rail]) => railDigest(rail));
 		const unchanged = prepared?.revision === cache.revision &&
 			prepared.width === width && prepared.mode === host.mode && prepared.root === root && prepared.theme === theme &&
-			prepared.parts.length === parts.length && prepared.parts.every(([key, part], index) => parts[index]?.[0] === key && parts[index]?.[1] === part);
+			prepared.parts.length === parts.length && prepared.parts.every(([key, part], index) => parts[index]?.[0] === key && parts[index]?.[1] === part) &&
+			prepared.digests.length === digests.length && prepared.digests.every((digest, index) => digest === digests[index]);
 		if (unchanged) {
 			railLines = prepared.lines;
 			state.active = prepared.active;
@@ -137,7 +154,7 @@ export function installSidebar(tui: TUI, theme: ShellBarTheme): () => void {
 			}
 			// Height is owned by the native ScrollView, never by the transcript.
 			const active = railLines.length > 0 && railLines.every((line) => visibleWidth(line) <= contentWidth);
-			prepared = { revision: cache.revision, width, mode: host.mode, root, theme, parts, contentWidth, active, lines: railLines, hits };
+			prepared = { revision: cache.revision, width, mode: host.mode, root, theme, parts, digests, contentWidth, active, lines: railLines, hits };
 			state.active = active;
 			return active;
 		} catch {

--- a/lib/shell-sidebar.ts
+++ b/lib/shell-sidebar.ts
@@ -6,7 +6,18 @@ const STATE = Symbol.for("gentle-pi.experimental-sidebar.state");
 export interface SidebarState {
 	active: boolean;
 	ownsHost?: () => boolean;
-	parts: Map<string, Component>;
+	parts: Map<string, SidebarRail>;
+}
+
+/** A rail slot in the fullscreen sidebar. */
+export interface SidebarRail extends Component {
+	/**
+	 * Cheap digest of the live state this rail paints. The fullscreen layout memo
+	 * re-renders a part only when its digest changes, so a rail that reads session
+	 * data (model, thinking level, context, cost, extension statuses) must declare
+	 * one; explicit invalidateSidebar() stays for discrete state changes.
+	 */
+	digest?(): string;
 }
 export function sidebarState(tui: TUI): SidebarState {
 	const terminal = tui.terminal as unknown as Record<symbol, SidebarState>;
@@ -14,7 +25,7 @@ export function sidebarState(tui: TUI): SidebarState {
 }
 
 /** Keep the original bottom component mounted, suppressing only its paint. */
-export function sidebarPart<T extends Component & { dispose?(): void }>(tui: TUI, key: string, bottom: T, rail: Component = bottom): T {
+export function sidebarPart<T extends Component & { dispose?(): void }>(tui: TUI, key: string, bottom: T, rail: SidebarRail = bottom): T {
 	// Minimal extension hosts cannot share terminal-owned layout state.
 	if (!tui.terminal) return bottom;
 	const state = sidebarState(tui);

--- a/tests/gentle-shell.test.ts
+++ b/tests/gentle-shell.test.ts
@@ -5,8 +5,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { initTheme, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { TUI } from "@earendil-works/pi-tui";
 import installGentleShell, { buildShellBarModel, changesShortcut, devBinaryCard, fetchCodexUsage, loadFileDiff, shellGitRunner, openInExternalEditor, type GentlePromptEditor } from "../extensions/gentle-shell.ts";
 import { CHANGE_STATUS } from "../lib/shell-changes.ts";
+import { sidebarState, type SidebarRail } from "../lib/shell-sidebar.ts";
 import type { ShellBarTheme } from "../lib/shell-bar.ts";
 import { stripAnsi } from "../lib/terminal-theme.ts";
 
@@ -226,6 +228,49 @@ test("gentleShell installs the footer on session_start when a UI exists", () => 
 	const lines = component.render(120);
 	assert.equal(lines.length, 1);
 	assert.match(lines[0], /main ⟡ gpt-5\.5 · medium/);
+});
+
+test("the fullscreen Status rail carries a live digest so a model switch refreshes it", async () => {
+	const { pi, handlers } = fakePi();
+	gentleShell(pi, { GENTLE_PI_SHELL_CHANGES_WATCH_MS: "off" });
+	const entries: unknown[] = [];
+	const { ctx, ui } = fakeContext({ entries });
+	await fire(handlers, "session_start", ctx);
+
+	const statuses = new Map<string, string>();
+	const liveFooterData = { getGitBranch: () => "main", getExtensionStatuses: () => statuses, getAvailableProviderCount: () => 1, onBranchChange: () => () => {} };
+	const tui = { terminal: { rows: 40, columns: 160 }, requestRender() {} };
+	const factory = ui.footerFactory as (tui: unknown, theme: ShellBarTheme, footerData: unknown) => { render(width: number): string[]; dispose(): void };
+	const component = factory(tui, plainTheme, liveFooterData);
+	try {
+		const rail = sidebarState(tui as unknown as TUI).parts.get("footer") as SidebarRail;
+		const live = () => rail.digest?.();
+		assert.equal(typeof rail.digest, "function", "the Status card paints live state and must declare a digest");
+		assert.match(rail.render(46).join("\n"), /gpt-5\.5/);
+
+		const beforeModel = live();
+		(ctx.model as { id: string }).id = "gpt-5.6";
+		assert.notEqual(live(), beforeModel, "/model must change the digest");
+		assert.match(rail.render(46).join("\n"), /gpt-5\.6/);
+
+		const beforeUsage = live();
+		(ctx as unknown as { getContextUsage: () => unknown }).getContextUsage = () => ({ tokens: 200_000, contextWindow: 272_000, percent: 74 });
+		assert.notEqual(live(), beforeUsage, "context usage must change the digest");
+		assert.match(rail.render(46).join("\n"), /74%/);
+
+		const beforeCost = live();
+		entries.push(assistantEntry({ input: 100, output: 20, cost: 0.42 }));
+		assert.notEqual(live(), beforeCost, "session cost must change the digest");
+		assert.match(rail.render(46).join("\n"), /\$0\.420/);
+
+		const beforeStatus = live();
+		statuses.set("mcp", "MCP: 3 servers enabled");
+		assert.notEqual(live(), beforeStatus, "extension statuses have no event and must change the digest");
+		assert.match(rail.render(46).join("\n"), /MCP: 3 servers enabled/);
+		assert.equal(live(), live(), "an unchanged digest still reuses the prepared rail");
+	} finally {
+		component.dispose();
+	}
 });
 
 test("gentleShell stays out of the way without a UI or when disabled", () => {

--- a/tests/shell-sidebar-layout.test.ts
+++ b/tests/shell-sidebar-layout.test.ts
@@ -287,6 +287,52 @@ test("real layout frames reuse unchanged sidebar output and invalidate at state 
 	assert.equal(replacementRenders, 1);
 });
 
+test("a rail digest refreshes live state that no invalidation announces", (t) => {
+	const f = fixture();
+	let model = "model-a";
+	let renders = 0;
+	// The digest is the only signal: no part is re-registered and invalidateSidebar
+	// is never called here, which is exactly the /model case in fullscreen.
+	sidebarPart(f.tui, "footer", { render: () => ["Status"], invalidate() {} }, {
+		digest: () => model,
+		render: () => {
+			renders++;
+			return [`Model ${model}`];
+		},
+		invalidate() {},
+	});
+	t.after(installSidebar(f.tui, theme));
+
+	assert.match(renderLayoutFrame(f.root, 140, 20, () => {}).lines.join("\n"), /Model model-a/);
+	assert.equal(renders, 1);
+	renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.equal(renders, 1, "an unchanged digest still reuses the prepared rail");
+
+	model = "model-b";
+	assert.match(renderLayoutFrame(f.root, 140, 20, () => {}).lines.join("\n"), /Model model-b/);
+	assert.equal(renders, 2);
+
+	// Rail digests run inside the layout frame, so a broken one must not disable
+	// the sidebar for the parts that still work.
+	let todoRenders = 0;
+	sidebarPart(f.tui, "todo", { render: () => ["Todo bottom"], invalidate() {} }, {
+		digest: () => { throw new Error("broken digest"); },
+		render: () => {
+			todoRenders++;
+			return ["Todo card"];
+		},
+		invalidate() {},
+	});
+	model = "model-c";
+	assert.match(renderLayoutFrame(f.root, 140, 20, () => {}).lines.join("\n"), /Model model-c/);
+	assert.equal(todoRenders, 1);
+	assert.match(renderLayoutFrame(f.root, 140, 20, () => {}).lines.join("\n"), /Todo card/);
+	assert.equal(todoRenders, 1, "a throwing digest degrades to invalidation-only");
+	invalidateSidebar(f.tui);
+	renderLayoutFrame(f.root, 140, 20, () => {});
+	assert.equal(todoRenders, 2, "explicit invalidation still reaches a rail without a digest");
+});
+
 test("reuses final sidebar presentation until a relevant invalidation", (t) => {
 	const f = fixture();
 	sidebarPart(f.tui, "todo", { render: () => Array.from({ length: 10 }, (_, index) => `Todo ${index}`), invalidate() {} });


### PR DESCRIPTION
## Linked issue

Closes #873

## Type

- [x] Bug fix

## Summary

- The fullscreen rail reused its last prepared frame unless the revision counter, the geometry or the part set changed, so the Status card kept painting the model, thinking level, context, cost, session name and integration statuses captured at the last full recompute.
- A rail that paints live state now declares a cheap digest of it (`SidebarRail.digest()`), and the layout memo re-renders only that part when the digest changes. Rails that already invalidate themselves on every mutation (`changes`, `todo`, `agents`) stay exactly as they are.
- A digest that throws degrades that rail to explicit invalidation instead of marking the sidebar failed and dropping the whole rail.

## Why a digest instead of one more event hook

`model_select`, `thinking_level_select` and `session_info_changed` are the obvious hooks, but they are not the whole surface: `ctx.ui.setStatus` emits no event, and context usage and session cost move with ordinary turns. Pi cannot cover the gap either — `interactive-mode.js` calls `this.footer.invalidate()`, but that targets the native `FooterComponent`, which is unmounted when an extension footer is set (`interactive-mode.js:1804-1818`), and its own invalidate is a documented no-op (`components/footer.js:65-66`). The rail is unreachable from `tui.invalidate()` as well, since it is not in the layout root's `children`.

Declaring the inputs makes the memo honest for any part that reads live state, and keeps the perf intent of #832/#840: parts still render only when something they paint actually changed. Digests run per layout frame only while the sidebar is active (fullscreen at 140 columns or wider), so narrow terminals pay nothing.

## Changes

| File | Change |
|------|--------|
| `lib/shell-sidebar.ts` | New `SidebarRail` interface with optional `digest()`; rail slots typed to it |
| `lib/shell-sidebar-layout.ts` | `railDigest()` helper and `PreparedRail.digests`, compared before reusing prepared lines |
| `extensions/gentle-shell.ts` | The footer Status rail declares `digest: () => JSON.stringify(footerModel())`, the same model the narrow bottom bar already builds every frame |
| `tests/shell-sidebar-layout.test.ts` | Digest refresh with no invalidation, unchanged-digest reuse, throwing digest |
| `tests/gentle-shell.test.ts` | Footer rail digest follows a model switch, context usage, session cost and extension statuses |
| `README.md` | Documents rail frame reuse plus live-state freshness |

## Test plan

- [x] RED: with `lib/shell-sidebar.ts`, `lib/shell-sidebar-layout.ts` and `extensions/gentle-shell.ts` stashed, both new tests fail
- [x] GREEN: with the fix, both new tests pass
- [x] `pnpm test` — 2250 tests, 0 failures (includes provider contract and runtime harness)
- [x] `pnpm run typecheck` — 205 recorded diagnostics, no regressions
- [x] `pnpm run check:runtime-modules`
- [x] `node scripts/verify-package-files.mjs`
- [x] `pnpm run test:packed-package` — packed package E2E passed

## Checklist

- [x] Linked an approved issue (#873)
- [x] Exactly one `type:*` label
- [x] Conventional commit, no `Co-Authored-By` trailers
- [x] Tests and docs included with the behavior they cover
- N/A — no shell scripts modified (`shellcheck`), no skills modified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The fullscreen sidebar now refreshes live session details—such as model, context usage, cost, and extension status—without unnecessarily redrawing unchanged content.
  * Silent frames reuse the last rendered sidebar output for improved efficiency.

* **Documentation**
  * Updated the README with details about sidebar refresh behavior.

* **Tests**
  * Added coverage for live-state updates, unchanged rendering, and graceful handling of refresh failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->