### PR TITLE
fix(agents): accept canonical max thinking level

### DIFF
--- a/lib/agents-config.ts
+++ b/lib/agents-config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { basename, join } from "node:path";
+import { THINKING_LEVELS as ROUTING_THINKING_LEVELS, type ThinkingLevel as RoutingThinkingLevel } from "./model-routing-authority.ts";
 
 // Gentle Agents configuration. Agent definitions are markdown files with YAML
 // frontmatter (the format gentle-ai installs) and runtime settings come from
@@ -13,16 +14,12 @@ export const AGENT_MODE = {
 
 export type AgentMode = (typeof AGENT_MODE)[keyof typeof AGENT_MODE];
 
-export const THINKING_LEVEL = {
-	OFF: "off",
-	MINIMAL: "minimal",
-	LOW: "low",
-	MEDIUM: "medium",
-	HIGH: "high",
-	XHIGH: "xhigh",
-} as const;
+export type ThinkingLevel = RoutingThinkingLevel;
 
-export type ThinkingLevel = (typeof THINKING_LEVEL)[keyof typeof THINKING_LEVEL];
+// Preserve the uppercase compatibility keys without maintaining a second level list.
+export const THINKING_LEVEL = Object.fromEntries(
+	ROUTING_THINKING_LEVELS.map((level) => [level.toUpperCase(), level]),
+) as { readonly [Level in ThinkingLevel as Uppercase<Level>]: Level };
 
 export const AGENT_SCOPE = {
 	GLOBAL: "global",
@@ -109,7 +106,7 @@ export interface Frontmatter {
 const DEFAULT_STALL_TIMEOUT_MS = 4 * 60_000;
 const DEFAULT_MAX_CONCURRENCY = 5;
 const DEFAULT_HISTORY_MAX_TASKS = 200;
-const THINKING_LEVELS = Object.values(THINKING_LEVEL) as string[];
+const THINKING_LEVELS: readonly string[] = ROUTING_THINKING_LEVELS;
 const AGENT_MODES = Object.values(AGENT_MODE) as string[];
 
 function unquote(value: string): string {

--- a/tests/agents-config.test.ts
+++ b/tests/agents-config.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test, { after } from "node:test";
 import {
 	AGENT_MODE,
+	THINKING_LEVEL,
 	agentDirectories,
 	discoverAgents,
 	loadAgentsConfig,
@@ -14,6 +15,7 @@ import {
 	parseModelRef,
 	resolveAgentProfile,
 } from "../lib/agents-config.ts";
+import { THINKING_LEVELS } from "../lib/model-routing-authority.ts";
 
 // Gentle Agents configuration: markdown agent definitions (the same files
 // gentle-ai installs) and subagents.json, both parsed without touching pi.
@@ -75,6 +77,66 @@ test("parseAgentDefinition rejects unknown thinking levels, modes, and empty bod
 	assert.match((parseAgentDefinition("---\nname: a\nthinking: extreme\n---\nbody", "/a.md", "global") as { error: string }).error, /thinking "extreme"/);
 	assert.match((parseAgentDefinition("---\nname: a\nsubagent_mode: forever\n---\nbody", "/a.md", "global") as { error: string }).error, /mode "forever"/);
 	assert.match((parseAgentDefinition("---\nname: a\n---\n   \n", "/a.md", "global") as { error: string }).error, /no instructions/);
+});
+
+test("runtime thinking levels stay aligned with model routing authority", () => {
+	assert.deepEqual(Object.values(THINKING_LEVEL), THINKING_LEVELS);
+	assert.equal(THINKING_LEVEL.MAX, "max");
+});
+
+test("parseAgentDefinition accepts max through every thinking alias", () => {
+	for (const field of ["thinking", "effort", "thinking_level"]) {
+		const agent = parseAgentDefinition(`---\nname: worker\n${field}: max\n---\nbody`, "/worker.md", "global");
+		assert.ok(!("error" in agent), `${field} must accept max`);
+		assert.equal(agent.thinking, "max");
+	}
+});
+
+test("discoverAgents retains max definitions instead of falling back to medium", () => {
+	const home = join(root, "max-home");
+	const cwd = join(root, "max-project");
+	const agentHome = join(home, ".pi", "agent");
+	for (const dir of ["agents", "subagents"]) mkdirSync(join(agentHome, dir), { recursive: true });
+	writeFileSync(join(agentHome, "agents", "worker.md"), "---\nname: worker\nthinking: medium\n---\nlegacy worker");
+	writeFileSync(join(agentHome, "subagents", "worker.md"), "---\nname: worker\nthinking: max\n---\nselected worker");
+	writeFileSync(join(agentHome, "subagents.json"), JSON.stringify({ model_profiles: { worker: { model: "openai-codex/gpt-5.6-luna", effort: "max" } } }));
+	const { agents, errors } = discoverAgents({ cwd, home });
+	assert.deepEqual(errors, []);
+	assert.equal(agents.length, 1);
+	assert.equal(agents[0].thinking, "max");
+	assert.equal(agents[0].instructions, "selected worker");
+	const resolved = resolveAgentProfile(agents[0], loadAgentsConfig({ cwd, home }));
+	assert.equal(resolved.model?.id, "gpt-5.6-luna");
+	assert.equal(resolved.thinking, "max");
+	assert.equal(resolved.source.thinking, "profile");
+});
+
+test("max defaults and model profiles preserve routing precedence", () => {
+	const bare = parseAgentDefinition("---\nname: worker\n---\nbody", "/worker.md", "global");
+	const medium = parseAgentDefinition("---\nname: worker\nthinking: medium\n---\nbody", "/worker.md", "global");
+	assert.ok(!("error" in bare));
+	assert.ok(!("error" in medium));
+	for (const field of ["default_effort", "default_thinking_level", "default_thinking"]) {
+		const config = parseAgentsConfig({ [field]: "max" }, undefined);
+		assert.equal(config.defaultThinking, "max");
+		assert.equal(resolveAgentProfile(bare, config).thinking, "max");
+		assert.equal(resolveAgentProfile(bare, config).source.thinking, "default");
+		assert.equal(resolveAgentProfile(medium, config).thinking, "medium");
+	}
+	for (const field of ["effort", "thinking"]) {
+		const global = { model_profiles: { worker: { [field]: "max" } } };
+		const config = parseAgentsConfig(global, { model_profiles: { worker: { model: "openai-codex/gpt-5.6-luna" } } });
+		assert.equal(config.modelProfiles.worker.thinking, "max");
+		assert.equal(resolveAgentProfile(medium, config).thinking, "max");
+		assert.equal(resolveAgentProfile(medium, config).source.thinking, "profile");
+	}
+	const override = parseAgentsConfig(
+		{ model_profiles: { worker: { model: "openai-codex/gpt-5.6-luna", effort: "high" } } },
+		{ model_profiles: { worker: { effort: "max" } } },
+	);
+	assert.equal(override.modelProfiles.worker.thinking, "max");
+	assert.equal(resolveAgentProfile(medium, override).thinking, "max");
+	assert.equal(resolveAgentProfile(medium, override).model?.id, "gpt-5.6-luna");
 });
 
 test("discoverAgents merges the four directories with project over global and subagents over agents", () => {

--- a/tests/agents-runner.test.ts
+++ b/tests/agents-runner.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { AGENT_MODE, type AgentDefinition } from "../lib/agents-config.ts";
+import { AGENT_MODE, parseAgentsConfig, resolveAgentProfile, type AgentDefinition } from "../lib/agents-config.ts";
 import { TASK_STATUS, TaskStore } from "../lib/agents-protocol.ts";
 import { AgentRunner, childArguments, JsonLines, piCommand, abortReasonText, type RunnerDeps, type RunnerHooks, type TaskRequest } from "../lib/agents-runner.ts";
 import { fakeChild, type FakeChild } from "./agents-fake-child.ts";
@@ -363,6 +363,21 @@ test("childArguments builds an rpc launch with model, thinking, tools, session d
 	const resumed = childArguments(request({ resumeSessionPath: "/sessions/old.jsonl", model: undefined, thinking: undefined, agent: { ...explorer, tools: [] } }));
 	assert.equal(resumed[resumed.indexOf("--session") + 1], "/sessions/old.jsonl");
 	assert.ok(!resumed.includes("--model") && !resumed.includes("--tools"));
+});
+
+test("childArguments preserves a max profile instead of the definition's medium effort", () => {
+	const agent: AgentDefinition = { ...explorer, name: "worker", thinking: "medium" };
+	const config = parseAgentsConfig({ model_profiles: { worker: { model: "openai-codex/gpt-5.6-luna", effort: "max" } } }, undefined);
+	const profile = resolveAgentProfile(agent, config);
+	const args = childArguments(request({ agent, model: profile.model, thinking: profile.thinking }));
+	assert.equal(args[args.indexOf("--model") + 1], "openai-codex/gpt-5.6-luna:max");
+});
+
+test("childArguments preserves a max default without a selected model", () => {
+	const profile = resolveAgentProfile(explorer, parseAgentsConfig({ default_effort: "max" }, undefined));
+	const args = childArguments(request({ model: profile.model, thinking: profile.thinking }));
+	assert.ok(!args.includes("--model"));
+	assert.equal(args[args.indexOf("--thinking") + 1], "max");
 });
 
 test("childArguments grants every child the notification-only parent message tool", () => {


### PR DESCRIPTION
## Linked issue

Closes #760

## PR type

- [x] Bug fix

## Summary

- Derive runtime thinking levels and their compatibility keys from the existing model-routing authority instead of maintaining a second list.
- Preserve `max` through agent discovery, definition aliases, defaults, profile precedence, and child launch arguments.
- Keep existing unknown-value handling, routing precedence, and runner production behavior unchanged.

## Changes

| File | Change |
| --- | --- |
| `lib/agents-config.ts` | Use the canonical thinking-level list and type; preserve uppercase compatibility keys. |
| `tests/agents-config.test.ts` | Cover canonical parity, max discovery, aliases, defaults, and precedence without medium fallback. |
| `tests/agents-runner.test.ts` | Cover configured-model `:max` and model-less `--thinking max` launch arguments. |

## Test plan

- [x] Independent static verification completed.
- [x] `git diff --check` passed.
- [x] Hosted CI tests and typecheck passed (run 34682205835, attempt 2).

Regression sources were written before the production change. Tests, typecheck, builds, and installs were not run locally because local execution was explicitly prohibited. No runtime RED/GREEN result is claimed; hosted CI provided validation. The full suite passed with 2,248 passes and 9 skips; typecheck reported no new diagnostics. One authorized Windows retry passed on the unchanged candidate after the first ownership-test failure; the original cause remains undetermined.

## Scope

No user configuration, model selection, generated runtime, dependency, watchdog, or unrelated PR changes. This fixes acceptance of the user-selected level; it does not force a model to support a level it does not expose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the **Max** thinking level across agent configuration and model profiles.
  - The Max level is available through thinking, effort, and thinking-level settings.

- **Bug Fixes**
  - Agent definitions and profiles now preserve Max effort settings instead of falling back to Medium.
  - Default thinking preferences and model-specific settings now apply consistently.
  - Running agents with Max thinking correctly passes the setting through, including when no model is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->