### PR TITLE
fix(review): expose reconciled START continuation

### DIFF
--- a/extensions/gentle-ai.ts
+++ b/extensions/gentle-ai.ts
@@ -5555,7 +5555,9 @@ async function reconcileNativeMutationFailure(
 	try {
 		const status = await nativeReviewCli.targetStatus(target);
 		syncRetainedNativeStatusSelections(retainedSelections, canonicalRetentionRoot, status, target.baseRef);
-		const { required_status_action: staleStatusDirective, ...reconciledBase } = failure;
+		const projectedStatus = mapNativeTargetStatus(operation, status, target.lineageId);
+		const { next_action: staleNextAction, required_status_action: staleStatusDirective, ...reconciledBase } = failure;
+		void staleNextAction;
 		void staleStatusDirective;
 		// Field defect (fambig, 2026-08-16): an envelope-less mutating failure
 		// is stamped mutationOutcome "unknown", but a reconciled authority
@@ -5569,6 +5571,8 @@ async function reconcileNativeMutationFailure(
 			void staleReplayability;
 			return {
 				...provenBase,
+				...projectedStatus,
+				status: "blocked",
 				outcome: "native-mutation-status-reconciled",
 				reconciliation: status.raw,
 				authority_applicability: status.applicability,
@@ -5576,17 +5580,17 @@ async function reconcileNativeMutationFailure(
 				mutation_performed: false,
 				mutation_outcome: "none",
 				mutation_outcome_reason: `authority revision unchanged across reconciliation (${preOperationRevision}); the failed operation provably did not mutate`,
-				next_action: status.action,
 			};
 		}
 		return {
 			...reconciledBase,
+			...projectedStatus,
+			status: "blocked",
 			outcome: "native-mutation-status-reconciled",
 			reconciliation: status.raw,
 			authority_applicability: status.applicability,
 			provider_action: status.action,
 			replayability: status.replayability,
-			next_action: status.action,
 		};
 	} catch (statusError) {
 		return {

--- a/tests/review-controller-native-routing.test.ts
+++ b/tests/review-controller-native-routing.test.ts
@@ -1846,13 +1846,17 @@ test("START and consent ambiguity reconciliation register their returned committ
 	const lineageId = "reconciled-collect", input = correctionPlanInput(lineageId), unknown = () => { throw new NativeReviewCliError(NATIVE_REVIEW_ERROR_CODE.NON_ZERO, "review/start", true, true, "unknown mutation"); };
 	const selectors = (requests: readonly Record<string, unknown>[]) => requests.map(({ baseRef: base, committedOnly }) => ({ baseRef: base, committedOnly }));
 	const directRequests: Array<Record<string, unknown>> = [], directRoutes = new Map();
+	let directStartCalls = 0;
 	const directNative = {
 		targetStatus: async (request: Record<string, unknown>) => { directRequests.push(request); return directRequests.length === 1 ? startStatus(cwd, baseRef) : status(lineageId, [input]); },
-		start: unknown,
+		start: () => { directStartCalls += 1; return unknown(); },
 		captureCorrectionPlan: async () => ({ schema: "gentle-ai.review-last-event-closure/v1", operation: "review.capture-correction-plan", lineageId, state: "correction_required", storeRevision: SHA }),
 	} as unknown as NativeReviewCli;
-	await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef, committedOnly: true }) }, cwd, directNative, undefined, undefined, undefined, directRoutes);
-	const directCapture = await __testing.executeReviewCaptureOperation({ lineageId, collectBinding: JSON.stringify(input), correctionLines: 1 }, cwd, directNative, undefined, undefined, directRoutes, true);
+	const directStart = await __testing.executeReviewControllerOperation({ operation: "start", input: JSON.stringify({ mode: "ordinary", baseRef, committedOnly: true }) }, cwd, directNative, undefined, undefined, undefined, directRoutes);
+	assert.deepEqual({ outcome: directStart.outcome, status: directStart.status, mutationOutcome: directStart.mutation_outcome, startCalls: directStartCalls, statusCalls: directRequests.length }, { outcome: "native-mutation-status-reconciled", status: "blocked", mutationOutcome: "unknown", startCalls: 1, statusCalls: 2 });
+	assert.equal((directStart.diagnostics as { error_code?: string }).error_code, NATIVE_REVIEW_ERROR_CODE.NON_ZERO);
+	assert.equal("next_action" in directStart, false);
+	const directCapture = await __testing.executeReviewCaptureOperation({ lineageId, collectBinding: bindingOf(directStart), correctionLines: 1 }, cwd, directNative, undefined, undefined, directRoutes, true);
 	const consent = decodeReviewConsentV3(JSON.parse(readFileSync(join(process.cwd(), "tests", "fixtures", "devbinary", "consent-v3.captured.json"), "utf8")));
 	const consentRequests: Array<Record<string, unknown>> = [], consentRoutes = new Map(), registry = new PendingReviewConsentRegistry(), session = Symbol("consent-session");
 	const consentNative = {
@@ -1867,9 +1871,11 @@ test("START and consent ambiguity reconciliation register their returned committ
 	const consentCapture = await __testing.executeReviewCaptureOperation({ lineageId, collectBinding: JSON.stringify(input), correctionLines: 1 }, cwd, consentNative, undefined, undefined, consentRoutes, true);
 	assert.deepEqual({
 		outcomes: [directCapture.outcome, consentCapture.outcome],
+		directStartCalls,
 		selectors: [selectors(directRequests), selectors(consentRequests)],
 	}, {
 		outcomes: ["native-last-event-closure", "native-last-event-closure"],
+		directStartCalls: 1,
 		selectors: [Array.from({ length: 3 }, () => ({ baseRef, committedOnly: true })), Array.from({ length: 3 }, () => ({ baseRef, committedOnly: true }))],
 	});
 });


### PR DESCRIPTION
Closes #857

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Expose the canonical STATUS continuation after an ambiguous native review START outcome.
- Preserve blocked/unknown mutation semantics without replaying START or returning contradictory synthetic guidance.
- Exercise the returned opaque collect binding directly in regression coverage.

## Changes

| File | Change |
|------|--------|
| `extensions/gentle-ai.ts` | Project the reconciled native STATUS route while preserving the failure envelope. |
| `tests/review-controller-native-routing.test.ts` | Verify the returned binding can continue capture and START is attempted only once. |

## Test Plan

- [x] Focused regression: `node --experimental-strip-types --test --test-name-pattern="^START and consent ambiguity reconciliation register their returned committed collect route$" tests/review-controller-native-routing.test.ts` — 1 passed.
- [x] `node --experimental-strip-types --check extensions/gentle-ai.ts`
- [x] `git diff --check`
- [x] Native four-lens RDD review completed with no findings.
- [ ] Full routing test file did not complete locally on Windows; CI owns broader coverage.

## Contributor Checklist

- [x] Linked approved issue #857.
- [x] Added exactly one `type:*` label.
- [x] No shell scripts changed; shellcheck is not applicable.
- [x] Relevant agent skills were loaded during implementation and validation.
- [x] No documentation change is required for this internal recovery-path correction.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of native mutation failures during START and consent reconciliation.
  * Reconciled failures now consistently report a blocked outcome and unknown mutation status.
  * Prevented stale next-action details from appearing in reconciled results.
  * Corrected direct START tracking to ensure operations are executed only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->