### PR TITLE
fix(review): adopt the committed-range START the provider offers

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -7402,6 +7402,31 @@ async function executeReviewControllerOperation(
 				}, retainedUntrackedSelections, defaultCwd);
 				if (negotiated.transport !== undefined) return hostTransportUnavailable(parameters.operation, negotiated.transport);
 				target = negotiated.status!;
+				// gentle-pi#874: the STATUS this START already fetched can itself
+				// offer the committed-range START for an empty workspace candidate.
+				// Adopt its own base commit *here*, before the candidate view and the
+				// native START are resolved, and re-derive the target for that range,
+				// so all three agree on one base-diff identity. Adopting the offer
+				// later left the workspace target and the base-diff candidate view
+				// disagreeing, and START failed with identity-mismatch. Both an
+				// explicit caller baseRef and any START with an untracked selection in
+				// play keep today's single-STATUS flow; only an adopted offer pays the
+				// second read-only STATUS.
+				if (canonicalBaseRef === undefined && untrackedSelection.untrackedScope === undefined && untrackedSubmission === undefined) {
+					const offeredBaseRef = offeredCommittedRangeBaseRef(target);
+					if (offeredBaseRef !== undefined) {
+						const renegotiated = await negotiatedStatusForHostTransport(nativeReviewCli, {
+							cwd: defaultCwd,
+							...(parameters.lineageId === undefined ? {} : { lineageId: parameters.lineageId }),
+							baseRef: offeredBaseRef,
+							committedOnly: true,
+							...(signal === undefined ? {} : { signal }),
+						}, retainedUntrackedSelections, defaultCwd);
+						if (renegotiated.transport !== undefined) return hostTransportUnavailable(parameters.operation, renegotiated.transport);
+						canonicalBaseRef = offeredBaseRef;
+						target = renegotiated.status!;
+					}
+				}
 				if (
 					retainedPreLineageSelection !== undefined &&
 					!sameNativePreLineageCandidate(retainedPreLineageSelection, target)
@@ -7419,18 +7444,6 @@ async function executeReviewControllerOperation(
 				if (target.nextTransition?.kind === "collect" || target.applicability !== "unrelated" || target.action !== "start") return mapNativeTargetStatus(parameters.operation, target, parameters.lineageId);
 			} catch (error) {
 				return nativeOperationFailure(parameters.operation, error);
-			}
-			// gentle-pi#874: with no explicit caller baseRef, adopt the
-			// committed-range selector this same START's STATUS just offered for
-			// this workspace, so `input: {"mode":"ordinary"}` starts exactly the
-			// route the provider rendered. An explicit caller baseRef was already
-			// resolved above and always wins; an absent or non-committed-range
-			// offer leaves today's workspace candidate byte-for-byte. The adopted
-			// value is the provider's own offered argument passed through
-			// unchanged into the existing START argument assembly, so the existing
-			// candidate-view resolution remains the guard on it.
-			if (canonicalBaseRef === undefined) {
-				canonicalBaseRef = offeredCommittedRangeBaseRef(target);
 			}
 			// gentle-pi#323: the replay key must fold in the current candidate
 			// content identity. Without it, a second START with identical

--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5372,6 +5372,27 @@ function consentBindingRepositoryMismatchOutcome(operation: ReviewControllerOper
 	};
 }
 
+// gentle-pi#874: the committed-range selector a current STATUS owns. A
+// selectorless STATUS on a clean, fully committed worktree answers with a
+// review.start execute transition naming the exact merge-base the provider
+// wants, so a plain START can adopt the route the provider just rendered
+// instead of making the caller hand-copy `base-ref` into its input. Only the
+// provider's own offered argument is read -- never a guess, a persisted value,
+// or a stale transition -- and anything that is not a full commit id paired
+// with committed-only is refused, so every other STATUS keeps today's
+// behaviour byte-for-byte.
+const OFFERED_COMMITTED_RANGE_BASE_REF = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+
+function offeredCommittedRangeBaseRef(target: ReviewStatusV3): string | undefined {
+	const execute = target.nextTransition?.kind === "execute" ? target.nextTransition.execute : undefined;
+	if (execute?.operation !== "review.start") return undefined;
+	if (execute.arguments.some((argument) => argument.name === "workspace-overlay")) return undefined;
+	const baseRef = execute.arguments.find((argument) => argument.name === "base-ref")?.value;
+	if (baseRef === undefined || !OFFERED_COMMITTED_RANGE_BASE_REF.test(baseRef)) return undefined;
+	if (execute.arguments.find((argument) => argument.name === "committed-only")?.value !== "true") return undefined;
+	return baseRef;
+}
+
 function assertNativeStartCandidateBinding(candidateView: CandidateView, target: ReviewStatusV3): void {
 	candidateView.verify();
 	if (
@@ -7398,6 +7419,18 @@ async function executeReviewControllerOperation(
 				if (target.nextTransition?.kind === "collect" || target.applicability !== "unrelated" || target.action !== "start") return mapNativeTargetStatus(parameters.operation, target, parameters.lineageId);
 			} catch (error) {
 				return nativeOperationFailure(parameters.operation, error);
+			}
+			// gentle-pi#874: with no explicit caller baseRef, adopt the
+			// committed-range selector this same START's STATUS just offered for
+			// this workspace, so `input: {"mode":"ordinary"}` starts exactly the
+			// route the provider rendered. An explicit caller baseRef was already
+			// resolved above and always wins; an absent or non-committed-range
+			// offer leaves today's workspace candidate byte-for-byte. The adopted
+			// value is the provider's own offered argument passed through
+			// unchanged into the existing START argument assembly, so the existing
+			// candidate-view resolution remains the guard on it.
+			if (canonicalBaseRef === undefined) {
+				canonicalBaseRef = offeredCommittedRangeBaseRef(target);
 			}
 			// gentle-pi#323: the replay key must fold in the current candidate
 			// content identity. Without it, a second START with identical

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/alanbuscaglia/work/gentle-pi/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/alanbuscaglia/work/gentle-pi/node_modules

--- a/tests/gentle-ai.test.ts
+++ b/tests/gentle-ai.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -61,6 +62,121 @@ function lifecycleContext(overrides: Record<string, unknown> = {}): Record<strin
 		isError: false,
 		lastComponent: undefined,
 		...overrides,
+	};
+}
+
+// gentle-pi#874: the provider's fresh_target_ready offer. The argument order
+// mirrors the live selectorless STATUS a clean, fully committed worktree
+// receives: it names the merge-base it wants so a plain START can adopt it.
+function offeredCommittedRangeStatus(baseRef: string, baseTree: string, candidateTree: string, paths: readonly string[] = ["app.ts"]): ReviewStatusV3 {
+	const targetIdentity = `sha256:${"a".repeat(64)}`;
+	return {
+		contract: "gentle-ai.review-integration/v2",
+		applicability: "unrelated",
+		action: "start",
+		replayability: "not_replayable",
+		targetIdentity,
+		projection: {
+			schema: "gentle-ai.review-candidate-projection/v1",
+			kind: "base-diff",
+			projection: "workspace",
+			baseTree,
+			initialReviewTree: candidateTree,
+			currentCandidateTree: candidateTree,
+			pathsDigest: `sha256:${"b".repeat(64)}`,
+			paths: [...paths],
+			intendedUntracked: [],
+			intendedUntrackedProof: `sha256:${"c".repeat(64)}`,
+			initialSnapshotIdentity: `sha256:${"d".repeat(64)}`,
+			currentSnapshotIdentity: `sha256:${"d".repeat(64)}`,
+		},
+		candidates: [],
+		nextTransition: {
+			kind: "execute",
+			reasonCode: "fresh_target_ready",
+			execute: {
+				operation: "review.start",
+				arguments: [
+					{ name: "target", value: targetIdentity, token: `--target=${targetIdentity}` },
+					{ name: "target-evidence", value: `v1:base-diff:workspace:${baseTree}:${candidateTree}:sha256:${"e".repeat(64)}`, token: `--target-evidence=v1:base-diff:workspace:${baseTree}:${candidateTree}:sha256:${"e".repeat(64)}` },
+					{ name: "projection", value: "workspace", token: "--projection=workspace" },
+					{ name: "base-ref", value: baseRef, token: `--base-ref=${baseRef}` },
+					{ name: "committed-only", value: "true", token: "--committed-only=true" },
+					{ name: "lineage", value: "review-offered", token: "--lineage=review-offered" },
+					{ name: "agent", value: "pi", token: "--agent=pi" },
+					{ name: "consent", value: "relay", token: "--consent=relay" },
+				],
+				preconditions: [],
+				binding: { targetIdentity },
+			},
+		},
+		raw: { schema: "gentle-ai.review-integration.status/v5" },
+	} as unknown as ReviewStatusV3;
+}
+
+// The clean, fully committed worktree STATUS with no committed-range offer:
+// the current-changes candidate view a plain START builds today.
+function cleanWorkspaceStatus(headTree: string, nextTransition?: ReviewStatusV3["nextTransition"]): ReviewStatusV3 {
+	const targetIdentity = `sha256:${"a".repeat(64)}`;
+	return {
+		contract: "gentle-ai.review-integration/v2",
+		applicability: "unrelated",
+		action: "start",
+		replayability: "not_replayable",
+		targetIdentity,
+		projection: {
+			schema: "gentle-ai.review-candidate-projection/v1",
+			kind: "current-changes",
+			projection: "workspace",
+			baseTree: headTree,
+			initialReviewTree: headTree,
+			currentCandidateTree: headTree,
+			pathsDigest: `sha256:${"b".repeat(64)}`,
+			paths: [],
+			intendedUntracked: [],
+			intendedUntrackedProof: `sha256:${"c".repeat(64)}`,
+			initialSnapshotIdentity: `sha256:${"d".repeat(64)}`,
+			currentSnapshotIdentity: `sha256:${"d".repeat(64)}`,
+		},
+		candidates: [],
+		...(nextTransition === undefined ? {} : { nextTransition }),
+		raw: { schema: "gentle-ai.review-integration.status/v5" },
+	} as unknown as ReviewStatusV3;
+}
+
+function startedReviewResult(): Record<string, unknown> {
+	return { lineageId: "adopted-range", state: "reviewing", riskLevel: "low", selectedLenses: [], changedFiles: 1, changedLines: 1, correctionBudget: 1, action: "created", lensesRequired: false, riskReasons: [], raw: {} };
+}
+
+interface ReviewStartRepository {
+	cwd: string;
+	baseCommit: string;
+	baseTree: string;
+	headTree: string;
+}
+
+// A hermetic two-commit repository whose candidate range is a real committed
+// change, so both the adopted and explicit base-ref paths resolve through the
+// real candidate-view guard.
+function reviewRepository(t: test.TestContext): ReviewStartRepository {
+	const cwd = realpathSync(mkdtempSync(join(tmpdir(), "gentle-pi-review-start-")));
+	t.after(() => {
+		try { execFileSync("chmod", ["-R", "u+w", cwd], { stdio: "ignore" }); } catch { /* best effort */ }
+		rmSync(cwd, { recursive: true, force: true });
+	});
+	execFileSync("git", ["init", "-b", "main"], { cwd, stdio: "ignore" });
+	writeFileSync(join(cwd, "app.ts"), "export const value = 1;\n");
+	execFileSync("git", ["add", "app.ts"], { cwd, stdio: "ignore" });
+	execFileSync("git", ["-c", "user.name=Review Test", "-c", "user.email=review@example.invalid", "commit", "-m", "base"], { cwd, stdio: "ignore" });
+	const baseCommit = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
+	writeFileSync(join(cwd, "app.ts"), "export const value = 2;\n");
+	execFileSync("git", ["add", "app.ts"], { cwd, stdio: "ignore" });
+	execFileSync("git", ["-c", "user.name=Review Test", "-c", "user.email=review@example.invalid", "commit", "-m", "candidate"], { cwd, stdio: "ignore" });
+	return {
+		cwd,
+		baseCommit,
+		baseTree: execFileSync("git", ["rev-parse", `${baseCommit}^{tree}`], { cwd, encoding: "utf8" }).trim(),
+		headTree: execFileSync("git", ["rev-parse", "HEAD^{tree}"], { cwd, encoding: "utf8" }).trim(),
 	};
 }
 
@@ -791,6 +907,57 @@ test("ordinary native capture exposes a registered schema and STATUS binding cop
 	}, process.cwd(), native);
 	assert.equal(captured.status, "captured");
 	assert.equal(launches, 1);
+});
+
+test("ordinary START adopts the committed-range selectors the provider just offered", async (t) => {
+	const { cwd, baseCommit, baseTree, headTree: candidateTree } = reviewRepository(t);
+	const starts: Array<Record<string, unknown>> = [];
+	const native = {
+		targetStatus: async () => offeredCommittedRangeStatus(baseCommit, baseTree, candidateTree),
+		start: async (request: Record<string, unknown>) => { starts.push(request); return startedReviewResult(); },
+	} as unknown as NativeReviewCli;
+	const result = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native);
+	assert.equal(result.operation, "start");
+	assert.equal(starts.length, 1);
+	assert.equal(starts[0]?.baseRef, baseCommit);
+	assert.equal(starts[0]?.committedOnly, true);
+});
+
+test("ordinary START keeps an explicit caller baseRef and ignores the offered selector", async (t) => {
+	const { cwd, baseCommit, baseTree, headTree: candidateTree } = reviewRepository(t);
+	const starts: Array<Record<string, unknown>> = [];
+	const native = {
+		// A shape-valid but never-invoked offer: the explicit caller value must win
+		// before this is ever considered.
+		targetStatus: async () => offeredCommittedRangeStatus("f".repeat(40), baseTree, candidateTree),
+		start: async (request: Record<string, unknown>) => { starts.push(request); return startedReviewResult(); },
+	} as unknown as NativeReviewCli;
+	const result = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef: baseCommit, committedOnly: true }) }, cwd, native);
+	assert.equal(result.operation, "start");
+	assert.equal(starts.length, 1);
+	assert.equal(starts[0]?.baseRef, baseCommit);
+	assert.equal(starts[0]?.committedOnly, true);
+});
+
+test("ordinary START keeps today's invocation when STATUS offers no committed-range selector", async (t) => {
+	const { cwd, headTree } = reviewRepository(t);
+	const offeredWithoutBaseRef = cleanWorkspaceStatus(headTree, {
+		kind: "execute",
+		reasonCode: "fresh_target_ready",
+		execute: { operation: "review.start", arguments: [{ name: "projection", value: "workspace", token: "--projection=workspace" }], preconditions: [], binding: { targetIdentity: `sha256:${"a".repeat(64)}` } },
+	});
+	for (const [label, target] of [["no execute transition", cleanWorkspaceStatus(headTree)], ["no base-ref", offeredWithoutBaseRef]] as const) {
+		const starts: Array<Record<string, unknown>> = [];
+		const native = {
+			targetStatus: async () => target,
+			start: async (request: Record<string, unknown>) => { starts.push(request); return startedReviewResult(); },
+		} as unknown as NativeReviewCli;
+		const result = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary" }) }, cwd, native);
+		assert.equal(result.operation, "start", label);
+		assert.equal(starts.length, 1, label);
+		assert.equal(starts[0]?.baseRef, undefined, label);
+		assert.equal("committedOnly" in starts[0]!, false, label);
+	}
 });
 
 test("ordinary START reports candidate-owner preparation failure as pre-native no mutation", async () => {


### PR DESCRIPTION
## Linked issue

Closes #874

## Type

- [x] Bug fix

## Summary

- With a clean, fully committed worktree, START could only reach the committed range if the caller hand-copied the provider's offered `base-ref` into its own `input`; otherwise it fell back to the zero-path workspace candidate and failed.
- START now adopts the selector the same operation's STATUS just offered: only `review.start`, only a full commit id paired with `committed-only=true`, never a workspace overlay, and only when the caller named no base ref. An explicit caller value always wins.
- Companion fix in the native provider (gentle-ai #4412): STATUS stops emitting the unroutable `empty_candidate_base_ref_required` collect for that case and offers the executable committed-range START instead.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | `offeredCommittedRangeBaseRef()` reads the fresh STATUS the START path already holds and adopts its offered `base-ref`/`committed-only` when the caller named none |
| `tests/gentle-ai.test.ts` | Adoption, explicit-wins and no-offer cases |

## Test plan

- [x] RED/GREEN on the three new START tests (adoption disabled fails the assertion)
- [x] `node --experimental-strip-types --test tests/native-review-cli.test.ts tests/gentle-ai.test.ts tests/native-review-parity.test.ts` — 109 pass, 0 fail
- [x] `pnpm test` — 2254 tests, 0 fail
- [x] `pnpm run typecheck` — 205 recorded diagnostics, no regressions
- [x] Field-verified end to end against a dev provider binary: `inspect` → `ready` with the executable committed-range START → `start` → approved (lineage `review-76a8181dddcb43b1`)

## Checklist

- [x] Linked issue (#874)
- [x] Exactly one `type:*` label
- [x] Conventional commit, no `Co-Authored-By` trailers
- [x] Tests included, no schema or contract change
- N/A — no shell scripts or skills modified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Ordinary START operations now automatically use a provider-offered committed range when no base reference is specified.
  - Explicit base reference and committed-only settings continue to take precedence.

- **Bug Fixes**
  - Preserved existing behavior when no valid committed-range offer is available.
  - Maintained existing invocation behavior for workspace-based reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->